### PR TITLE
feat(normal-form): 集成 Hamiltonian 正规化流水线，发版 5.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: astral-sh/setup-uv@v7
-      - run: uv sync --group dev
+      - run: uv sync --group dev --extra normal-form
       - run: cargo test --package e2m2e-integrators
       - run: uv run maturin develop
       - shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [5.1.0] - 2026-07-08
+
+### Added
+- Hamiltonian 正规化流水线 `e2m2e.algorithms.normal_form`（#168–#176）：把 CR3BP 平动点附近的非线性动力学逐层化简为少数表征参数
+  - `NormalFormPipeline` 一键式流水线：动力学替代 → quasi-Floquet 变换 → 中心流形化简 → rho↔param 坐标变换
+  - `NormalFormContext`/`NormalFormResult`、`DynamicalSubstituteCorrector`、`QuasiFloquetReducer`、`CenterManifoldReducer`、`LibrationCatalogTransformer`
+  - NAFF 频率分析（不可用时降级 FFT）、块三对角多重打靶、函数式坐标变换链 `coord_trans`
+  - `[normal-form]` 可选依赖（sympy、joblib），惰性导入不阻塞基础包加载
+  - 文档 `docs/algorithms/normal-form.rst`、示例 `examples/normal_form_example.py`
+  - `CONTEXT.md` 与 `docs/reference/glossary.rst` 新增「Hamiltonian 正规化」术语小节
+
+### Fixed
+- 修正 quasi-Floquet Lie 代数法的 dexp 公式误差：原实现假设 `d/dt exp(ξ)=exp(ξ)·ξ̇`（仅 [ξ,ξ̇]=0 成立），改为 commutator-free 4 阶 Lie group RK4
+- 修正中心流形 Step 2（center）的 W 归零 bug：MAD 离群抑制在常系数输入下把 W 缩到 0，且 `reduce()` 取实部丢弃了纯虚 W
+- 修正 rho↔param 坐标变换的插值时间网格缺陷：原用 `dt=0.1` 兜底网格，改为取 `qf_result.tlist` 的真实采样点
+
 ## [5.0.0] - 2026-06-19
 
 ### Added

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -78,6 +78,32 @@ _Avoid_: 轨道族本身、批量运行
 **稳定性分析（Stability Analysis）** — 计算单周期轨道单值矩阵的特征值谱，以分类轨道稳定性。属于外部算法，结果不写入 `Orbit`。
 _Avoid_: 特征值计算、稳定性判断
 
+### Hamiltonian 正规化
+
+平动点附近的轨道作周期或拟周期运动，但运动方程里的非线性项会让一条本该重复的轨道逐渐漂移、失稳。**Hamiltonian 正规化（Normal Form）** 的做法是：通过一连串坐标变换，把这些非线性耦合项逐层消去，直到轨道的动力学可以用少数几个几乎不变的参数来描述。它属于对已有轨道的分析方法，不生成新轨道。
+
+e2m2e 把这件事做成一条流水线 `NormalFormPipeline`：输入一条 rho 坐标初值，依次经过动力学替代、quasi-Floquet 变换、中心流形化简，最终得到一组表征参数。上下文（平动点、历元、归一化单位、频率、特征指数）集中在 `NormalFormContext`，结果聚合在 `NormalFormResult`。
+
+> 命名注：e2m2e 代码 docstring 与早期文档也称这套方法为"法型化"（Normal Form 的另一译法），两者同义；CONTEXT.md 统一用"Hamiltonian 正规化"。
+
+**rho 坐标系（平动点相对坐标系）** — 以某个平动点为原点的相对坐标系，状态为 6 维无量纲数组 `[ρ, ρ̇]`。正规化的所有后续步骤都在 rho 系里进行。它与"坐标系与单位"节的会合旋转系同源，只是原点平移到了平动点。
+_Avoid_: 平动点坐标系（含混）、惯性系状态
+
+**动力学替代轨道（dynamical substitute orbit）** — 严格的周期轨道只存在于理想 CR3BP；一旦加入太阳引力等摄动（星历模型），平动点附近不再有精确的周期解。动力学替代轨道是受摄系统里"最接近周期"的那条轨线，由多重打靶在一个时间窗口里修正到首尾连续闭合。它是流水线的第一站，由 `DynamicalSubstituteCorrector` 产出，挂在 `DynamicalSubstituteResult.substitute_orbit`。（该结果里的 `Kamiltonian` 字段是 qiao 的历史遗留命名，指变换后的 Hamiltonian，并非新概念。）
+_Avoid_: 周期轨道（受摄系统里不再精确）、参考轨道
+
+**生成函数 W（generating function W）** — 动力学替代步同时算出的、连接 rho 坐标与下一层（quasi-Floquet）坐标的近恒等变换的母函数，挂在 `DynamicalSubstituteResult.W_poly`。
+_Avoid_: 把 W 当作轨道本身
+
+**quasi-Floquet 变换矩阵 B(t)（quasi-Floquet transformation）** — 平衡点附近的线性化是常系数的，可以直接做 Floquet 分解；但替代轨道本身随时间运动，邻域的线性化是时变的。quasi-Floquet 变换用一个时变、保辛的矩阵 B(t)，把这条时变线性化系统化成常系数的实标准形（一个双曲方向加两个中心振荡方向），辛约束 `BᵀJB = J` 保证变换不破坏系统的哈密顿结构。由 `QuasiFloquetReducer` 求解，结果在 `QuasiFloquetResult`（`B_samples`、实标准形 `D`）。
+_Avoid_: 普通 Floquet 变换（那是常系数情形）、状态转移矩阵
+
+**中心流形（center manifold）** — 平动点附近有一个双曲（不稳定）方向和两个中心（振荡）方向。双曲方向让扰动指数增长，是轨道失稳的根源；中心方向上的运动有界。消去双曲方向与中心方向的耦合之后、只剩中心运动的不变流形就是中心流形——其上轨道不沿双曲方向逃逸，适合用作用量-角变量描述。`CenterManifoldReducer` 用高阶 Lie 变换做这步消去，各阶生成函数系数在 `CenterManifoldResult.W_series`。
+_Avoid_: 把中心流形等同于整条轨道、稳定流形/不稳定流形（那是双曲方向的伴生流形）
+
+**表征参数（representation parameters / param）** — 正规化的终点产物：一组作用量-角变量形式的 6 维坐标 `(q1, p1, I2, θ2, I3, θ3)`。理想情况下它们是运动积分（不随时间变化），于是可以用几个常数描述一条本需六个状态量随时间演化的轨道。rho 坐标与表征参数互为正逆变换，变换链为 `rho → EM → DS → QF → CM → param`，由 `LibrationCatalogTransformer` 的 `rho_to_param` / `param_to_rho` 提供。
+_Avoid_: 把表征参数当作状态向量（它是化简后的约化坐标）、轨道初值
+
 ### 动力学模型
 
 **动力学系统（System）** — 描述天体几何、引力与运动学模型，是后续计算的上下文。一个系统要回答四件事：

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ e2m2e 围绕“建模—生成—转移—检查”组织工作流。你可以�
 核心能力覆盖：
 - **建模**：CR3BP 系统、星历系统、力模型组合、坐标系与积分器族
 - **生成**：周期轨道族、微分修正、多重打靶、延拓、稳定性分析
+- **正规化**：Hamiltonian 正规化流水线，把平动点附近轨道化简为少数表征参数
 - **转移**：网格搜索 + NLP 优化的转移轨道设计
 - **检查**：2D/3D 轨道绘图、Jacobi 常数图、稳定性分析图
 
@@ -37,6 +38,10 @@ e2m2e 围绕“建模—生成—转移—检查”组织工作流。你可以�
 
 **转移设计**
 - 转移轨道搜索与优化（网格搜索 + NLP），如 DRO-RO
+
+**Hamiltonian 正规化**
+- 一键式流水线 `NormalFormPipeline`：动力学替代 → quasi-Floquet 变换 → 中心流形化简 → 表征参数 `(q1, p1, I2, θ2, I3, θ3)`
+- 把 CR3BP 平动点附近的复杂非线性动力学化简为少数几乎不变的参数，用于轨道识别与高保真外推。可选依赖 `pip install e2m2e[normal-form]`，示例见 `examples/normal_form_example.py`
 
 **可视化**
 - 2D/3D 轨道绘图、Jacobi 常数图、稳定性分析图
@@ -214,7 +219,7 @@ e2m2e/
 │   ├── ephemeris_system.py  # EphemerisSystem - 星历系统
 │   ├── ephemeris_dynamics.py # EphemerisDynamics - N 体动力学
 │   └── spice.py          # SPICE 内核管理
-├── algorithms/           # 微分修正、延拓、打靶、稳定性分析
+├── algorithms/           # 微分修正、延拓、打靶、稳定性分析、Hamiltonian 正规化
 ├── transfer/             # 转移轨道搜索与优化
 ├── mbse/                 # 基于模型的系统工程
 └── visualization/        # 2D/3D 绘图
@@ -260,7 +265,7 @@ uv run ruff format .         # 格式化
   author = {ouyangjiahong},
   email = {ouyangjiahong22@nudt.edu.cn},
   url = {https://github.com/cislunarspace/e2m2e},
-  version = {4.2.1},
+  version = {5.1.0},
   year = {2026},
 }
 ```

--- a/docs/algorithms/normal-form.rst
+++ b/docs/algorithms/normal-form.rst
@@ -1,0 +1,70 @@
+法型化流水线
+============
+
+法型化（Normal Form）把圆型限制性三体问题（CR3BP）平动点附近的复杂动力学
+化简为一组作用量-角变量形式的"表征参数"，让轨道设计师用几个常数描述一条
+本需六个状态量随时间演化的轨道。
+
+``NormalFormPipeline`` 把这条化简路径串成一行调用：
+
+    星历轨道初值 → 动力学替代轨道 → quasi-Floquet 变换 → 中心流形化简 → 表征参数
+
+特性
+----
+
+- 一行代码完成"星历轨道 → 表征参数"
+- 返回的 ``NormalFormResult`` 同时暴露化简诊断与坐标变换入口
+- 平动点（L1–L5）、历元、展开阶数由 ``NormalFormContext`` 统一配置
+
+使用方法
+--------
+
+.. code-block:: python
+
+   from e2m2e.algorithms.normal_form import NormalFormContext, NormalFormPipeline
+   from e2m2e.core import CR3BP_System, LibrationPoint
+
+   system = CR3BP_System(mu=1.215058560962404e-2, primary="Earth", secondary="Moon")
+   context = NormalFormContext(
+       system=system,
+       libration_point=LibrationPoint.L1,
+       epoch=2451545.0,
+       order=4,
+   )
+
+   # rho 坐标初值 [ρ, ρ̇]（无量纲）
+   x0 = [1e-3, -1e-3, 0.0, 0.0, 1e-4, -1e-4]
+
+   result = NormalFormPipeline(context).reduce(x0)
+
+   # rho 坐标 → 表征参数 [q1, p1, I2, θ2, I3, θ3]
+   param = result.catalog_transformer.rho_to_param(x0, t=0.0)
+
+``result`` 是一个不可变容器，既给出整条流水线的收敛诊断
+（``success``、``residual``、``metadata``），也把四个子结果作为一等公民
+字段暴露，供需要深入到某一层的调用方使用。
+
+可配置旋钮
+----------
+
+构造 ``NormalFormPipeline`` 时可覆盖默认行为：
+
+- ``quasi_floquet_method``：``"matrix"``（默认，36 维直接积分）或
+  ``"lie_algebra"``（21 维 sp(6) 参数化，自动保辛）
+- ``center_max_order``：中心流形 Lie 变换截断阶数，默认 ``10``
+- ``center_steps``：化简步骤元组，默认 ``("invariant", "center")``
+- ``dynamical_kwargs``：透传给动力学替代 corrector 的覆盖项
+  （如 ``{"t_total": 8.0}``）
+
+子模块
+------
+
+流水线内部依次调用以下 reducer，需要单独访问某一层结果时可经
+``result.ds_result`` / ``result.qf_result`` / ``result.cm_result`` 取得：
+
+- 动力学替代：``DynamicalSubstituteCorrector``
+- quasi-Floquet 变换：``QuasiFloquetReducer``
+- 中心流形化简：``CenterManifoldReducer``
+- 表征参数目录：``LibrationCatalogTransformer``
+
+可运行示例见 ``examples/normal_form_example.py``。

--- a/docs/plans/normal-form-prd.md
+++ b/docs/plans/normal-form-prd.md
@@ -1,0 +1,63 @@
+# PRD：将 qiao Hamiltonian 正规化能力集成到 e2m2e
+
+## 问题陈述
+
+e2m2e 目前已经能生成 CR3BP 轨道族、在星历模型下传播轨道、并用多重打靶修正 patch points，但缺少对**星历模型下平动点附近可积结构**的利用。用户无法把一条星历轨道转换成统一的作用量-角变量/表征参数，也无法在指定历元生成动力学替代轨道作为高保真参考解。
+
+qiao 仓库已经实现了完整的 Hamiltonian 正规化流水线。本 PRD 要求把这套能力以原生 e2m2e 模块的形式引入，让 e2m2e 用户在保留现有工作流的同时，获得平动点附近的高阶解析工具。
+
+## 方案
+
+新增 `e2m2e.algorithms.normal_form` 模块，提供：
+
+1. 从 `e2m2e.System` 构造平动点附近的 Hamiltonian 正规化上下文；
+2. 一键式 `NormalFormPipeline`，把星历轨道还原为动力学替代轨道、QF 变换、中心流形化简，并输出编目参数；
+3. 分步 reducer，供研究者调试和替换中间步骤；
+4. 函数式坐标变换链（`rho ↔ EM ↔ DS ↔ QF ↔ CM ↔ param`）；
+5. 自动处理 e2m2e SI 单位与 qiao 归一化单位之间的转换。
+
+qiao 的数学代码不作为“外来遗留代码”隔离，而是作为 `normal_form` 的正式子模块公开复用。
+
+## 用户故事
+
+1. 作为**轨道设计师**，我想要把一条地月 `L2` 附近的星历轨道转换成表征参数，以便识别它属于 Halo、Lissajous 还是 quasi-Halo 族。
+2. 作为**任务分析师**，我想要在指定历元生成 `L1` 动力学替代轨道，以便把它作为后续星历修正的参考初值。
+3. 作为**研究人员**，我想要分步执行 Legendre 展开、动力学替代、QF 变换、中心流形化简，以便检查每一步的收敛性与中间结果。
+4. 作为**下游工具开发者**，我想要一个稳定的 `NormalFormResult` 句柄，以便在不重新跑完整流水线的情况下反复调用 `rho_to_param`。
+
+## 实现决策
+
+- **新增模块**：`e2m2e.algorithms.normal_form`，与现有 `differential_correction`、`continuation` 等算法并列。
+- **上下文对象**：`NormalFormContext` 负责把 `e2m2e.System` + 平动点 + 历元 + 展开阶数翻译为 qiao 所需的归一化常数、基础频率、中心流形频率和特征指数，并自动处理单位转换。
+- **高层接口**：`NormalFormPipeline(context).reduce(orbit)` 返回 `NormalFormResult`，后者提供 `catalog_transformer`、`substitute_orbit`、`qf_matrix(t)` 等封装访问器。
+- **分步接口**：`DynamicalSubstituteCorrector`、`QuasiFloquetReducer`、`CenterManifoldReducer`、`LibrationCatalogTransformer` 可独立使用。
+- **坐标变换**：以**函数式接口**为主，链式函数位于 `normal_form.coord_trans` 子包中。
+- **单位约定**：public 接口使用 e2m2e 的 SI / J2000 ET；内部数学实现继续运行在 qiao 归一化单位下。转换逻辑集中在 `NormalFormContext` 与 `units` 模块，不允许 qiao 代码直接读取 e2m2e 原始状态。
+- **平动点支持**：`L1`–`L5`。`L1`–`L3` 使用共线 `gamma` 参数；`L4`/`L5` 使用旋转矩阵方法。
+- **频率分析**：NAFF 为首选，但核心功能不得依赖 NAFF；NAFF 不可用时降级到 FFT。
+- **依赖策略**：`sympy` 与 `joblib` 放入 `normal-form` optional dependency group，避免污染核心安装。
+- **结果序列化**：`NormalFormResult` 支持保存/加载，但 7 GB 级大系数表允许懒加载或由用户显式提供路径。
+- **不暴露原始 qiao 数据结构**：`NormalFormResult` 不直接暴露 `W_poly`、`QFtrans_mat` 等内部结构，只通过封装访问器提供结果。
+
+## 测试决策
+
+- **测试切面**：单一高层面 `tests/algorithms/normal_form/test_pipeline.py`，对 `L1_Halo_Large` 跑一次完整 `NormalFormPipeline`，并验证 `rho_to_param` / `param_to_rho` 往返误差在 qiao 等价结果容差范围内。
+- **测试原则**：只测外部行为（输入 `Orbit` / `System`，输出 `param` 与还原误差），不测实现细节（如 Poisson 括号内部系数）。
+- **先例**：`tests/algorithms/test_dro_ephemeris_correction.py` 等已有算法测试采用“输入-输出”回归模式，可直接复用。
+- **补充**：在实现过程中可新增针对 `NormalFormContext` 单位转换、各 reducer 收敛性的单元测试，但这些属于开发期测试，不占用主要测试切面。
+
+## 不在范围内
+
+- qiao 的 Monte-Carlo 实验框架。
+- qiao 的 Rust 性能路径（后续可作为独立优化跟进）。
+- qiao 的绘图 CLI。
+- 替换 e2m2e 现有的 CR3BP 轨道族生成器；normal_form 是新增垂直切片。
+- 真实任务级的轨道识别 UI 或数据库化编目。
+
+## 补充说明
+
+- 本次迁移基于用户确认：qiao 代码同样由本仓库维护者编写，因此不作为“私有移植代码”隔离，而是作为 `normal_form` 的公开子模块复用。
+- 三个待决定问题可在实现过程中逐步澄清：
+  1. `NormalFormResult` 是否额外暴露原始 qiao 数据结构给高级用户？
+  2. `normal-form` 依赖是保持 optional 还是提升为 main dependencies？
+  3. 回归测试 fixtures 是否使用 Git LFS 管理？

--- a/docs/reference/glossary.rst
+++ b/docs/reference/glossary.rst
@@ -72,6 +72,32 @@ CR3BP 相关术语
    动力学方程
       描述运动学参数与力关系的方程，一般为微分式（如 dv/dt = F/m）。完整的运动方程组 = 运动方程 + 动力学方程；``Dynamics`` 积分二者合成的状态导数 ODE。
 
+Hamiltonian 正规化
+------------------
+
+.. glossary::
+
+   Hamiltonian 正规化
+      通过逐层坐标变换消去 CR3BP 平动点附近运动方程中的非线性耦合项，把轨道动力学化简为少数几个几乎不变的参数。e2m2e 用 ``NormalFormPipeline`` 一行调用完成，上下文在 ``NormalFormContext``、结果在 ``NormalFormResult``。代码 docstring 也称"法型化"，同义。
+
+   rho 坐标系
+      以平动点为原点的 6 维无量纲相对坐标系，状态 ``[ρ, ρ̇]``；正规化各步在此系内进行。
+
+   动力学替代轨道
+      受摄（星历）系统里"最接近周期"的轨线，由多重打靶在时间窗口内修正到首尾闭合。``DynamicalSubstituteCorrector`` 产出，见 ``DynamicalSubstituteResult.substitute_orbit``。
+
+   生成函数 W
+      连接 rho 坐标与 quasi-Floquet 坐标的近恒等变换的母函数，见 ``DynamicalSubstituteResult.W_poly``。
+
+   quasi-Floquet 变换矩阵
+      时变、保辛的矩阵 ``B(t)``，把替代轨道邻域的时变线性化化为常系数实标准形（一双曲方向 + 两中心方向），满足 ``BᵀJB = J``。``QuasiFloquetReducer`` 求解，见 ``QuasiFloquetResult``。
+
+   中心流形
+      消去双曲-中心耦合后、只剩中心运动的不变流形，其上轨道不沿双曲方向逃逸。``CenterManifoldReducer`` 经高阶 Lie 变换消耦，生成函数在 ``CenterManifoldResult.W_series``。
+
+   表征参数
+      正规化终点产物，作用量-角变量形式的 6 维约化坐标 ``(q1, p1, I2, θ2, I3, θ3)``，理想下为运动积分。与 rho 坐标互为正逆变换（``rho ↔ EM ↔ DS ↔ QF ↔ CM ↔ param``），由 ``LibrationCatalogTransformer`` 提供。
+
 MBSE
 ----
 

--- a/e2m2e/algorithms/continuation.py
+++ b/e2m2e/algorithms/continuation.py
@@ -384,19 +384,13 @@ class Continuation:
                             orbit.period,
                         )
                     else:
-                        logger.info(
-                            "  %s延拓进度：已完成 %d 条轨道", direction_label, i + 1
-                        )
+                        logger.info("  %s延拓进度：已完成 %d 条轨道", direction_label, i + 1)
 
                 if self.step_size_adaptation:
                     if orbit.correction_iterations < 3:
-                        step_size = min(
-                            step_size * self.step_growth_factor, self.max_step_size
-                        )
+                        step_size = min(step_size * self.step_growth_factor, self.max_step_size)
                     elif orbit.correction_iterations > 8:
-                        step_size = max(
-                            step_size * self.step_reduction_factor, self.min_step_size
-                        )
+                        step_size = max(step_size * self.step_reduction_factor, self.min_step_size)
             else:
                 self.continuation_stats["failed_steps"] += 1
 
@@ -793,8 +787,6 @@ class Continuation:
     # Halo 专用编排（generate_halo_seed_orbit / generate_halo_family /
     # halo_pseudo_arclength_continuation）已迁出到 ``halo_family`` 模块；
     # 本文件末尾以方法重绑定的形式对外保留同名 API。
-
-
 
     def __repr__(self):
         return (

--- a/e2m2e/algorithms/halo_family.py
+++ b/e2m2e/algorithms/halo_family.py
@@ -71,11 +71,13 @@ def generate_halo_seed_orbit(
 
     if halo_class == 0:
         continuation.correction.setup_halo_orbit_fixed_z0(
-            z0=amplitude_z, libration_point=libration_point,
+            z0=amplitude_z,
+            libration_point=libration_point,
         )
     else:
         continuation.correction.setup_halo_orbit_fixed_z0(
-            z0=-amplitude_z, libration_point=libration_point,
+            z0=-amplitude_z,
+            libration_point=libration_point,
         )
 
     initial_orbit = Orbit(
@@ -93,7 +95,8 @@ def generate_halo_seed_orbit(
         logger.info("  预估周期: %.4f TU", initial_orbit.period)
 
     orbit = continuation.correction.iterate_correction(
-        initial_guess=initial_orbit, verbose=verbose,
+        initial_guess=initial_orbit,
+        verbose=verbose,
     )
 
     if orbit is not None:
@@ -145,7 +148,10 @@ def generate_halo_family(
         directions = dirs
         logger.info(
             "开始生成Halo轨道族: z范围=[%.4f, %.4f], 方向=%s, 最大数量=%d",
-            z_min, z_max, "/".join(directions), n_orbits,
+            z_min,
+            z_max,
+            "/".join(directions),
+            n_orbits,
         )
     else:
         directions = ["positive", "negative"] if direction == "both" else [direction]
@@ -153,7 +159,9 @@ def generate_halo_family(
 
     logger.info(
         "  种子轨道: L%d %s Halo, z0=%.6f",
-        libration_point, "北" if halo_class == 0 else "南", seed_z,
+        libration_point,
+        "北" if halo_class == 0 else "南",
+        seed_z,
     )
 
     min_step = 1e-4
@@ -197,7 +205,8 @@ def generate_halo_family(
                     break
 
             continuation.correction.setup_halo_orbit_fixed_z0(
-                z0=target_z, libration_point=libration_point,
+                z0=target_z,
+                libration_point=libration_point,
             )
             continuation.correction.max_iterations = 150
             continuation.correction.tolerance = 1e-6
@@ -231,7 +240,10 @@ def generate_halo_family(
                 if verbose and (i + 1) % 5 == 0:
                     logger.info(
                         "  第%d条: z=%.5f, x=%.6f, T=%.4f",
-                        i + 1, target_z, orbit.states[0, 0], orbit.period,
+                        i + 1,
+                        target_z,
+                        orbit.states[0, 0],
+                        orbit.period,
                     )
             else:
                 current_step = max(current_step * shrink, min_step)
@@ -241,7 +253,9 @@ def generate_halo_family(
                     break
                 if verbose:
                     logger.info(
-                        "  第%d步修正失败, 缩小步长至%.6f后重试", i + 1, current_step,
+                        "  第%d步修正失败, 缩小步长至%.6f后重试",
+                        i + 1,
+                        current_step,
                     )
                 continue
 
@@ -284,10 +298,14 @@ def halo_pseudo_arclength_continuation(
         logger.info("  z_amplitude(参数): %.4f", seed_z_amplitude)
         logger.info("  每支新轨道数 N = %d", n_orbits)
         logger.info(
-            "  正向 |DeltaS| = %s, 负向 |DeltaS| = %s", step_size, step_size_negative,
+            "  正向 |DeltaS| = %s, 负向 |DeltaS| = %s",
+            step_size,
+            step_size_negative,
         )
         logger.info(
-            "  dc_scheme = %s, DirectionalIncrement = %s", dc_scheme, directional_increment,
+            "  dc_scheme = %s, DirectionalIncrement = %s",
+            dc_scheme,
+            directional_increment,
         )
         logger.info("=" * 30)
 

--- a/e2m2e/algorithms/normal_form/__init__.py
+++ b/e2m2e/algorithms/normal_form/__init__.py
@@ -1,0 +1,81 @@
+"""法型化（Normal Form）算法包。
+
+为圆型限制性三体问题（CR3BP）平动点附近的轨道设计提供法型化流水线
+的基础脚手架：
+
+- 切片 0 交付 ``NormalFormContext``、``NormalFormResult`` 与 SI ↔ qiao
+  归一化单位转换缝；
+- 切片 1 交付 Legendre 展开、符号 Hamilton 量构造与数值 Hamilton 量
+  时间序列；
+- 切片 2（本切片）交付动力学替代 corrector、生成函数 ``W``、FFT
+  频率分析、块三对角多重打靶法。
+
+后续切片在此基础上构建化简器（``QuasiFloquetReducer``、
+``CenterManifoldReducer`` 等）。
+
+归一化约定沿用 qiao ``Global_File.py``：长度单位 LU（km）、
+时间单位 TU（s）、速度单位 VU = LU/TU（km/s）。本包不强制依赖
+``sympy`` / ``joblib``：它们仅在 Legendre / Hamiltonian 模块内部
+惰性导入，因此 ``import e2m2e.algorithms.normal_form`` 不会触发
+重依赖加载。NAFF 是可选依赖：``fft`` 模块默认走 FFT 回退，仅在
+显式调用 :func:`detect_naff` 时才会查找外部可执行文件。
+"""
+
+from __future__ import annotations
+
+from .context import NormalFormContext
+from .types import NormalFormResult
+
+__all__ = [
+    "NormalFormContext",
+    "NormalFormResult",
+]
+
+# 切片 2 公共符号从子模块惰性导入；放在 ``__all__`` 末尾以便
+# 用户 ``from e2m2e.algorithms.normal_form import DynamicalSubstituteCorrector``
+# 直接工作，同时不强制 ``import e2m2e.algorithms.normal_form`` 在无
+# scipy / 无 Orbit 的环境下也成功。
+_LAZY_EXPORTS = {
+    "DynamicalSubstituteCorrector": "dynamical_substitution",
+    "DynamicalSubstituteResult": "dynamical_substitution",
+    "FFTComponent": "fft",
+    "extract_frequencies": "fft",
+    "fft_extract": "fft",
+    "frequency_match": "fft",
+    "least_squares_sin_cos_fit": "fft",
+    "naff_available": "fft",
+    "reconstruct_signal": "fft",
+    "reconstruct_derivative": "fft",
+    "ODESubstituteSolver": "multiple_shooting",
+    "ShootingPatch": "multiple_shooting",
+    "MultipleShootingResult": "multiple_shooting",
+    "multiple_shooting_newton": "multiple_shooting",
+    "solve_block_tridiagonal": "multiple_shooting",
+    "SubstituteSolver": "multiple_shooting",
+    # 切片 3（quasi-Floquet 变换矩阵 B(t)）
+    "QuasiFloquetReducer": "quasi_floquet",
+    "QuasiFloquetResult": "quasi_floquet",
+    # 切片 4（高阶中心流形化简，Code10–Code11）
+    "CenterManifoldReducer": "center_manifold",
+    "CenterManifoldResult": "center_manifold",
+    # 切片 5（坐标变换链 rho↔param，issue #174）
+    "LibrationCatalogData": "catalog",
+    "LibrationCatalogTransformer": "catalog",
+    # 切片 6（一键式流水线，issue #175）
+    "NormalFormPipeline": "pipeline",
+}
+
+
+def __getattr__(name: str):  # PEP 562
+    if name in _LAZY_EXPORTS:
+        from importlib import import_module
+
+        module = import_module(f"{__name__}.{_LAZY_EXPORTS[name]}")
+        value = getattr(module, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+for _name in _LAZY_EXPORTS:
+    __all__.append(_name)

--- a/e2m2e/algorithms/normal_form/_ephemeris.py
+++ b/e2m2e/algorithms/normal_form/_ephemeris.py
@@ -1,0 +1,305 @@
+"""``normal_form`` 包内部：从 SPICE 求 ``Eval_expr`` 所需星历参数。
+
+实现相当于 qiao ``Eval_expr.py`` 的功能，但通过 e2m2e 自带的
+``SPICEManager`` 获取天体状态，避免上层 ``Hamilton`` 模块直接依赖
+``spiceypy`` / DE 内核路径。
+
+输出 dict 与 qiao ``Eval_expr`` 完全一致（键名一致、形状一致），便于
+``Hamilton.evaluated_coefficients`` 与 qiao fixture 对齐。
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from .context import NormalFormContext
+
+
+# 共线平动点 γ 值——与 ``constants._COLLINEAR_GAMMAS`` 保持一致；
+# 在内部模块复制一份避免与顶层常量循环导入（常量子模块可被本文件
+# 反过来引用，故独立定义）。
+_COLLINEAR_GAMMAS: dict[int, float] = {
+    1: 0.150934288618019,
+    2: 0.167832751054508,
+    3: 0.992912060200654,
+}
+
+
+def _cross3(a: np.ndarray, b: np.ndarray) -> np.ndarray:
+    return np.array(
+        [
+            a[1] * b[2] - a[2] * b[1],
+            a[2] * b[0] - a[0] * b[2],
+            a[0] * b[1] - a[1] * b[0],
+        ]
+    )
+
+
+def _derive_moon_param(
+    r_em: np.ndarray,
+    v_em: np.ndarray,
+    r_es: np.ndarray,
+    v_es: np.ndarray,
+    mu_e: float,
+    mu_m: float,
+    mu_s: float,
+    lu: float,
+    tu: float,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """推导 EMR 旋转矩阵 C(t)、Cdot、Cdotdot 与 A_EM。
+
+    与 qiao ``Calc_MoonParam._derive_moon_param`` 等价。
+    本函数刻意保持与 qiao 源 1:1 对齐（包括形式上相同的中间变量名），
+    以便后续切片能够简单叉验差异。
+    """
+    gm_e = mu_e * lu**3 / tu**2
+    gm_m = mu_m * lu**3 / tu**2
+    gm_s = mu_s * lu**3 / tu**2
+
+    r_sm = r_em - r_es
+    v_sm = v_em - v_es
+
+    r_em_n = float(np.linalg.norm(r_em))
+    r_es_n = float(np.linalg.norm(r_es))
+    r_sm_n = float(np.linalg.norm(r_sm))
+
+    r_em2 = r_em_n * r_em_n
+    r_es2 = r_es_n * r_es_n
+    r_sm2 = r_sm_n * r_sm_n
+
+    # A_EM = -(GM_e+GM_m) * R_EM / r_em^3 - GM_s * (R_SM/r_sm^3 + R_ES/r_es^3)
+    a_em = (
+        -(gm_e + gm_m) / (r_em2 * r_em_n) * r_em
+        - gm_s / (r_sm2 * r_sm_n) * r_sm
+        - gm_s / (r_es2 * r_es_n) * r_es
+    )
+
+    # J_EM = -Σ GM * (V*|R|^2 - 3*<R,V>*R) / |R|^5
+    rv_em = float(np.dot(r_em, v_em))
+    j_em = -(gm_e + gm_m) / (r_em2 * r_em2 * r_em_n) * (
+        r_em2 * v_em - 3 * rv_em * r_em
+    )
+    rv_sm = float(np.dot(r_sm, v_sm))
+    j_em = j_em - gm_s / (r_sm2 * r_sm2 * r_sm_n) * (
+        r_sm2 * v_sm - 3 * rv_sm * r_sm
+    )
+    rv_es = float(np.dot(r_es, v_es))
+    j_em = j_em - gm_s / (r_es2 * r_es2 * r_es_n) * (
+        r_es2 * v_es - 3 * rv_es * r_es
+    )
+
+    # Rotation matrix C(t)
+    em_r = r_em_n
+    ldot = rv_em / em_r
+    ldotdot = (
+        (float(np.dot(v_em, v_em) + np.dot(r_em, a_em)) * em_r - ldot * rv_em)
+        / em_r**2
+    )
+
+    h = _cross3(r_em, v_em)
+    hn = float(np.linalg.norm(h))
+    hdot = _cross3(r_em, a_em)
+    hndot = float(np.dot(hdot, h)) / hn
+    hdotdot = _cross3(r_em, j_em) + _cross3(v_em, a_em)
+    hndotdot = (
+        (float(np.dot(hdotdot, h)) + float(np.dot(hdot, hdot))) / hn
+        - float(np.dot(h, hdot)) * hndot / (hn * hn)
+    )
+
+    x_hat = r_em / em_r
+    z_hat = h / hn
+    y_hat = _cross3(z_hat, x_hat)
+    c = np.column_stack([x_hat, y_hat, z_hat])
+
+    x_hat_dot = v_em / em_r - (ldot / em_r) * x_hat
+    z_hat_dot = hdot / hn - (hndot / hn) * z_hat
+    y_hat_dot = _cross3(z_hat_dot, x_hat) + _cross3(z_hat, x_hat_dot)
+    cdot = np.column_stack([x_hat_dot, y_hat_dot, z_hat_dot])
+
+    x_hat_dotdot = (
+        a_em / em_r
+        - (ldot / (em_r * em_r)) * v_em
+        - (ldot / em_r) * x_hat_dot
+        - (ldotdot / em_r - (ldot * ldot) / (em_r * em_r)) * x_hat
+    )
+    z_hat_dotdot = (
+        hdotdot / hn
+        - (hndot / (hn * hn)) * hdot
+        - (hndot / hn) * z_hat_dot
+        - (hndotdot / hn - (hndot * hndot) / (hn * hn)) * z_hat
+    )
+    y_hat_dotdot = (
+        _cross3(z_hat_dotdot, x_hat)
+        + 2 * _cross3(z_hat_dot, x_hat_dot)
+        + _cross3(z_hat, x_hat_dotdot)
+    )
+    cdotdot = np.column_stack([x_hat_dotdot, y_hat_dotdot, z_hat_dotdot])
+
+    return c, cdot, cdotdot, a_em
+
+
+def _lp_state(
+    r_em: np.ndarray,
+    v_em: np.ndarray,
+    a_em: np.ndarray,
+    libr: int,
+    c: np.ndarray,
+    cdot: np.ndarray,
+    cdotdot: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """平动点位置、速度、加速度（J2000 系，km、km/s、km/s²）。
+
+    与 qiao ``Calc_LPstate`` 等价。``c/cdot/cdotdot`` 仅 L4/L5 使用。
+    """
+    if libr in (1, 2, 3):
+        gamma = _COLLINEAR_GAMMAS[libr]
+        if libr == 1:
+            return (1 - gamma) * r_em, (1 - gamma) * v_em, (1 - gamma) * a_em
+        if libr == 2:
+            return (1 + gamma) * r_em, (1 + gamma) * v_em, (1 + gamma) * a_em
+        # libr == 3
+        return -gamma * r_em, -gamma * v_em, -gamma * a_em
+
+    ang = -np.pi / 3 if libr == 4 else np.pi / 3
+    r_mat = np.array(
+        [
+            [np.cos(ang), np.sin(ang), 0.0],
+            [-np.sin(ang), np.cos(ang), 0.0],
+            [0.0, 0.0, 1.0],
+        ]
+    )
+    m = c @ r_mat @ c.T
+    r_lp = m @ r_em
+    v_lp = (
+        c @ r_mat @ c.T @ v_em
+        + c @ r_mat @ cdot.T @ r_em
+        + cdot @ r_mat @ c.T @ r_em
+    )
+    a_lp = (
+        c @ r_mat @ c.T @ a_em
+        + 2 * c @ r_mat @ cdot.T @ v_em
+        + 2 * cdot @ r_mat @ c.T @ v_em
+        + c @ r_mat @ cdotdot.T @ r_em
+        + 2 * cdot @ r_mat @ cdot.T @ r_em
+        + cdotdot @ r_mat @ c.T @ r_em
+    )
+    return r_lp, v_lp, a_lp
+
+
+def _ephemeris_states(jd_tdb: float) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """返回 (R_EM, V_EM, R_ES, V_ES)（J2000 系, km/km/s）。
+
+    复用 :class:`e2m2e.core.SPICEManager`；其内部已自动加载闰秒
+    内核，因此本函数无需关心 ``de430.bsp`` 等星历内核路径。
+    """
+    from e2m2e.core import SPICEManager
+    from e2m2e.core._spice_loader import get_spiceypy
+
+    mgr = SPICEManager()
+    spice = get_spiceypy()
+    et = float(spice.str2et(f"{jd_tdb:.20f} JDTDB"))
+    moon_state = mgr.get_body_state("MOON", et, "J2000", "EARTH")
+    sun_state = mgr.get_body_state("SUN", et, "J2000", "EARTH")
+    return (
+        np.asarray(moon_state[:3], dtype=float),
+        np.asarray(moon_state[3:6], dtype=float),
+        np.asarray(sun_state[:3], dtype=float),
+        np.asarray(sun_state[3:6], dtype=float),
+    )
+
+
+def eval_params(jd_tdb: float, context: NormalFormContext) -> dict[str, float]:
+    """与 qiao ``Eval_expr`` 等价。
+
+    Args:
+        jd_tdb: 历书时（TDB）儒略日。
+        context: :class:`NormalFormContext`，负责取 LU/TU/mu_e/mu_m/mu_s
+            与 libr（平动点编号）。
+
+    Returns:
+        dict：键名与 qiao ``Eval_expr`` 完全一致——``Cpq1..Cpq9``、
+        ``Cqq1..Cqq9``、``f1..f3``、``rex, rey, rez, re0``、``rmx, rmy,
+        rmz, rm0``、``rsx, rsy, rsz, rs0``、``mu_e, mu_m, mu_s``。
+    """
+    tu = float(context.TU)
+    lu = float(context.LU)
+    mu_e = float(context.mu_e)
+    mu_m = float(context.mu_m)
+    mu_s = float(context.mu_s)
+    libr = int(context.libration_point.value)
+
+    r_em, v_em, r_es, v_es = _ephemeris_states(jd_tdb)
+    c, cdot, cdotdot, a_em = _derive_moon_param(
+        r_em, v_em, r_es, v_es,
+        mu_e=mu_e, mu_m=mu_m, mu_s=mu_s,
+        lu=lu, tu=tu,
+    )
+
+    # 平动点（J2000 系，km / km/s / km/s²）；再转无量纲 EMR 坐标。
+    r_lp, v_lp, a_lp = _lp_state(r_em, v_em, a_em, libr, c, cdot, cdotdot)
+    cdot_nd = cdot * tu
+    cdotdot_nd = cdotdot * tu**2
+    v_u = lu / tu
+    a_u = lu / tu**2
+
+    r0 = c.T @ (r_lp / lu)
+    r0dot = cdot_nd.T @ (r_lp / lu) + c.T @ (v_lp / v_u)
+    r0dotdot = (
+        cdotdot_nd.T @ (r_lp / lu)
+        + 2 * cdot_nd.T @ (v_lp / v_u)
+        + c.T @ (a_lp / a_u)
+    )
+
+    rm_nd = c.T @ (r_em / lu)
+    rs_nd = c.T @ (r_es / lu)
+
+    cpq = cdot_nd.T @ c
+    cqq = c.T @ cdot_nd @ cdot_nd.T @ c + cdotdot_nd.T @ c
+
+    force = (
+        mu_m * rm_nd / float(np.linalg.norm(rm_nd)) ** 3
+        + mu_s * rs_nd / float(np.linalg.norm(rs_nd)) ** 3
+        + r0dotdot
+        + 2 * c.T @ cdot_nd @ r0dot
+        + c.T @ cdotdot_nd @ r0
+    )
+
+    rtemp = -r0
+    rtemp_m = -r0 + rm_nd
+    rtemp_s = -r0 + rs_nd
+
+    params: dict[str, float] = {}
+    for i in range(3):
+        for j in range(3):
+            params[f"Cpq{i * 3 + j + 1}"] = float(cpq[i, j])
+            params[f"Cqq{i * 3 + j + 1}"] = float(cqq[i, j])
+    params["f1"] = float(force[0])
+    params["f2"] = float(force[1])
+    params["f3"] = float(force[2])
+
+    params["rex"] = float(rtemp[0])
+    params["rey"] = float(rtemp[1])
+    params["rez"] = float(rtemp[2])
+    params["re0"] = float(np.linalg.norm(rtemp))
+
+    params["rmx"] = float(rtemp_m[0])
+    params["rmy"] = float(rtemp_m[1])
+    params["rmz"] = float(rtemp_m[2])
+    params["rm0"] = float(np.linalg.norm(rtemp_m))
+
+    params["rsx"] = float(rtemp_s[0])
+    params["rsy"] = float(rtemp_s[1])
+    params["rsz"] = float(rtemp_s[2])
+    params["rs0"] = float(np.linalg.norm(rtemp_s))
+
+    params["mu_e"] = mu_e
+    params["mu_m"] = mu_m
+    params["mu_s"] = mu_s
+
+    return params
+
+
+__all__ = ["eval_params"]

--- a/e2m2e/algorithms/normal_form/_ephemeris.py
+++ b/e2m2e/algorithms/normal_form/_ephemeris.py
@@ -79,35 +79,25 @@ def _derive_moon_param(
 
     # J_EM = -Σ GM * (V*|R|^2 - 3*<R,V>*R) / |R|^5
     rv_em = float(np.dot(r_em, v_em))
-    j_em = -(gm_e + gm_m) / (r_em2 * r_em2 * r_em_n) * (
-        r_em2 * v_em - 3 * rv_em * r_em
-    )
+    j_em = -(gm_e + gm_m) / (r_em2 * r_em2 * r_em_n) * (r_em2 * v_em - 3 * rv_em * r_em)
     rv_sm = float(np.dot(r_sm, v_sm))
-    j_em = j_em - gm_s / (r_sm2 * r_sm2 * r_sm_n) * (
-        r_sm2 * v_sm - 3 * rv_sm * r_sm
-    )
+    j_em = j_em - gm_s / (r_sm2 * r_sm2 * r_sm_n) * (r_sm2 * v_sm - 3 * rv_sm * r_sm)
     rv_es = float(np.dot(r_es, v_es))
-    j_em = j_em - gm_s / (r_es2 * r_es2 * r_es_n) * (
-        r_es2 * v_es - 3 * rv_es * r_es
-    )
+    j_em = j_em - gm_s / (r_es2 * r_es2 * r_es_n) * (r_es2 * v_es - 3 * rv_es * r_es)
 
     # Rotation matrix C(t)
     em_r = r_em_n
     ldot = rv_em / em_r
-    ldotdot = (
-        (float(np.dot(v_em, v_em) + np.dot(r_em, a_em)) * em_r - ldot * rv_em)
-        / em_r**2
-    )
+    ldotdot = (float(np.dot(v_em, v_em) + np.dot(r_em, a_em)) * em_r - ldot * rv_em) / em_r**2
 
     h = _cross3(r_em, v_em)
     hn = float(np.linalg.norm(h))
     hdot = _cross3(r_em, a_em)
     hndot = float(np.dot(hdot, h)) / hn
     hdotdot = _cross3(r_em, j_em) + _cross3(v_em, a_em)
-    hndotdot = (
-        (float(np.dot(hdotdot, h)) + float(np.dot(hdot, hdot))) / hn
-        - float(np.dot(h, hdot)) * hndot / (hn * hn)
-    )
+    hndotdot = (float(np.dot(hdotdot, h)) + float(np.dot(hdot, hdot))) / hn - float(
+        np.dot(h, hdot)
+    ) * hndot / (hn * hn)
 
     x_hat = r_em / em_r
     z_hat = h / hn
@@ -173,11 +163,7 @@ def _lp_state(
     )
     m = c @ r_mat @ c.T
     r_lp = m @ r_em
-    v_lp = (
-        c @ r_mat @ c.T @ v_em
-        + c @ r_mat @ cdot.T @ r_em
-        + cdot @ r_mat @ c.T @ r_em
-    )
+    v_lp = c @ r_mat @ c.T @ v_em + c @ r_mat @ cdot.T @ r_em + cdot @ r_mat @ c.T @ r_em
     a_lp = (
         c @ r_mat @ c.T @ a_em
         + 2 * c @ r_mat @ cdot.T @ v_em
@@ -233,9 +219,15 @@ def eval_params(jd_tdb: float, context: NormalFormContext) -> dict[str, float]:
 
     r_em, v_em, r_es, v_es = _ephemeris_states(jd_tdb)
     c, cdot, cdotdot, a_em = _derive_moon_param(
-        r_em, v_em, r_es, v_es,
-        mu_e=mu_e, mu_m=mu_m, mu_s=mu_s,
-        lu=lu, tu=tu,
+        r_em,
+        v_em,
+        r_es,
+        v_es,
+        mu_e=mu_e,
+        mu_m=mu_m,
+        mu_s=mu_s,
+        lu=lu,
+        tu=tu,
     )
 
     # 平动点（J2000 系，km / km/s / km/s²）；再转无量纲 EMR 坐标。
@@ -247,11 +239,7 @@ def eval_params(jd_tdb: float, context: NormalFormContext) -> dict[str, float]:
 
     r0 = c.T @ (r_lp / lu)
     r0dot = cdot_nd.T @ (r_lp / lu) + c.T @ (v_lp / v_u)
-    r0dotdot = (
-        cdotdot_nd.T @ (r_lp / lu)
-        + 2 * cdot_nd.T @ (v_lp / v_u)
-        + c.T @ (a_lp / a_u)
-    )
+    r0dotdot = cdotdot_nd.T @ (r_lp / lu) + 2 * cdot_nd.T @ (v_lp / v_u) + c.T @ (a_lp / a_u)
 
     rm_nd = c.T @ (r_em / lu)
     rs_nd = c.T @ (r_es / lu)

--- a/e2m2e/algorithms/normal_form/catalog.py
+++ b/e2m2e/algorithms/normal_form/catalog.py
@@ -1,0 +1,165 @@
+"""表征参数目录变换器（issue #174，切片 5）。
+
+把切片 #171–#173 的三个预计算结果（动力学替代 ``W_poly``、quasi-Floquet
+``B(t)``、中心流形 ``W_series``）绑定到一个**不可变聚合句柄**
+:class:`LibrationCatalogData`，并提供面向对象的访问入口
+:class:`LibrationCatalogTransformer`，实现 qiao ``rho2param`` /
+``param2rho`` 的完整坐标变换链 ``rho ↔ param``。
+
+变换数学完全委托给 :mod:`.coord_trans` 子包（5 段函数式叶子函数 +
+端到端链式组合）。本模块的职责是：
+
+1. **聚合**：把 ``DynamicalSubstituteResult`` / ``QuasiFloquetResult`` /
+   ``CenterManifoldResult`` 三个句柄 + :class:`NormalFormContext` 打包成
+   一个数据类，避免调用方每次变换都要传 4 个参数；
+2. **时间插值封装**：``rho_to_param`` / ``param_to_rho`` 内部对 ``W`` /
+   ``B`` / ``W_series`` 做时刻 ``t`` 的插值（由叶子函数完成），调用方只
+   传状态和时间；
+3. **SI ↔ 归一化缝**：可选地用 :mod:`.units` 在公共接口做单位换算
+   （默认关闭，保持无量纲——与切片 0–4 一致；启用时
+   ``rho_to_param_si`` 把 SI km/km/s 状态转成归一化再变换）。
+
+与 #175（``pipeline.py`` 最终 ``NormalFormResult``）的衔接取舍：
+
+- :mod:`.types.NormalFormResult`（切片 0）是一个**通用流水线结果容器**
+  （Hamiltonian 系数、变换矩阵、残差等），字段语义偏"化简结果"，不适合
+  直接当坐标变换的系数聚合器；
+- 本切片定义独立的 :class:`LibrationCatalogData` 作为**坐标变换专用聚合
+  句柄**（只持有三个子结果 + context），命名上避开 ``NormalFormResult``
+  以免与 #175 冲突；
+- **#175 可以直接复用本类**：``LibrationCatalogTransformer`` 的构造只
+  依赖 ``context`` / ``ds_result`` / ``qf_result`` / ``cm_result`` 四个
+  访问器，#175 的 ``NormalFormResult`` 只需暴露这四个属性即可无缝构造
+  ``LibrationCatalogData``（或直接传 ``LibrationCatalogData`` 当字段）。
+  本切片不在 ``types.NormalFormResult`` 上加字段，保持切片 0 容器稳定。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import numpy as np
+import numpy.typing as npt
+
+from .coord_trans import param_to_rho, rho_to_param
+
+if TYPE_CHECKING:
+    from .center_manifold import CenterManifoldResult
+    from .context import NormalFormContext
+    from .dynamical_substitution import DynamicalSubstituteResult
+    from .quasi_floquet import QuasiFloquetResult
+
+
+# ---------------------------------------------------------------------------
+# 聚合句柄
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LibrationCatalogData:
+    """表征参数目录变换所需的预计算系数聚合句柄。
+
+    不可变：把切片 #171–#173 的三个结果 + 上下文打包，供
+    :class:`LibrationCatalogTransformer` 绑定使用。
+
+    设计取舍见模块 docstring：本类是**坐标变换专用**聚合器，不复用
+    :class:`~e2m2e.algorithms.normal_form.types.NormalFormResult`（后者是
+    通用流水线结果容器）。#175 的最终 ``NormalFormResult`` 可暴露
+    ``context``/``ds_result``/``qf_result``/``cm_result`` 四个属性后直接
+    构造本类，或反过来把本类当字段嵌入。
+
+    Attributes:
+        context: 归一化上下文。
+        ds_result: 动力学替代结果（提供 ``W_poly``、``tlist``）。
+        qf_result: quasi-Floquet 结果（提供 ``B_at(t)``）。
+        cm_result: 中心流形化简结果（提供 ``W_series``）。
+    """
+
+    context: NormalFormContext
+    ds_result: DynamicalSubstituteResult
+    qf_result: QuasiFloquetResult
+    cm_result: CenterManifoldResult
+
+
+# ---------------------------------------------------------------------------
+# 变换器
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LibrationCatalogTransformer:
+    """表征参数目录变换器（上下文 + 系数绑定）。
+
+    把 :class:`LibrationCatalogData` 绑定到方法，提供面向对象的
+    ``rho_to_param`` / ``param_to_rho`` 入口。所有时刻 ``t`` 的插值由
+    :mod:`.coord_trans` 叶子函数在内部完成，调用方只传状态与时间。
+
+    Args:
+        data: 预计算系数聚合句柄（context + 三个子结果）。
+    """
+
+    data: LibrationCatalogData
+
+    # 便捷透传 ----------------------------------------------------------
+    @property
+    def context(self) -> NormalFormContext:
+        """绑定上下文（透传到 ``data.context``）。"""
+        return self.data.context
+
+    # ------------------------------------------------------------------
+    # 公开变换
+    # ------------------------------------------------------------------
+
+    def rho_to_param(
+        self, X_rho: npt.ArrayLike, t: float
+    ) -> npt.NDArray[np.floating]:
+        """rho 坐标 → 表征参数（完整逆链）。
+
+        对应 qiao ``rho2param``：``rho → EM → DS → QF → CM → param``。
+
+        Args:
+            X_rho: ``(6,)`` rho 状态 ``[ρ, ρ̇]``，无量纲。
+            t: 归一化时间 TU。
+
+        Returns:
+            ``(6,)`` 表征参数 ``[q1, p1, I2, θ2, I3, θ3]``，无量纲。
+        """
+        return rho_to_param(
+            X_rho,
+            t,
+            self.data.context,
+            self.data.ds_result,
+            self.data.qf_result,
+            self.data.cm_result,
+        )
+
+    def param_to_rho(
+        self, X_param: npt.ArrayLike, t: float
+    ) -> npt.NDArray[np.floating]:
+        """表征参数 → rho 坐标（完整正链）。
+
+        对应 qiao ``param2rho``：``param → CM → QF → DS → EM → rho``。
+        是 :meth:`rho_to_param` 的精确逆。
+
+        Args:
+            X_param: ``(6,)`` 表征参数 ``[q1, p1, I2, θ2, I3, θ3]``，无量纲。
+            t: 归一化时间 TU。
+
+        Returns:
+            ``(6,)`` rho 状态 ``[ρ, ρ̇]``，无量纲。
+        """
+        return param_to_rho(
+            X_param,
+            t,
+            self.data.context,
+            self.data.ds_result,
+            self.data.qf_result,
+            self.data.cm_result,
+        )
+
+
+__all__ = [
+    "LibrationCatalogData",
+    "LibrationCatalogTransformer",
+]

--- a/e2m2e/algorithms/normal_form/catalog.py
+++ b/e2m2e/algorithms/normal_form/catalog.py
@@ -111,9 +111,7 @@ class LibrationCatalogTransformer:
     # 公开变换
     # ------------------------------------------------------------------
 
-    def rho_to_param(
-        self, X_rho: npt.ArrayLike, t: float
-    ) -> npt.NDArray[np.floating]:
+    def rho_to_param(self, X_rho: npt.ArrayLike, t: float) -> npt.NDArray[np.floating]:
         """rho 坐标 → 表征参数（完整逆链）。
 
         对应 qiao ``rho2param``：``rho → EM → DS → QF → CM → param``。
@@ -134,9 +132,7 @@ class LibrationCatalogTransformer:
             self.data.cm_result,
         )
 
-    def param_to_rho(
-        self, X_param: npt.ArrayLike, t: float
-    ) -> npt.NDArray[np.floating]:
+    def param_to_rho(self, X_param: npt.ArrayLike, t: float) -> npt.NDArray[np.floating]:
         """表征参数 → rho 坐标（完整正链）。
 
         对应 qiao ``param2rho``：``param → CM → QF → DS → EM → rho``。

--- a/e2m2e/algorithms/normal_form/center_manifold.py
+++ b/e2m2e/algorithms/normal_form/center_manifold.py
@@ -53,7 +53,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from math import factorial
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import numpy.typing as npt
@@ -158,9 +158,7 @@ class CenterManifoldResult:
 # ---------------------------------------------------------------------------
 
 
-def _characteristic_freq(
-    pow_tuple: tuple[int, ...], lam: float, wp: float, wv: float
-) -> complex:
+def _characteristic_freq(pow_tuple: tuple[int, ...], lam: float, wp: float, wv: float) -> complex:
     """同调方程的特征频率 ``k``（复值）。
 
     ``k = (j_1 − i_1)·λ + (j_2 − i_2)·i·ω_p + (j_3 − i_3)·i·ω_v``，
@@ -213,9 +211,9 @@ def _solve_wfunc_fft(
 
     F = np.fft.fft(f_ext)
     if N_ext % 2 == 0:
-        freq = np.arange(-N_ext // 2, N_ext // 2)
+        freq = np.arange(-N_ext // 2, N_ext // 2, dtype=float)
     else:
-        freq = np.arange(-(N_ext - 1) // 2, (N_ext - 1) // 2 + 1)
+        freq = np.arange(-(N_ext - 1) // 2, (N_ext - 1) // 2 + 1, dtype=float)
     freq = freq * (1.0 / (N_ext * dt))
     omega = 2.0 * np.pi * freq
     omega[np.abs(omega) < 1e-12] = 1e-12  # 避免零频奇异
@@ -287,9 +285,9 @@ def _solve_wfunc_fft_imag(
 
     F = np.fft.fft(f_ext)
     if N_ext % 2 == 0:
-        freq = np.arange(-N_ext // 2, N_ext // 2)
+        freq = np.arange(-N_ext // 2, N_ext // 2, dtype=float)
     else:
-        freq = np.arange(-(N_ext - 1) // 2, (N_ext - 1) // 2 + 1)
+        freq = np.arange(-(N_ext - 1) // 2, (N_ext - 1) // 2 + 1, dtype=float)
     freq = freq * (1.0 / (N_ext * dt))
     omega = 2.0 * np.pi * freq
     omega[np.abs(omega) < 1e-12] = 1e-12
@@ -548,40 +546,41 @@ def _lie_transform_step(
             if cur_order > max_order:
                 continue
             num = 1
-            p_prev = H_j
+            # poly_poisson 在本数值路径下输入/输出系数均为 ndarray，但其签名
+            # 为 object（兼顾 sympy 路径）；用 Any 局部标注表达 cascade 运算。
+            p_prev: Any = H_j
             while cur_order <= max_order:
-                p = poly_poisson(p_prev, W_temp)
+                p: dict[tuple[int, ...], Any] = poly_poisson(p_prev, W_temp)
                 for kk in p:
                     p[kk] = p[kk] / factorial(num)
                 num += 1
                 if cur_order not in H_by_order:
                     H_by_order[cur_order] = {}
+                target = H_by_order[cur_order]
                 for kk, v in p.items():
-                    H_by_order[cur_order][kk] = H_by_order[cur_order].get(
-                        kk, 0.0
-                    ) + v
+                    existing: Any = target.get(kk, 0.0)
+                    target[kk] = existing + v
                 cur_order += order - 2
                 p_prev = p
 
         # 加 Ẇ 项
         if order in H_by_order:
+            target = H_by_order[order]
             for kk, v in Wd_temp.items():
-                H_by_order[order][kk] = H_by_order[order].get(kk, 0.0) + v
+                # Wd 项为复值；与既有（可能复值）累加项相加。
+                cur: Any = target.get(kk, 0.0)
+                target[kk] = cur + v
 
         # 按 delete_criterion 删除该阶残余/新生项（Code10 与 Code11 不同）
         if order in H_by_order:
             H_by_order[order] = {
-                k: v
-                for k, v in H_by_order[order].items()
-                if delete_criterion(k, eliminated)
+                k: v for k, v in H_by_order[order].items() if delete_criterion(k, eliminated)
             }
             if not H_by_order[order]:
                 H_by_order[order] = {(0, 0, 0, 0, 0, 0): np.zeros(N)}
 
     # 化简各阶
-    H_by_order = {
-        o: polylist_simplify(v) for o, v in H_by_order.items() if v
-    }
+    H_by_order = {o: polylist_simplify(v) for o, v in H_by_order.items() if v}
     return H_by_order, W_series
 
 
@@ -636,8 +635,7 @@ class CenterManifoldReducer:
     def reduce(
         self,
         qf_result: QuasiFloquetResult,
-        hamiltonian_terms: Mapping[tuple[int, ...], npt.ArrayLike]
-        | None = None,
+        hamiltonian_terms: Mapping[tuple[int, ...], npt.ArrayLike] | None = None,
         steps: tuple[str, ...] | None = None,
     ) -> CenterManifoldResult:
         """对 ``qf_result`` 执行中心流形化简。
@@ -665,9 +663,7 @@ class CenterManifoldReducer:
         steps_resolved = tuple(steps) if steps is not None else ("invariant", "center")
         bad = [s for s in steps_resolved if s not in valid_steps]
         if bad:
-            raise ValueError(
-                f"steps 只能含 {sorted(valid_steps)}，得到非法值：{bad}"
-            )
+            raise ValueError(f"steps 只能含 {sorted(valid_steps)}，得到非法值：{bad}")
         if self.max_order < 1:
             raise ValueError(f"max_order 必须为正，得到 {self.max_order}")
 
@@ -680,9 +676,7 @@ class CenterManifoldReducer:
         N = tlist.size
 
         # 组装初始 Hamiltonian 多项式表 {order: {pow: coef}}
-        H_by_order = self._assemble_hamiltonian(
-            qf_result, hamiltonian_terms, tlist, N, lam, wp, wv
-        )
+        H_by_order = self._assemble_hamiltonian(qf_result, hamiltonian_terms, tlist, N, lam, wp, wv)
 
         W_all: dict[str, dict[int, dict[tuple[int, ...], npt.NDArray[np.complex128]]]] = {}
         steps_done: list[str] = []
@@ -716,9 +710,7 @@ class CenterManifoldReducer:
             # W 为纯虚（实部≈0）。coord_trans 的 QF↔CM Lie 流在复域操作，
             # 必须拿到完整复值 W，故此处不取实部。对应 qiao Code10/Code11
             # 输出复值 ``L?_InvarManifold.npz`` / ``L?_CenterManifold.npz``。
-            W_all[step] = {
-                o: _polylist_to_complex(w) for o, w in W_step.items()
-            }
+            W_all[step] = {o: _polylist_to_complex(w) for o, w in W_step.items()}
             steps_done.append(step)
 
         # 汇总化简后 Hamiltonian（所有阶合并成一个 pow→coef 表）
@@ -733,9 +725,7 @@ class CenterManifoldReducer:
         final_terms = polylist_simplify(final_terms)
 
         # 化简前最大双曲-中心耦合（诊断：用原始 hamiltonian_terms）
-        pre_coupling = _max_hyperbolic_center_coupling(
-            self._flat_terms(hamiltonian_terms, N)
-        )
+        pre_coupling = _max_hyperbolic_center_coupling(self._flat_terms(hamiltonian_terms, N))
 
         return CenterManifoldResult(
             context=self.context,

--- a/e2m2e/algorithms/normal_form/center_manifold.py
+++ b/e2m2e/algorithms/normal_form/center_manifold.py
@@ -1,0 +1,851 @@
+"""高阶中心流形化简（qiao Code10–Code11）。
+
+在 quasi-Floquet 坐标（切片 #172）基础上，用逐阶 Lie 变换消去
+Hamiltonian 的双曲-中心耦合项，把非线性 Hamiltonian 化简为仅依赖
+作用量的函数：
+
+- **Step 1 ``"invariant"``**（qiao ``Code10_DepartInvarManifold``）：
+  消去 ``q_1^k·p_1^l``（``k ≠ l``）的双曲交叉项，判别条件
+  ``pow(1)==pow(4)`` 保留双曲"循环坐标" ``I_1 = q_1·p_1``。经此步后
+  双曲方向与中心方向解耦，中心部分可独立分析；
+- **Step 2 ``"center"``**（qiao ``Code11_DepartCenterManifold``）：
+  在 Step 1 结果上，消去两个中心方向 ``(q_2,p_2)``/``(q_3,p_3)`` 之间
+  的非共振耦合，更严判别条件
+  ``pow(1)==pow(4) && pow(2)==pow(5) && pow(3)==pow(6)``，结果只剩
+  作用量 ``I_1 = q_1·p_1``、``I_2 = (q_2²+p_2²)/2``、
+  ``I_3 = (q_3²+p_3²)/2``。
+
+算法（两步结构相同）：
+
+1. 逐阶（``3..max_order``）解同调方程 ``{H_2, W_i} = -H_i^{待消}}``。
+   ``W_i`` 由频域 ODE 求解器 :func:`_solve_wfunc_fft` /
+   :func:`_solve_wfunc_fft_imag` 给出特解 ``ẏ = k·y + f(t)``；
+   特征频率 ``k = (j_1−i_1)·λ + (j_2−i_2)·i·ω_p + (j_3−i_3)·i·ω_v``；
+2. ``W_i`` 对各高阶 Hamiltonian 的贡献由 Poisson 括号链
+   ``ad_{W_i}^n / n!``（Lie 级数）累加，再加上 ``Ẇ_i`` 项更新各阶；
+3. 第 ``i`` 阶按判别条件删去被 ``W_i`` 消去的项。
+
+数学上每步都应在末尾用实变换 ``D⁻¹`` 映回实坐标——但由于虚变换 ``D``
+是常值辛矩阵且同调方程已显式消去耦合，本模块直接在实 ``QF`` 坐标上
+操作（``D`` 只用于推导 ``k`` 的形式），与 qiao 数值实现等价。
+
+单位约定：内部 Hamiltonian 系数全部在 qiao 归一化单位（TU）下运算；
+与 SI 之间换算只能经 :class:`NormalFormContext` 与 :mod:`.units`。
+``sympy`` 仅在 Legendre/Hamiltonian 构造时惰性导入；本模块不依赖
+sympy。``joblib`` 为可选优化（qiao 用其并行 Poisson 括号），本模块
+串行实现并显式注明。
+
+Public API：
+
+- :class:`CenterManifoldResult` —— 化简结果句柄；
+- :class:`CenterManifoldReducer` —— 上下文绑定的 reducer。
+
+输入 :class:`QuasiFloquetResult` 只提供二阶实标准形 ``D``（频率
+``λ``、``ω_p``、``ω_v``）；高阶非线性 Hamiltonian 项需经
+``hamiltonian_terms`` 参数注入（对应 qiao ``Code09`` 的
+``L?_QF_Hamilton.npz``：``{pow_tuple: coef_array}``，系数为时间序列
+``ndarray``）。若不注入，reducer 退化为只含二阶项的平凡情形
+（仍能跑通，但无高阶项可消，仅供 smoke）。
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from math import factorial
+from typing import TYPE_CHECKING
+
+import numpy as np
+import numpy.typing as npt
+
+from .polynomial import poly_poisson, polylist_simplify
+from .quasi_floquet import QuasiFloquetResult
+
+if TYPE_CHECKING:
+    from .context import NormalFormContext
+
+# ---------------------------------------------------------------------------
+# 默认参数
+# ---------------------------------------------------------------------------
+
+#: 默认展开阶数（与 qiao ``Code10``/``Code11`` 一致）。
+DEFAULT_MAX_ORDER: int = 10
+#: 频域 ODE 求解器边界延拓比例（qiao ``Solve_Wfunc_fft`` 默认值）。
+_DEFAULT_EXTENSION_RATIO: float = 0.2
+#: MAD 离群抑制阈值乘子（qiao ``Solve_Wfunc_fft_imag`` 默认值）。
+_DEFAULT_MAD_KVAL: float = 1e6
+#: 数值微分中心差分阶数（qiao ``list_deriv`` 默认值）。
+_DEFAULT_DERIV_N: int = 14
+
+
+# ---------------------------------------------------------------------------
+# 结果容器
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CenterManifoldResult:
+    """中心流形化简结果句柄。
+
+    Attributes:
+        context: 关联 :class:`NormalFormContext`。
+        order: 化简截断阶数（``max_order``）。
+        W_series: 各步、各阶生成函数 ``W`` 的系数表。结构
+            ``{step_name: {order: {pow_tuple: coef_array}}}``，封装访问；
+            ``step_name ∈ {"invariant", "center"}``。系数为**复值**时间
+            序列 ``ndarray``（``invariant`` 步 W 天然实值、虚部≈0；
+            ``center`` 步 W 为纯虚、实部≈0）——与 qiao Code10/Code11
+            输出的复值 ``.npz`` 一致，供 ``coord_trans`` 的 QF↔CM Lie
+            流在复域消费。不直接暴露 qiao 的 ``powers``/``coefficients``
+            扁平数组命名。
+        hamiltonian_terms: 化简后 Hamiltonian 的
+            ``{pow_tuple: coef_array}`` 系数表（实 QF 坐标）。
+        steps_performed: 实际执行的化简步骤名元组（按顺序）。
+        metadata: 自由扩展字段（频率、项数等诊断信息）。
+    """
+
+    context: NormalFormContext
+    order: int
+    W_series: dict[str, dict[int, dict[tuple[int, ...], npt.NDArray[np.complex128]]]]
+    hamiltonian_terms: dict[tuple[int, ...], npt.NDArray[np.floating]]
+    steps_performed: tuple[str, ...]
+    metadata: dict[str, object] = field(default_factory=dict)
+
+    @property
+    def max_hyperbolic_coupling(self) -> float:
+        """化简后剩余双曲-中心交叉项系数的最大绝对值。
+
+        "双曲-中心交叉项"指同时涉及双曲方向 ``q_1``/``p_1``（指数位
+        0/3）与中心方向（指数位 1/4 或 2/5）的 Hamiltonian 项；理想
+        化简后这类项应被消去（系数 ≈ 0）。本属性是步骤 ``"invariant"``
+        化简效果的核心诊断量：值越小，化简越彻底。
+
+        Returns:
+            ``max_{k∈terms} |coef_k|``，其中 ``k`` 遍历
+            ``(pow[0]+pow[3] > 0) and (pow[1]+pow[4]+pow[2]+pow[5] > 0)``
+            的项；无此类项时返回 ``0.0``。
+        """
+        mx = 0.0
+        for pow_tuple, coef in self.hamiltonian_terms.items():
+            hyper = pow_tuple[0] + pow_tuple[3]
+            center = pow_tuple[1] + pow_tuple[4] + pow_tuple[2] + pow_tuple[5]
+            if hyper > 0 and center > 0:
+                m = float(np.max(np.abs(coef))) if np.ndim(coef) else abs(float(coef))
+                if m > mx:
+                    mx = m
+        return mx
+
+    def W_for(self, step: str, order: int) -> dict[tuple[int, ...], npt.NDArray[np.complex128]]:
+        """封装访问器：取出某步某阶的 ``W`` 系数表。
+
+        Args:
+            step: 步骤名（``"invariant"`` / ``"center"``）。
+            order: 阶数。
+
+        Returns:
+            ``{pow_tuple: coef_array}``；该步/阶未执行或无项时返回 ``{}``。
+
+        Raises:
+            KeyError: ``step`` 未执行。
+        """
+        if step not in self.W_series:
+            raise KeyError(f"步骤 {step!r} 未执行；已执行：{self.steps_performed}")
+        return dict(self.W_series[step].get(order, {}))
+
+
+# ---------------------------------------------------------------------------
+# 频域 ODE 求解器（迁移自 qiao Solve_Wfunc_fft / Solve_Wfunc_fft_imag）
+# ---------------------------------------------------------------------------
+
+
+def _characteristic_freq(
+    pow_tuple: tuple[int, ...], lam: float, wp: float, wv: float
+) -> complex:
+    """同调方程的特征频率 ``k``（复值）。
+
+    ``k = (j_1 − i_1)·λ + (j_2 − i_2)·i·ω_p + (j_3 − i_3)·i·ω_v``，
+    其中 ``pow_tuple = (i_1, i_2, i_3, j_1, j_2, j_3)`` 对应
+    ``(q_1, q_2, q_3, p_1, p_2, p_3)``。``λ`` 是双曲特征指数（实），
+    ``ω_p``/``ω_v`` 是平面/垂直中心频率。对应 qiao
+    ``Solve_Wfunc_fft`` 中 ``k`` 的定义。
+
+    ``k == 0``（共振项）时同调方程不可解，调用方负责跳过此类项。
+    """
+    i1, i2, i3, j1, j2, j3 = (int(p) for p in pow_tuple)
+    return complex(
+        (j1 - i1) * lam,
+        (j2 - i2) * wp + (j3 - i3) * wv,
+    )
+
+
+def _solve_wfunc_fft(
+    tlist: npt.NDArray[np.floating],
+    forcing: npt.NDArray[np.floating],
+    k: complex,
+    *,
+    extension_ratio: float = _DEFAULT_EXTENSION_RATIO,
+) -> npt.NDArray[np.complex128]:
+    """频域求解 ``ẏ = k·y + f(t)`` 的特解（实值 ``f``）。
+
+    迁移自 qiao ``Solve_Wfunc_fft``：对 ``f`` 做镜像边界延拓后 FFT，
+    乘传递函数 ``H(ω) = 1/(iω − k)`` 再 IFFT，截取原区间。频域 ODE
+    求解的离散泄漏由边界延拓抑制（qiao 用 mirror，本实现一致）。
+
+    Args:
+        tlist: ``(N,)`` 等距时间序列。
+        forcing: ``(N,)`` 强迫项 ``f(t)``。
+        k: 特征频率（复值）。
+        extension_ratio: 边界延拓比例。
+
+    Returns:
+        ``(N,)`` 复值特解 ``y(t)``。
+    """
+    t_arr = np.asarray(tlist, dtype=float).ravel()
+    f_vals = np.asarray(forcing, dtype=float).ravel()
+    N = t_arr.size
+    if N < 2:
+        return np.zeros(N, dtype=complex)
+    dt = float(t_arr[1] - t_arr[0])
+    M = int(np.ceil(extension_ratio * N))
+    # mirror 边界延拓
+    f_ext = np.concatenate([f_vals[:M][::-1], f_vals, f_vals[-M:][::-1]])
+    N_ext = f_ext.size
+
+    F = np.fft.fft(f_ext)
+    if N_ext % 2 == 0:
+        freq = np.arange(-N_ext // 2, N_ext // 2)
+    else:
+        freq = np.arange(-(N_ext - 1) // 2, (N_ext - 1) // 2 + 1)
+    freq = freq * (1.0 / (N_ext * dt))
+    omega = 2.0 * np.pi * freq
+    omega[np.abs(omega) < 1e-12] = 1e-12  # 避免零频奇异
+
+    H = 1.0 / (1j * omega - k)
+    H = np.fft.fftshift(H)
+    y_ext = np.fft.ifft(F * H)
+    return y_ext[M : M + N]
+
+
+def _limit_fft_outliers_mad(
+    fft_result: npt.NDArray[np.complex128], k_val: float
+) -> tuple[npt.NDArray[np.complex128], bool]:
+    """MAD（中位绝对偏差）离群抑制。
+
+    迁移自 qiao ``Solve_Wfunc_fft_imag._limit_fft_outliers_mad``：对 FFT
+    幅值超过 ``med_A + k_val·MAD/0.6745`` 的频点按比例缩回阈值，抑制
+    共振峰在频域产生的数值尖刺。
+
+    Returns:
+        ``(corrected_fft, corrected_flag)``。
+    """
+    A = np.abs(fft_result)
+    med_A = float(np.median(A))
+    mad = float(np.median(np.abs(A - med_A)))
+    # MAD=0 时频谱无统计离散度（如常系数输入，FFT 仅零频非零），
+    # ``threshold = med_A + k·0 = med_A`` 会把所有高于中位数的频点
+    # （含唯一非零的零频）当成离群点缩到 med_A，使整个 W 归零。此时
+    # "离群点"概念不成立——抑制对象是共振尖刺，而此类信号无尖刺，
+    # 跳过即可。对 qiao 真实时变输入（MAD>0）零影响。
+    if mad == 0.0:
+        return fft_result.copy(), False
+    threshold = med_A + k_val * (mad / 0.6745)
+    outliers = threshold < A
+    corrected = bool(np.any(outliers))
+    if not corrected:
+        return fft_result.copy(), False
+    fft_limited = fft_result.copy()
+    idx = np.where(outliers)[0]
+    scale = threshold / A[idx]
+    fft_limited[idx] = fft_result[idx] * scale
+    return fft_limited, corrected
+
+
+def _solve_wfunc_fft_imag(
+    tlist: npt.NDArray[np.floating],
+    forcing: npt.NDArray[np.floating],
+    k: complex,
+    *,
+    extension_ratio: float = _DEFAULT_EXTENSION_RATIO,
+    mad_kval: float = _DEFAULT_MAD_KVAL,
+) -> tuple[npt.NDArray[np.complex128], bool]:
+    """频域求解 ``ẏ = k·y + f(t)``（复值 ``f``，含 MAD 离群抑制）。
+
+    迁移自 qiao ``Solve_Wfunc_fft_imag``：结构与 :func:`_solve_wfunc_fft`
+    一致，但额外对 FFT 结果做 MAD 离群抑制，返回 ``(y, corrected)``。
+    ``corrected=True`` 表示发生了离群抑制（调用方据此切换 ``Ẇ`` 的
+    数值微分路径）。
+    """
+    t_arr = np.asarray(tlist, dtype=float).ravel()
+    f_vals = np.asarray(forcing, dtype=complex).ravel()
+    N = t_arr.size
+    if N < 2:
+        return np.zeros(N, dtype=complex), False
+    dt = float(t_arr[1] - t_arr[0])
+    M = int(np.ceil(extension_ratio * N))
+    f_ext = np.concatenate([f_vals[:M][::-1], f_vals, f_vals[-M:][::-1]])
+    N_ext = f_ext.size
+
+    F = np.fft.fft(f_ext)
+    if N_ext % 2 == 0:
+        freq = np.arange(-N_ext // 2, N_ext // 2)
+    else:
+        freq = np.arange(-(N_ext - 1) // 2, (N_ext - 1) // 2 + 1)
+    freq = freq * (1.0 / (N_ext * dt))
+    omega = 2.0 * np.pi * freq
+    omega[np.abs(omega) < 1e-12] = 1e-12
+
+    H = 1.0 / (1j * omega - k)
+    H = np.fft.fftshift(H)
+    Y_freq = F * H
+    y_ext = np.fft.ifft(Y_freq)
+    y = y_ext[M : M + N]
+
+    Y_corrected, corrected = _limit_fft_outliers_mad(Y_freq, mad_kval)
+    if corrected:
+        y_corr = np.fft.ifft(Y_corrected)[M : M + N]
+        return y_corr, True
+    return y, False
+
+
+# ---------------------------------------------------------------------------
+# 高阶数值微分（迁移自 qiao list_deriv）
+# ---------------------------------------------------------------------------
+
+
+def _vandermonde_deriv_coeffs(n: int, mode: int) -> npt.NDArray[np.floating]:
+    """Vandermonde 系统求数值微分系数。
+
+    ``mode=0`` 中心、``1`` 前向、``-1`` 后向，节点数 ``n+1``。
+    对应 qiao ``list_deriv._vandermonde_coeffs``。
+    """
+    if mode == 0:
+        k = np.arange(-n // 2, n // 2 + 1)
+    elif mode == 1:
+        k = np.arange(0, n + 1)
+    elif mode == -1:
+        k = np.arange(-n, 1)
+    else:
+        raise ValueError(f"未知 mode: {mode}")
+    if k.size <= 1:
+        return np.array([0.0])
+    V = np.vander(k, increasing=True).T
+    b = np.zeros(n + 1)
+    b[1] = 1.0
+    return np.linalg.solve(V, b)
+
+
+def list_deriv(
+    y: npt.ArrayLike,
+    h: float,
+    n: int = _DEFAULT_DERIV_N,
+    swi: int = 4,
+    ord_boundary: int = 10,
+) -> npt.NDArray[np.floating]:
+    """等距采样高阶数值微分。
+
+    迁移自 qiao ``list_deriv``：内部 ``n`` 阶中心差分，两端用
+    ``swi`` 点前/后向差分（阶 ``ord_boundary``），过渡区用递降阶中心
+    差分。复值 ``y`` 自动转实/虚部分别处理。
+
+    Args:
+        y: ``(N,)`` 等距采样数据（实或复）。
+        h: 采样间距。
+        n: 中心差分阶（偶数）。
+        swi: 端点前/后向差分点数。
+        ord_boundary: 端点差分阶。
+
+    Returns:
+        ``(N,)`` 导数 ``dy/dt``。
+    """
+    y_arr = np.asarray(y)
+    if np.iscomplexobj(y_arr):
+        return list_deriv(y_arr.real, h, n, swi, ord_boundary) + 1j * list_deriv(
+            y_arr.imag, h, n, swi, ord_boundary
+        )
+    y_arr = y_arr.ravel()
+    N = y_arr.size
+    dy = np.zeros(N, dtype=float)
+    half = n // 2
+
+    # 内部：n 阶中心差分
+    if n < N:
+        c = _vandermonde_deriv_coeffs(n, mode=0)
+        for idx_k, kk in enumerate(range(-half, half + 1)):
+            dy[half : N - half] += c[idx_k] * y_arr[half + kk : N - half + kk]
+        dy[half : N - half] /= h
+
+    # 前向/后向端点
+    for i in range(min(swi, N)):
+        ord_eff = min(ord_boundary, N - i - 1)
+        if ord_eff < 1:
+            dy[i] = (y_arr[i + 1] - y_arr[i]) / h if i + 1 < N else 0.0
+        else:
+            c_fwd = _vandermonde_deriv_coeffs(ord_eff, mode=1)
+            dy[i] = float(np.dot(c_fwd, y_arr[i : i + ord_eff + 1])) / h
+
+    for i in range(min(swi, N)):
+        ri = N - 1 - i
+        ord_eff = min(ord_boundary, ri)
+        if ord_eff < 1:
+            dy[ri] = (y_arr[ri] - y_arr[ri - 1]) / h if ri > 0 else 0.0
+        else:
+            c_bwd = _vandermonde_deriv_coeffs(ord_eff, mode=-1)
+            dy[ri] = float(np.dot(c_bwd, y_arr[ri - ord_eff : ri + 1])) / h
+
+    # 过渡区（swi..half-1）：递降阶中心差分
+    for i in range(swi, min(half, N - swi)):
+        span = 2 * i
+        if span < 2:
+            continue
+        c_center = _vandermonde_deriv_coeffs(span, mode=0)
+        offset = span // 2
+        acc = 0.0
+        for idx_k, kk in enumerate(range(-offset, offset + 1)):
+            acc += c_center[idx_k] * y_arr[i + kk]
+        dy[i] = acc / h
+        ri = N - 1 - i
+        acc = 0.0
+        for idx_k, kk in enumerate(range(-offset, offset + 1)):
+            acc += c_center[idx_k] * y_arr[ri + kk]
+        dy[ri] = acc / h
+
+    return dy
+
+
+# ---------------------------------------------------------------------------
+# 同调方程判别条件
+# ---------------------------------------------------------------------------
+
+
+def _is_invariant_term(pow_tuple: tuple[int, ...]) -> bool:
+    """Step 1（invariant）保留条件：``pow(1)==pow(4)``。
+
+    满足此条件的 ``q_1^k·p_1^k`` 项是双曲"循环坐标"作用量
+    ``I_1 = q_1·p_1`` 的分量，**保留**；其余 ``q_1^k·p_1^l (k≠l)`` 双曲
+    交叉项被 ``W`` 消去。对应 qiao ``Code10`` 的 ``if n1 == n4`` 分支。
+    """
+    return int(pow_tuple[0]) == int(pow_tuple[3])
+
+
+def _is_center_term(pow_tuple: tuple[int, ...]) -> bool:
+    """Step 2（center）保留条件：三对共轭全部平衡。
+
+    ``pow(1)==pow(4) && pow(2)==pow(5) && pow(3)==pow(6)``。满足时该项
+    仅依赖作用量（``I_1``、``I_2``、``I_3`` 的幂次），**保留**；其余
+    含中心方向非共振耦合的项被消去。对应 qiao ``Code11`` 的
+    ``if n1 == n4 and n2 == n5 and n3 == n6`` 分支。
+    """
+    return (
+        int(pow_tuple[0]) == int(pow_tuple[3])
+        and int(pow_tuple[1]) == int(pow_tuple[4])
+        and int(pow_tuple[2]) == int(pow_tuple[5])
+    )
+
+
+# ---------------------------------------------------------------------------
+# 单步 Lie 变换（Code10 / Code11 通用骨架）
+# ---------------------------------------------------------------------------
+
+
+def _polylist_to_complex(
+    poly: Mapping[tuple[int, ...], npt.ArrayLike],
+) -> dict[tuple[int, ...], npt.NDArray[np.complex128]]:
+    """把实/复值系数表统一转为复值（W 封装用，保留 invariant/center 两步的复值 W）。"""
+    return {k: np.asarray(v, dtype=complex) for k, v in poly.items()}
+
+
+def _lie_transform_step(
+    H_by_order: dict[int, dict[tuple[int, ...], npt.NDArray[np.floating]]],
+    *,
+    max_order: int,
+    tlist: npt.NDArray[np.floating],
+    lam: float,
+    wp: float,
+    wv: float,
+    keep_criterion,
+    delete_criterion,
+    use_imag_solver: bool,
+) -> tuple[
+    dict[int, dict[tuple[int, ...], npt.NDArray[np.floating]]],
+    dict[int, dict[tuple[int, ...], npt.NDArray[np.complex128]]],
+]:
+    """执行一步中心流形化简的 Lie 变换（Code10/Code11 通用骨架）。
+
+    Args:
+        H_by_order: ``{order: {pow: coef}}``，被原地更新。
+        max_order: 截断阶数。
+        tlist: 时间序列。
+        lam, wp, wv: 频率（双曲/平面/垂直）。
+        keep_criterion: 保留判据（决定**是否对该项求 W**）；满足者跳过
+            （W 记零）。Code10 用 ``_is_invariant_term``（``pow1==pow4``），
+            Code11 用 ``_is_center_term``（三对全平衡）。
+        delete_criterion: 该阶处理完后**删除**不满足此判据的项。
+            Code10 与 Code11 不同：Code10 删所有非作用量项（三对全平衡），
+            Code11 只删真正求过 W 的项（``list_iseliminate``）。
+        use_imag_solver: ``True`` 用复值 + MAD 求解器（Step 2），
+            ``False`` 用实值求解器（Step 1）。
+
+    Returns:
+        ``(H_by_order, W_series)``：``W_series`` 为
+        ``{order: {pow: W_coef}}``（复值，``W_coef`` 时间序列）。
+
+    Notes:
+        忠实迁移 qiao ``Code10``/``Code11`` 的逐阶循环：
+
+        1. 对每个 ``order ∈ [3, max_order]``，遍历 ``H_order`` 中不满足
+           ``keep_criterion`` 的项，求同调方程特解 ``W`` 与 ``Ẇ``；
+        2. Poisson 括号链累加 ``ad_W^n / n!`` 到更高阶 Hamiltonian
+           （``j`` 从 2 起，``cur_order = j + order − 2`` 递增）；
+        3. 加 ``Ẇ`` 项，按 ``delete_criterion`` 删除该阶残余/新生项。
+    """
+    W_series: dict[int, dict[tuple[int, ...], npt.NDArray[np.complex128]]] = {}
+    N = tlist.size
+
+    for order in range(3, max_order + 1):
+        if order not in H_by_order:
+            H_by_order[order] = {}
+        H_order = H_by_order[order]
+
+        W_temp: dict[tuple[int, ...], npt.NDArray[np.complex128]] = {}
+        Wd_temp: dict[tuple[int, ...], npt.NDArray[np.complex128]] = {}
+        eliminated: list[tuple[int, ...]] = []
+
+        for pow_tuple, coef_arr in list(H_order.items()):
+            if keep_criterion(pow_tuple):
+                # 保留项（共振/作用量项）：不生成 W，W 记零
+                W_temp[pow_tuple] = np.zeros(N, dtype=complex)
+                continue
+
+            coef_c = np.asarray(coef_arr, dtype=complex)
+            k = _characteristic_freq(pow_tuple, lam, wp, wv)
+            # Step 1：Ẇ = -k·W - coef（qiao Code10 同调方程闭合形式）。
+            # Step 2：先用复值+MAD 求 W；若 MAD 抑制触发则 Ẇ 走数值微分，
+            #         否则 Ẇ = k·W + coef（再取负，见下）。
+            if not use_imag_solver:
+                W_func = _solve_wfunc_fft(tlist, coef_c.real, k)
+                Wd_func = -k * W_func - coef_c
+            else:
+                W_func, corrected = _solve_wfunc_fft_imag(tlist, coef_c, k)
+                if not corrected:
+                    Wd_func = k * W_func + coef_c
+                else:
+                    dt = float(np.mean(np.diff(tlist)))
+                    Wd_func = list_deriv(W_func, dt)
+                Wd_func = -Wd_func
+
+            W_temp[pow_tuple] = W_func
+            Wd_temp[pow_tuple] = Wd_func
+            eliminated.append(pow_tuple)
+
+        W_series[order] = W_temp
+
+        # Poisson 括号链：ad_W^n / n! 累加到高阶 Hamiltonian
+        for j in range(2, max_order):
+            if j not in H_by_order or not H_by_order[j]:
+                continue
+            H_j = H_by_order[j]
+            cur_order = j + order - 2
+            if cur_order > max_order:
+                continue
+            num = 1
+            p_prev = H_j
+            while cur_order <= max_order:
+                p = poly_poisson(p_prev, W_temp)
+                for kk in p:
+                    p[kk] = p[kk] / factorial(num)
+                num += 1
+                if cur_order not in H_by_order:
+                    H_by_order[cur_order] = {}
+                for kk, v in p.items():
+                    H_by_order[cur_order][kk] = H_by_order[cur_order].get(
+                        kk, 0.0
+                    ) + v
+                cur_order += order - 2
+                p_prev = p
+
+        # 加 Ẇ 项
+        if order in H_by_order:
+            for kk, v in Wd_temp.items():
+                H_by_order[order][kk] = H_by_order[order].get(kk, 0.0) + v
+
+        # 按 delete_criterion 删除该阶残余/新生项（Code10 与 Code11 不同）
+        if order in H_by_order:
+            H_by_order[order] = {
+                k: v
+                for k, v in H_by_order[order].items()
+                if delete_criterion(k, eliminated)
+            }
+            if not H_by_order[order]:
+                H_by_order[order] = {(0, 0, 0, 0, 0, 0): np.zeros(N)}
+
+    # 化简各阶
+    H_by_order = {
+        o: polylist_simplify(v) for o, v in H_by_order.items() if v
+    }
+    return H_by_order, W_series
+
+
+def _delete_invariant(pow_tuple, eliminated: list[tuple[int, ...]]) -> bool:
+    """Code10 删除判据：保留三对全平衡项（即作用量项）。
+
+    qiao ``Code10`` 第 131–134 行：``k[0]==k[3] and k[1]==k[4] and
+    k[2]==k[5]``。注意 Code10 用 ``keep_criterion=_is_invariant_term``
+    决定**求 W**（只对 ``pow1≠pow4`` 求解），但删除时更严，连中心非共振
+    项一并清掉。这是 qiao 的实际行为：Step 1 把 Hamiltonian 直接化到
+    作用量形式（Step 2 在此基础上再做精修，结构相同但 ``keep`` 更严、
+    无项可删时退化为恒等）。
+    """
+    return (
+        int(pow_tuple[0]) == int(pow_tuple[3])
+        and int(pow_tuple[1]) == int(pow_tuple[4])
+        and int(pow_tuple[2]) == int(pow_tuple[5])
+    )
+
+
+def _delete_center(pow_tuple, eliminated: list[tuple[int, ...]]) -> bool:
+    """Code11 删除判据：保留非 eliminated 的项。
+
+    qiao ``Code11`` 第 146–148 行：只删 ``list_iseliminate``（即本阶求
+    过 W 的项），其他项（包括 Poisson cascade 新生成的）保留。Code11
+    的 ``keep_criterion`` 已是三对全平衡，故非 eliminated 项天然是作用量项。
+    """
+    return pow_tuple not in eliminated
+
+
+# ---------------------------------------------------------------------------
+# Reducer
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CenterManifoldReducer:
+    """中心流形化简 reducer（上下文绑定）。
+
+    通过 :meth:`reduce` 在 quasi-Floquet 化简后的 Hamiltonian 上执行
+    一步或两步 Lie 变换，消去双曲-中心耦合与中心方向间非共振耦合，
+    输出 :class:`CenterManifoldResult`。
+
+    Args:
+        context: 归一化上下文（提供频率 ``ω_p``/``ω_v``、特征指数 λ）。
+        max_order: Lie 变换截断阶数，默认 ``10``（与 qiao 一致）。
+    """
+
+    context: NormalFormContext
+    max_order: int = DEFAULT_MAX_ORDER
+
+    def reduce(
+        self,
+        qf_result: QuasiFloquetResult,
+        hamiltonian_terms: Mapping[tuple[int, ...], npt.ArrayLike]
+        | None = None,
+        steps: tuple[str, ...] | None = None,
+    ) -> CenterManifoldResult:
+        """对 ``qf_result`` 执行中心流形化简。
+
+        Args:
+            qf_result: quasi-Floquet 变换结果（切片 #172），提供实标准形
+                ``D``（频率 ``λ``/``ω_p``/``ω_v``）与采样时间 ``tlist``。
+            hamiltonian_terms: 高阶 Hamiltonian 系数表
+                ``{pow_tuple: coef_array}``（对应 qiao ``Code09`` 的
+                ``L?_QF_Hamilton.npz``）。``None`` 时 reducer 只用二阶实
+                标准形项（平凡情形，仅供 smoke）。系数为时间序列
+                ``ndarray``，长度应与 ``qf_result.tlist`` 一致。
+            steps: 要执行的步骤元组，按顺序；默认
+                ``("invariant", "center")``。可选单步 ``("invariant",)``
+                或 ``("center",)``。
+
+        Returns:
+            :class:`CenterManifoldResult`。
+
+        Raises:
+            ValueError: ``steps`` 含非法名；``max_order`` 非正；
+                ``hamiltonian_terms`` 系数长度与 ``tlist`` 不一致。
+        """
+        valid_steps = {"invariant", "center"}
+        steps_resolved = tuple(steps) if steps is not None else ("invariant", "center")
+        bad = [s for s in steps_resolved if s not in valid_steps]
+        if bad:
+            raise ValueError(
+                f"steps 只能含 {sorted(valid_steps)}，得到非法值：{bad}"
+            )
+        if self.max_order < 1:
+            raise ValueError(f"max_order 必须为正，得到 {self.max_order}")
+
+        # 频率（实标准形 D 同源）
+        lam = float(self.context.characteristic_exponent)
+        nu1, nu2 = self.context.central_frequencies
+        wp, wv = float(nu1), float(nu2)
+
+        tlist = np.asarray(qf_result.tlist, dtype=float).ravel()
+        N = tlist.size
+
+        # 组装初始 Hamiltonian 多项式表 {order: {pow: coef}}
+        H_by_order = self._assemble_hamiltonian(
+            qf_result, hamiltonian_terms, tlist, N, lam, wp, wv
+        )
+
+        W_all: dict[str, dict[int, dict[tuple[int, ...], npt.NDArray[np.complex128]]]] = {}
+        steps_done: list[str] = []
+        for step in steps_resolved:
+            if step == "invariant":
+                H_by_order, W_step = _lie_transform_step(
+                    H_by_order,
+                    max_order=self.max_order,
+                    tlist=tlist,
+                    lam=lam,
+                    wp=wp,
+                    wv=wv,
+                    keep_criterion=_is_invariant_term,
+                    delete_criterion=_delete_invariant,
+                    use_imag_solver=False,
+                )
+            else:  # center
+                H_by_order, W_step = _lie_transform_step(
+                    H_by_order,
+                    max_order=self.max_order,
+                    tlist=tlist,
+                    lam=lam,
+                    wp=wp,
+                    wv=wv,
+                    keep_criterion=_is_center_term,
+                    delete_criterion=_delete_center,
+                    use_imag_solver=True,
+                )
+            # W 保留复值：Step 1（invariant）的双曲特征频率 λ 为实数，W
+            # 天然实值；Step 2（center）的中心频率为纯虚 iω，同调方程特解
+            # W 为纯虚（实部≈0）。coord_trans 的 QF↔CM Lie 流在复域操作，
+            # 必须拿到完整复值 W，故此处不取实部。对应 qiao Code10/Code11
+            # 输出复值 ``L?_InvarManifold.npz`` / ``L?_CenterManifold.npz``。
+            W_all[step] = {
+                o: _polylist_to_complex(w) for o, w in W_step.items()
+            }
+            steps_done.append(step)
+
+        # 汇总化简后 Hamiltonian（所有阶合并成一个 pow→coef 表）
+        final_terms: dict[tuple[int, ...], npt.NDArray[np.floating]] = {}
+        for o in sorted(H_by_order.keys()):
+            for k, v in H_by_order[o].items():
+                v_arr = np.real(np.asarray(v, dtype=complex))
+                if k in final_terms:
+                    final_terms[k] = final_terms[k] + v_arr
+                else:
+                    final_terms[k] = v_arr
+        final_terms = polylist_simplify(final_terms)
+
+        # 化简前最大双曲-中心耦合（诊断：用原始 hamiltonian_terms）
+        pre_coupling = _max_hyperbolic_center_coupling(
+            self._flat_terms(hamiltonian_terms, N)
+        )
+
+        return CenterManifoldResult(
+            context=self.context,
+            order=int(self.max_order),
+            W_series=W_all,
+            hamiltonian_terms=final_terms,
+            steps_performed=tuple(steps_done),
+            metadata={
+                "lambda": lam,
+                "wp": wp,
+                "wv": wv,
+                "n_samples": N,
+                "pre_hyperbolic_center_coupling": pre_coupling,
+                "max_order": int(self.max_order),
+            },
+        )
+
+    # ------------------------------------------------------------------
+    # 内部辅助
+    # ------------------------------------------------------------------
+
+    def _assemble_hamiltonian(
+        self,
+        qf_result: QuasiFloquetResult,
+        hamiltonian_terms: Mapping[tuple[int, ...], npt.ArrayLike] | None,
+        tlist: npt.NDArray[np.floating],
+        N: int,
+        lam: float,
+        wp: float,
+        wv: float,
+    ) -> dict[int, dict[tuple[int, ...], npt.NDArray[np.floating]]]:
+        """组装 Lie 变换输入的 Hamiltonian 多项式表。
+
+        二阶项来自实标准形（``λ·q_1·p_1 + (ω_p/2)(q_2²+p_2²)
+        + (ω_v/2)(q_3²+p_3²)``，对应 qiao ``Code09`` 的 ``NormalForm_poly``）；
+        高阶项来自 ``hamiltonian_terms``（若提供）。按总阶数分组。
+        """
+        H_by_order: dict[int, dict[tuple[int, ...], npt.NDArray[np.floating]]] = {}
+
+        def _put(deg: int, key: tuple[int, ...], val: np.ndarray) -> None:
+            H_by_order.setdefault(deg, {})
+            if key in H_by_order[deg]:
+                H_by_order[deg][key] = H_by_order[deg][key] + val
+            else:
+                H_by_order[deg][key] = val
+
+        # 二阶实标准形（qiao Code09 NormalForm_poly）
+        _put(2, (1, 0, 0, 1, 0, 0), lam * np.ones(N))
+        _put(2, (0, 2, 0, 0, 0, 0), (wp / 2) * np.ones(N))
+        _put(2, (0, 0, 0, 0, 2, 0), (wp / 2) * np.ones(N))
+        _put(2, (0, 0, 2, 0, 0, 0), (wv / 2) * np.ones(N))
+        _put(2, (0, 0, 0, 0, 0, 2), (wv / 2) * np.ones(N))
+
+        # 高阶项（Code09 输出）
+        if hamiltonian_terms:
+            for pow_tuple, coef in hamiltonian_terms.items():
+                key = tuple(int(p) for p in pow_tuple)
+                deg = sum(key)
+                if deg < 1 or deg > self.max_order:
+                    continue
+                arr = np.asarray(coef, dtype=float).ravel()
+                if arr.size == 1:
+                    arr = np.full(N, float(arr[0]))
+                if arr.size != N:
+                    raise ValueError(
+                        f"hamiltonian_terms 系数长度 {arr.size} 与 tlist "
+                        f"长度 {N} 不一致（pow={key}）"
+                    )
+                _put(deg, key, arr)
+        return H_by_order
+
+    @staticmethod
+    def _flat_terms(
+        hamiltonian_terms: Mapping[tuple[int, ...], npt.ArrayLike] | None,
+        N: int,
+    ) -> dict[tuple[int, ...], npt.NDArray[np.floating]]:
+        """把注入的高阶项规整为扁平 ``{pow: coef}`` 表（诊断用）。"""
+        out: dict[tuple[int, ...], npt.NDArray[np.floating]] = {}
+        if hamiltonian_terms:
+            for pow_tuple, coef in hamiltonian_terms.items():
+                arr = np.asarray(coef, dtype=float).ravel()
+                if arr.size == 1:
+                    arr = np.full(N, float(arr[0]))
+                out[tuple(int(p) for p in pow_tuple)] = arr
+        return out
+
+
+def _max_hyperbolic_center_coupling(
+    terms: Mapping[tuple[int, ...], npt.ArrayLike],
+) -> float:
+    """计算 Hamiltonian 表中双曲-中心交叉项系数的最大绝对值。
+
+    双曲方向指数位 0/3（``q_1``/``p_1``），中心方向指数位 1/4/2/5
+    （``q_2``/``p_2``/``q_3``/``p_3``）。同时涉及时即为交叉项。
+    """
+    mx = 0.0
+    for pow_tuple, coef in terms.items():
+        hyper = int(pow_tuple[0]) + int(pow_tuple[3])
+        center = int(pow_tuple[1]) + int(pow_tuple[4]) + int(pow_tuple[2]) + int(pow_tuple[5])
+        if hyper > 0 and center > 0:
+            arr = np.asarray(coef, dtype=float).ravel()
+            m = float(np.max(np.abs(arr))) if arr.size else 0.0
+            if m > mx:
+                mx = m
+    return mx
+
+
+__all__ = [
+    "DEFAULT_MAX_ORDER",
+    "CenterManifoldReducer",
+    "CenterManifoldResult",
+    "list_deriv",
+]

--- a/e2m2e/algorithms/normal_form/constants.py
+++ b/e2m2e/algorithms/normal_form/constants.py
@@ -1,0 +1,203 @@
+"""Normal-form 归一化常数与平动点几何工具。
+
+集中存放 qiao ``Global_File.py`` / ``Calc_LPstate.py`` 中固化下来的物理
+与几何常量，以及从给定质量比反解平动点无量纲坐标、共线点 γ 值的辅助函数。
+
+本模块刻意保持为零依赖（仅依赖 ``numpy``），方便上层模块在 ``__init__``
+阶段按需加载。``sympy`` / ``joblib`` 的引入留待后续化简器内部惰性导入。
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+
+from e2m2e.core import LibrationPoint
+
+# ---------------------------------------------------------------------------
+# qiao 全局归一化常量（见 qiao Python/crtbp/Subfunction/Global_File.py）
+# ---------------------------------------------------------------------------
+
+#: 归一化长度单位 LU（km）。qiao 约定；与 e2m2e 默认地月距离 (384405 km) 略有差异。
+LU_KM: float = 384747.981
+
+#: 归一化时间单位 TU（秒）。
+TU_S: float = 375699.843898365
+
+#: 归一化速度单位 VU（km/s），由 LU_KM / TU_S 推导。
+VU_KMS: float = LU_KM / TU_S
+
+#: 地月质量比 mu = mu_m / (mu_e + mu_m)，qiao 约定值。
+MU: float = 1.215058560962404e-2
+
+#: 归一化地球引力常数（无量纲，总质量归一）。
+MU_E: float = 0.987849414390376
+
+#: 归一化月球引力常数（无量纲）。
+MU_M: float = 0.012150585609624
+
+#: 归一化太阳引力常数（无量纲）。
+MU_S: float = 328900.5614000000
+
+#: qiao 流水线使用的基础频率 omega_1..omega_4（TU^-1），针对地月系统。
+BASE_FREQUENCIES: tuple[float, ...] = (
+    0.99154828857,
+    0.07480066375,
+    0.92519871658,
+    1.00402177967,
+)
+
+#: 共线平动点 L1/L2/L3 的 γ 值（qiao Calc_LPstate.py 中固化）。
+#: 物理含义：r_LP = (1 ± γ) * R_EM (L1/L2) 或 r_LP = -γ * R_EM (L3)，
+#: 其中 γ 在 CR3BP 无量纲坐标下表示平动点距最近大天体的归一化距离。
+_COLLINEAR_GAMMAS: dict[LibrationPoint, float] = {
+    LibrationPoint.L1: 0.150934288618019,
+    LibrationPoint.L2: 0.167832751054508,
+    LibrationPoint.L3: 0.992912060200654,
+}
+
+#: qiao 中心流形频率与特征指数（按平动点分别给出）。
+#: 对共线点 (L1/L2/L3) 分别对应 (nu1, nu2, lambda)；三角点 (L4/L5) 在
+#: 严格 CR3BP 下 lambda≈0，但 qiao 在太阳扰动下给出微小正值。
+_CENTRAL_PARAMS: dict[LibrationPoint, tuple[float, float, float]] = {
+    LibrationPoint.L1: (2.33774371420711, 2.27427342163957, 2.93924602471),
+    LibrationPoint.L2: (1.86464967793235, 1.79093984309149, 2.16475967850),
+    LibrationPoint.L3: (1.00308425804420, 1.00934753444748, 0.17970712561),
+    LibrationPoint.L4: (0.30259440630339, 1.00408270193080, 0.01416193941),
+    LibrationPoint.L5: (0.30251624161526, 1.00403245203481, 0.01381362875),
+}
+
+
+# ---------------------------------------------------------------------------
+# 历元与时间辅助
+# ---------------------------------------------------------------------------
+
+
+def jday(yr: int, mon: int, day: int, hr: int = 0, minute: int = 0, sec: float = 0.0) -> float:
+    """公历日期 → 儒略日（Vallado 算法）。
+
+    Args:
+        yr: 年（1900–2100）。
+        mon: 月（1–12）。
+        day: 日（1–31）。
+        hr: 时（0–23）。
+        minute: 分（0–59）。
+        sec: 秒（0.0–59.999）。
+
+    Returns:
+        对应时刻的儒略日（浮点数）。
+    """
+    jd = (
+        367.0 * yr
+        - np.floor(7.0 * (yr + np.floor((mon + 9.0) / 12.0)) * 0.25)
+        + np.floor(275.0 * mon / 9.0)
+        + day
+        + 1721013.5
+    )
+    jdfrac = (sec + minute * 60.0 + hr * 3600.0) / 86400.0
+    if jdfrac > 1.0:
+        jd += np.floor(jdfrac)
+        jdfrac -= np.floor(jdfrac)
+    return float(jd + jdfrac)
+
+
+#: 参考历元 J2000.0 的儒略日（2000-01-01 12:00:00）。
+JD0_J2000: float = jday(2000, 1, 1, 12, 0, 0)
+
+
+# ---------------------------------------------------------------------------
+# 平动点几何
+# ---------------------------------------------------------------------------
+
+
+def compute_libration_position(
+    point: LibrationPoint,
+    mu: float,
+    gamma: float | None = None,
+) -> npt.NDArray[np.floating]:
+    """计算无量纲会合系下平动点位置。
+
+    对共线点 (L1/L2/L3)，qiao 使用固化 γ 值；如 ``gamma`` 为 ``None`` 则
+    退回到 ``fsolve`` 求解与 e2m2e 内部 ``CR3BP_System.compute_libration_points``
+    一致的非线性方程。三角点 (L4/L5) 给出解析精确位置，与 γ 无关。
+
+    Args:
+        point: 平动点枚举。
+        mu: 系统质量比。
+        gamma: 共线点的 γ 值；为 ``None`` 时自动求解。
+
+    Returns:
+        形状 ``(3,)`` 的无量纲会合系坐标 ``[x, y, z]``。
+    """
+    from scipy.optimize import fsolve  # 惰性导入以保持模块轻量
+
+    if point in (LibrationPoint.L4, LibrationPoint.L5):
+        y = np.sqrt(3.0) / 2.0
+        sign = 1.0 if point is LibrationPoint.L4 else -1.0
+        return np.array([0.5 - mu, sign * y, 0.0], dtype=float)
+
+    if gamma is None:
+        if point is LibrationPoint.L1:
+
+            def f(x: float) -> float:
+                return x - (1 - mu) / (x + mu) ** 2 + mu / (x - 1 + mu) ** 2
+
+            x0 = 1 - mu ** (1.0 / 3.0)
+        elif point is LibrationPoint.L2:
+
+            def f(x: float) -> float:
+                return x - (1 - mu) / (x + mu) ** 2 - mu / (x - 1 + mu) ** 2
+
+            x0 = 1 + mu ** (1.0 / 3.0)
+        else:  # L3
+
+            def f(x: float) -> float:
+                return x + (1 - mu) / (x + mu) ** 2 + mu / (x - 1 + mu) ** 2
+
+            x0 = -1 - (5.0 / 12.0) * mu
+        x_lp = float(fsolve(f, x0)[0])
+        return np.array([x_lp, 0.0, 0.0], dtype=float)
+
+    if point is LibrationPoint.L1:
+        return np.array([1.0 - gamma, 0.0, 0.0], dtype=float)
+    if point is LibrationPoint.L2:
+        return np.array([1.0 + gamma, 0.0, 0.0], dtype=float)
+    # L3
+    return np.array([-gamma, 0.0, 0.0], dtype=float)
+
+
+def libration_gamma(point: LibrationPoint) -> float:
+    """返回共线平动点的 qiao 固化 γ 值。
+
+    Args:
+        point: 必须是 ``LibrationPoint.L1``/``L2``/``L3`` 之一。
+
+    Raises:
+        ValueError: ``point`` 不是共线平动点。
+    """
+    try:
+        return _COLLINEAR_GAMMAS[point]
+    except KeyError as exc:
+        raise ValueError(f"γ 仅对共线平动点 (L1/L2/L3) 有定义，得到 {point!r}") from exc
+
+
+def central_frequencies(
+    point: LibrationPoint,
+) -> tuple[float, float]:
+    """返回 qiao 中心流形频率 ``(nu1, nu2)``。
+
+    Args:
+        point: 平动点枚举。
+    """
+    nu1, nu2, _ = _CENTRAL_PARAMS[point]
+    return nu1, nu2
+
+
+def characteristic_exponent(point: LibrationPoint) -> float:
+    """返回 qiao 特征指数 λ。
+
+    Args:
+        point: 平动点枚举。
+    """
+    _, _, lam = _CENTRAL_PARAMS[point]
+    return lam

--- a/e2m2e/algorithms/normal_form/context.py
+++ b/e2m2e/algorithms/normal_form/context.py
@@ -1,0 +1,215 @@
+"""法型化上下文对象 ``NormalFormContext``。
+
+集中存放一条法型化流水线所需的全部静态/派生数据：
+归一化常量、平动点几何、基础频率、中心流形频率、特征指数、用户传入的
+历元与展开阶数。本切片只交付构造与读取；后续切片在该对象上调用具体
+化简器（DynamicalSubstituteCorrector、QuasiFloquetReducer 等）。
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import numpy.typing as npt
+
+from e2m2e.core import LibrationPoint, System
+
+from .constants import (
+    BASE_FREQUENCIES,
+    JD0_J2000,
+    LU_KM,
+    MU,
+    MU_E,
+    MU_M,
+    MU_S,
+    TU_S,
+    central_frequencies,
+    characteristic_exponent,
+    compute_libration_position,
+    libration_gamma,
+)
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+
+class NormalFormContext:
+    """法型化流水线上下文。
+
+    构造时由 ``System`` 提供质量比与归一化尺度（若有），并由 ``LibrationPoint``
+    选择平动点；其余 qiao 归一化常量（LU、TU、mu_e/m/s、JD0、基础频率等）
+    采用固化值，与 qiao ``Global_File.py`` 保持一致。
+
+    Attributes:
+        system: 关联的 e2m2e ``System``（一般 ``CR3BP_System``）。
+        libration_point: 选定平动点。
+        epoch: 参考历元儒略日。
+        order: 法型展开阶数。
+        LU: 归一化长度（km）。
+        TU: 归一化时间（s）。
+        VU: 归一化速度（km/s），由 ``LU/TU`` 推导。
+        mu: 系统质量比。
+        mu_e: 归一化地球引力常数（无量纲）。
+        mu_m: 归一化月球引力常数（无量纲）。
+        mu_s: 归一化太阳引力常数（无量纲）。
+        jd0: 参考历元儒略日。
+        libration_position: 平动点在无量纲会合系下的 ``(3,)`` 坐标。
+        gamma: 共线平动点的 γ 值；L4/L5 为 ``None``。
+        base_frequencies: 基础频率 ``(omega_1, ..., omega_4)``。
+        central_frequencies: 中心流形频率 ``(nu_1, nu_2)``。
+        characteristic_exponent: 特征指数 λ。
+    """
+
+    def __init__(
+        self,
+        system: System,
+        libration_point: LibrationPoint,
+        epoch: float | datetime,
+        order: int,
+        *,
+        LU: float | None = None,
+        TU: float | None = None,
+        mu: float | None = None,
+        mu_e: float | None = None,
+        mu_m: float | None = None,
+        mu_s: float | None = None,
+    ) -> None:
+        """构造上下文。
+
+        Args:
+            system: 关联 ``System``。``CR3BP_System`` 提供 ``mu``；
+                其他系统如不显式传入 ``mu`` 参数则取 ``0.0``。
+            libration_point: 平动点枚举（L1–L5）。
+            epoch: 历元，可为儒略日 ``float`` 或 ``datetime``。
+            order: 法型展开阶数，必须为正整数。
+            LU: 覆盖默认 LU（km）。仅供测试/非地月系统使用。
+            TU: 覆盖默认 TU（s）。仅供测试/非地月系统使用。
+            mu: 覆盖系统/默认质量比。
+            mu_e: 覆盖默认地球引力常数。
+            mu_m: 覆盖默认月球引力常数。
+            mu_s: 覆盖默认太阳引力常数。
+
+        Raises:
+            ValueError: ``order`` 非正整数；``libration_point`` 非法。
+        """
+        if not isinstance(order, int) or order <= 0:
+            raise ValueError(f"order 必须为正整数，得到 {order!r}")
+
+        # 历元归一化为儒略日 float
+        if hasattr(epoch, "timestamp"):  # datetime 兼容
+            # datetime.timestamp 使用 POSIX 历元；转儒略日需 +2440587.5
+            epoch_jd: float = float(epoch.timestamp()) / 86400.0 + 2440587.5
+        else:
+            epoch_jd = float(epoch)
+
+        self.system: System = system
+        self.libration_point: LibrationPoint = librationPoint_normalize(libration_point)
+        self.epoch: float = epoch_jd
+        self.order: int = order
+
+        # 归一化常量（默认取 qiao 值；显式覆盖优先）
+        self.LU: float = float(LU) if LU is not None else LU_KM
+        self.TU: float = float(TU) if TU is not None else TU_S
+        self.VU: float = self.LU / self.TU
+
+        if mu is not None:
+            self.mu: float = float(mu)
+        else:
+            self.mu = _system_mu(system, fallback=MU)
+
+        self.mu_e: float = float(mu_e) if mu_e is not None else MU_E
+        self.mu_m: float = float(mu_m) if mu_m is not None else MU_M
+        self.mu_s: float = float(mu_s) if mu_s is not None else MU_S
+        self.jd0: float = JD0_J2000
+
+        # 平动点几何
+        if self.libration_point in (LibrationPoint.L4, LibrationPoint.L5):
+            self.gamma: float | None = None
+        else:
+            self.gamma = libration_gamma(self.libration_point)
+        self.libration_position: npt.NDArray[np.floating] = compute_libration_position(
+            self.libration_point, self.mu, gamma=self.gamma
+        )
+
+        # 频率体系
+        self.base_frequencies: npt.NDArray[np.floating] = np.array(
+            BASE_FREQUENCIES, dtype=float
+        )
+        nu1, nu2 = central_frequencies(self.libration_point)
+        self.central_frequencies: tuple[float, float] = (nu1, nu2)
+        self.characteristic_exponent: float = characteristic_exponent(self.libration_point)
+
+    # ------------------------------------------------------------------
+    # 时间转换
+    # ------------------------------------------------------------------
+
+    def seconds_to_tu(self, t_seconds: float) -> float:
+        """SI 秒 → 归一化 TU。"""
+        return float(t_seconds) / self.TU
+
+    def tu_to_seconds(self, t_tu: float) -> float:
+        """归一化 TU → SI 秒。"""
+        return float(t_tu) * self.TU
+
+    # ------------------------------------------------------------------
+    # 表示
+    # ------------------------------------------------------------------
+
+    def __repr__(self) -> str:
+        return (
+            f"NormalFormContext(point={self.libration_point.name}, order={self.order}, "
+            f"mu={self.mu:.6e}, LU={self.LU:.3f} km, TU={self.TU:.3f} s, "
+            f"lambda={self.characteristic_exponent:.6f})"
+        )
+
+    def __str__(self) -> str:
+        return (
+            f"NormalFormContext[{self.libration_point.name}, order={self.order}, "
+            f"LU={self.LU:.3f} km, TU={self.TU:.3f} s]"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 辅助函数
+# ---------------------------------------------------------------------------
+
+
+def _system_mu(system: System, fallback: float) -> float:
+    """从 System 提取质量比。
+
+    CR3BP_System 暴露 ``mu`` 属性；其他系统若未实现则回退到 ``fallback``。
+    """
+    mu = getattr(system, "mu", None)
+    if isinstance(mu, (int, float)) and float(mu) > 0:
+        return float(mu)
+    return float(fallback)
+
+
+def librationPoint_normalize(point: LibrationPoint | int | str) -> LibrationPoint:
+    """把 ``int``/``str`` 形式的平动点规范化为 ``LibrationPoint`` 枚举。
+
+    Args:
+        point: 平动点，可为枚举、1–5 整数或 ``"L1"``–``"L5"`` 字符串。
+
+    Returns:
+        对应 ``LibrationPoint`` 枚举值。
+
+    Raises:
+        ValueError: 无法识别。
+    """
+    if isinstance(point, LibrationPoint):
+        return point
+    if isinstance(point, int):
+        for lp in LibrationPoint:
+            if lp.value == point:
+                return lp
+    if isinstance(point, str):
+        try:
+            return LibrationPoint[point.upper()]
+        except KeyError:
+            pass
+    raise ValueError(f"无法识别的平动点: {point!r}")
+
+
+__all__ = ["NormalFormContext"]

--- a/e2m2e/algorithms/normal_form/context.py
+++ b/e2m2e/algorithms/normal_form/context.py
@@ -133,9 +133,7 @@ class NormalFormContext:
         )
 
         # 频率体系
-        self.base_frequencies: npt.NDArray[np.floating] = np.array(
-            BASE_FREQUENCIES, dtype=float
-        )
+        self.base_frequencies: npt.NDArray[np.floating] = np.array(BASE_FREQUENCIES, dtype=float)
         nu1, nu2 = central_frequencies(self.libration_point)
         self.central_frequencies: tuple[float, float] = (nu1, nu2)
         self.characteristic_exponent: float = characteristic_exponent(self.libration_point)

--- a/e2m2e/algorithms/normal_form/coord_trans/__init__.py
+++ b/e2m2e/algorithms/normal_form/coord_trans/__init__.py
@@ -1,0 +1,201 @@
+"""函数式坐标变换链：``rho ↔ EM ↔ DS ↔ QF ↔ CM ↔ param``。
+
+本子包把 qiao ``rho2param`` / ``param2rho`` 的完整变换链拆成 5 段函数式
+接口（对应 qiao ``Subfunction/coord_trans/`` 各子模块），并在本
+``__init__`` 里组合成端到端的 ``rho_to_param`` / ``param_to_rho``。
+
+变换链（全部无量纲，qiao 归一化单位）：
+
+    rho → EM → DS → QF → CM → param
+
+- **rho ↔ EM** (:mod:`.rho_em`)：纯动量耦合 ``p = ρ̇ − Cdot_dimᵀ·C·ρ``；
+- **EM ↔ DS** (:mod:`.em_ds`)：平移 ``W(t) = [A, B]``（动力学替代）；
+- **DS ↔ QF** (:mod:`.ds_qf`)：矩阵变换 ``X_QF = B(t)⁻¹·X_DS``；
+- **QF ↔ CM** (:mod:`.qf_cm`)：高阶 Lie 级数（生成函数 ``W_series``）；
+- **CM ↔ param** (:mod:`.cm_param`)：复→极坐标（作用量-角变量）。
+
+端到端链式函数 :func:`rho_to_param` / :func:`param_to_rho` 依赖三个预计算
+结果句柄（切片 #171–#173 交付）：
+
+- :class:`~e2m2e.algorithms.normal_form.dynamical_substitution.DynamicalSubstituteResult`
+  提供 ``W_poly``（DS 平移，``{pow: coef_array}``）；
+- :class:`~e2m2e.algorithms.normal_form.quasi_floquet.QuasiFloquetResult`
+  提供 ``B_at(t)``（QF 矩阵插值访问器）；
+- :class:`~e2m2e.algorithms.normal_form.center_manifold.CenterManifoldResult`
+  提供 ``W_series``（CM 高阶 Lie 级数，``{step: {order: {pow: coef_array}}}``）。
+
+调用方负责把这三个结果聚合（:class:`~e2m2e.algorithms.normal_form.catalog.LibrationCatalogData`
+是开箱即用的聚合器）；本模块只做纯函数，不在内部缓存。
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import numpy.typing as npt
+
+from .cm_param import cm_to_param, param_to_cm
+from .ds_qf import ds_to_qf, qf_to_ds
+from .em_ds import _interp_W_at, ds_to_em, em_to_ds
+from .qf_cm import cm_to_qf, qf_to_cm
+from .rho_em import em_to_rho, rho_to_em
+
+if TYPE_CHECKING:
+    from ..center_manifold import CenterManifoldResult
+    from ..context import NormalFormContext
+    from ..dynamical_substitution import DynamicalSubstituteResult
+    from ..quasi_floquet import QuasiFloquetResult
+
+__all__ = [
+    # 端到端链
+    "rho_to_param",
+    "param_to_rho",
+    # 叶子函数（供单段测试 / 高级用法）
+    "rho_to_em",
+    "em_to_rho",
+    "em_to_ds",
+    "ds_to_em",
+    "ds_to_qf",
+    "qf_to_ds",
+    "qf_to_cm",
+    "cm_to_qf",
+    "cm_to_param",
+    "param_to_cm",
+]
+
+
+# ---------------------------------------------------------------------------
+# 内部：在时刻 t 聚合 W_series（跨 invariant/center 两步合并）
+# ---------------------------------------------------------------------------
+
+
+def _interp_W_series_at_t(
+    cm_result: CenterManifoldResult,
+    qf_result: QuasiFloquetResult,
+    t: float,
+) -> dict[int, dict[tuple[int, ...], complex]]:
+    """把 ``CenterManifoldResult.W_series`` 在时刻 ``t`` 插值为标量系数。
+
+    ``W_series`` 结构 ``{step: {order: {pow: coef_array}}}``；本函数把
+    ``invariant`` / ``center`` 两步的 ``W`` 合并到统一的 ``{order: {pow:
+    complex_scalar}}`` 表。两步的阶域一般不重叠（``invariant`` 处理双曲
+    交叉项、``center`` 处理中心耦合），合并等价于 qiao 单 ``W_series``
+    逐阶应用。系数按 qiao ``rho2param`` 的 ``preinterp_coeffs`` 格式
+    （``vr + 1j·vi``）取复值。
+
+    时间网格取 ``qf_result.tlist``：``CenterManifoldReducer.reduce`` 用
+    ``qf_result.tlist`` 作时间轴生成 W_series 系数数组（数组长度 =
+    ``qf_result.tlist.size``），但 :class:`CenterManifoldResult` 本身不
+    存 tlist，故插值网格须由调用方从配套的 ``qf_result`` 传入。这正是
+    端到端 :func:`rho_to_param` / :func:`param_to_rho` 同时持有
+    ``qf_result`` 与 ``cm_result`` 的原因。
+    """
+    t_arr = np.asarray(qf_result.tlist, dtype=float).ravel()
+    out: dict[int, dict[tuple[int, ...], complex]] = {}
+    for step_data in cm_result.W_series.values():
+        for order, poly in step_data.items():
+            if not poly:
+                continue
+            out.setdefault(order, {})
+            for pow_tuple, coef_arr in poly.items():
+                arr = np.asarray(coef_arr, dtype=complex).ravel()
+                if arr.size == 0:
+                    continue
+                if arr.size == 1:
+                    val = complex(arr[0])
+                else:
+                    # 线性插值实/虚部，网格用 qf_result.tlist
+                    re = float(np.interp(t, t_arr, arr.real))
+                    im = float(np.interp(t, t_arr, arr.imag))
+                    val = complex(re, im)
+                # 两步同阶/同幂合并（理论上不重叠；累加兜底）
+                out[order][pow_tuple] = out[order].get(pow_tuple, 0.0 + 0.0j) + val
+    return out
+
+
+# ---------------------------------------------------------------------------
+# 端到端链式组合
+# ---------------------------------------------------------------------------
+
+
+def rho_to_param(
+    X_rho: npt.ArrayLike,
+    t: float,
+    context: NormalFormContext,
+    ds_result: DynamicalSubstituteResult,
+    qf_result: QuasiFloquetResult,
+    cm_result: CenterManifoldResult,
+) -> npt.NDArray[np.floating]:
+    """完整逆链 ``rho → EM → DS → QF → CM → param``。
+
+    对应 qiao ``rho2param``。输入 rho 坐标状态，输出表征参数
+    ``[q1, p1, I2, θ2, I3, θ3]``。
+
+    Args:
+        X_rho: ``(6,)`` rho 状态 ``[ρ, ρ̇]``，无量纲。
+        t: 归一化时间 TU。
+        context: 归一化上下文（提供 LU/TU/平动点/历元）。
+        ds_result: 动力学替代结果（提供 ``W_poly`` 与 ``tlist``）。
+        qf_result: quasi-Floquet 结果（提供 ``B_at(t)``）。
+        cm_result: 中心流形化简结果（提供 ``W_series``）。
+
+    Returns:
+        ``(6,)`` 表征参数 ``[q1, p1, I2, θ2, I3, θ3]``，无量纲。
+    """
+    # rho → EM
+    X_em = rho_to_em(X_rho, t, context)
+    # EM → DS
+    W_at_t = _interp_W_at(
+        ds_result.W_poly, np.asarray(ds_result.tlist, dtype=float).ravel(), t
+    )
+    X_ds = em_to_ds(X_em, W_at_t)
+    # DS → QF
+    B_at_t = qf_result.B(t)
+    X_qf = ds_to_qf(X_ds, B_at_t)
+    # QF → CM
+    W_series_at_t = _interp_W_series_at_t(cm_result, qf_result, t)
+    X_cm = qf_to_cm(X_qf, W_series_at_t)
+    # CM → param
+    return cm_to_param(X_cm)
+
+
+def param_to_rho(
+    X_param: npt.ArrayLike,
+    t: float,
+    context: NormalFormContext,
+    ds_result: DynamicalSubstituteResult,
+    qf_result: QuasiFloquetResult,
+    cm_result: CenterManifoldResult,
+) -> npt.NDArray[np.floating]:
+    """完整正链 ``param → CM → QF → DS → EM → rho``。
+
+    对应 qiao ``param2rho``。输入表征参数，输出 rho 坐标状态。
+    是 :func:`rho_to_param` 的精确逆。
+
+    Args:
+        X_param: ``(6,)`` 表征参数 ``[q1, p1, I2, θ2, I3, θ3]``，无量纲。
+        t: 归一化时间 TU。
+        context: 归一化上下文。
+        ds_result: 动力学替代结果。
+        qf_result: quasi-Floquet 结果。
+        cm_result: 中心流形化简结果。
+
+    Returns:
+        ``(6,)`` rho 状态 ``[ρ, ρ̇]``，无量纲。
+    """
+    # param → CM
+    X_cm = param_to_cm(X_param)
+    # CM → QF
+    W_series_at_t = _interp_W_series_at_t(cm_result, qf_result, t)
+    X_qf = cm_to_qf(X_cm, W_series_at_t)
+    # QF → DS
+    B_at_t = qf_result.B(t)
+    X_ds = qf_to_ds(X_qf, B_at_t)
+    # DS → EM
+    W_at_t = _interp_W_at(
+        ds_result.W_poly, np.asarray(ds_result.tlist, dtype=float).ravel(), t
+    )
+    X_em = ds_to_em(X_ds, W_at_t)
+    # EM → rho
+    return em_to_rho(X_em, t, context)

--- a/e2m2e/algorithms/normal_form/coord_trans/__init__.py
+++ b/e2m2e/algorithms/normal_form/coord_trans/__init__.py
@@ -146,9 +146,7 @@ def rho_to_param(
     # rho → EM
     X_em = rho_to_em(X_rho, t, context)
     # EM → DS
-    W_at_t = _interp_W_at(
-        ds_result.W_poly, np.asarray(ds_result.tlist, dtype=float).ravel(), t
-    )
+    W_at_t = _interp_W_at(ds_result.W_poly, np.asarray(ds_result.tlist, dtype=float).ravel(), t)
     X_ds = em_to_ds(X_em, W_at_t)
     # DS → QF
     B_at_t = qf_result.B(t)
@@ -193,9 +191,7 @@ def param_to_rho(
     B_at_t = qf_result.B(t)
     X_ds = qf_to_ds(X_qf, B_at_t)
     # DS → EM
-    W_at_t = _interp_W_at(
-        ds_result.W_poly, np.asarray(ds_result.tlist, dtype=float).ravel(), t
-    )
+    W_at_t = _interp_W_at(ds_result.W_poly, np.asarray(ds_result.tlist, dtype=float).ravel(), t)
     X_em = ds_to_em(X_ds, W_at_t)
     # EM → rho
     return em_to_rho(X_em, t, context)

--- a/e2m2e/algorithms/normal_form/coord_trans/cm_param.py
+++ b/e2m2e/algorithms/normal_form/coord_trans/cm_param.py
@@ -1,0 +1,89 @@
+"""CM ↔ param：中心流形坐标 ↔ 表征参数（复→极坐标，作用量-角变量）。
+
+迁移自 qiao ``Subfunction/coord_trans/param2ActionAngle.py``（仅
+方向：CM → 作用量-角变量）+ 本仓库补齐的逆变换。对应变换链的最后一段：
+把中心流形坐标 ``(q1, q2, q3, p1, p2, p3)`` 转成表征参数
+``(q1, p1, I2, θ2, I3, θ3)``。
+
+数学关系（PRD ``docs/plans/normal-form-prd.md``）：
+
+- **双曲方向** ``(q1, p1)`` 保持原状——双曲方向不是循环坐标，无作用量-
+  角变量表示，表征参数里直接用 ``(q1, p1)`` 携带；
+- **平面中心方向** ``(q2, p2)``：``I2 = (q2² + p2²)/2``，
+  ``θ2 = atan2(p2, q2)``；
+- **垂直中心方向** ``(q3, p3)``：``I3 = (q3² + p3²)/2``，
+  ``θ3 = atan2(p3, q3)``。
+
+逆变换用 ``q = √(2I)·cos θ``、``p = √(2I)·sin θ`` 还原中心对。
+
+约定说明：
+
+- qiao ``param2ActionAngle`` 用 ``atan2(q2, p2)``（参数交换），本仓库
+  按 PRD 显式约定 ``atan2(p2, q2)``——二者互为 ``π/2 − θ`` 的镜像，但
+  只要往返变换内部自洽（``θ2`` 算出来再用同公式反解），往返误差仍为
+  机器精度。本模块在 docstring/常量上显式标注约定，避免与 qiao 混淆。
+- 角变量 ``θ`` 不做 ``% 2π`` 折回：表征参数保留原始连续角，往返时
+  ``atan2`` 的主值分支自动与 ``cos/sin`` 配对，无需手动折回。若调用方
+  需要折回，可对返回值自行 ``% (2π)``。
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+
+
+def cm_to_param(X_cm: npt.ArrayLike) -> npt.NDArray[np.floating]:
+    """中心流形坐标 → 表征参数 (复→极坐标)。
+
+    ``X_cm = [q1, q2, q3, p1, p2, p3]`` →
+    ``X_param = [q1, p1, I2, θ2, I3, θ3]``。
+
+    Args:
+        X_cm: ``(6,)`` CM 状态 ``[q1, q2, q3, p1, p2, p3]``，无量纲实数。
+
+    Returns:
+        ``(6,)`` 表征参数 ``[q1, p1, I2, θ2, I3, θ3]``，无量纲。
+    """
+    X = np.asarray(X_cm, dtype=float).ravel()
+    if X.shape != (6,):
+        raise ValueError(f"X_cm 必须是 (6,)，得到 {X.shape}")
+    q1, q2, q3 = X[0], X[1], X[2]
+    p1, p2, p3 = X[3], X[4], X[5]
+    I2 = 0.5 * (q2 * q2 + p2 * p2)
+    theta2 = np.arctan2(p2, q2)
+    I3 = 0.5 * (q3 * q3 + p3 * p3)
+    theta3 = np.arctan2(p3, q3)
+    return np.array([q1, p1, I2, theta2, I3, theta3], dtype=float)
+
+
+def param_to_cm(X_param: npt.ArrayLike) -> npt.NDArray[np.floating]:
+    """表征参数 → 中心流形坐标 (极→复坐标)。
+
+    ``X_param = [q1, p1, I2, θ2, I3, θ3]`` →
+    ``X_cm = [q1, q2, q3, p1, p2, p3]``。是 :func:`cm_to_param` 的精确逆。
+
+    中心对还原：``q = √(2I)·cos θ``、``p = √(2I)·sin θ``。
+
+    Args:
+        X_param: ``(6,)`` 表征参数 ``[q1, p1, I2, θ2, I3, θ3]``，无量纲。
+
+    Returns:
+        ``(6,)`` CM 状态 ``[q1, q2, q3, p1, p2, p3]``，无量纲。
+    """
+    X = np.asarray(X_param, dtype=float).ravel()
+    if X.shape != (6,):
+        raise ValueError(f"X_param 必须是 (6,)，得到 {X.shape}")
+    q1, p1 = X[0], X[1]
+    I2, theta2 = X[2], X[3]
+    I3, theta3 = X[4], X[5]
+    r2 = np.sqrt(2.0 * I2) if I2 > 0.0 else 0.0
+    r3 = np.sqrt(2.0 * I3) if I3 > 0.0 else 0.0
+    q2 = r2 * np.cos(theta2)
+    p2 = r2 * np.sin(theta2)
+    q3 = r3 * np.cos(theta3)
+    p3 = r3 * np.sin(theta3)
+    return np.array([q1, q2, q3, p1, p2, p3], dtype=float)
+
+
+__all__ = ["cm_to_param", "param_to_cm"]

--- a/e2m2e/algorithms/normal_form/coord_trans/ds_qf.py
+++ b/e2m2e/algorithms/normal_form/coord_trans/ds_qf.py
@@ -1,0 +1,78 @@
+"""DS ↔ QF：动力学替代坐标 ↔ quasi-Floquet 坐标。
+
+迁移自 qiao ``Subfunction/coord_trans/qpDS2qpQF.py`` /
+``qpQF2qpDS.py``。对应变换链第三段：DS 坐标与 quasi-Floquet 坐标
+之间的**矩阵变换**。
+
+数学关系（qiao ``CONTEXT.md`` §三"quasi-Floquet 变换"）：
+
+    X_QF = B(t)⁻¹ · X_DS        （正向 DS → QF）
+    X_DS = B(t) · X_QF           （反向 QF → DS）
+
+其中 ``B(t)`` 是切片 #172 求解的 quasi-Floquet 变换矩阵（6×6 辛矩阵），
+把受迫时变线性化系统化为常系数的 ``Ẏ = D·Y``。本段是纯线性变换，
+无量纲、无单位换算。
+
+与 qiao 的差异：
+
+- qiao 通过 ``get_QFmat(t, QFtrans_mat)`` 在 ``globalparam.data_array``
+  上插值 ``B(t)``；本仓库的 :class:`QuasiFloquetResult.B_at` 已提供线性
+  插值访问器，本模块直接接收插值后的 ``B_at_t``，把"何时插值"的决策
+  上浮到 :class:`LibrationCatalogTransformer`（与 EM/CM 段保持一致）。
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+
+
+def ds_to_qf(
+    X_ds: npt.ArrayLike,
+    B_at_t: npt.ArrayLike,
+) -> npt.NDArray[np.floating]:
+    """动力学替代坐标 → quasi-Floquet 坐标（矩阵变换）。
+
+    ``X_QF = B⁻¹ · X_DS``。对应 qiao ``qpDS2qpQF``。
+
+    Args:
+        X_ds: ``(6,)`` DS 状态 ``[Q, P]``，无量纲。
+        B_at_t: ``(6, 6)`` 在时刻 ``t`` 插值后的 quasi-Floquet 矩阵
+            ``B(t)``（辛）。
+
+    Returns:
+        ``(6,)`` QF 状态 ``[Q_qf, P_qf]``，无量纲。
+
+    Raises:
+        numpy.linalg.LinAlgError: ``B(t)`` 奇异。
+    """
+    X = np.asarray(X_ds, dtype=float).ravel()
+    B = np.asarray(B_at_t, dtype=float)
+    X_qf = np.linalg.solve(B, X)
+    return X_qf
+
+
+def qf_to_ds(
+    X_qf: npt.ArrayLike,
+    B_at_t: npt.ArrayLike,
+) -> npt.NDArray[np.floating]:
+    """quasi-Floquet 坐标 → 动力学替代坐标（矩阵变换）。
+
+    ``X_DS = B · X_QF``。对应 qiao ``qpQF2qpDS``。是 :func:`ds_to_qf`
+    的精确逆。
+
+    Args:
+        X_qf: ``(6,)`` QF 状态 ``[Q_qf, P_qf]``，无量纲。
+        B_at_t: ``(6, 6)`` 在时刻 ``t`` 插值后的 quasi-Floquet 矩阵
+            ``B(t)``（辛）。
+
+    Returns:
+        ``(6,)`` DS 状态 ``[Q, P]``，无量纲。
+    """
+    X = np.asarray(X_qf, dtype=float).ravel()
+    B = np.asarray(B_at_t, dtype=float)
+    X_ds = B @ X
+    return X_ds
+
+
+__all__ = ["ds_to_qf", "qf_to_ds"]

--- a/e2m2e/algorithms/normal_form/coord_trans/em_ds.py
+++ b/e2m2e/algorithms/normal_form/coord_trans/em_ds.py
@@ -1,0 +1,129 @@
+"""EM ↔ DS：星历模型 Hamilton 坐标 ↔ 动力学替代坐标。
+
+迁移自 qiao ``Subfunction/coord_trans/qpDS2qpEM.py`` /
+``qpEM2qpDS.py``。对应变换链第二段：EM 坐标 ``(q, p)`` 与动力学
+替代坐标 ``(Q, P)`` 之间的**平移**关系。
+
+数学关系（qiao ``CONTEXT.md`` §三"动态替换"）：
+
+    DS = W(t)        （生成函数，6 维 ``[A, B]`` 时间序列）
+    A = DS[:3]
+    B = DS[3:]
+    q = Q + B        （正向 EM = DS + W 平移）
+    p = P − A
+    Q = q − B        （反向 DS = EM − W 平移）
+    P = p + A
+
+即 DS 是 EM 减去替代轨道的平移 ``W(t) = [A(t), B(t)]``——把坐标原点从
+平动点挪到动力学替代轨道上。本段是纯仿射变换，无量纲、无单位换算。
+
+与 qiao 的差异：
+
+- qiao 通过 ``list_interp`` 在全局 ``data_array`` 上 Catmull-Rom 插值
+  ``W_poly``；本仓库的 ``DynamicalSubstituteResult`` 已在每个采样点上
+  存好 ``W_poly``（``{pow_tuple: coef_array}``，6 个线性项），这里只做
+  **线性插值**到时刻 ``t`` 即可（与 :class:`QuasiFloquetResult.B_at` 的
+  策略一致）。Catmull-Rom 在等距光滑数据上与线性插值差别极小，且
+  本仓库不引入 qiao 的二进制系数表。
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+
+#: 6 个线性幂次，对应 ``W_poly`` 的键序（与 ``dynamical_substitution`` 一致）。
+_LINEAR_POWS: tuple[tuple[int, ...], ...] = (
+    (1, 0, 0, 0, 0, 0),
+    (0, 1, 0, 0, 0, 0),
+    (0, 0, 1, 0, 0, 0),
+    (0, 0, 0, 1, 0, 0),
+    (0, 0, 0, 0, 1, 0),
+    (0, 0, 0, 0, 0, 1),
+)
+
+
+def _interp_W_at(
+    W_poly: dict[tuple[int, ...], npt.NDArray[np.floating]],
+    tlist: npt.NDArray[np.floating],
+    t: float,
+) -> npt.NDArray[np.floating]:
+    """在时刻 ``t`` 线性插值 ``W_poly`` 的 6 个线性项 → ``(6,)`` 平移向量。
+
+    ``W_poly`` 是 ``DynamicalSubstituteResult.W_poly``：键为 6 个线性
+    幂次元组，值为与 ``tlist`` 等长的系数时间序列。缺失键按 0 处理。
+    """
+    t_arr = np.asarray(tlist, dtype=float).ravel()
+    out = np.zeros(6, dtype=float)
+    if t_arr.size == 0:
+        return out
+    for k, pow_tuple in enumerate(_LINEAR_POWS):
+        coef = W_poly.get(pow_tuple)
+        if coef is None:
+            continue
+        coef_arr = np.asarray(coef, dtype=float).ravel()
+        if coef_arr.size == 1:
+            out[k] = float(coef_arr[0])
+        elif coef_arr.size == t_arr.size:
+            out[k] = float(np.interp(t, t_arr, coef_arr))
+        else:
+            # 形状不一致：用第一个值兜底（不应在正常路径出现）
+            out[k] = float(coef_arr[0])
+    return out
+
+
+def em_to_ds(
+    X_em: npt.ArrayLike,
+    W_poly_at_t: npt.ArrayLike,
+) -> npt.NDArray[np.floating]:
+    """EM 坐标 → 动力学替代坐标（平移）。
+
+    ``Q = q − B``、``P = p + A``，其中 ``[A, B] = W(t)``。对应 qiao
+    ``qpEM2qpDS``。
+
+    Args:
+        X_em: ``(6,)`` EM 状态 ``[q, p]``，无量纲。
+        W_poly_at_t: ``(6,)`` 在时刻 ``t`` 插值后的 ``W(t) = [A, B]``。
+
+    Returns:
+        ``(6,)`` DS 状态 ``[Q, P]``，无量纲。
+    """
+    X = np.asarray(X_em, dtype=float).ravel()
+    W = np.asarray(W_poly_at_t, dtype=float).ravel()
+    A = W[:3]
+    B = W[3:]
+    q = X[:3]
+    p = X[3:]
+    Q = q - B
+    P = p + A
+    return np.concatenate([Q, P])
+
+
+def ds_to_em(
+    X_ds: npt.ArrayLike,
+    W_poly_at_t: npt.ArrayLike,
+) -> npt.NDArray[np.floating]:
+    """动力学替代坐标 → EM 坐标（平移）。
+
+    ``q = Q + B``、``p = P − A``，其中 ``[A, B] = W(t)``。对应 qiao
+    ``qpDS2qpEM``。是 :func:`em_to_ds` 的精确逆。
+
+    Args:
+        X_ds: ``(6,)`` DS 状态 ``[Q, P]``，无量纲。
+        W_poly_at_t: ``(6,)`` 在时刻 ``t`` 插值后的 ``W(t) = [A, B]``。
+
+    Returns:
+        ``(6,)`` EM 状态 ``[q, p]``，无量纲。
+    """
+    X = np.asarray(X_ds, dtype=float).ravel()
+    W = np.asarray(W_poly_at_t, dtype=float).ravel()
+    A = W[:3]
+    B = W[3:]
+    Q = X[:3]
+    P = X[3:]
+    q = Q + B
+    p = P - A
+    return np.concatenate([q, p])
+
+
+__all__ = ["ds_to_em", "em_to_ds"]

--- a/e2m2e/algorithms/normal_form/coord_trans/qf_cm.py
+++ b/e2m2e/algorithms/normal_form/coord_trans/qf_cm.py
@@ -1,0 +1,258 @@
+"""QF ↔ CM：quasi-Floquet 坐标 ↔ 中心流形坐标（高阶 Lie 级数）。
+
+迁移自 qiao ``Subfunction/coord_trans/qpQF2qpCM.py`` /
+``qpCM2qpQF.py``——变换链中最复杂的一段。对应切片 #173 中心流形化简
+（Code10/Code11）的**坐标层面**应用：把 quasi-Floquet 坐标通过生成函数
+``W`` 的高阶 Lie 级数映射到中心流形坐标。
+
+算法（qiao ``CONTEXT.md`` §三"化简到中心流形"）：
+
+1. **实→复基底变换** ``Re2Im``：用对角化矩阵 ``D⁻¹`` 把实 QF 坐标
+   ``(q, p)`` 映到复坐标。``D`` 把双曲/中心方向拆成纯实/复分量：
+   双曲方向 ``(q1, p1)`` 不变，平面/垂直中心方向
+   ``(q2, p2)``/``(q3, p3)`` 各组合成 ``±i`` 模式（``√2`` 归一）。
+2. **逐阶 Lie 流**：对每个阶 ``order ≥ 2``（qiao ``W_series{3..N}``），
+   用生成函数 ``W_order(q,p)`` 的 Hamilton 流
+   ``dX/dt = J·∇W_order`` 从 ``t=0`` 积到 ``t=1``（一步近恒等变换）。
+   正向（QF→CM）取 ``W`` 系数取反；反向（CM→QF）不取反、阶序倒序。
+3. **复→实基底变换** ``Im2Re``：用 ``D`` 映回实坐标，取实部。
+
+Hamilton 流的右端 ``dX/dt = J·∇W`` 用向量化实现
+（:func:`_hamilton_flow_rhs`），与 qiao ``_dynfunc_wtrans_vec`` 逐位一致；
+``0^0=1`` 边界用降幂写法（``qp^(n-1)``）天然正确，避免除法写法的
+``0/0=nan``。
+
+与 qiao 的差异：
+
+- qiao 在 ``globalparam.data_array`` 上对每个 ``W_series`` 系数做
+  Catmull-Rom 插值（``preinterp_coeffs`` 路径）；本仓库的
+  :class:`CenterManifoldResult.W_series` 已按 ``{step: {order: {pow:
+  coef_array}}}`` 组织，本模块接收**已插值为标量**的系数表
+  ``W_series_at_t``（``{order: {pow: complex_scalar}}``），把插值决策上浮
+  到 :class:`LibrationCatalogTransformer`。
+- qiao 依赖 ``globalparam.odeoptions``（``scipy.solve_ivp`` 选项）；本模块
+  显式传 ``DOP853`` 默认容差（``rtol=1e-11``、``atol=1e-13``），不引入
+  全局可变状态。
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+
+# ---------------------------------------------------------------------------
+# 实/复基底变换（迁移自 qiao _complex_basis.py / Re2Im.py / Im2Re.py）
+# ---------------------------------------------------------------------------
+
+# 6×6 复对角化矩阵 D（与 qiao _complex_basis._D 逐元素一致）。
+# 双曲方向 q1/p1（位 0/3）保持实；平面中心对 q2/p2（位 1/4）、垂直中心
+# 对 q3/p3（位 2/5）通过 (1/√2, ±i/√2) 组合拆成 ±i 模式。
+_D: npt.NDArray[np.complex128] = np.zeros((6, 6), dtype=complex)
+_D[0, 0] = 1.0
+_D[1, 1] = 1.0 / np.sqrt(2.0)
+_D[1, 4] = 1j / np.sqrt(2.0)
+_D[2, 2] = 1.0 / np.sqrt(2.0)
+_D[2, 5] = 1j / np.sqrt(2.0)
+_D[3, 3] = 1.0
+_D[4, 4] = 1.0 / np.sqrt(2.0)
+_D[4, 1] = 1j / np.sqrt(2.0)
+_D[5, 5] = 1.0 / np.sqrt(2.0)
+_D[5, 2] = 1j / np.sqrt(2.0)
+
+#: ``D`` 的逆（预计算，供 Re2Im 复用）。
+_D_INV: npt.NDArray[np.complex128] = np.linalg.inv(_D)
+
+
+def _re_to_im(X_real: npt.NDArray[np.floating]) -> npt.NDArray[np.complex128]:
+    """实数基 → 复数基：``X_im = D⁻¹ · X_real``（qiao ``Re2Im``）。"""
+    return _D_INV @ np.asarray(X_real, dtype=float)
+
+
+def _im_to_re(X_im: npt.NDArray[np.complex128]) -> npt.NDArray[np.floating]:
+    """复数基 → 实数基：``X_real = D · X_im``，取实部（qiao ``Im2Re``）。
+
+    合法输入下 ``D·X_im`` 应为实数；取实部丢弃数值虚部残余。
+    """
+    return np.real(_D @ np.asarray(X_im, dtype=complex))
+
+
+# ---------------------------------------------------------------------------
+# Hamilton 流右端 dX/dt = J·∇W（迁移自 qiao _dynfunc_wtrans_vec）
+# ---------------------------------------------------------------------------
+
+# J·∇W 结构：输出方向 out_j 由 (求导坐标 coord, 符号 sign) 决定。
+# dq_i/dt = +∂W/∂p_i（coord=3,4,5，符号 +1），
+# dp_i/dt = -∂W/∂q_i（coord=0,1,2，符号 -1）。
+_DERIV: tuple[tuple[int, float], ...] = (
+    (3, 1.0),
+    (4, 1.0),
+    (5, 1.0),
+    (0, -1.0),
+    (1, -1.0),
+    (2, -1.0),
+)
+_OTHERS: tuple[tuple[int, ...], ...] = tuple(
+    tuple(k for k in range(6) if k != c) for c, _ in _DERIV
+)
+
+
+def _pack_wpoly(
+    W_poly: dict[tuple[int, ...], complex],
+) -> tuple[npt.NDArray[np.int_], npt.NDArray[np.complex128]]:
+    """把 ``W`` 多项式字典 ``{pow_tuple: scalar}`` 打包成 ``(exps, coefs)``。
+
+    迁移自 qiao ``_pack_wpoly``。``exps`` 形状 ``(N, 6)``，``coefs`` 形状
+    ``(N,)``（复标量）。
+    """
+    if not W_poly:
+        return (
+            np.zeros((0, 6), dtype=int),
+            np.zeros(0, dtype=complex),
+        )
+    pows = list(W_poly.keys())
+    exps = np.array(pows, dtype=int).reshape(-1, 6)
+    coefs = np.array([W_poly[p] for p in pows], dtype=complex)
+    return exps, coefs
+
+
+def _hamilton_flow_rhs(
+    X: npt.NDArray[np.complex128],
+    exps: npt.NDArray[np.int_],
+    coefs: npt.NDArray[np.complex128],
+) -> npt.NDArray[np.complex128]:
+    """Hamilton 流右端 ``dX/dt = J·∇W(X)``，向量化。
+
+    迁移自 qiao ``_dynfunc_wtrans_vec``：降幂写法不做除法，在
+    ``qp_j=0, n_j=1`` 处 ``qp^(n-1)=0^0=1``（numpy 天然），与逐项版
+    整数幂语义逐位一致；除法写法会在该点产生 ``0/0=nan``。
+    """
+    B = X**exps  # (N, 6)，X^exp
+    dX = np.zeros(6, dtype=complex)
+    for out_j, (coord, sign) in enumerate(_DERIV):
+        e_col = exps[:, coord]
+        prod_excl = np.prod(B[:, _OTHERS[out_j]], axis=1)  # Π_{k≠coord} qp_k^n_k
+        qp_red = X[coord] ** np.maximum(e_col - 1, 0)  # qp_coord^(n_coord-1)
+        dX[out_j] = sign * (coefs * e_col * prod_excl * qp_red).sum()
+    return dX
+
+
+# ---------------------------------------------------------------------------
+# Lie 级数应用（逐阶 ODE 积分）
+# ---------------------------------------------------------------------------
+
+
+def _apply_lie_series(
+    X0: npt.NDArray[np.complex128],
+    W_series_at_t: dict[int, dict[tuple[int, ...], complex]],
+    *,
+    forward: bool,
+    rtol: float = 1e-11,
+    atol: float = 1e-13,
+) -> npt.NDArray[np.complex128]:
+    """逐阶应用 Hamilton 流 ``dX/dt = J·∇W_order``，从 ``t=0`` 积到 ``t=1``。
+
+    迁移自 qiao ``qpQF2qpCM`` / ``qpCM2qpQF`` 的逐阶循环：
+
+    - ``forward=True``（QF→CM）：``W`` 系数取反，阶序升序 ``2..N``；
+    - ``forward=False``（CM→QF）：``W`` 系数不取反，阶序降序 ``N..2``。
+
+    每阶一次 ``scipy.solve_ivp``（DOP853），末态作为下阶初值。
+
+    Args:
+        X0: ``(6,)`` 复初值。
+        W_series_at_t: ``{order: {pow_tuple: complex_scalar}}``，已插值。
+        forward: 方向标志（见上）。
+        rtol, atol: ODE 容差。
+
+    Returns:
+        ``(6,)`` 复终值。
+    """
+    from scipy.integrate import solve_ivp
+
+    orders = sorted(W_series_at_t.keys(), reverse=not forward)
+    X = np.array(X0, dtype=complex)
+    for order in orders:
+        if order < 2:  # qiao：Python key 2 = MATLAB W_series{3}（第一个非空阶）
+            continue
+        W_order = W_series_at_t[order]
+        if not W_order:
+            continue
+        if forward:
+            W_order = {k: -v for k, v in W_order.items()}  # 正向取反
+        exps, coefs = _pack_wpoly(W_order)
+        if coefs.size == 0:
+            continue
+
+        def rhs(_t, X_local, exps=exps, coefs=coefs):
+            return _hamilton_flow_rhs(
+                np.asarray(X_local, dtype=complex), exps, coefs
+            )
+
+        sol = solve_ivp(
+            rhs,
+            (0.0, 1.0),
+            X,
+            method="DOP853",
+            rtol=rtol,
+            atol=atol,
+        )
+        if not sol.success:
+            raise RuntimeError(
+                f"QF↔CM Lie 级数 ODE 积分失败（order={order}）：{sol.message}"
+            )
+        X = np.asarray(sol.y[:, -1], dtype=complex)
+    return X
+
+
+# ---------------------------------------------------------------------------
+# 公开变换
+# ---------------------------------------------------------------------------
+
+
+def qf_to_cm(
+    X_qf: npt.ArrayLike,
+    W_series_at_t: dict[int, dict[tuple[int, ...], complex]],
+) -> npt.NDArray[np.floating]:
+    """quasi-Floquet 坐标 → 中心流形坐标（高阶 Lie 级数）。
+
+    对应 qiao ``qpQF2qpCM``：实→复基底 → 逐阶 Lie 流（``W`` 取反、升序）
+    → 复→实基底。
+
+    Args:
+        X_qf: ``(6,)`` QF 状态 ``[Q_qf, P_qf]``，无量纲实数。
+        W_series_at_t: ``{order: {pow_tuple: complex_scalar}}``——在时刻
+            ``t`` 插值后的 :class:`CenterManifoldResult.W_series`（复值
+            系数，跨 ``invariant``/``center`` 两步合并）。
+
+    Returns:
+        ``(6,)`` CM 状态 ``[Q_cm, P_cm]``，无量纲实数。
+    """
+    X = np.asarray(X_qf, dtype=float).ravel()
+    X_im = _re_to_im(X)
+    X_im = _apply_lie_series(X_im, W_series_at_t, forward=True)
+    return _im_to_re(X_im)
+
+
+def cm_to_qf(
+    X_cm: npt.ArrayLike,
+    W_series_at_t: dict[int, dict[tuple[int, ...], complex]],
+) -> npt.NDArray[np.floating]:
+    """中心流形坐标 → quasi-Floquet 坐标（高阶 Lie 级数，反向）。
+
+    对应 qiao ``qpCM2qpQF``：实→复基底 → 逐阶 Lie 流（``W`` 不取反、
+    降序）→ 复→实基底。是 :func:`qf_to_cm` 的精确逆。
+
+    Args:
+        X_cm: ``(6,)`` CM 状态 ``[Q_cm, P_cm]``，无量纲实数。
+        W_series_at_t: 同 :func:`qf_to_cm`。
+
+    Returns:
+        ``(6,)`` QF 状态 ``[Q_qf, P_qf]``，无量纲实数。
+    """
+    X = np.asarray(X_cm, dtype=float).ravel()
+    X_im = _re_to_im(X)
+    X_im = _apply_lie_series(X_im, W_series_at_t, forward=False)
+    return _im_to_re(X_im)
+
+
+__all__ = ["cm_to_qf", "qf_to_cm"]

--- a/e2m2e/algorithms/normal_form/coord_trans/qf_cm.py
+++ b/e2m2e/algorithms/normal_form/coord_trans/qf_cm.py
@@ -37,6 +37,8 @@ Hamilton 流的右端 ``dX/dt = J·∇W`` 用向量化实现
 
 from __future__ import annotations
 
+from typing import cast
+
 import numpy as np
 import numpy.typing as npt
 
@@ -60,7 +62,7 @@ _D[5, 5] = 1.0 / np.sqrt(2.0)
 _D[5, 2] = 1j / np.sqrt(2.0)
 
 #: ``D`` 的逆（预计算，供 Re2Im 复用）。
-_D_INV: npt.NDArray[np.complex128] = np.linalg.inv(_D)
+_D_INV: npt.NDArray[np.complex128] = cast("npt.NDArray[np.complex128]", np.linalg.inv(_D))
 
 
 def _re_to_im(X_real: npt.NDArray[np.floating]) -> npt.NDArray[np.complex128]:
@@ -184,9 +186,7 @@ def _apply_lie_series(
             continue
 
         def rhs(_t, X_local, exps=exps, coefs=coefs):
-            return _hamilton_flow_rhs(
-                np.asarray(X_local, dtype=complex), exps, coefs
-            )
+            return _hamilton_flow_rhs(np.asarray(X_local, dtype=complex), exps, coefs)
 
         sol = solve_ivp(
             rhs,
@@ -197,9 +197,7 @@ def _apply_lie_series(
             atol=atol,
         )
         if not sol.success:
-            raise RuntimeError(
-                f"QF↔CM Lie 级数 ODE 积分失败（order={order}）：{sol.message}"
-            )
+            raise RuntimeError(f"QF↔CM Lie 级数 ODE 积分失败（order={order}）：{sol.message}")
         X = np.asarray(sol.y[:, -1], dtype=complex)
     return X
 

--- a/e2m2e/algorithms/normal_form/coord_trans/rho_em.py
+++ b/e2m2e/algorithms/normal_form/coord_trans/rho_em.py
@@ -1,0 +1,150 @@
+"""rho ↔ EM：平动点相对坐标 ↔ 星历模型 Hamilton 坐标 (q, p)。
+
+迁移自 qiao ``Subfunction/coord_trans/rho2qpEM.py`` /
+``qpEM2rho.py``。本模块对应变换链的第一段：rho（无量纲平动点相对
+坐标 ``[ρ, ρ̇]``）与星历模型 Hamilton 坐标 ``(q, p)`` 之间的**纯动量
+耦合**层。
+
+数学关系（qiao ``CONTEXT.md`` §二）：
+
+    q   = ρ
+    p   = ρ̇ − Cdot_dimᵀ · C · ρ
+
+其中 ``C`` 是 EMR 旋转矩阵（月球瞬时姿态），``Cdot_dim = Cdot · TU``
+是其无量纲时间导数。该耦合把会合系下的速度 ``ρ̇`` 投影到非惯性
+Hamilton 系的共轭动量 ``p``，**不做物理量换算**——``q``、``p`` 仍在
+无量纲 rho 单位下。
+
+与 qiao 的差异：
+
+- qiao 的 ``rho2qpEM`` / ``qpEM2rho`` 同时做单位换算（输出 km/km/s）并
+  平移平动点位置；本仓库按 PRD 约定**全程无量纲**，单位换算交给
+  :mod:`e2m2e.algorithms.normal_form.units` 的调用方；平动点平移在
+  DS 段（``em_ds``）由生成函数 ``W`` 完成。
+- ``C``、``Cdot`` 不通过 qiao 的 ``globalparam.data_array`` 二进制表
+  暴露，而由 :class:`NormalFormContext` + :mod:`._ephemeris` 在请求时刻
+  重新解析求值（SPICE 不可用时退化到纯 CR3BP 常值旋转）。
+
+退化（纯 CR3BP）：``C`` 取会合系单位旋转 ``[[0,1,0],[-1,0,0],[0,0,0]]``、
+``Cdot = 0``（无量纲时间下为常数）。此时动量耦合项消失，
+``p = ρ̇``——这正是切片 0–4 测试一直使用的纯 CR3BP 退路，往返误差
+应在机器精度内。
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import numpy.typing as npt
+
+if TYPE_CHECKING:
+    from ..context import NormalFormContext
+
+# ---------------------------------------------------------------------------
+# 默认（纯 CR3BP 退路）姿态矩阵
+# ---------------------------------------------------------------------------
+
+#: 纯 CR3BP 退路用的常值 EMR 旋转矩阵 ``C``（无量纲会合系）。
+_CR3BP_C: npt.NDArray[np.floating] = np.array(
+    [[0.0, 1.0, 0.0], [-1.0, 0.0, 0.0], [0.0, 0.0, 0.0]], dtype=float
+)
+
+
+def _resolve_C_Cdot(
+    context: NormalFormContext, t: float
+) -> tuple[npt.NDArray[np.floating], npt.NDArray[np.floating]]:
+    """在时刻 ``t``（归一化 TU）求值 EMR 旋转矩阵 ``C`` 与 ``Cdot_dim``。
+
+    返回 ``C`` 与无量纲化时间导数 ``Cdot_dim = Cdot · TU``——这是
+    动量耦合公式 ``p = ρ̇ − Cdot_dimᵀ · C · ρ`` 直接需要的形式。SPICE
+    不可用时退化到纯 CR3BP（``C`` 常值、``Cdot_dim = 0``）。
+
+    与 :mod:`._ephemeris.eval_params` 一致：``Cpq = Cdot_dimᵀ · C``。
+    """
+    tu_days = float(context.TU) / 86400.0
+    jd = float(context.epoch) + float(t) * tu_days
+    try:
+        from .._ephemeris import _derive_moon_param, _ephemeris_states
+
+        r_em, v_em, r_es, v_es = _ephemeris_states(jd)
+        # _derive_moon_param 返回 (A_em, J_em, C, Cdot, Cdotdot)
+        _, _, C, cdot, _ = _derive_moon_param(
+            r_em, v_em, r_es, v_es,
+            mu_e=float(context.mu_e),
+            mu_m=float(context.mu_m),
+            mu_s=float(context.mu_s),
+            lu=float(context.LU),
+            tu=float(context.TU),
+        )
+        cdot_dim = np.asarray(cdot, dtype=float) * float(context.TU)
+        return np.asarray(C, dtype=float), cdot_dim
+    except Exception:
+        return _CR3BP_C.copy(), np.zeros((3, 3), dtype=float)
+
+
+# ---------------------------------------------------------------------------
+# 公开变换
+# ---------------------------------------------------------------------------
+
+
+def rho_to_em(
+    X_rho: npt.ArrayLike,
+    t: float,
+    context: NormalFormContext,
+) -> npt.NDArray[np.floating]:
+    """rho 状态 → EM 坐标 ``(q, p)``（无量纲）。
+
+    对应 qiao ``rho2param`` 第一段：``q = ρ``，
+    ``p = ρ̇ − Cdot_dimᵀ · C · ρ``。
+
+    Args:
+        X_rho: ``(6,)`` rho 状态 ``[ρ_x, ρ_y, ρ_z, ρ̇_x, ρ̇_y, ρ̇_z]``，
+            无量纲。
+        t: 归一化时间 TU。
+        context: 归一化上下文。
+
+    Returns:
+        ``(6,)`` EM 状态 ``[q_x, q_y, q_z, p_x, p_y, p_z]``，无量纲。
+    """
+    X = np.asarray(X_rho, dtype=float).ravel()
+    if X.shape != (6,):
+        raise ValueError(f"X_rho 必须是 (6,)，得到 {X.shape}")
+    rho = X[:3]
+    rhodot = X[3:]
+    C, Cdot_dim = _resolve_C_Cdot(context, t)
+    q = rho
+    p = rhodot - Cdot_dim.T @ C @ rho
+    return np.concatenate([q, p])
+
+
+def em_to_rho(
+    X_em: npt.ArrayLike,
+    t: float,
+    context: NormalFormContext,
+) -> npt.NDArray[np.floating]:
+    """EM 坐标 ``(q, p)`` → rho 状态（无量纲）。
+
+    对应 qiao ``param2rho`` 末段（逆动量耦合）：``ρ = q``，
+    ``ρ̇ = p + Cdot_dimᵀ · C · q``。是 :func:`rho_to_em` 的精确逆。
+
+    Args:
+        X_em: ``(6,)`` EM 状态 ``[q, p]``，无量纲。
+        t: 归一化时间 TU。
+        context: 归一化上下文。
+
+    Returns:
+        ``(6,)`` rho 状态 ``[ρ, ρ̇]``，无量纲。
+    """
+    X = np.asarray(X_em, dtype=float).ravel()
+    if X.shape != (6,):
+        raise ValueError(f"X_em 必须是 (6,)，得到 {X.shape}")
+    q = X[:3]
+    p = X[3:]
+    C, Cdot_dim = _resolve_C_Cdot(context, t)
+    rho = q
+    rhodot = p + Cdot_dim.T @ C @ q
+    return np.concatenate([rho, rhodot])
+
+
+__all__ = ["em_to_rho", "rho_to_em"]

--- a/e2m2e/algorithms/normal_form/coord_trans/rho_em.py
+++ b/e2m2e/algorithms/normal_form/coord_trans/rho_em.py
@@ -68,9 +68,12 @@ def _resolve_C_Cdot(
         from .._ephemeris import _derive_moon_param, _ephemeris_states
 
         r_em, v_em, r_es, v_es = _ephemeris_states(jd)
-        # _derive_moon_param 返回 (A_em, J_em, C, Cdot, Cdotdot)
-        _, _, C, cdot, _ = _derive_moon_param(
-            r_em, v_em, r_es, v_es,
+        # _derive_moon_param 返回 (C, Cdot, Cdotdot, A_em)（见 _ephemeris.py）
+        C, cdot, _, _ = _derive_moon_param(
+            r_em,
+            v_em,
+            r_es,
+            v_es,
             mu_e=float(context.mu_e),
             mu_m=float(context.mu_m),
             mu_s=float(context.mu_s),

--- a/e2m2e/algorithms/normal_form/dynamical_substitution.py
+++ b/e2m2e/algorithms/normal_form/dynamical_substitution.py
@@ -1,0 +1,675 @@
+"""动力学替代轨道与生成函数 ``W`` 计算（Code5）。
+
+对应 qiao ``Code05_DynSubs_Gfunc.py``：
+
+1. **多点打靶**：在归一化时间窗口上以等距节点构造初值；用块三对角
+   Newton 迭代求解连续性方程，得到一条围绕平动点的闭轨道
+   ``b(t) = (rho, rhodot)``；
+2. **频域分解**：对 ``b(t)`` 做频率分析（NAFF/FFT），把受迫分量与
+   中心流形分量分离；
+3. **生成函数 ``W(t)``**：对动量分量数值微分得 ``B̈``，由 ``Bdot2A``
+   公式把 ``B`` 与 ``A`` 拼起来，组装 ``W_poly`` / ``Wdot_poly``；
+4. **动力学替代 Hamilton 量**：在 slice 3 才真正展开 Lie 级数消除
+   ``H`` 的一阶项；本切片只交付 :class:`DynamicalSubstituteResult`
+   的 ``Kamiltonian`` 字段为 ``None`` 的占位壳，留待 slice 3 填充。
+
+Public API：
+
+- :class:`DynamicalSubstituteCorrector` —— 上下文绑定的 corrector，
+  通过 :meth:`reduce` 给出 :class:`DynamicalSubstituteResult`；
+- :class:`DynamicalSubstituteResult` —— 不透明结果句柄；
+- :func:`_build_dynamics_rhs` —— 把 ``NormalFormContext`` 翻译为
+  ODE 右端项的内部辅助（也供 slice 3 测试 / 复用）。
+
+实现策略：
+
+- 复用 :mod:`.multiple_shooting` 的块三对角消元；
+- 复用 :mod:`.fft` 的 NAFF/FFT 自动选择；
+- 复用 :func:`.hamiltonian.evaluate_hamiltonian` / 星历参数（与
+  slice 1 保持接口一致）；
+- 当外部 SPICE 内核不可用时（如 CI 环境），``reduce`` 走 ``Pure
+  CR3BP`` 退路：忽略太阳与三体摄动，使用旋转系下的 Hill 方程；
+  该退路仅供烟雾测试，不用于生产数据。
+"""
+
+from __future__ import annotations
+
+import warnings
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import numpy as np
+import numpy.typing as npt
+
+from .fft import (
+    FFTComponent,
+    extract_frequencies,
+)
+from .multiple_shooting import (
+    MultipleShootingResult,
+    ODESubstituteSolver,
+    ShootingPatch,
+    SubstituteSolver,
+    multiple_shooting_newton,
+)
+
+if TYPE_CHECKING:
+    from .context import NormalFormContext
+
+
+# ---------------------------------------------------------------------------
+# 默认打靶窗口与节点间距
+# ---------------------------------------------------------------------------
+
+#: qiao Code05 默认总窗口：``0.1 * 2^16 = 6553.6 TU``。
+DEFAULT_TOTAL_TU: float = 0.1 * (2 ** 16)
+#: qiao Code05 默认节点间距：``0.8 TU``。
+DEFAULT_NODE_STEP: float = 0.8
+#: qiao Code05 稠密输出采样间距：``0.1 TU``。
+DEFAULT_DENSE_STEP: float = 0.1
+#: qiao Code05 Newton 迭代最大轮数：``20``。
+DEFAULT_MAX_ITER: int = 19
+#: qiao Code05 收敛容差：``1e-11``。
+DEFAULT_TOLERANCE: float = 1e-11
+
+
+# ---------------------------------------------------------------------------
+# 结果容器
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DynamicalSubstituteResult:
+    """动力学替代校正结果。
+
+    Attributes:
+        context: 关联 :class:`NormalFormContext`。
+        order: 展开阶数（与 ``context.order`` 一致）。
+        substitute_orbit: 替代轨道 ``e2m2e.Orbit`` 或等价的 ``(n, 6)`` 数组。
+        tlist: 稠密输出时间数组，形状 ``(n,)``，归一化 TU。
+        Xlist: 稠密输出状态数组，形状 ``(n, 6)``。
+        W_poly: ``(pow, coef_array)`` 形式的生成函数 ``W(t)``；6 个
+            线性项各对应一个幂次 ``(1,0,0,0,0,0)``/.../``(0,0,0,0,0,1)``。
+        Wdot_poly: 与 ``W_poly`` 同结构的 ``Wdot(t)``。
+        Kamiltonian: 动力学替代 Hamilton 量。本切片仅占位 ``None``；
+            slice 3 将通过 Lie 级数填充。
+        fft_components: ``x/y/z`` 三个方向的 :class:`FFTComponent` 列表；
+            供后续 slice 引用。
+        shooting_result: 多重打靶迭代结果（节点、残差历史、收敛标志）。
+        backend: 实际使用的频率分析后端：``"naff"`` / ``"fft"``。
+        spice_available: 本次 ``reduce`` 是否实际使用了 SPICE 星历模型。
+        metadata: 自由扩展字段。
+    """
+
+    context: NormalFormContext
+    order: int
+    substitute_orbit: object  # e2m2e.Orbit or ndarray
+    tlist: npt.NDArray[np.floating]
+    Xlist: npt.NDArray[np.floating]
+    W_poly: dict[tuple[int, ...], npt.NDArray[np.floating]]
+    Wdot_poly: dict[tuple[int, ...], npt.NDArray[np.floating]]
+    Kamiltonian: object = None
+    fft_components: dict[str, list[FFTComponent]] = field(default_factory=dict)
+    shooting_result: MultipleShootingResult | None = None
+    backend: str = "fft"
+    spice_available: bool = False
+    metadata: dict[str, object] = field(default_factory=dict)
+
+    @property
+    def residual_norm(self) -> float:
+        """打靶连续性残差最大值（供调用方快速判定收敛性）。"""
+        if self.shooting_result is None:
+            return float("nan")
+        return self.shooting_result.max_residual
+
+
+# ---------------------------------------------------------------------------
+# Corrector 类
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DynamicalSubstituteCorrector:
+    """动力学替代 corrector（上下文绑定）。
+
+    通过 :meth:`reduce` 把 ``seed`` 状态修正到动力学替代轨道 ``b(t)``，
+    并输出生成函数 ``W`` / ``Wdot`` 与频率分析结果。
+
+    Args:
+        context: 归一化上下文。
+        t_total: 打靶总窗口（TU）。
+        node_step: 节点间距（TU）。
+        dense_step: 稠密输出采样间距（TU）。
+        max_iter: Newton 最大迭代轮数。
+        tolerance: 收敛容差（最大连续性残差）。
+        prefer: 频率分析后端选择（``"auto"``/``"naff"``/``"fft"``）。
+        spice_optional: SPICE 内核不可用时是否降级到纯 CR3BP。
+            ``True`` 时静默降级；``False`` 时抛 :class:`RuntimeError`。
+    """
+
+    context: NormalFormContext
+    t_total: float = DEFAULT_TOTAL_TU
+    node_step: float = DEFAULT_NODE_STEP
+    dense_step: float = DEFAULT_DENSE_STEP
+    max_iter: int = DEFAULT_MAX_ITER
+    tolerance: float = DEFAULT_TOLERANCE
+    prefer: str = "auto"
+    spice_optional: bool = True
+
+    # ------------------------------------------------------------------
+    # 公开入口
+    # ------------------------------------------------------------------
+
+    def reduce(
+        self,
+        seed: npt.ArrayLike | None = None,
+    ) -> DynamicalSubstituteResult:
+        """对 ``seed`` 状态执行动力学替代校正。
+
+        Args:
+            seed: ``(6,)`` rho 坐标初始状态；``None`` 时用平动点位置
+                零速度作为初始猜测（``X_Q`` 全零初值）。
+
+        Returns:
+            :class:`DynamicalSubstituteResult`。
+
+        Raises:
+            RuntimeError: 当 ``spice_optional=False`` 且 SPICE 不可用。
+        """
+        seed_arr = self._normalize_seed(seed)
+        n_nodes = int(round(self.t_total / self.node_step)) + 1
+        t_Q = np.linspace(0.0, self.t_total, n_nodes)
+
+        # 初始 X_Q 拷贝到全部节点
+        X_Q = np.tile(seed_arr, (n_nodes, 1))
+
+        rhs, provider = self._build_dynamics()
+        spice_available = provider is not None
+
+        if not spice_available and not self.spice_optional:
+            raise RuntimeError(
+                "SPICE 内核不可用且 spice_optional=False。"
+                "请加载 .tls + .bsp 或显式允许降级。"
+            )
+
+        solver: SubstituteSolver = ODESubstituteSolver(
+            rhs=rhs, rtol=1e-10, atol=1e-12
+        )
+
+        # ---- 多重打靶 ----
+        patch = ShootingPatch(t_Q=t_Q, X_Q=X_Q)
+        shooting = multiple_shooting_newton(
+            patch,
+            solver,
+            max_iter=self.max_iter,
+            tolerance=self.tolerance,
+        )
+
+        # ---- 稠密输出 ----
+        tlist, Xlist = self._dense_output(shooting, solver)
+
+        # ---- 频率分析 ----
+        fft_components, backend = self._frequency_analysis(tlist, Xlist)
+
+        # ---- 生成函数 W ----
+        W_poly, Wdot_poly = self._build_W(tlist, Xlist)
+
+        # ---- 包装成 Orbit ----
+        substitute_orbit = self._wrap_orbit(tlist, Xlist)
+
+        return DynamicalSubstituteResult(
+            context=self.context,
+            order=int(self.context.order),
+            substitute_orbit=substitute_orbit,
+            tlist=tlist,
+            Xlist=Xlist,
+            W_poly=W_poly,
+            Wdot_poly=Wdot_poly,
+            Kamiltonian=None,
+            fft_components=fft_components,
+            shooting_result=shooting,
+            backend=backend,
+            spice_available=spice_available,
+            metadata={
+                "t_total": float(self.t_total),
+                "node_step": float(self.node_step),
+                "dense_step": float(self.dense_step),
+                "n_nodes": int(shooting.t_Q.shape[0]),
+                "n_segments": int(shooting.t_Q.shape[0] - 1),
+            },
+        )
+
+    # ------------------------------------------------------------------
+    # 内部辅助
+    # ------------------------------------------------------------------
+
+    def _normalize_seed(
+        self, seed: npt.ArrayLike | None
+    ) -> npt.NDArray[np.floating]:
+        if seed is None:
+            return np.zeros(6, dtype=float)
+        arr = np.asarray(seed, dtype=float).ravel()
+        if arr.shape != (6,):
+            raise ValueError(f"seed 必须是形状 (6,)，得到 {arr.shape}")
+        return arr
+
+    def _build_dynamics(self) -> tuple[
+        Callable[[float, npt.ArrayLike], npt.ArrayLike],
+        Callable[[float], tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]] | None,
+    ]:
+        """构造 rho 坐标 ODE 右端项与（可选）SPICE provider。
+
+        探测性求值一次：SPICE 缺失（如未加载 ``naif*.tls``）会在
+        ``str2et`` 抛 :class:`SpiceNOLEAPSECONDS`，此时回退到纯 CR3BP。
+        """
+        try:
+            rhs, provider = _build_dynamics_rhs_spice(self.context)
+            _ = rhs(0.0, np.zeros(6))
+        except Exception as exc:
+            if not self.spice_optional:
+                raise
+            warnings.warn(
+                f"SPICE 求值失败（{type(exc).__name__}: {exc}）；"
+                "降级到纯 CR3BP 旋转系。"
+                "该退路仅供烟雾测试，不用于生产数据。",
+                stacklevel=3,
+            )
+            return _build_dynamics_rhs_circular(self.context), None
+        return rhs, provider
+
+    def _dense_output(
+        self,
+        shooting: MultipleShootingResult,
+        solver: SubstituteSolver,
+    ) -> tuple[npt.NDArray[np.floating], npt.NDArray[np.floating]]:
+        """在 ``t_Q`` 节点基础上做稠密输出（DOP853 高阶积分）。"""
+        from scipy.integrate import solve_ivp
+
+        t_Q = shooting.t_Q
+        X_Q = shooting.X_Q
+        n_seg = t_Q.shape[0] - 1
+
+        # 稠密采样网格
+        t_dense = np.arange(0.0, self.t_total + 0.5 * self.dense_step, self.dense_step)
+
+        pieces_t: list[np.ndarray] = []
+        pieces_X: list[np.ndarray] = []
+        for i in range(n_seg):
+            t_lo = float(t_Q[i])
+            t_hi = float(t_Q[i + 1])
+            seg_t = t_dense[(t_dense >= t_lo - 1e-9) & (t_dense <= t_hi + 1e-9)]
+            if seg_t.size == 0:
+                continue
+            sol = solve_ivp(
+                lambda t, X: np.asarray(
+                    solver.propagate_segment.__self__.rhs(t, X),  # type: ignore[attr-defined]
+                    dtype=float,
+                ).ravel()
+                if hasattr(solver.propagate_segment, "__self__")
+                else _ode_rhs_via_solver(solver, t, X),
+                (float(seg_t[0]), float(seg_t[-1])),
+                np.asarray(X_Q[i], dtype=float),
+                t_eval=seg_t,
+                method="DOP853",
+                rtol=1e-10,
+                atol=1e-12,
+            )
+            if not sol.success:
+                # 稠密输出失败不致命：回退到用节点的简化输出
+                pieces_t.append(np.array([t_lo, t_hi]))
+                pieces_X.append(np.vstack([X_Q[i], X_Q[i + 1]]))
+                continue
+            # 段 i 的末时刻 = 段 i+1 的初时刻，避免 tlist 出现重复点
+            if i < n_seg - 1 and sol.t.size > 1:
+                pieces_t.append(sol.t[:-1])
+                pieces_X.append(sol.y[:, :-1].T)
+            else:
+                pieces_t.append(sol.t)
+                pieces_X.append(sol.y.T)
+
+        if not pieces_t:
+            return t_Q.copy(), X_Q.copy()
+
+        tlist = np.concatenate(pieces_t)
+        Xlist = np.concatenate(pieces_X, axis=0)
+        return tlist, Xlist
+
+    def _frequency_analysis(
+        self,
+        tlist: npt.NDArray[np.floating],
+        Xlist: npt.NDArray[np.floating],
+    ) -> tuple[dict[str, list[FFTComponent]], str]:
+        """对 x/y/z 三方向做 NAFF/FFT 频率分析。"""
+        result: dict[str, list[FFTComponent]] = {}
+        backend = "fft"
+        for idx, label in enumerate(("x", "y", "z")):
+            comps, used = extract_frequencies(
+                tlist,
+                Xlist[:, idx],
+                n_components=20,
+                prefer=self.prefer,
+            )
+            result[label] = comps
+            # 三个方向应使用同一种后端
+            if used == "naff":
+                backend = "naff"
+        return result, backend
+
+    def _build_W(
+        self,
+        tlist: npt.NDArray[np.floating],
+        Xlist: npt.NDArray[np.floating],
+    ) -> tuple[
+        dict[tuple[int, ...], npt.NDArray[np.floating]],
+        dict[tuple[int, ...], npt.NDArray[np.floating]],
+    ]:
+        """由 ``Xlist`` 数值微分得 ``W_poly`` / ``Wdot_poly``。"""
+        if tlist.size < 2:
+            empty: dict[tuple[int, ...], npt.NDArray[np.floating]] = {}
+            return empty, empty
+
+        dt = float(np.mean(np.diff(tlist)))
+        B = Xlist[:, :3]
+        Bdot = Xlist[:, 3:6]
+        # 二阶导：用中心差分，避免引入额外依赖
+        Bddot = _second_derivative(Bdot, dt)
+
+        A, Adot = _bdot2a(self.context, B, Bdot, Bddot, tlist)
+
+        W_poly: dict[tuple[int, ...], npt.NDArray[np.floating]] = {}
+        Wdot_poly: dict[tuple[int, ...], npt.NDArray[np.floating]] = {}
+        pow_units = [
+            (1, 0, 0, 0, 0, 0),
+            (0, 1, 0, 0, 0, 0),
+            (0, 0, 1, 0, 0, 0),
+            (0, 0, 0, 1, 0, 0),
+            (0, 0, 0, 0, 1, 0),
+            (0, 0, 0, 0, 0, 1),
+        ]
+        for k, pow_tuple in enumerate(pow_units):
+            if k < 3:
+                W_poly[pow_tuple] = A[:, k]
+                Wdot_poly[pow_tuple] = Adot[:, k]
+            else:
+                W_poly[pow_tuple] = B[:, k - 3]
+                Wdot_poly[pow_tuple] = Bdot[:, k - 3]
+        return W_poly, Wdot_poly
+
+    def _wrap_orbit(
+        self, tlist: npt.NDArray[np.floating], Xlist: npt.NDArray[np.floating]
+    ) -> object:
+        """把稠密输出包装为 ``e2m2e.Orbit``（失败则退到 ``ndarray``）。"""
+        try:
+            from e2m2e.core.orbit import Orbit
+
+            return Orbit(states=Xlist, times=tlist, system=self.context.system)
+        except Exception:
+            return Xlist
+
+
+# ---------------------------------------------------------------------------
+# 内部辅助
+# ---------------------------------------------------------------------------
+
+
+def _ode_rhs_via_solver(
+    solver: SubstituteSolver, t: float, X: npt.ArrayLike
+) -> npt.NDArray[np.floating]:
+    """从 :class:`ODESubstituteSolver` 中取出 ``rhs`` 调用。"""
+    rhs = getattr(solver, "rhs", None)
+    if rhs is None:
+        raise RuntimeError("solver 必须暴露 rhs 才能用于稠密输出")
+    return np.asarray(rhs(t, X), dtype=float).ravel()
+
+
+def _second_derivative(
+    y: npt.NDArray[np.floating], dt: float
+) -> npt.NDArray[np.floating]:
+    """等距采样的二阶中心差分；首末端用一阶差分。
+
+    对应 qiao ``list_deriv`` 的两遍应用：``ddot = deriv(deriv(y))``。
+    本切片刻意走更简洁的中心差分（足以满足烟雾测试），slice 3 可
+    再换成 qiao 风格的高阶 Vandermonde 系数。
+    """
+    y = np.asarray(y, dtype=float)
+    out = np.zeros_like(y)
+    if y.shape[0] < 3:
+        # 全一阶差分兜底
+        if y.shape[0] >= 2:
+            out[1:-1] = (y[2:] - 2 * y[1:-1] + y[:-2]) / (dt * dt)
+            out[0] = (y[1] - y[0]) / dt
+            out[-1] = (y[-1] - y[-2]) / dt
+        return out
+    out[1:-1] = (y[2:] - 2 * y[1:-1] + y[:-2]) / (dt * dt)
+    out[0] = (y[1] - y[0]) / dt
+    out[-1] = (y[-1] - y[-2]) / dt
+    return out
+
+
+def _bdot2a(
+    context: NormalFormContext,
+    B: npt.NDArray[np.floating],
+    Bdot: npt.NDArray[np.floating],
+    Bddot: npt.NDArray[np.floating],
+    tlist: npt.NDArray[np.floating],
+) -> tuple[npt.NDArray[np.floating], npt.NDArray[np.floating]]:
+    """``B, Bdot, Bddot`` → ``(A, Adot)``（qiao ``Bdot2A``）。
+
+    A = -Bdot + C_pq @ B
+    Adot = -Bddot + (dC_pq) @ B + C_pq @ Bdot
+
+    ``C_pq`` 与 ``dC_pq`` 通过 :func:`._ephemeris.eval_params` 取；
+    退化到纯 CR3BP 时 ``C_pq`` 为旋转矩阵系数 ``[[0,1,0],[-1,0,0],[0,0,0]]``、
+    ``dC_pq = 0``（无量纲时间下为常数）。
+    """
+    B = np.asarray(B, dtype=float)
+    Bdot = np.asarray(Bdot, dtype=float)
+    Bddot = np.asarray(Bddot, dtype=float)
+    tlist = np.asarray(tlist, dtype=float)
+
+    n = B.shape[0]
+    if Bdot.shape != B.shape or Bddot.shape != B.shape:
+        raise ValueError(
+            f"B/Bdot/Bddot 形状不一致：{B.shape}/{Bdot.shape}/{Bddot.shape}"
+        )
+    if tlist.shape[0] != n:
+        raise ValueError(
+            f"tlist 长度必须等于 B 行数：{tlist.shape[0]} vs {n}"
+        )
+
+    try:
+        from ._ephemeris import eval_params as _eval_params
+
+        Cpq_seq: list[np.ndarray] = []
+        dCpq_seq: list[np.ndarray] = []
+        tu_days = float(context.TU) / 86400.0
+        for t in tlist:
+            jd = float(context.epoch) + float(t) * tu_days
+            params = _eval_params(jd, context)
+            cpq = np.array(
+                [
+                    [params["Cpq1"], params["Cpq2"], params["Cpq3"]],
+                    [params["Cpq4"], params["Cpq5"], params["Cpq6"]],
+                    [params["Cpq7"], params["Cpq8"], params["Cpq9"]],
+                ],
+                dtype=float,
+            )
+            cqq = np.array(
+                [
+                    [params["Cqq1"], params["Cqq2"], params["Cqq3"]],
+                    [params["Cqq4"], params["Cqq5"], params["Cqq6"]],
+                    [params["Cqq7"], params["Cqq8"], params["Cqq9"]],
+                ],
+                dtype=float,
+            )
+            dcpq = cqq - cpq @ cpq  # d/dt(C_pq) = C_qq - C_pq^2
+            Cpq_seq.append(cpq)
+            dCpq_seq.append(dcpq)
+    except Exception as exc:
+        warnings.warn(
+            f"_ephemeris.eval_params 失败（{exc}）；退化到纯 CR3BP 旋转矩阵。",
+            stacklevel=2,
+        )
+        cpq_const = np.array([[0.0, 1.0, 0.0], [-1.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
+        Cpq_seq = [cpq_const] * n
+        dCpq_seq = [np.zeros((3, 3))] * n
+
+    A = np.zeros_like(B)
+    Adot = np.zeros_like(B)
+    for i in range(n):
+        cpq_i = Cpq_seq[i]
+        dcpq_i = dCpq_seq[i]
+        A[i] = -Bdot[i] + cpq_i @ B[i]
+        Adot[i] = -Bddot[i] + dcpq_i @ B[i] + cpq_i @ Bdot[i]
+    return A, Adot
+
+
+def _build_dynamics_rhs_circular(
+    context: NormalFormContext,
+) -> Callable[[float, npt.ArrayLike], npt.NDArray[np.floating]]:
+    """纯 CR3BP 旋转系下的 rho 坐标右端项（用作无 SPICE 退路）。
+
+    对应 qiao ``Subfunction/dynfunc/dynfunc_circ_rho`` 的简化版：忽略
+    太阳与三体摄动，只保留两个主天体的引力。
+    """
+    mu = float(context.mu)
+    # 平动点位置（无量纲）：与 rho = 0 对应的就是平动点
+    r_lp = np.asarray(context.libration_position, dtype=float)
+    omega = np.array([0.0, 0.0, 1.0])  # 旋转系角速度（无量纲 = 1）
+
+    def rhs(t: float, X: npt.ArrayLike) -> npt.NDArray[np.floating]:
+        X_arr = np.asarray(X, dtype=float).ravel()
+        rho = X_arr[:3]
+        rhodot = X_arr[3:6]
+        # rho 在会合系下的实际位置：q1=earth, q2=moon 固定
+        # 这里以平动点为原点，取 earth=( -mu, 0, 0 ), moon=(1-mu, 0, 0)
+        earth = np.array([-mu, 0.0, 0.0])
+        moon = np.array([1.0 - mu, 0.0, 0.0])
+        d1 = rho + r_lp - earth
+        d2 = rho + r_lp - moon
+        d1n = d1 / np.linalg.norm(d1) ** 3
+        d2n = d2 / np.linalg.norm(d2) ** 3
+        # CR3BP 运动方程：忽略太阳；ρ̈ = -∇U - 2 ω×ρ̇ - ω×(ω×ρ)
+        # U = ½(x²+y²) + (1-μ)/r1 + μ/r2  (围绕原点展开)
+        U_rho = -(
+            (1.0 - mu) * d1n
+            + mu * d2n
+        )
+        coriolis = -2.0 * np.cross(omega, rhodot)
+        centrifugal = -np.cross(omega, np.cross(omega, rho))
+        rhodotdot = U_rho + coriolis + centrifugal
+        return np.concatenate([rhodot, rhodotdot])
+
+    return rhs
+
+
+def _build_dynamics_rhs_spice(
+    context: NormalFormContext,
+) -> tuple[
+    Callable[[float, npt.ArrayLike], npt.NDArray[np.floating]],
+    Callable[[float], tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]],
+]:
+    """星历模型 rho 坐标右端项；复用 :mod:`._ephemeris` 推导的 EMR 参数。
+
+    失败时抛 ``RuntimeError``，由 :meth:`_build_dynamics` 决定是否降级。
+    """
+    from ._ephemeris import eval_params as _eval_params
+
+    def rhs(t: float, X: npt.ArrayLike) -> npt.NDArray[np.floating]:
+        X_arr = np.asarray(X, dtype=float).ravel()
+        rho = X_arr[:3]
+        rhodot = X_arr[3:6]
+
+        tu_days = float(context.TU) / 86400.0
+        jd = float(context.epoch) + float(t) * tu_days
+        params = _eval_params(jd, context)
+
+        cpq = np.array(
+            [
+                [params["Cpq1"], params["Cpq2"], params["Cpq3"]],
+                [params["Cpq4"], params["Cpq5"], params["Cpq6"]],
+                [params["Cpq7"], params["Cpq8"], params["Cpq9"]],
+            ],
+            dtype=float,
+        )
+        cqq = np.array(
+            [
+                [params["Cqq1"], params["Cqq2"], params["Cqq3"]],
+                [params["Cqq4"], params["Cqq5"], params["Cqq6"]],
+                [params["Cqq7"], params["Cqq8"], params["Cqq9"]],
+            ],
+            dtype=float,
+        )
+        force = np.array([params["f1"], params["f2"], params["f3"]], dtype=float)
+        rex = np.array([params["rex"], params["rey"], params["rez"]], dtype=float)
+        re0 = float(params["re0"])
+        rmx = np.array([params["rmx"], params["rmy"], params["rmz"]], dtype=float)
+        rm0 = float(params["rm0"])
+        rsx = np.array([params["rsx"], params["rsy"], params["rsz"]], dtype=float)
+        rs0 = float(params["rs0"])
+        mu_e = float(params["mu_e"])
+        mu_m = float(params["mu_m"])
+        mu_s = float(params["mu_s"])
+
+        d_e = rex + rho  # 平动点相对地球
+        d_m = rmx + rho
+        d_s = rsx + rho
+        d_e3 = float(np.linalg.norm(d_e)) ** 3
+        d_m3 = float(np.linalg.norm(d_m)) ** 3
+        d_s3 = float(np.linalg.norm(d_s)) ** 3
+        r0dotdot = (
+            np.array(
+                [
+                    params.get("r0dotdot_x", 0.0),
+                    params.get("r0dotdot_y", 0.0),
+                    params.get("r0dotdot_z", 0.0),
+                ],
+                dtype=float,
+            )
+            if all(k in params for k in ("r0dotdot_x", "r0dotdot_y", "r0dotdot_z"))
+            else np.zeros(3)
+        )
+
+        # 简化版：与 qiao dynfunc_rho_core 1:1 公式对齐；把二阶非惯性项
+        # 折叠到 cqq 矩阵上。完整推导见 qiao Python/crtbp/Subfunction/dynfunc/dynfunc_rho_core.py。
+        rho_dotdot = (
+            force
+            - cqq @ rho
+            - 2.0 * cpq @ rhodot
+            + (
+                -mu_e * (rex + rho) / d_e3
+                - mu_m * (rmx + rho) / d_m3
+                - mu_s * (rsx + rho) / d_s3
+            )
+            - (
+                -mu_e * rex / re0 ** 3
+                - mu_m * rmx / rm0 ** 3
+                - mu_s * rsx / rs0 ** 3
+            )
+            - r0dotdot
+        )
+
+        return np.concatenate([rhodot, rho_dotdot])
+
+    # provider：仅供稠密输出诊断使用；与 qiao make_spice_provider 一致
+    def provider(t: float) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        tu_days = float(context.TU) / 86400.0
+        jd = float(context.epoch) + float(t) * tu_days
+        from ._ephemeris import _ephemeris_states
+
+        r_em, v_em, r_es, v_es = _ephemeris_states(jd)
+        return r_em, v_em, r_es, v_es
+
+    return rhs, provider
+
+
+__all__ = [
+    "DEFAULT_TOTAL_TU",
+    "DEFAULT_NODE_STEP",
+    "DEFAULT_DENSE_STEP",
+    "DEFAULT_MAX_ITER",
+    "DEFAULT_TOLERANCE",
+    "DynamicalSubstituteCorrector",
+    "DynamicalSubstituteResult",
+]

--- a/e2m2e/algorithms/normal_form/dynamical_substitution.py
+++ b/e2m2e/algorithms/normal_form/dynamical_substitution.py
@@ -63,7 +63,7 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 
 #: qiao Code05 默认总窗口：``0.1 * 2^16 = 6553.6 TU``。
-DEFAULT_TOTAL_TU: float = 0.1 * (2 ** 16)
+DEFAULT_TOTAL_TU: float = 0.1 * (2**16)
 #: qiao Code05 默认节点间距：``0.8 TU``。
 DEFAULT_NODE_STEP: float = 0.8
 #: qiao Code05 稠密输出采样间距：``0.1 TU``。
@@ -189,13 +189,10 @@ class DynamicalSubstituteCorrector:
 
         if not spice_available and not self.spice_optional:
             raise RuntimeError(
-                "SPICE 内核不可用且 spice_optional=False。"
-                "请加载 .tls + .bsp 或显式允许降级。"
+                "SPICE 内核不可用且 spice_optional=False。请加载 .tls + .bsp 或显式允许降级。"
             )
 
-        solver: SubstituteSolver = ODESubstituteSolver(
-            rhs=rhs, rtol=1e-10, atol=1e-12
-        )
+        solver: SubstituteSolver = ODESubstituteSolver(rhs=rhs, rtol=1e-10, atol=1e-12)
 
         # ---- 多重打靶 ----
         patch = ShootingPatch(t_Q=t_Q, X_Q=X_Q)
@@ -244,9 +241,7 @@ class DynamicalSubstituteCorrector:
     # 内部辅助
     # ------------------------------------------------------------------
 
-    def _normalize_seed(
-        self, seed: npt.ArrayLike | None
-    ) -> npt.NDArray[np.floating]:
+    def _normalize_seed(self, seed: npt.ArrayLike | None) -> npt.NDArray[np.floating]:
         if seed is None:
             return np.zeros(6, dtype=float)
         arr = np.asarray(seed, dtype=float).ravel()
@@ -254,7 +249,9 @@ class DynamicalSubstituteCorrector:
             raise ValueError(f"seed 必须是形状 (6,)，得到 {arr.shape}")
         return arr
 
-    def _build_dynamics(self) -> tuple[
+    def _build_dynamics(
+        self,
+    ) -> tuple[
         Callable[[float, npt.ArrayLike], npt.ArrayLike],
         Callable[[float], tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]] | None,
     ]:
@@ -302,12 +299,14 @@ class DynamicalSubstituteCorrector:
             if seg_t.size == 0:
                 continue
             sol = solve_ivp(
-                lambda t, X: np.asarray(
-                    solver.propagate_segment.__self__.rhs(t, X),  # type: ignore[attr-defined]
-                    dtype=float,
-                ).ravel()
-                if hasattr(solver.propagate_segment, "__self__")
-                else _ode_rhs_via_solver(solver, t, X),
+                lambda t, X: (
+                    np.asarray(
+                        solver.propagate_segment.__self__.rhs(t, X),  # type: ignore[attr-defined]
+                        dtype=float,
+                    ).ravel()
+                    if hasattr(solver.propagate_segment, "__self__")
+                    else _ode_rhs_via_solver(solver, t, X)
+                ),
                 (float(seg_t[0]), float(seg_t[-1])),
                 np.asarray(X_Q[i], dtype=float),
                 t_eval=seg_t,
@@ -423,9 +422,7 @@ def _ode_rhs_via_solver(
     return np.asarray(rhs(t, X), dtype=float).ravel()
 
 
-def _second_derivative(
-    y: npt.NDArray[np.floating], dt: float
-) -> npt.NDArray[np.floating]:
+def _second_derivative(y: npt.NDArray[np.floating], dt: float) -> npt.NDArray[np.floating]:
     """等距采样的二阶中心差分；首末端用一阶差分。
 
     对应 qiao ``list_deriv`` 的两遍应用：``ddot = deriv(deriv(y))``。
@@ -470,13 +467,9 @@ def _bdot2a(
 
     n = B.shape[0]
     if Bdot.shape != B.shape or Bddot.shape != B.shape:
-        raise ValueError(
-            f"B/Bdot/Bddot 形状不一致：{B.shape}/{Bdot.shape}/{Bddot.shape}"
-        )
+        raise ValueError(f"B/Bdot/Bddot 形状不一致：{B.shape}/{Bdot.shape}/{Bddot.shape}")
     if tlist.shape[0] != n:
-        raise ValueError(
-            f"tlist 长度必须等于 B 行数：{tlist.shape[0]} vs {n}"
-        )
+        raise ValueError(f"tlist 长度必须等于 B 行数：{tlist.shape[0]} vs {n}")
 
     try:
         from ._ephemeris import eval_params as _eval_params
@@ -552,10 +545,7 @@ def _build_dynamics_rhs_circular(
         d2n = d2 / np.linalg.norm(d2) ** 3
         # CR3BP 运动方程：忽略太阳；ρ̈ = -∇U - 2 ω×ρ̇ - ω×(ω×ρ)
         # U = ½(x²+y²) + (1-μ)/r1 + μ/r2  (围绕原点展开)
-        U_rho = -(
-            (1.0 - mu) * d1n
-            + mu * d2n
-        )
+        U_rho = -((1.0 - mu) * d1n + mu * d2n)
         coriolis = -2.0 * np.cross(omega, rhodot)
         centrifugal = -np.cross(omega, np.cross(omega, rho))
         rhodotdot = U_rho + coriolis + centrifugal
@@ -637,16 +627,8 @@ def _build_dynamics_rhs_spice(
             force
             - cqq @ rho
             - 2.0 * cpq @ rhodot
-            + (
-                -mu_e * (rex + rho) / d_e3
-                - mu_m * (rmx + rho) / d_m3
-                - mu_s * (rsx + rho) / d_s3
-            )
-            - (
-                -mu_e * rex / re0 ** 3
-                - mu_m * rmx / rm0 ** 3
-                - mu_s * rsx / rs0 ** 3
-            )
+            + (-mu_e * (rex + rho) / d_e3 - mu_m * (rmx + rho) / d_m3 - mu_s * (rsx + rho) / d_s3)
+            - (-mu_e * rex / re0**3 - mu_m * rmx / rm0**3 - mu_s * rsx / rs0**3)
             - r0dotdot
         )
 

--- a/e2m2e/algorithms/normal_form/fft.py
+++ b/e2m2e/algorithms/normal_form/fft.py
@@ -124,9 +124,7 @@ def detect_naff(
     t = np.asarray(times, dtype=float).ravel()
     y = np.asarray(data, dtype=float).ravel()
     if t.shape != y.shape:
-        raise ValueError(
-            f"times 与 data 形状不一致：times={t.shape} data={y.shape}"
-        )
+        raise ValueError(f"times 与 data 形状不一致：times={t.shape} data={y.shape}")
     if t.size < 2:
         raise ValueError("时间序列至少需要 2 个采样点")
     dt = float(np.mean(np.diff(t)))
@@ -241,9 +239,7 @@ def fft_extract(
     t = np.asarray(times, dtype=float).ravel()
     y = np.asarray(data, dtype=float).ravel()
     if t.shape != y.shape:
-        raise ValueError(
-            f"times 与 data 形状不一致：times={t.shape} data={y.shape}"
-        )
+        raise ValueError(f"times 与 data 形状不一致：times={t.shape} data={y.shape}")
     n = int(t.size)
     if n < 4:
         return []
@@ -460,9 +456,7 @@ def least_squares_sin_cos_fit(
     y = np.asarray(data, dtype=float).ravel()
     w = np.asarray(frequencies, dtype=float).ravel()
     if t.shape != y.shape:
-        raise ValueError(
-            f"times 与 data 形状不一致：times={t.shape} data={y.shape}"
-        )
+        raise ValueError(f"times 与 data 形状不一致：times={t.shape} data={y.shape}")
     if w.size == 0 or t.size == 0:
         return []
 
@@ -472,7 +466,7 @@ def least_squares_sin_cos_fit(
     components: list[FFTComponent] = []
     for omega in w:
         if abs(omega) < 1e-14:
-            mean_val = float(np.mean(data))
+            mean_val = float(np.mean(np.asarray(data, dtype=float)))
             components.append(
                 FFTComponent(
                     freq=0.0,
@@ -494,9 +488,7 @@ def least_squares_sin_cos_fit(
         b2 = float(np.dot(s_cos, y))
         det = a11 * a22 - a12 * a12
         if abs(det) < 1e-30:
-            components.append(
-                FFTComponent(freq=float(omega), amp_s=0.0, amp_c=0.0, amp=0.0)
-            )
+            components.append(FFTComponent(freq=float(omega), amp_s=0.0, amp_c=0.0, amp=0.0))
             continue
         amp_s = (a22 * b1 - a12 * b2) / det
         amp_c = (a11 * b2 - a12 * b1) / det

--- a/e2m2e/algorithms/normal_form/fft.py
+++ b/e2m2e/algorithms/normal_form/fft.py
@@ -1,0 +1,576 @@
+"""频率分析（FFT/NAFF）辅助函数。
+
+对应 qiao ``Subfunction/fft_operator`` 与 ``Subfunction/fft2num``：
+
+- :class:`FFTComponent` —— 一个频域分量 ``s·sin(ωt) + c·cos(ωt)``；
+- :func:`naff_available` —— 通过 ``shutil.which`` 探测外部 ``naff_uv``
+  Fortran 可执行文件；
+- :func:`detect_naff` —— 调用外部 NAFF；不可用时抛 :class:`RuntimeError`，
+  调用方应改用 :func:`fft_extract`；
+- :func:`fft_extract` —— 纯 NumPy FFT 实现的频率提取（NAFF 不可用时的
+  降级路径），返回按振幅排序的 ``FFTComponent`` 列表；
+- :func:`frequency_match` —— 把检测到的频率匹配到预计算基频表；
+- :func:`reconstruct_signal` / :func:`reconstruct_derivative` —— 从
+  FFT 频域表示重构时域信号（或其导数）。
+
+NAFF 检测只在调用方显式调用 :func:`detect_naff` 时触发；本模块其余函数
+不强制依赖 NAFF 可用性，从而保证 ``import e2m2e.algorithms.normal_form``
+在任何环境都能正常工作。
+"""
+
+from __future__ import annotations
+
+import shutil
+import warnings
+from dataclasses import dataclass, field
+
+import numpy as np
+import numpy.typing as npt
+
+#: 外部 NAFF 可执行文件名（按 qiao ``FrequencyMatch._find_naff_binary``）。
+#: 通过 ``shutil.which`` 在 ``PATH`` 中探测；亦可由环境变量 ``NAFF_BINARY``
+#: 显式指定。
+_NAFF_BINARY_CANDIDATES: tuple[str, ...] = ("naff_uv", "NUAA.exe", "naff")
+
+#: NAFF 调用超时（秒）。
+NAFF_TIMEOUT_S: float = 300.0
+
+
+@dataclass(frozen=True)
+class FFTComponent:
+    """单个频域分量 ``s·sin(ωt) + c·cos(ωt)``。
+
+    Attributes:
+        freq: 角频率 ``ω``。
+        amp_s: 正弦振幅 ``s``。
+        amp_c: 余弦振幅 ``c``。
+        amp: 总振幅 ``sqrt(s² + c²)``。
+        match_freq: 在基频表上最近邻匹配频率（``frequency_match`` 写入）。
+        coef: 与 ``match_freq`` 对应的整数系数向量。
+        err: 频率匹配误差 ``|freq - match_freq|``。
+    """
+
+    freq: float
+    amp_s: float = 0.0
+    amp_c: float = 0.0
+    amp: float = 0.0
+    match_freq: float = 0.0
+    coef: tuple[int, ...] = field(default_factory=lambda: (0, 0, 0, 0, 0, 0))
+    err: float = 0.0
+
+
+# ---------------------------------------------------------------------------
+# NAFF 探测与调用
+# ---------------------------------------------------------------------------
+
+
+def _resolve_naff_binary() -> str | None:
+    """查找可用的 NAFF 可执行文件。
+
+    优先使用 ``NAFF_BINARY`` 环境变量，否则在 ``PATH`` 中探测
+    ``naff_uv`` / ``NUAA.exe`` / ``naff``。找不到返回 ``None``。
+    """
+    import os
+
+    override = os.environ.get("NAFF_BINARY")
+    if override:
+        return override if os.path.isfile(override) else None
+    for name in _NAFF_BINARY_CANDIDATES:
+        path = shutil.which(name)
+        if path is not None:
+            return path
+    return None
+
+
+def naff_available() -> bool:
+    """当前环境是否可调用外部 NAFF（无须抛错）。"""
+    return _resolve_naff_binary() is not None
+
+
+def detect_naff(
+    times: npt.ArrayLike,
+    data: npt.ArrayLike,
+    *,
+    n_components: int = 10,
+    timeout: float = NAFF_TIMEOUT_S,
+) -> list[FFTComponent]:
+    """调用外部 NAFF 提取时间序列主要频率分量。
+
+    Args:
+        times: 等距采样时间序列，形状 ``(N,)``。
+        data: 与 ``times`` 对应的实信号，形状 ``(N,)``。
+        n_components: NAFF 期望返回的分量数（透传给控制文件第 8 行）。
+        timeout: NAFF 调用超时（秒）。
+
+    Returns:
+        按振幅降序排列的 :class:`FFTComponent` 列表；直流分量（``ω=0``）
+        始终位于首位。
+
+    Raises:
+        RuntimeError: NAFF 不可用（:func:`naff_available` 返回 ``False``），
+            或调用失败。
+    """
+    import os
+    import subprocess
+    import tempfile
+
+    exe = _resolve_naff_binary()
+    if exe is None:
+        raise RuntimeError(
+            "NAFF binary not found on PATH. "
+            "Set NAFF_BINARY or install naff_uv (see qiao FFTanalysis/)."
+        )
+
+    t = np.asarray(times, dtype=float).ravel()
+    y = np.asarray(data, dtype=float).ravel()
+    if t.shape != y.shape:
+        raise ValueError(
+            f"times 与 data 形状不一致：times={t.shape} data={y.shape}"
+        )
+    if t.size < 2:
+        raise ValueError("时间序列至少需要 2 个采样点")
+    dt = float(np.mean(np.diff(t)))
+    if dt <= 0:
+        raise ValueError("时间序列非单调递增")
+    if not np.all(np.diff(t) > 0):
+        raise ValueError("时间序列必须严格单调递增")
+    fs = 1.0 / dt
+
+    with tempfile.TemporaryDirectory(prefix="e2m2e_naff_") as tmp:
+        # 输入数据
+        input_path = os.path.join(tmp, "Input.txt")
+        with open(input_path, "w") as f:
+            for v in y:
+                f.write(f"{v:20.18f}\n")
+
+        # 控制文件
+        control_path = os.path.join(tmp, "naff_uv_control_file.txt")
+        with open(control_path, "w") as f:
+            f.write("Input.txt\n")
+            f.write("r\n")
+            f.write("full\n")
+            f.write("1\n")
+            f.write("1\n")
+            f.write("1\n")
+            f.write(f"{fs:20.18f}\n")
+            f.write(f"{int(n_components)}\n")
+            f.write("1\n")
+            f.write("han_5\n")
+            f.write("hft\n")
+            f.write("0\n")
+            f.write("Output.txt\n")
+
+        # 拷贝可执行文件到 tmp（与 qiao 一致），便于 DLL 解析
+        exe_name = os.path.basename(exe)
+        exe_dest = os.path.join(tmp, exe_name)
+        shutil.copy2(exe, exe_dest)
+        os.chmod(exe_dest, 0o755)
+
+        result = subprocess.run(
+            [f"./{exe_name}"],
+            cwd=tmp,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"NAFF binary failed (code {result.returncode}): "
+                f"{(result.stderr or result.stdout)[:512]}"
+            )
+
+        output_path = os.path.join(tmp, "Output.txt")
+        if not os.path.exists(output_path):
+            raise RuntimeError(f"NAFF 未生成 Output.txt（{output_path}）")
+
+        with open(output_path) as f:
+            lines = f.readlines()
+
+    freqs: list[float] = []
+    amps: list[float] = []
+    amp_cs: list[float] = []
+    amp_ss: list[float] = []
+    for line in lines[2:]:
+        parts = line.strip().split()
+        if len(parts) < 5:
+            continue
+        freqs.append(2.0 * np.pi * float(parts[1]))
+        amps.append(float(parts[2]))
+        amp_cs.append(float(parts[3]))
+        amp_ss.append(-float(parts[4]))  # 与 qiao 保持一致：s 反号
+
+    return [
+        FFTComponent(freq=f, amp_s=s, amp_c=c, amp=a)
+        for f, s, c, a in zip(freqs, amp_ss, amp_cs, amps, strict=True)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# FFT 回退实现（NAFF 不可用时）
+# ---------------------------------------------------------------------------
+
+
+def fft_extract(
+    times: npt.ArrayLike,
+    data: npt.ArrayLike,
+    *,
+    n_components: int | None = None,
+    detrend: bool = True,
+) -> list[FFTComponent]:
+    """用 NumPy FFT 提取时间序列的主要频率分量（NAFF 不可用时的降级路径）。
+
+    算法：去均值 → Hanning 窗 → FFT → 取正频率 → 找 ``n_components``
+    个最大幅值 → 二次谱插值校正（提高频率估计精度）→ 构造
+    :class:`FFTComponent`。
+
+    与真正的 NAFF 相比，FFT 路径的频率估计误差量级为 ``Δf / N``，对
+    本切片（``T_total = 0.1·2^16 TU``、``N ≈ 6554``）足以分辨受迫
+    频率与中心流形频率。
+
+    Args:
+        times: 等距采样时间序列。
+        data: 同形状实信号。
+        n_components: 保留分量数。``None`` 时取 ``min(N // 2, 50)``，
+            并去掉直流项；显式给定 ``0`` 或负数返回空列表。
+        detrend: 是否先减去均值再变换。
+
+    Returns:
+        按振幅降序排列的 :class:`FFTComponent`` 列表；直流分量始终位于
+        首位（若信号均值非零）。
+    """
+    t = np.asarray(times, dtype=float).ravel()
+    y = np.asarray(data, dtype=float).ravel()
+    if t.shape != y.shape:
+        raise ValueError(
+            f"times 与 data 形状不一致：times={t.shape} data={y.shape}"
+        )
+    n = int(t.size)
+    if n < 4:
+        return []
+
+    dt = float(np.mean(np.diff(t)))
+    if dt <= 0:
+        raise ValueError("时间序列非单调递增")
+    if not np.all(np.diff(t) > 0):
+        raise ValueError("时间序列必须严格单调递增")
+    fs = 1.0 / dt
+
+    if detrend:
+        y = y - float(np.mean(y))
+
+    window = np.hanning(n)
+    yw = y * window
+    spectrum = np.fft.rfft(yw)
+    freqs_full = np.fft.rfftfreq(n, d=dt) * 2.0 * np.pi  # 转角频率
+
+    # 直流分量另算（不在 rfft 中做正弦/余弦分解）
+    dc = FFTComponent(
+        freq=0.0,
+        amp_s=0.0,
+        amp_c=float(np.mean(y)) if detrend else 0.0,
+        amp=float(np.mean(y)) if detrend else 0.0,
+    )
+
+    # 取正频率部分（k=1..n//2）
+    pos_freqs = freqs_full[1:]
+    pos_amps = np.abs(spectrum[1:])
+    if pos_amps.size == 0:
+        return [dc]
+
+    # Hanning 窗的相干增益（用于复原真实振幅）
+    cg = float(np.sum(window)) / n
+    if cg <= 0:
+        cg = 1.0
+
+    if n_components is None or n_components <= 0:
+        keep = pos_amps.size
+    else:
+        keep = min(n_components, pos_amps.size)
+
+    top_idx = np.argsort(pos_amps)[::-1][:keep]
+    components: list[FFTComponent] = []
+    for k in top_idx:
+        omega = float(pos_freqs[k])
+        mag = float(pos_amps[k]) / (n * cg)  # 复原振幅
+        # 二次谱插值：使用 k±1 三点；校正后频率更接近真值
+        if 1 <= k < pos_amps.size - 1:
+            a_prev = float(pos_amps[k - 1])
+            a_curr = mag * n * cg  # 用原始幅值做比值
+            a_next = float(pos_amps[k + 1])
+            denom = a_prev - 2 * a_curr + a_next
+            if denom != 0:
+                delta = 0.5 * (a_prev - a_next) / denom
+                # 限制插值范围，避免数值发散
+                delta = max(-1.0, min(1.0, delta))
+                df = (2.0 * np.pi * fs) / n
+                omega = omega + delta * df
+
+        # 复原正弦/余弦分量（同一幅值下给 ``amp_c`` 一个保守的全幅分配；
+        # 调用方可通过 :func:`frequency_match`/线性回归再做精细分配）
+        components.append(
+            FFTComponent(
+                freq=omega,
+                amp_s=0.0,
+                amp_c=mag,
+                amp=mag,
+            )
+        )
+
+    components.sort(key=lambda c: c.amp, reverse=True)
+    return [dc, *components]
+
+
+# ---------------------------------------------------------------------------
+# 频率匹配与频域重构
+# ---------------------------------------------------------------------------
+
+
+def frequency_match(
+    components: list[FFTComponent],
+    basis_freqs: npt.ArrayLike,
+    basis_coefs: npt.ArrayLike | None = None,
+) -> list[FFTComponent]:
+    """把 FFT 分量匹配到预计算基频表最近邻。
+
+    对应 qiao ``fft_match``。
+
+    Args:
+        components: :func:`detect_naff` 或 :func:`fft_extract` 输出。
+        basis_freqs: ``(M,)`` 基频角频率数组。
+        basis_coefs: ``(M, k)`` 整数系数矩阵（每行一个基频对应的
+            整数系数向量）。``None`` 时系数填零向量。
+
+    Returns:
+        原列表的浅拷贝（每个 :class:`FFTComponent` 替换为带匹配信息
+        的新实例）。
+    """
+    basis_w = np.asarray(basis_freqs, dtype=float).ravel()
+    if basis_w.size == 0:
+        raise ValueError("basis_freqs 不能为空")
+    if basis_coefs is None:
+        basis_coefs_mat = np.zeros((basis_w.size, 6), dtype=int)
+    else:
+        basis_coefs_mat = np.asarray(basis_coefs)
+        if basis_coefs_mat.shape[0] != basis_w.size:
+            raise ValueError(
+                "basis_coefs 行数必须与 basis_freqs 一致："
+                f"{basis_coefs_mat.shape[0]} vs {basis_w.size}"
+            )
+
+    matched: list[FFTComponent] = []
+    for comp in components:
+        if abs(comp.freq) < 1e-14:
+            matched.append(
+                FFTComponent(
+                    freq=0.0,
+                    amp_s=comp.amp_s,
+                    amp_c=comp.amp_c,
+                    amp=comp.amp,
+                    match_freq=0.0,
+                    coef=tuple(int(c) for c in basis_coefs_mat[0]),
+                    err=0.0,
+                )
+            )
+            continue
+        idx = int(np.argmin(np.abs(basis_w - comp.freq)))
+        match_w = float(basis_w[idx])
+        matched.append(
+            FFTComponent(
+                freq=comp.freq,
+                amp_s=comp.amp_s,
+                amp_c=comp.amp_c,
+                amp=comp.amp,
+                match_freq=match_w,
+                coef=tuple(int(c) for c in basis_coefs_mat[idx]),
+                err=abs(comp.freq - match_w),
+            )
+        )
+    return matched
+
+
+def reconstruct_signal(
+    t: npt.ArrayLike, components: list[FFTComponent]
+) -> npt.NDArray[np.floating]:
+    """从 FFT 频域表示重构时域信号 ``X(t) = Σ s·sin(ωt) + c·cos(ωt)``。
+
+    对应 qiao ``FFT_X``。当所有 ``amp_s == 0``（FFT 路径常见情况）时，
+    该函数退化为余弦和；一般配合 :func:`least_squares_sin_cos_fit`
+    精细分配 ``(amp_s, amp_c)`` 后使用。
+
+    Args:
+        t: 标量或 ``(M,)`` 数组。
+        components: 频域分量列表。
+
+    Returns:
+        与 ``t`` 同形状的实数数组。
+    """
+    if not components:
+        return np.zeros_like(np.asarray(t, dtype=float), dtype=float)
+
+    w = np.array([c.freq for c in components], dtype=float)
+    s = np.array([c.amp_s for c in components], dtype=float)
+    c = np.array([c.amp_c for c in components], dtype=float)
+    t_arr = np.atleast_1d(np.asarray(t, dtype=float))
+    phase = w[:, None] * t_arr[None, :]
+    return (s[:, None] * np.sin(phase) + c[:, None] * np.cos(phase)).sum(axis=0)
+
+
+def reconstruct_derivative(
+    t: npt.ArrayLike, components: list[FFTComponent]
+) -> npt.NDArray[np.floating]:
+    """从 FFT 频域表示重构时域信号的一阶导数 ``dX/dt``。
+
+    对应 qiao ``FFT_dX``。``d(sin)/dt = ω·cos``，``d(cos)/dt = -ω·sin``。
+    """
+    if not components:
+        return np.zeros_like(np.asarray(t, dtype=float), dtype=float)
+
+    w = np.array([c.freq for c in components], dtype=float)
+    s = np.array([c.amp_s for c in components], dtype=float)
+    c = np.array([c.amp_c for c in components], dtype=float)
+    t_arr = np.atleast_1d(np.asarray(t, dtype=float))
+    phase = w[:, None] * t_arr[None, :]
+    return (s[:, None] * w[:, None] * np.cos(phase) - c[:, None] * w[:, None] * np.sin(phase)).sum(
+        axis=0
+    )
+
+
+def least_squares_sin_cos_fit(
+    times: npt.ArrayLike,
+    data: npt.ArrayLike,
+    frequencies: npt.ArrayLike,
+    *,
+    subtract_mean: bool = True,
+) -> list[FFTComponent]:
+    """对给定频率集合用最小二乘拟合 ``s·sin(ωt) + c·cos(ωt)``。
+
+    当频率由 :func:`fft_extract` 得到但 ``amp_s == 0`` 时，本函数可
+    给出更精确的正弦/余弦振幅分配：每个频率解一个 ``2×2`` 正规方程。
+
+    Args:
+        times: ``(N,)`` 采样时刻。
+        data: ``(N,)`` 信号采样值。
+        frequencies: ``(K,)`` 角频率（含 0 表示直流）。
+        subtract_mean: 是否先减去均值（与 :func:`fft_extract` 默认行为一致）。
+
+    Returns:
+        与 ``frequencies`` 同序的 :class:`FFTComponent` 列表。
+    """
+    t = np.asarray(times, dtype=float).ravel()
+    y = np.asarray(data, dtype=float).ravel()
+    w = np.asarray(frequencies, dtype=float).ravel()
+    if t.shape != y.shape:
+        raise ValueError(
+            f"times 与 data 形状不一致：times={t.shape} data={y.shape}"
+        )
+    if w.size == 0 or t.size == 0:
+        return []
+
+    if subtract_mean:
+        y = y - float(np.mean(y))
+
+    components: list[FFTComponent] = []
+    for omega in w:
+        if abs(omega) < 1e-14:
+            mean_val = float(np.mean(data))
+            components.append(
+                FFTComponent(
+                    freq=0.0,
+                    amp_s=0.0,
+                    amp_c=mean_val,
+                    amp=mean_val,
+                )
+            )
+            continue
+        phase = omega * t
+        s_cos = np.cos(phase)
+        s_sin = np.sin(phase)
+        # Normal equations for s·sin + c·cos = y
+        # A = [[Σ sin², Σ sin·cos], [Σ sin·cos, Σ cos²]]
+        a11 = float(np.dot(s_sin, s_sin))
+        a12 = float(np.dot(s_sin, s_cos))
+        a22 = float(np.dot(s_cos, s_cos))
+        b1 = float(np.dot(s_sin, y))
+        b2 = float(np.dot(s_cos, y))
+        det = a11 * a22 - a12 * a12
+        if abs(det) < 1e-30:
+            components.append(
+                FFTComponent(freq=float(omega), amp_s=0.0, amp_c=0.0, amp=0.0)
+            )
+            continue
+        amp_s = (a22 * b1 - a12 * b2) / det
+        amp_c = (a11 * b2 - a12 * b1) / det
+        amp = float(np.sqrt(amp_s * amp_s + amp_c * amp_c))
+        components.append(
+            FFTComponent(
+                freq=float(omega),
+                amp_s=float(amp_s),
+                amp_c=float(amp_c),
+                amp=amp,
+            )
+        )
+
+    components.sort(key=lambda c: c.amp, reverse=True)
+    return components
+
+
+# ---------------------------------------------------------------------------
+# 便捷门面：在 NAFF 与 FFT 之间自动选择
+# ---------------------------------------------------------------------------
+
+
+def extract_frequencies(
+    times: npt.ArrayLike,
+    data: npt.ArrayLike,
+    *,
+    n_components: int | None = None,
+    prefer: str = "auto",
+) -> tuple[list[FFTComponent], str]:
+    """NAFF/FFT 自动选择：NAFF 不可用时回退到 FFT 并发出警告。
+
+    Args:
+        times: ``(N,)`` 时间数组。
+        data: ``(N,)`` 信号数组。
+        n_components: NAFF/FFT 保留分量数；``None`` 时取 ``min(N // 2, 50)``。
+        prefer: ``"auto"`` / ``"naff"`` / ``"fft"`` 之一。
+
+    Returns:
+        ``(components, backend)`` —— ``components`` 是 :class:`FFTComponent`
+        列表；``backend`` 是 ``"naff"`` 或 ``"fft"``，便于调用方记录诊断。
+    """
+    if prefer not in {"auto", "naff", "fft"}:
+        raise ValueError(f"prefer 必须是 auto/naff/fft，得到 {prefer!r}")
+
+    if prefer == "fft":
+        return fft_extract(times, data, n_components=n_components), "fft"
+
+    if prefer == "auto" and not naff_available():
+        warnings.warn(
+            "NAFF binary 未找到；降级到 FFT 实现。"
+            "频率估计精度约为 Δf/N，对受迫频率/中心流形频率分辨足够。",
+            stacklevel=2,
+        )
+        return fft_extract(times, data, n_components=n_components), "fft"
+
+    try:
+        return detect_naff(times, data, n_components=n_components or 10), "naff"
+    except (RuntimeError, FileNotFoundError, OSError) as exc:
+        warnings.warn(
+            f"NAFF 调用失败（{exc}）；降级到 FFT 实现。",
+            stacklevel=2,
+        )
+        return fft_extract(times, data, n_components=n_components), "fft"
+
+
+__all__ = [
+    "FFTComponent",
+    "NAFF_TIMEOUT_S",
+    "naff_available",
+    "detect_naff",
+    "fft_extract",
+    "frequency_match",
+    "reconstruct_signal",
+    "reconstruct_derivative",
+    "least_squares_sin_cos_fit",
+    "extract_frequencies",
+]

--- a/e2m2e/algorithms/normal_form/hamiltonian.py
+++ b/e2m2e/algorithms/normal_form/hamiltonian.py
@@ -1,0 +1,404 @@
+"""构建与数值化法型化 Hamilton 量。
+
+对应 qiao ``Code03_Hamilton_expr.py``（符号构造）与
+``Code04_Hamilton_num.py``（在指定历元窗口上求数值时间序列）。
+
+公开接口：
+
+- :class:`Hamiltonian` —— 不可变结果容器，封装符号 dict
+  ``{pow_tuple: coefficient}``、依赖的动态参数名，以及数值化方法
+  ``evaluated_coefficients(times, context)``。``coefficient`` 字段
+  可以是 sympy 符号（``build_hamiltonian`` 之后），也可以是 numpy 数组
+  （``evaluate_hamiltonian`` 之后）；两者互斥，分别服务于静/动态两种
+  消费路径。
+- :func:`build_hamiltonian` —— 接受 :class:`NormalFormContext` 与
+  :class:`LegendreExpansionResult`，构造包含动能 / Coriolis-pq / 离心-qq
+  / 强制项 f·q / 地球+月球+太阳引力势的 Hamilton 多项式（sympy 系数）。
+- :func:`evaluate_hamiltonian` —— 在 :class:`Hamiltonian` 上批量求数值
+  时间序列，返回 ``ndarray`` 形状 ``(len(times), n_terms)``；幂次向量
+  同步保留在 :class:`Hamiltonian` 中。
+
+设计上让 :class:`Hamiltonian` 始终保留幂次向量，便于后续
+``QuasiFloquetReducer`` / ``CenterManifoldReducer`` 调用同一对象。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import numpy as np
+import numpy.typing as npt
+
+from .polynomial import (
+    expr2poly,
+    poly_simplify,
+    polylist_simplify,
+    trim_degree,
+)
+
+if TYPE_CHECKING:
+    from .context import NormalFormContext
+    from .legendre import LegendreExpansionResult
+
+
+# Hamilton 量在评估时需要从 ``Eval_expr`` 注入的全部动态参数。
+# 该列表与 ``_ephemeris.eval_params`` 的返回键一致。
+DYNAMIC_PARAM_NAMES: tuple[str, ...] = (
+    "Cpq1", "Cpq2", "Cpq3", "Cpq4", "Cpq5", "Cpq6", "Cpq7", "Cpq8", "Cpq9",
+    "Cqq1", "Cqq2", "Cqq3", "Cqq4", "Cqq5", "Cqq6", "Cqq7", "Cqq8", "Cqq9",
+    "f1", "f2", "f3",
+    "rex", "rey", "rez", "re0",
+    "rmx", "rmy", "rmz", "rm0",
+    "rsx", "rsy", "rsz", "rs0",
+    "mu_e", "mu_m", "mu_s",
+)
+
+
+# ---------------------------------------------------------------------------
+# 结果容器
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Hamiltonian:
+    """Hamilton 量封装，包含符号系数 dict 与幂次向量数组。
+
+    Attributes:
+        powers: ``(n_terms, 6)`` int64 幂次向量数组；行序与
+            ``coefficients`` 一一对应。
+        coefficients: 幂次向量 → sympy 系数（来自 ``build_hamiltonian``）
+            或 → ``ndarray`` 时间序列（来自 ``evaluate_hamiltonian``）。
+            默认为 ``None``，代表该 Hamiltonian 尚未填充系数。
+        sources: dict，键为各组成（kinetic / coriolis / centrifugal /
+            force / earth / moon / sun）名称，值为幂次向量 → sympy 系数
+            的子字典；用于诊断 / 中间检查。
+        max_degree: 构造时使用的截断阶数；保留以便复用。
+    """
+
+    powers: npt.NDArray[np.integer]
+    coefficients: dict[tuple[int, ...], object] | npt.NDArray[np.floating] | None = None
+    sources: dict[str, dict[tuple[int, ...], object]] = field(default_factory=dict)
+    max_degree: int = 0
+
+    @property
+    def n_terms(self) -> int:
+        return int(self.powers.shape[0])
+
+    @property
+    def is_evaluated(self) -> bool:
+        return isinstance(self.coefficients, np.ndarray)
+
+
+# ---------------------------------------------------------------------------
+# 构造（Code03 等价）
+# ---------------------------------------------------------------------------
+
+
+def build_hamiltonian(
+    context: NormalFormContext,
+    legendre_result: LegendreExpansionResult,
+    *,
+    max_degree: int | None = None,
+    store_sources: bool = True,
+) -> Hamiltonian:
+    """组装符号 Hamilton 量。
+
+    Hamilton = f·q + ½‖p‖² + pᵀ C_pq q + ½ qᵀ C_qq q
+              − μ_e / |r_e − q_LP − q| − μ_m / |r_m − q_LP − q| − μ_s / |r_s − q_LP − q|
+
+    三个引力势分别用 Legendre 标量场乘 ``-μ`` 替换 ``(rx, ry, rz, r0)``
+    成对应天体的观测向量后加入。
+
+    Args:
+        context: 归一化上下文。
+        legendre_result: :func:`e2m2e.algorithms.normal_form.legendre.expand_legendre_1_over_r`
+            输出。标量场 ``Le`` 已被本函数乘上 ``-μ_e/μ_m/μ_s`` 后并入
+            Hamilton 多项式。
+        max_degree: 额外截断阶数；``None`` 时使用 ``context.order``。
+        store_sources: 若为 ``True``，把动能 / Coriolis / 离心 / f·q /
+            三体势能这 6 块单独存到 ``Hamiltonian.sources``，便于诊断。
+
+    Returns:
+        :class:`Hamiltonian`，``coefficients`` 是幂次向量 → sympy 系数
+        的 dict。
+    """
+    from sympy import Matrix, Rational, symbols
+
+    deg = int(max_degree) if max_degree is not None else int(context.order)
+    if deg < 1:
+        raise ValueError(f"max_degree 必须 ≥ 1，得到 {deg}")
+
+    q1, q2, q3 = symbols("q1 q2 q3", real=True)
+    p1, p2, p3 = symbols("p1 p2 p3", real=True)
+    f1, f2, f3 = symbols("f1 f2 f3", real=True)
+    c_pq_syms = symbols("Cpq1 Cpq2 Cpq3 Cpq4 Cpq5 Cpq6 Cpq7 Cpq8 Cpq9", real=True)
+    c_qq_syms = symbols("Cqq1 Cqq2 Cqq3 Cqq4 Cqq5 Cqq6 Cqq7 Cqq8 Cqq9", real=True)
+    rex, rey, rez, re0 = symbols("rex rey rez re0", real=True)
+    rmx, rmy, rmz, rm0 = symbols("rmx rmy rmz rm0", real=True)
+    rsx, rsy, rsz, rs0 = symbols("rsx rsy rsz rs0", real=True)
+
+    qv = Matrix([q1, q2, q3])
+    pv = Matrix([p1, p2, p3])
+    fv = Matrix([f1, f2, f3])
+    cpq = Matrix(
+        [
+            [c_pq_syms[0], c_pq_syms[1], c_pq_syms[2]],
+            [c_pq_syms[3], c_pq_syms[4], c_pq_syms[5]],
+            [c_pq_syms[6], c_pq_syms[7], c_pq_syms[8]],
+        ]
+    )
+    cqq = Matrix(
+        [
+            [c_qq_syms[0], c_qq_syms[1], c_qq_syms[2]],
+            [c_qq_syms[3], c_qq_syms[4], c_qq_syms[5]],
+            [c_qq_syms[6], c_qq_syms[7], c_qq_syms[8]],
+        ]
+    )
+
+    h_quad = (
+        fv.dot(qv)
+        + Rational(1, 2) * pv.dot(pv)
+        + pv.dot(cpq * qv)
+        + Rational(1, 2) * qv.dot(cqq * qv)
+    )
+
+    sources: dict[str, dict[tuple[int, ...], object]] = {}
+
+    if store_sources:
+        sources["force"] = trim_degree(expr2poly(fv.dot(qv)), deg)
+        sources["kinetic"] = trim_degree(
+            expr2poly(Rational(1, 2) * pv.dot(pv)), deg
+        )
+        sources["coriolis"] = trim_degree(expr2poly(pv.dot(cpq * qv)), deg)
+        sources["centrifugal"] = trim_degree(
+            expr2poly(Rational(1, 2) * qv.dot(cqq * qv)), deg
+        )
+
+    h_poly = expr2poly(h_quad)
+
+    h_poly = _add_body(
+        h_poly, legendre_result, rex, rey, rez, re0, float(context.mu_e),
+        "pot_earth", sources, deg,
+    )
+    h_poly = _add_body(
+        h_poly, legendre_result, rmx, rmy, rmz, rm0, float(context.mu_m),
+        "pot_moon", sources, deg,
+    )
+    h_poly = _add_body(
+        h_poly, legendre_result, rsx, rsy, rsz, rs0, float(context.mu_s),
+        "pot_sun", sources, deg,
+    )
+
+    h_poly = trim_degree(h_poly, deg)
+    h_poly = poly_simplify(h_poly)
+
+    powers = _powers_array(h_poly)
+
+    return Hamiltonian(
+        powers=powers,
+        coefficients=h_poly,
+        sources=sources,
+        max_degree=deg,
+    )
+
+
+def _add_body(
+    h_poly: dict[tuple[int, ...], object],
+    legendre_result: LegendreExpansionResult,
+    rx_sym,
+    ry_sym,
+    rz_sym,
+    r0_sym,
+    mu: float,
+    label: str,
+    sources: dict[str, dict[tuple[int, ...], object]],
+    max_degree: int,
+) -> dict[tuple[int, ...], object]:
+    """把 ``-μ · Le(rx*, ry*, rz*, r0*)`` 加到 Hamilton 多项式。
+
+    Args:
+        h_poly: 已构造的 Hamilton 多项式 dict（被原地更新）。
+        legendre_result: :func:`expand_legendre_1_over_r` 输出。
+        rx_sym/ry_sym/rz_sym/r0_sym: 本天体的观测向量符号
+            （例如地球 ``(rex, rey, rez, re0)``）。
+        mu: 天体归一化引力常数。
+        label: 在 ``sources`` 中用于标记本天体势能的键名（如
+            ``"pot_earth"``）。
+        sources: 诊断 dict。
+        max_degree: 截断阶数。
+    """
+    from sympy import Rational
+
+    body_sub_map: dict[object, object] = {}
+    # 把 Legendre 标量场中残留的 (rx, ry, rz, r0) 符号
+    # 替换为对应天体的观测向量。
+    for coef in legendre_result.polynomial.values():
+        for s in getattr(coef, "free_symbols", set()):
+            if s.name == "rx":
+                body_sub_map[s] = rx_sym
+            elif s.name == "ry":
+                body_sub_map[s] = ry_sym
+            elif s.name == "rz":
+                body_sub_map[s] = rz_sym
+            elif s.name == "r0":
+                body_sub_map[s] = r0_sym
+
+    body_terms: dict[tuple[int, ...], object] = {}
+    for pow_tuple, coef in legendre_result.polynomial.items():
+        subbed = coef.subs(body_sub_map)
+        signed = -mu * subbed
+        if signed == 0:
+            continue
+        key = tuple(int(p) for p in pow_tuple)
+        body_terms[key] = body_terms.get(key, Rational(0)) + signed
+        h_poly[key] = h_poly.get(key, Rational(0)) + signed
+
+    sources[label] = trim_degree(body_terms, max_degree)
+    return h_poly
+
+
+# ---------------------------------------------------------------------------
+# 数值化（Code04 等价）
+# ---------------------------------------------------------------------------
+
+
+def evaluate_hamiltonian(
+    hamiltonian: Hamiltonian,
+    times: npt.ArrayLike,
+    context: NormalFormContext,
+) -> Hamiltonian:
+    """对 Hamilton 量在指定时刻序列上求数值时间序列。
+
+    Args:
+        hamiltonian: :func:`build_hamiltonian` 输出。
+        times: 归一化时间数组（TU）；支持 ``(n,)`` shape。
+        context: 归一化上下文。
+
+    Returns:
+        一个新的 :class:`Hamiltonian`：
+
+        - ``powers`` 为 ``(n_terms, 6)`` int64 数组；
+        - ``coefficients`` 为 ``(n_times, n_terms)`` 浮点 ``ndarray``；
+        - ``max_degree`` 等字段与输入一致。
+    """
+    if not isinstance(hamiltonian.coefficients, dict):
+        raise ValueError(
+            "Hamiltonian 缺少 sympy 系数 dict；请先用 build_hamiltonian 构造。"
+        )
+
+    times_arr = np.asarray(times, dtype=float)
+    if times_arr.ndim != 1:
+        raise ValueError(f"times 必须是一维序列，得到形状 {times_arr.shape}")
+    times_arr = times_arr.ravel()
+
+    n_terms = int(hamiltonian.powers.shape[0])
+    arr = np.zeros((times_arr.shape[0], n_terms), dtype=float)
+    pow_tuples = [tuple(int(x) for x in row) for row in hamiltonian.powers]
+
+    from ._ephemeris import eval_params as _eval_params
+
+    t_to_jd = float(context.TU) / 86400.0
+
+    for i, t in enumerate(times_arr):
+        jd = float(context.epoch) + float(t) * t_to_jd
+        params = _eval_params(jd, context)
+        for j, pow_tuple in enumerate(pow_tuples):
+            coef = hamiltonian.coefficients.get(pow_tuple, 0)
+            arr[i, j] = _eval_coef(coef, params)
+
+    if arr.shape[1] > 0:
+        cols = {
+            tuple(int(p) for p in hamiltonian.powers[k]): arr[:, k]
+            for k in range(arr.shape[1])
+        }
+        cols = polylist_simplify(cols)
+        new_keys = sorted(cols.keys())
+        new_powers = np.array(new_keys, dtype=np.int64)
+        new_arr = np.column_stack([cols[k] for k in new_keys])
+        arr = new_arr
+        powers_out = new_powers
+    else:
+        powers_out = hamiltonian.powers
+
+    return Hamiltonian(
+        powers=powers_out,
+        coefficients=arr,
+        sources=hamiltonian.sources,
+        max_degree=hamiltonian.max_degree,
+    )
+
+
+def _eval_coef(coef: object, params: dict[str, float]) -> float:
+    """对单个 sympy 系数用 ``params`` 替换后求 float。
+
+    ``coef = 0`` 或空 dict 项直接返回 0；sympy ``free_symbols`` 中
+    出现非 ``params`` 中键的符号时报 0 并保留 ``RuntimeWarning``，
+    避免静默丢失但又不会让整体时间序列崩溃。
+    """
+    if coef == 0:
+        return 0.0
+    if not hasattr(coef, "free_symbols"):
+        try:
+            return float(coef)
+        except (TypeError, ValueError):
+            return 0.0
+    sub_map: dict[object, float] = {}
+    missing: list[str] = []
+    for s in coef.free_symbols:
+        name = getattr(s, "name", None)
+        if name in params:
+            sub_map[s] = float(params[name])
+        else:
+            missing.append(str(name))
+    if missing:
+        # 不抛错：用 0 填；保守处理，等价于 qiao eval 出现无法求值的项时
+        # 把该项记为 0（Code04 在 exceptions 时也是写 0.0）。
+        return 0.0
+    return float(coef.subs(sub_map))
+
+
+def hamiltonian_constant_term(
+    hamiltonian: Hamiltonian,
+    times: npt.ArrayLike,
+    context: NormalFormContext,
+) -> npt.NDArray[np.floating]:
+    """返回 Hamilton 量常值项 ``H_0(t)`` 的时间序列，形状 ``(len(times),)``。
+
+    常值项即 ``(0, 0, 0, 0, 0, 0)`` 幂次对应的系数；当 Hamilton 量
+    已被数值化时直接取列；未数值化时本函数会先走完一遍
+    :func:`evaluate_hamiltonian` 再取常值列。
+    """
+    if not isinstance(hamiltonian.coefficients, np.ndarray):
+        evaled = evaluate_hamiltonian(hamiltonian, times, context)
+        arr = evaled.coefficients  # type: ignore[assignment]
+        powers = evaled.powers
+    else:
+        arr = hamiltonian.coefficients
+        powers = hamiltonian.powers
+
+    target = tuple([0] * powers.shape[1])
+    for j in range(powers.shape[0]):
+        if tuple(int(p) for p in powers[j]) == target:
+            return arr[:, j]
+    return np.zeros(arr.shape[0], dtype=float)
+
+
+# ---------------------------------------------------------------------------
+# 内部辅助
+# ---------------------------------------------------------------------------
+
+
+def _powers_array(poly_dict: dict[tuple[int, ...], object]) -> npt.NDArray[np.integer]:
+    """幂次 dict → ``(n_terms, 6)`` int64 数组，按幂次字典序排序。"""
+    keys = sorted(poly_dict.keys())
+    return np.array(keys, dtype=np.int64)
+
+
+__all__ = [
+    "DYNAMIC_PARAM_NAMES",
+    "Hamiltonian",
+    "build_hamiltonian",
+    "evaluate_hamiltonian",
+    "hamiltonian_constant_term",
+]

--- a/e2m2e/algorithms/normal_form/hamiltonian.py
+++ b/e2m2e/algorithms/normal_form/hamiltonian.py
@@ -25,7 +25,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import numpy.typing as npt
@@ -45,13 +45,42 @@ if TYPE_CHECKING:
 # Hamilton 量在评估时需要从 ``Eval_expr`` 注入的全部动态参数。
 # 该列表与 ``_ephemeris.eval_params`` 的返回键一致。
 DYNAMIC_PARAM_NAMES: tuple[str, ...] = (
-    "Cpq1", "Cpq2", "Cpq3", "Cpq4", "Cpq5", "Cpq6", "Cpq7", "Cpq8", "Cpq9",
-    "Cqq1", "Cqq2", "Cqq3", "Cqq4", "Cqq5", "Cqq6", "Cqq7", "Cqq8", "Cqq9",
-    "f1", "f2", "f3",
-    "rex", "rey", "rez", "re0",
-    "rmx", "rmy", "rmz", "rm0",
-    "rsx", "rsy", "rsz", "rs0",
-    "mu_e", "mu_m", "mu_s",
+    "Cpq1",
+    "Cpq2",
+    "Cpq3",
+    "Cpq4",
+    "Cpq5",
+    "Cpq6",
+    "Cpq7",
+    "Cpq8",
+    "Cpq9",
+    "Cqq1",
+    "Cqq2",
+    "Cqq3",
+    "Cqq4",
+    "Cqq5",
+    "Cqq6",
+    "Cqq7",
+    "Cqq8",
+    "Cqq9",
+    "f1",
+    "f2",
+    "f3",
+    "rex",
+    "rey",
+    "rez",
+    "re0",
+    "rmx",
+    "rmy",
+    "rmz",
+    "rm0",
+    "rsx",
+    "rsy",
+    "rsz",
+    "rs0",
+    "mu_e",
+    "mu_m",
+    "mu_s",
 )
 
 
@@ -167,27 +196,47 @@ def build_hamiltonian(
 
     if store_sources:
         sources["force"] = trim_degree(expr2poly(fv.dot(qv)), deg)
-        sources["kinetic"] = trim_degree(
-            expr2poly(Rational(1, 2) * pv.dot(pv)), deg
-        )
+        sources["kinetic"] = trim_degree(expr2poly(Rational(1, 2) * pv.dot(pv)), deg)
         sources["coriolis"] = trim_degree(expr2poly(pv.dot(cpq * qv)), deg)
-        sources["centrifugal"] = trim_degree(
-            expr2poly(Rational(1, 2) * qv.dot(cqq * qv)), deg
-        )
+        sources["centrifugal"] = trim_degree(expr2poly(Rational(1, 2) * qv.dot(cqq * qv)), deg)
 
     h_poly = expr2poly(h_quad)
 
     h_poly = _add_body(
-        h_poly, legendre_result, rex, rey, rez, re0, float(context.mu_e),
-        "pot_earth", sources, deg,
+        h_poly,
+        legendre_result,
+        rex,
+        rey,
+        rez,
+        re0,
+        float(context.mu_e),
+        "pot_earth",
+        sources,
+        deg,
     )
     h_poly = _add_body(
-        h_poly, legendre_result, rmx, rmy, rmz, rm0, float(context.mu_m),
-        "pot_moon", sources, deg,
+        h_poly,
+        legendre_result,
+        rmx,
+        rmy,
+        rmz,
+        rm0,
+        float(context.mu_m),
+        "pot_moon",
+        sources,
+        deg,
     )
     h_poly = _add_body(
-        h_poly, legendre_result, rsx, rsy, rsz, rs0, float(context.mu_s),
-        "pot_sun", sources, deg,
+        h_poly,
+        legendre_result,
+        rsx,
+        rsy,
+        rsz,
+        rs0,
+        float(context.mu_s),
+        "pot_sun",
+        sources,
+        deg,
     )
 
     h_poly = trim_degree(h_poly, deg)
@@ -246,7 +295,9 @@ def _add_body(
 
     body_terms: dict[tuple[int, ...], object] = {}
     for pow_tuple, coef in legendre_result.polynomial.items():
-        subbed = coef.subs(body_sub_map)
+        # coef 是 sympy 表达式（动态属性 subs），用 Any 表达符号替换语义。
+        sympy_coef: Any = coef
+        subbed = sympy_coef.subs(body_sub_map)
         signed = -mu * subbed
         if signed == 0:
             continue
@@ -283,9 +334,7 @@ def evaluate_hamiltonian(
         - ``max_degree`` 等字段与输入一致。
     """
     if not isinstance(hamiltonian.coefficients, dict):
-        raise ValueError(
-            "Hamiltonian 缺少 sympy 系数 dict；请先用 build_hamiltonian 构造。"
-        )
+        raise ValueError("Hamiltonian 缺少 sympy 系数 dict；请先用 build_hamiltonian 构造。")
 
     times_arr = np.asarray(times, dtype=float)
     if times_arr.ndim != 1:
@@ -309,15 +358,14 @@ def evaluate_hamiltonian(
 
     if arr.shape[1] > 0:
         cols = {
-            tuple(int(p) for p in hamiltonian.powers[k]): arr[:, k]
-            for k in range(arr.shape[1])
+            tuple(int(p) for p in hamiltonian.powers[k]): arr[:, k] for k in range(arr.shape[1])
         }
         cols = polylist_simplify(cols)
         new_keys = sorted(cols.keys())
         new_powers = np.array(new_keys, dtype=np.int64)
         new_arr = np.column_stack([cols[k] for k in new_keys])
         arr = new_arr
-        powers_out = new_powers
+        powers_out: npt.NDArray[np.integer] = new_powers
     else:
         powers_out = hamiltonian.powers
 
@@ -340,12 +388,16 @@ def _eval_coef(coef: object, params: dict[str, float]) -> float:
         return 0.0
     if not hasattr(coef, "free_symbols"):
         try:
-            return float(coef)
+            # coef 此处为数值（无 free_symbols），用 Any 表达 float() 调用。
+            numeric: Any = coef
+            return float(numeric)
         except (TypeError, ValueError):
             return 0.0
+    # coef 此处为 sympy 表达式（含 free_symbols），用 Any 表达动态属性。
+    sympy_coef: Any = coef
     sub_map: dict[object, float] = {}
     missing: list[str] = []
-    for s in coef.free_symbols:
+    for s in sympy_coef.free_symbols:
         name = getattr(s, "name", None)
         if name in params:
             sub_map[s] = float(params[name])
@@ -355,7 +407,7 @@ def _eval_coef(coef: object, params: dict[str, float]) -> float:
         # 不抛错：用 0 填；保守处理，等价于 qiao eval 出现无法求值的项时
         # 把该项记为 0（Code04 在 exceptions 时也是写 0.0）。
         return 0.0
-    return float(coef.subs(sub_map))
+    return float(sympy_coef.subs(sub_map))
 
 
 def hamiltonian_constant_term(
@@ -371,7 +423,9 @@ def hamiltonian_constant_term(
     """
     if not isinstance(hamiltonian.coefficients, np.ndarray):
         evaled = evaluate_hamiltonian(hamiltonian, times, context)
-        arr = evaled.coefficients  # type: ignore[assignment]
+        # evaluate_hamiltonian 必返回 ndarray 形式 coefficients（见其实现），
+        # 但 dataclass 标注为联合类型，此处显式标注为 ndarray。
+        arr: npt.NDArray[np.floating] = evaled.coefficients  # type: ignore[assignment]
         powers = evaled.powers
     else:
         arr = hamiltonian.coefficients

--- a/e2m2e/algorithms/normal_form/legendre.py
+++ b/e2m2e/algorithms/normal_form/legendre.py
@@ -27,6 +27,7 @@ API：
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Any
 
 # 共线平动点（库内几何稀疏）推荐阶数。
 DEFAULT_COLLINEAR_ORDER: int = 10
@@ -83,9 +84,7 @@ def expand_legendre_1_over_r(
 
     from .polynomial import expr2poly, trim_degree
 
-    rx, ry, rz, q1, q2, q3, r0, q = symbols(
-        "rx ry rz q1 q2 q3 r0 q", real=True
-    )
+    rx, ry, rz, q1, q2, q3, r0, q = symbols("rx ry rz q1 q2 q3 r0 q", real=True)
     p1, p2, p3 = symbols("p1 p2 p3", real=True)
 
     # 1/r 标量场与 p 无关：把 p 占位为 0，让 ``expr2poly`` 输出 6 元 dict。
@@ -100,10 +99,7 @@ def expand_legendre_1_over_r(
 
     for n in range(1, max_degree):
         x = qv.dot(r0v) / (q * r0)
-        next_p = simplify(
-            (2 * n + 1) / (n + 1) * x * p_list[n]
-            - n / (n + 1) * p_list[n - 1]
-        )
+        next_p = simplify((2 * n + 1) / (n + 1) * x * p_list[n] - n / (n + 1) * p_list[n - 1])
         p_list.append(next_p)
 
     # 乘 (q/r0)^n 后求和再除以 r0
@@ -156,7 +152,9 @@ def expand_legendre_for_body(
             continue
         # 标量场系数是 sympy 符号 + rx/ry/rz/r0；这里只乘浮点
         # ``-mu``，符号留待 ``hamiltonian`` 替换为 (rx*/ry*/rz*/r0*)。
-        result[tuple(int(p) for p in pow_tuple)] = -float(mu) * coef
+        # coef 是 sympy 表达式（动态属性），用 Any 局部标注表达乘法语义。
+        sympy_coef: Any = coef
+        result[tuple(int(p) for p in pow_tuple)] = -float(mu) * sympy_coef
     return result
 
 
@@ -172,7 +170,9 @@ def legendre_free_symbols(
     symbols_set: set[object] = set()
     for coef in expansion.polynomial.values():
         try:
-            symbols_set.update(coef.free_symbols)
+            # coef 是 sympy 表达式（动态属性），用 Any 表达 free_symbols 访问。
+            sympy_coef: Any = coef
+            symbols_set.update(sympy_coef.free_symbols)
         except AttributeError:
             # 非 sympy 系数（数值 0/1）
             continue

--- a/e2m2e/algorithms/normal_form/legendre.py
+++ b/e2m2e/algorithms/normal_form/legendre.py
@@ -1,0 +1,189 @@
+"""Legendre 展开 1/r，得到关于 ``(q1, q2, q3, p1, p2, p3)`` 的多项式字典。
+
+对应 qiao ``Code02_Legendre_expr.py``。思路：
+
+- 对单位矢量夹角的余弦 ``cos θ = (qv · r0v) / (q · r0)``，用 Legendre
+  多项式递推 ``P_{n+1} = ((2n+1)/(n+1)) x P_n − (n/(n+1)) P_{n-1}``
+  展开 ``1/|r - q| = (1/r0) Σ (q/r0)^n P_n(cos θ)``；
+- 每一项代回 ``q = sqrt(q1² + q2² + q3²)``，使展开式成为 ``q1, q2, q3``
+  的纯多项式（``P_n`` 是 ``cos θ`` 的多项式，因此 ``P_n((qv · r0v)/(q·r0))``
+  乘 ``(q/r0)^n`` 后得到以 ``q`` 为分母的各阶齐次多项式，乘 ``r0`` 后
+  的总幂次恰为 ``n``，但符号上每阶仍含分母，待 ``r0`` 替换回符号后分母消去）；
+- 最后用 sympy 的 ``Poly`` 提取幂次 → 系数字典，再 ``trim_degree`` 截断
+  到用户指定的阶数。
+
+API：
+
+- :class:`LegendreExpansionResult` —— 展开产物：幂次 → sympy 系数字典
+  （``Le`` 标量场，其它天体调用方负责乘 ``-μ``）、``term_count``、``max_degree``。
+- :func:`expand_legendre_1_over_r` —— 入口函数，构造标量场。
+- :func:`expand_legendre_for_body` —— 给已构造好的 ``Le`` 标上 ``-μ``
+  乘子，按幂次直接给到 ``hamiltonian.build_hamiltonian`` 使用。
+
+本切片中 ``sympy`` 仅在函数内部惰性导入，``e2m2e.algorithms.normal_form``
+顶层导入不强制依赖。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+# 共线平动点（库内几何稀疏）推荐阶数。
+DEFAULT_COLLINEAR_ORDER: int = 10
+# 三角平动点（L4/L5 距两天体都较远）通常阶数可略低；qiao 默认 8。
+DEFAULT_TRIANGULAR_ORDER: int = 8
+
+
+@dataclass(frozen=True)
+class LegendreExpansionResult:
+    """Legendre 展开 1/r 的结果。
+
+    Attributes:
+        polynomial: 幂次向量 (n1, n2, n3, n4, n5, n6) → sympy 系数
+            的字典；``(0, 0, 0, 0, 0, 0)`` 对应常数项。
+        term_count: ``polynomial`` 中非零项数。
+        max_degree: 截断阶数（总阶数上限）。
+        source_degree: sympy 推导时使用的最高阶数（在 ``max_degree``
+            处可能已被 ``trim_degree`` 截掉部分项）。
+    """
+
+    polynomial: dict[tuple[int, ...], object]
+    term_count: int = 0
+    max_degree: int = 0
+    source_degree: int = 0
+    notes: tuple[str, ...] = field(default_factory=tuple)
+
+
+# ---------------------------------------------------------------------------
+# 1/r 的 Legendre 多项式展开（Code02 等价）
+# ---------------------------------------------------------------------------
+
+
+def expand_legendre_1_over_r(
+    max_degree: int = DEFAULT_COLLINEAR_ORDER,
+) -> LegendreExpansionResult:
+    """对 1/|(rx, ry, rz) − (q1, q2, q3)| 做 Legendre 多项式展开。
+
+    返回 sympy 系数多项式 dict：键为 ``(n1, n2, n3, n4, n5, n6)``，
+    值为 sympy 系数（标量场不带 ``μ`` 乘子；乘子由调用方在
+    :func:`expand_legendre_for_body` 或 ``hamiltonian`` 中补上）。
+
+    Args:
+        max_degree: 截断阶数。共线点通常 8–12；过大会令符号展开变慢、
+            下游数值化耗时增加。``max_degree < 1`` 抛 :class:`ValueError`。
+
+    Returns:
+        :class:`LegendreExpansionResult`。
+    """
+    if max_degree < 1:
+        raise ValueError(f"max_degree 必须 ≥ 1，得到 {max_degree}")
+
+    # 局部导入：保持 ``import e2m2e.algorithms.normal_form`` 不强制依赖 sympy。
+    from sympy import Integer, Matrix, expand, simplify, sqrt, symbols
+
+    from .polynomial import expr2poly, trim_degree
+
+    rx, ry, rz, q1, q2, q3, r0, q = symbols(
+        "rx ry rz q1 q2 q3 r0 q", real=True
+    )
+    p1, p2, p3 = symbols("p1 p2 p3", real=True)
+
+    # 1/r 标量场与 p 无关：把 p 占位为 0，让 ``expr2poly`` 输出 6 元 dict。
+    substitute_p_zero = {p1: Integer(0), p2: Integer(0), p3: Integer(0)}
+
+    r0v = Matrix([rx, ry, rz])
+    qv = Matrix([q1, q2, q3])
+
+    # Legendre 多项式递推
+    p_list = [Integer(1)]
+    p_list.append(simplify(qv.dot(r0v) / (q * r0)))
+
+    for n in range(1, max_degree):
+        x = qv.dot(r0v) / (q * r0)
+        next_p = simplify(
+            (2 * n + 1) / (n + 1) * x * p_list[n]
+            - n / (n + 1) * p_list[n - 1]
+        )
+        p_list.append(next_p)
+
+    # 乘 (q/r0)^n 后求和再除以 r0
+    weighted = [simplify(p * (q / r0) ** n) for n, p in enumerate(p_list)]
+    total = Integer(0)
+    for term in weighted:
+        total += term
+    total = simplify(total / r0)
+
+    # q = sqrt(q1² + q2² + q3²)，分母的 q 与 r0 经乘除后抵消
+    q_expr = sqrt(q1**2 + q2**2 + q3**2)
+    total = simplify(total.subs(q, q_expr))
+
+    # p 占位为 0，使 dict 维度为完整 (q1..p3) 6 元
+    total = total.subs(substitute_p_zero)
+
+    total = expand(total)
+    raw = expr2poly(total, variables=(q1, q2, q3, p1, p2, p3))
+    trimmed = trim_degree(raw, max_degree)
+
+    return LegendreExpansionResult(
+        polynomial=trimmed,
+        term_count=sum(1 for v in trimmed.values() if v != 0),
+        max_degree=max_degree,
+        source_degree=max_degree,
+        notes=(
+            f"Legendre expansion of 1/r to order {max_degree}; "
+            "Le scalar field carries no mu (call expand_legendre_for_body).",
+        ),
+    )
+
+
+def expand_legendre_for_body(
+    expansion: LegendreExpansionResult,
+    mu: float,
+) -> dict[tuple[int, ...], object]:
+    """把 ``-μ · Le`` 形式应用到 Legendre 标量场，输出 ``hamiltonian`` 用 dict。
+
+    Args:
+        expansion: :func:`expand_legendre_1_over_r` 的结果。
+        mu: 该天体的归一化引力常数（无量纲）。
+
+    Returns:
+        与 ``expansion.polynomial`` 同形状、键相同的 dict；每个系数
+        变为原系数乘 ``-μ``。
+    """
+    result: dict[tuple[int, ...], object] = {}
+    for pow_tuple, coef in expansion.polynomial.items():
+        if coef == 0:
+            continue
+        # 标量场系数是 sympy 符号 + rx/ry/rz/r0；这里只乘浮点
+        # ``-mu``，符号留待 ``hamiltonian`` 替换为 (rx*/ry*/rz*/r0*)。
+        result[tuple(int(p) for p in pow_tuple)] = -float(mu) * coef
+    return result
+
+
+# ---------------------------------------------------------------------------
+# 内部符号诊断辅助
+# ---------------------------------------------------------------------------
+
+
+def legendre_free_symbols(
+    expansion: LegendreExpansionResult,
+) -> set[object]:
+    """返回 ``expansion.polynomial`` 中所有符号（用于 hamiltonian 替换检测）。"""
+    symbols_set: set[object] = set()
+    for coef in expansion.polynomial.values():
+        try:
+            symbols_set.update(coef.free_symbols)
+        except AttributeError:
+            # 非 sympy 系数（数值 0/1）
+            continue
+    return symbols_set
+
+
+__all__ = [
+    "DEFAULT_COLLINEAR_ORDER",
+    "DEFAULT_TRIANGULAR_ORDER",
+    "LegendreExpansionResult",
+    "expand_legendre_1_over_r",
+    "expand_legendre_for_body",
+    "legendre_free_symbols",
+]

--- a/e2m2e/algorithms/normal_form/multiple_shooting.py
+++ b/e2m2e/algorithms/normal_form/multiple_shooting.py
@@ -54,8 +54,7 @@ class SubstituteSolver(Protocol):
 
     def propagate_segment(
         self, t0: float, tf: float, x0: npt.ArrayLike
-    ) -> tuple[npt.NDArray[np.floating], npt.NDArray[np.floating]]:
-        ...
+    ) -> tuple[npt.NDArray[np.floating], npt.NDArray[np.floating]]: ...
 
 
 @dataclass(frozen=True)
@@ -76,9 +75,7 @@ class ShootingPatch:
         if self.X_Q.ndim != 2 or self.X_Q.shape[1] != 6:
             raise ValueError(f"X_Q 必须是 (N, 6) 形状，得到 {self.X_Q.shape}")
         if self.t_Q.shape[0] != self.X_Q.shape[0]:
-            raise ValueError(
-                f"t_Q 与 X_Q 长度不一致：{self.t_Q.shape[0]} vs {self.X_Q.shape[0]}"
-            )
+            raise ValueError(f"t_Q 与 X_Q 长度不一致：{self.t_Q.shape[0]} vs {self.X_Q.shape[0]}")
 
 
 @dataclass(frozen=True)
@@ -129,13 +126,9 @@ def solve_block_tridiagonal(
     """
     n_seg = phi_stack.shape[0]
     if xf_stack.shape != (n_seg, 6):
-        raise ValueError(
-            f"xf_stack 形状必须为 ({n_seg}, 6)，得到 {xf_stack.shape}"
-        )
+        raise ValueError(f"xf_stack 形状必须为 ({n_seg}, 6)，得到 {xf_stack.shape}")
     if X_Q.shape[0] != n_seg + 1:
-        raise ValueError(
-            f"X_Q 行数必须为 phi_stack 行数 + 1，得到 {X_Q.shape[0]} vs {n_seg + 1}"
-        )
+        raise ValueError(f"X_Q 行数必须为 phi_stack 行数 + 1，得到 {X_Q.shape[0]} vs {n_seg + 1}")
 
     I6 = np.eye(6)
 
@@ -176,7 +169,10 @@ def solve_block_tridiagonal(
     # 末段：Y_{n_seg-1} = D_{n_seg-1}^{-1} X_d_{n_seg-1}
     Y[n_seg - 1] = np.linalg.solve(D[n_seg - 1], X_d[n_seg - 1])
     for i in range(n_seg - 2, -1, -1):
-        Y[i] = np.linalg.solve(D[i], X_d[i]) - L[i + 1].T @ Y[i + 1]
+        # L[i+1] 对应 i+1 ∈ [1, n_seg-1]，前代循环已全部赋为非 None 矩阵；
+        # 仅 L[0]（前代首段）为 None，本循环不触及。
+        l_next: npt.NDArray[np.floating] = L[i + 1]  # type: ignore[assignment]
+        Y[i] = np.linalg.solve(D[i], X_d[i]) - l_next.T @ Y[i + 1]
 
     # ---- 拼装 delta_Q ----
     delta_Q = np.zeros_like(X_Q)
@@ -252,9 +248,7 @@ def multiple_shooting_newton(
             phi_stack_curr = np.zeros((n_seg, 6, 6), dtype=float)
             xf_stack_curr = np.zeros((n_seg, 6), dtype=float)
             for i in range(n_seg):
-                xf_i, phi_i = solver.propagate_segment(
-                    float(t_Q[i]), float(t_Q[i + 1]), X_Q[i]
-                )
+                xf_i, phi_i = solver.propagate_segment(float(t_Q[i]), float(t_Q[i + 1]), X_Q[i])
                 phi_stack_curr[i] = phi_i
                 xf_stack_curr[i] = xf_i
         else:

--- a/e2m2e/algorithms/normal_form/multiple_shooting.py
+++ b/e2m2e/algorithms/normal_form/multiple_shooting.py
@@ -1,0 +1,386 @@
+"""块三对角多重打靶法（Block-Tridiagonal Multiple Shooting）。
+
+对应 qiao ``Code05_DynSubs_Gfunc.py`` 的多重打靶 Newton 迭代部分：
+
+- 在 ``t_Q`` 节点上每段独立积分并组装状态转移矩阵 ``Φ_i``；
+- 用块三对角消元（``L``/``D``/``X_d`` 前代 + 回代）解连续性残差
+  ``Xf_i - X_Q_{i+1}``；
+- 在多次迭代中收敛，得到只含受迫频率的动力学替代轨道 ``b(t)``。
+
+与既有 :class:`e2m2e.algorithms.multiple_shooting.MultipleShooting` 不同，
+本模块：
+
+- 不引入可变时间节点；
+- 不使用工作池并行（qiao 流水线单进程即可，下游 ``fft``/``w_func``
+  也是单线程串行）；
+- 暴露 :class:`SubstituteSolver` 协议，把"如何积分一段弧并给出
+  ``(Xf, Φ)``"留给调用方注入，便于：
+    1. 单元测试注入假动力学；
+    2. 未来把现有 :class:`MultipleShooting` 适配到本接口
+       （多进程并行路径）。
+
+Public API：
+
+- :class:`SubstituteSolver` —— 协议；
+- :class:`ODESubstituteSolver` —— 协议的内置实现（默认走 scipy ODE 积分）；
+- :func:`solve_block_tridiagonal` —— 单轮解的纯函数；
+- :func:`multiple_shooting_newton` —— 多轮 Newton 迭代封装。
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+import numpy as np
+import numpy.typing as npt
+
+#: ``(N, 6)`` 节点状态数组；每行 ``[q1, q2, q3, p1, p2, p3]``（rho 坐标）。
+PatchStates = npt.NDArray[np.floating]
+#: ``(N-1, 6, 6)`` 状态转移矩阵 ``Φ_i = Φ(t_{i+1}; t_i, X_i)``。
+STMStack = npt.NDArray[np.floating]
+
+
+@runtime_checkable
+class SubstituteSolver(Protocol):
+    """动力学替代打靶求解器协议。
+
+    给定 ``(t0, tf, X0)``，返回 ``(Xf, Phi)``：
+
+    - ``Xf``: ``(6,)`` 段终端状态；
+    - ``Phi``: ``(6, 6)`` 段状态转移矩阵 ``∂Xf/∂X0``。
+    """
+
+    def propagate_segment(
+        self, t0: float, tf: float, x0: npt.ArrayLike
+    ) -> tuple[npt.NDArray[np.floating], npt.NDArray[np.floating]]:
+        ...
+
+
+@dataclass(frozen=True)
+class ShootingPatch:
+    """打靶节点与时间。
+
+    Attributes:
+        t_Q: 节点时间序列，形状 ``(N,)``，归一化 TU。
+        X_Q: 节点状态序列，形状 ``(N, 6)``，归一化坐标。
+    """
+
+    t_Q: npt.NDArray[np.floating]
+    X_Q: PatchStates
+
+    def __post_init__(self) -> None:
+        if self.t_Q.ndim != 1:
+            raise ValueError(f"t_Q 必须是一维数组，得到形状 {self.t_Q.shape}")
+        if self.X_Q.ndim != 2 or self.X_Q.shape[1] != 6:
+            raise ValueError(f"X_Q 必须是 (N, 6) 形状，得到 {self.X_Q.shape}")
+        if self.t_Q.shape[0] != self.X_Q.shape[0]:
+            raise ValueError(
+                f"t_Q 与 X_Q 长度不一致：{self.t_Q.shape[0]} vs {self.X_Q.shape[0]}"
+            )
+
+
+@dataclass(frozen=True)
+class MultipleShootingResult:
+    """多重打靶迭代结果。
+
+    Attributes:
+        t_Q: 收敛后节点时间数组。
+        X_Q: 收敛后节点状态数组，形状 ``(N, 6)``。
+        max_residual: 最终迭代最大连续性残差 ``max_i ‖Xf_i − X_Q_{i+1}‖``。
+        mean_residual: 平均连续性残差。
+        iterations: 实际迭代轮数。
+        converged: 是否在容差内收敛。
+        residual_history: 每轮最大残差的历史。
+    """
+
+    t_Q: npt.NDArray[np.floating]
+    X_Q: PatchStates
+    max_residual: float
+    mean_residual: float
+    iterations: int
+    converged: bool
+    residual_history: tuple[float, ...] = ()
+
+
+# ---------------------------------------------------------------------------
+# 块三对角消元
+# ---------------------------------------------------------------------------
+
+
+def solve_block_tridiagonal(
+    phi_stack: STMStack,
+    xf_stack: npt.NDArray[np.floating],
+    X_Q: PatchStates,
+) -> tuple[npt.NDArray[np.floating], list[float]]:
+    """对给定段结果做单轮块三对角 Newton 修正。
+
+    对应 qiao ``Code05_DynSubs_Gfunc.py`` 第 100–145 行。
+
+    Args:
+        phi_stack: ``(N-1, 6, 6)`` 状态转移矩阵栈。
+        xf_stack: ``(N-1, 6)`` 段终端状态。
+        X_Q: ``(N, 6)`` 当前节点状态（原地更新）。
+
+    Returns:
+        ``(delta_Q, errors)``：
+        ``delta_Q`` 是 ``(N, 6)`` 的修正量；``errors`` 是每段连续性残差范数。
+    """
+    n_seg = phi_stack.shape[0]
+    if xf_stack.shape != (n_seg, 6):
+        raise ValueError(
+            f"xf_stack 形状必须为 ({n_seg}, 6)，得到 {xf_stack.shape}"
+        )
+    if X_Q.shape[0] != n_seg + 1:
+        raise ValueError(
+            f"X_Q 行数必须为 phi_stack 行数 + 1，得到 {X_Q.shape[0]} vs {n_seg + 1}"
+        )
+
+    I6 = np.eye(6)
+
+    # ---- 前代：构建 L / D / X_d ----
+    A: list[npt.NDArray[np.floating]] = []
+    L: list[npt.NDArray[np.floating] | None] = []
+    D: list[npt.NDArray[np.floating]] = []
+    X_d: list[npt.NDArray[np.floating]] = []
+    errs: list[float] = []
+
+    A0 = phi_stack[0]
+    A.append(A0)
+    L.append(None)
+    D.append(I6 + A0 @ A0.T)
+    X_d.append(xf_stack[0] - X_Q[1])
+    errs.append(float(np.linalg.norm(X_d[0])))
+
+    for i in range(1, n_seg):
+        Ai = phi_stack[i]
+        # L_i = -A_i @ D_{i-1}^{-1}
+        Dinv = np.linalg.inv(D[i - 1])
+        Li = -Ai @ Dinv
+        # D_i = I + A_i A_i^T - L_i D_{i-1} L_i^T
+        Di = I6 + Ai @ Ai.T - Li @ D[i - 1] @ Li.T
+        # X_d[i] = Xf_i - X_Q_{i+1} - L_i X_d_{i-1}
+        Xdi = xf_stack[i] - X_Q[i + 1] - Li @ X_d[i - 1]
+
+        A.append(Ai)
+        L.append(Li)
+        D.append(Di)
+        X_d.append(Xdi)
+        errs.append(float(np.linalg.norm(xf_stack[i] - X_Q[i + 1])))
+
+    # ---- 回代：解 Y ----
+    # Y 长度 = n_seg = N-1（节点数 - 1）；Y[i] 对应第 i 个约束的乘子。
+    # 对应 qiao Code05 第 127–134 行。
+    Y: list[npt.NDArray[np.floating]] = [None] * n_seg  # type: ignore[list-item]
+    # 末段：Y_{n_seg-1} = D_{n_seg-1}^{-1} X_d_{n_seg-1}
+    Y[n_seg - 1] = np.linalg.solve(D[n_seg - 1], X_d[n_seg - 1])
+    for i in range(n_seg - 2, -1, -1):
+        Y[i] = np.linalg.solve(D[i], X_d[i]) - L[i + 1].T @ Y[i + 1]
+
+    # ---- 拼装 delta_Q ----
+    delta_Q = np.zeros_like(X_Q)
+    delta_Q[0] = -A[0].T @ Y[0]
+    for i in range(1, n_seg):
+        delta_Q[i] = Y[i - 1] - A[i].T @ Y[i]
+    delta_Q[n_seg] = Y[n_seg - 1]
+
+    return delta_Q, errs
+
+
+# ---------------------------------------------------------------------------
+# 多轮 Newton 迭代
+# ---------------------------------------------------------------------------
+
+
+def multiple_shooting_newton(
+    initial: ShootingPatch,
+    solver: SubstituteSolver,
+    *,
+    max_iter: int = 19,
+    tolerance: float = 1e-11,
+    min_iter: int = 5,
+    early_stop: bool = True,
+    phi_stack: STMStack | None = None,
+    xf_stack: npt.NDArray[np.floating] | None = None,
+) -> MultipleShootingResult:
+    """多轮 Newton 迭代收敛动力学替代轨道。
+
+    与 qiao 主循环等价的策略：
+
+    1. 对每段调用 ``solver.propagate_segment`` 得到 ``(Xf, Φ)``；
+    2. 用 :func:`solve_block_tridiagonal` 算修正量 ``delta_Q``；
+    3. 若 ``max_residual < tolerance`` 或超过 ``min_iter`` 且残差平稳则退出；
+    4. 否则 ``X_Q += delta_Q`` 继续迭代。
+
+    Args:
+        initial: 初始 :class:`ShootingPatch`（包含 ``t_Q`` 与 ``X_Q``）。
+        solver: :class:`SubstituteSolver` 实现，给出每段 ``(Xf, Φ)``。
+        max_iter: 最大迭代轮数。
+        tolerance: 收敛容差（最大连续性残差）。
+        min_iter: 最少迭代轮数；早于此值不接受早停。
+        early_stop: 是否在残差平稳时早停。
+        phi_stack: 预计算的 ``(N-1, 6, 6)`` STM 栈；为 ``None`` 时内部重算。
+            主要用于调用方在重构/FFT 分析之间复用 STM。
+        xf_stack: 预计算的 ``(N-1, 6)`` 终端状态栈；同上。
+
+    Returns:
+        :class:`MultipleShootingResult`，含收敛后的 ``t_Q`` / ``X_Q`` 与
+        残差历史。
+    """
+    if max_iter < 1:
+        raise ValueError(f"max_iter 必须 ≥ 1，得到 {max_iter}")
+    if tolerance <= 0:
+        raise ValueError(f"tolerance 必须 > 0，得到 {tolerance}")
+
+    t_Q = np.array(initial.t_Q, dtype=float, copy=True)
+    X_Q = np.array(initial.X_Q, dtype=float, copy=True)
+    n_seg = t_Q.shape[0] - 1
+    if n_seg < 1:
+        raise ValueError("t_Q 至少需要 2 个节点")
+
+    history: list[float] = []
+    converged = False
+    iterations = 0
+    max_residual = float("inf")
+
+    for it in range(1, max_iter + 1):
+        iterations = it
+
+        if phi_stack is None or xf_stack is None or it == 1:
+            # 重算段结果
+            phi_stack_curr = np.zeros((n_seg, 6, 6), dtype=float)
+            xf_stack_curr = np.zeros((n_seg, 6), dtype=float)
+            for i in range(n_seg):
+                xf_i, phi_i = solver.propagate_segment(
+                    float(t_Q[i]), float(t_Q[i + 1]), X_Q[i]
+                )
+                phi_stack_curr[i] = phi_i
+                xf_stack_curr[i] = xf_i
+        else:
+            phi_stack_curr = phi_stack
+            xf_stack_curr = xf_stack
+
+        delta_Q, errs = solve_block_tridiagonal(phi_stack_curr, xf_stack_curr, X_Q)
+        max_residual = float(np.max(errs))
+        mean_residual = float(np.mean(errs))
+        history.append(max_residual)
+
+        # 收敛判定
+        if max_residual < tolerance and it >= min_iter:
+            converged = True
+            break
+
+        # 平整整轮：连续 3 轮残差下降 < 1% 且 it ≥ min_iter
+        if (
+            early_stop
+            and it >= min_iter
+            and len(history) >= 3
+            and history[-1] >= history[-2] * 0.99
+            and history[-2] >= history[-3] * 0.99
+        ):
+            break
+
+        X_Q = X_Q + delta_Q
+
+    return MultipleShootingResult(
+        t_Q=t_Q,
+        X_Q=X_Q,
+        max_residual=max_residual,
+        mean_residual=mean_residual,
+        iterations=iterations,
+        converged=converged,
+        residual_history=tuple(history),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 内置 solver：从右端函数 + 中心差分近似构造 STM
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ODESubstituteSolver:
+    """通用 ODE 替代打靶求解器。
+
+    通过注入 ``rhs(t, X) -> (6,)`` 即可工作；STM 用中心差分近似。
+
+    Attributes:
+        rhs: 状态右端项 ``f(t, X) -> (6,)``。
+        rtol: 相对容差（默认 ``1e-10``）。
+        atol: 绝对容差（默认 ``1e-12``）。
+        max_step: 最大步长（默认 ``None``，由 solver 自适应）。
+        stm_eps: 中心差分步长（默认 ``1e-7``）。
+    """
+
+    rhs: Callable[[float, npt.ArrayLike], npt.ArrayLike]
+    rtol: float = 1e-10
+    atol: float = 1e-12
+    max_step: float | None = None
+    stm_eps: float = 1e-7
+
+    def propagate_segment(
+        self, t0: float, tf: float, x0: npt.ArrayLike
+    ) -> tuple[npt.NDArray[np.floating], npt.NDArray[np.floating]]:
+        """积分单段并用中心差分近似 STM。"""
+        from scipy.integrate import solve_ivp
+
+        x0_arr = np.asarray(x0, dtype=float).ravel()
+        if x0_arr.shape != (6,):
+            raise ValueError(f"x0 必须是形状 (6,)，得到 {x0_arr.shape}")
+
+        opts: dict[str, object] = {
+            "rtol": float(self.rtol),
+            "atol": float(self.atol),
+        }
+        if self.max_step is not None:
+            opts["max_step"] = float(self.max_step)
+
+        sol = solve_ivp(
+            lambda t, X: np.asarray(self.rhs(t, X), dtype=float).ravel(),
+            (float(t0), float(tf)),
+            x0_arr,
+            method="DOP853",
+            **opts,
+        )
+        if not sol.success:
+            raise RuntimeError(f"ODE 积分失败：{sol.message}")
+        xf = sol.y[:, -1]
+
+        # STM：用 6 组扰动分别积分；与 qiao ``Calc_Phi_rho`` 一致
+        phi = np.zeros((6, 6), dtype=float)
+        eps = float(self.stm_eps)
+        for k in range(6):
+            xp = x0_arr.copy()
+            xp[k] += eps
+            xm = x0_arr.copy()
+            xm[k] -= eps
+            sol_p = solve_ivp(
+                lambda t, X: np.asarray(self.rhs(t, X), dtype=float).ravel(),
+                (float(t0), float(tf)),
+                xp,
+                method="DOP853",
+                **opts,
+            )
+            sol_m = solve_ivp(
+                lambda t, X: np.asarray(self.rhs(t, X), dtype=float).ravel(),
+                (float(t0), float(tf)),
+                xm,
+                method="DOP853",
+                **opts,
+            )
+            phi[:, k] = (sol_p.y[:, -1] - sol_m.y[:, -1]) / (2.0 * eps)
+
+        return xf, phi
+
+
+__all__ = [
+    "PatchStates",
+    "STMStack",
+    "SubstituteSolver",
+    "ShootingPatch",
+    "MultipleShootingResult",
+    "solve_block_tridiagonal",
+    "multiple_shooting_newton",
+    "ODESubstituteSolver",
+]

--- a/e2m2e/algorithms/normal_form/pipeline.py
+++ b/e2m2e/algorithms/normal_form/pipeline.py
@@ -1,0 +1,240 @@
+"""法型化一键式流水线（issue #175）。
+
+把前面四个切片的 reducer 串成一条完整路径：
+
+    星历轨道初值
+        │  DynamicalSubstituteCorrector  （切片 #171）
+        ▼
+    动力学替代轨道 + 生成函数 W
+        │  QuasiFloquetReducer           （切片 #172）
+        ▼
+    quasi-Floquet 变换 B(t) + 实标准形 D
+        │  CenterManifoldReducer         （切片 #173）
+        ▼
+    中心流形化简 W_series
+        │  LibrationCatalogTransformer   （切片 #174）
+        ▼
+    表征参数目录变换器（rho ↔ param）
+
+外部用户一行代码即可完成"星历轨道 → 表征参数"：
+
+.. code-block:: python
+
+   result = NormalFormPipeline(context).reduce(x0)
+   param = result.catalog_transformer.rho_to_param(x0, t=0.0)
+
+返回的 :class:`NormalFormResult` 既是通用化简诊断容器（Hamiltonian 系数、
+残差、收敛标志），也把四个子结果句柄作为一等公民字段暴露，使下游无需自行
+重组装 :class:`LibrationCatalogData` 即可做坐标变换。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+import numpy.typing as npt
+
+from .center_manifold import CenterManifoldReducer
+from .dynamical_substitution import (
+    DEFAULT_DENSE_STEP,
+    DEFAULT_NODE_STEP,
+    DEFAULT_TOLERANCE,
+    DEFAULT_TOTAL_TU,
+    DynamicalSubstituteCorrector,
+)
+from .quasi_floquet import QuasiFloquetReducer
+from .types import NormalFormResult
+
+if TYPE_CHECKING:
+    from .catalog import LibrationCatalogTransformer
+    from .center_manifold import CenterManifoldResult
+    from .context import NormalFormContext
+    from .dynamical_substitution import DynamicalSubstituteResult
+    from .quasi_floquet import QuasiFloquetResult
+
+__all__ = ["NormalFormPipeline"]
+
+
+@dataclass(frozen=True)
+class NormalFormPipeline:
+    """法型化一键式流水线（上下文绑定）。
+
+    通过 :meth:`reduce` 把一条 ``(6,)`` rho 坐标初值依次送进动力学替代
+    corrector、quasi-Floquet reducer、中心流形 reducer，最后绑定成表征
+    参数目录变换器，返回聚合的 :class:`NormalFormResult`。
+
+    只暴露用户真正需要的旋钮（quasi-Floquet 求解法、中心流形截断阶与步
+    序列）；动力学替代的打靶窗口/容差沿用 :class:`DynamicalSubstituteCorrector`
+    的默认值（与 qiao ``Code05`` 一致），需要覆盖时传 ``dynamical_kwargs``。
+
+    Args:
+        context: 归一化上下文（提供平动点、频率、历元等）。
+        quasi_floquet_method: quasi-Floquet 求解法，``"matrix"``（默认，
+            36 维直接积分 + 辛投影）或 ``"lie_algebra"``（21 维 sp(6)
+            参数化，自动保辛）。
+        center_max_order: 中心流形 Lie 变换截断阶数，默认 ``10``（与 qiao
+            ``Code10``/``Code11`` 一致）。
+        center_steps: 中心流形化简步骤元组，默认 ``("invariant", "center")``。
+        dynamical_kwargs: 透传给 :class:`DynamicalSubstituteCorrector` 的
+            覆盖项（如 ``{"t_total": 8.0, "node_step": 0.8}``）。``None``
+            时用该 corrector 的全部默认值。
+    """
+
+    context: NormalFormContext
+    quasi_floquet_method: str = "matrix"
+    center_max_order: int = 10
+    center_steps: tuple[str, ...] = ("invariant", "center")
+    dynamical_kwargs: dict[str, object] = field(default_factory=dict)
+
+    def reduce(
+        self, orbit: npt.ArrayLike
+    ) -> NormalFormResult:
+        """对 rho 坐标初值跑完整法型化流水线。
+
+        Args:
+            orbit: ``(6,)`` rho 坐标初始状态 ``[ρ, ρ̇]``（无量纲），作为
+                动力学替代 corrector 的种子。SPICE 内核不可用时底层自动
+                降级到纯 CR3BP（仅供烟雾测试）。
+
+        Returns:
+            :class:`NormalFormResult`：聚合了四个子结果句柄与通用化简诊断
+            字段。``catalog_transformer`` 字段在四步全部成功后非 ``None``。
+
+        Notes:
+            任一步抛异常时，流水线不向上传播，而是把已完成的子结果填进
+            :class:`NormalFormResult`，置 ``success=False``、``message``
+            记录失败步骤与原因——这样部分失败也保留诊断价值。输入校验
+            （如 orbit 形状非法）仍直接抛 :class:`ValueError`，因为这是
+            调用方错误而非流水线内部失败。
+        """
+        x0 = self._normalize_orbit(orbit)
+
+        ds_result: DynamicalSubstituteResult | None = None
+        qf_result: QuasiFloquetResult | None = None
+        cm_result: CenterManifoldResult | None = None
+        catalog_transformer: LibrationCatalogTransformer | None = None
+
+        # —— 步骤 1：动力学替代 ——
+        ds_kwargs: dict[str, Any] = {
+            "t_total": DEFAULT_TOTAL_TU,
+            "node_step": DEFAULT_NODE_STEP,
+            "dense_step": DEFAULT_DENSE_STEP,
+            "tolerance": DEFAULT_TOLERANCE,
+            "spice_optional": True,
+        }
+        ds_kwargs.update(self.dynamical_kwargs)
+        try:
+            ds_corrector = DynamicalSubstituteCorrector(
+                context=self.context, **ds_kwargs
+            )
+            ds_result = ds_corrector.reduce(seed=x0)
+        except Exception as exc:
+            return self._failure(
+                "dynamical_substitution", exc, ds_result, qf_result, cm_result
+            )
+
+        # —— 步骤 2：quasi-Floquet ——
+        try:
+            qf_reducer = QuasiFloquetReducer(
+                context=self.context, method=self.quasi_floquet_method
+            )
+            qf_result = qf_reducer.reduce(ds_result)
+        except Exception as exc:
+            return self._failure(
+                "quasi_floquet", exc, ds_result, qf_result, cm_result
+            )
+
+        # —— 步骤 3：中心流形化简 ——
+        try:
+            cm_reducer = CenterManifoldReducer(
+                context=self.context, max_order=self.center_max_order
+            )
+            cm_result = cm_reducer.reduce(
+                qf_result, steps=self.center_steps
+            )
+        except Exception as exc:
+            return self._failure(
+                "center_manifold", exc, ds_result, qf_result, cm_result
+            )
+
+        # —— 步骤 4：表征参数目录变换器 ——
+        try:
+            from .catalog import LibrationCatalogData, LibrationCatalogTransformer
+
+            data = LibrationCatalogData(
+                context=self.context,
+                ds_result=ds_result,
+                qf_result=qf_result,
+                cm_result=cm_result,
+            )
+            catalog_transformer = LibrationCatalogTransformer(data=data)
+        except Exception as exc:
+            return self._failure(
+                "catalog", exc, ds_result, qf_result, cm_result
+            )
+
+        return NormalFormResult(
+            context=self.context,
+            order=int(self.context.order),
+            residual=float(ds_result.residual_norm),
+            success=True,
+            message="流水线四步全部完成",
+            metadata={
+                "quasi_floquet_method": self.quasi_floquet_method,
+                "center_max_order": int(self.center_max_order),
+                "center_steps": tuple(self.center_steps),
+                "spice_available": bool(ds_result.spice_available),
+                "ds_backend": ds_result.backend,
+                "qf_symplectic_error": float(qf_result.max_symplectic_error),
+                "cm_hyperbolic_coupling": float(cm_result.max_hyperbolic_coupling),
+            },
+            ds_result=ds_result,
+            qf_result=qf_result,
+            cm_result=cm_result,
+            catalog_transformer=catalog_transformer,
+        )
+
+    # ------------------------------------------------------------------
+    # 内部辅助
+    # ------------------------------------------------------------------
+
+    def _normalize_orbit(self, orbit: npt.ArrayLike) -> npt.NDArray[np.floating]:
+        """把入参归一化为 ``(6,)`` rho 状态数组。
+
+        接受 ``(6,)`` 数组；Orbit-like 对象（带 ``.states``）取首帧。
+        形状非法时抛 :class:`ValueError`（调用方错误，直接上抛）。
+        """
+        if hasattr(orbit, "states"):
+            arr = np.asarray(orbit.states, dtype=float)
+            if arr.ndim == 2:
+                arr = arr[0]
+        else:
+            arr = np.asarray(orbit, dtype=float).ravel()
+        if arr.shape != (6,):
+            raise ValueError(
+                f"orbit 必须是形状 (6,) 的 rho 状态，得到 {arr.shape}"
+            )
+        return arr
+
+    def _failure(
+        self,
+        step: str,
+        exc: BaseException,
+        ds_result: DynamicalSubstituteResult | None,
+        qf_result: QuasiFloquetResult | None,
+        cm_result: CenterManifoldResult | None,
+    ) -> NormalFormResult:
+        """构造失败结果：保留已完成的子结果，记录失败原因。"""
+        return NormalFormResult(
+            context=self.context,
+            order=int(self.context.order),
+            success=False,
+            message=f"步骤 {step!r} 失败：{type(exc).__name__}: {exc}",
+            metadata={"failed_step": step, "exception_type": type(exc).__name__},
+            ds_result=ds_result,
+            qf_result=qf_result,
+            cm_result=cm_result,
+            catalog_transformer=None,
+        )

--- a/e2m2e/algorithms/normal_form/pipeline.py
+++ b/e2m2e/algorithms/normal_form/pipeline.py
@@ -88,9 +88,7 @@ class NormalFormPipeline:
     center_steps: tuple[str, ...] = ("invariant", "center")
     dynamical_kwargs: dict[str, object] = field(default_factory=dict)
 
-    def reduce(
-        self, orbit: npt.ArrayLike
-    ) -> NormalFormResult:
+    def reduce(self, orbit: npt.ArrayLike) -> NormalFormResult:
         """对 rho 坐标初值跑完整法型化流水线。
 
         Args:
@@ -126,38 +124,26 @@ class NormalFormPipeline:
         }
         ds_kwargs.update(self.dynamical_kwargs)
         try:
-            ds_corrector = DynamicalSubstituteCorrector(
-                context=self.context, **ds_kwargs
-            )
+            ds_corrector = DynamicalSubstituteCorrector(context=self.context, **ds_kwargs)
             ds_result = ds_corrector.reduce(seed=x0)
         except Exception as exc:
-            return self._failure(
-                "dynamical_substitution", exc, ds_result, qf_result, cm_result
-            )
+            return self._failure("dynamical_substitution", exc, ds_result, qf_result, cm_result)
 
         # —— 步骤 2：quasi-Floquet ——
         try:
-            qf_reducer = QuasiFloquetReducer(
-                context=self.context, method=self.quasi_floquet_method
-            )
+            qf_reducer = QuasiFloquetReducer(context=self.context, method=self.quasi_floquet_method)
             qf_result = qf_reducer.reduce(ds_result)
         except Exception as exc:
-            return self._failure(
-                "quasi_floquet", exc, ds_result, qf_result, cm_result
-            )
+            return self._failure("quasi_floquet", exc, ds_result, qf_result, cm_result)
 
         # —— 步骤 3：中心流形化简 ——
         try:
             cm_reducer = CenterManifoldReducer(
                 context=self.context, max_order=self.center_max_order
             )
-            cm_result = cm_reducer.reduce(
-                qf_result, steps=self.center_steps
-            )
+            cm_result = cm_reducer.reduce(qf_result, steps=self.center_steps)
         except Exception as exc:
-            return self._failure(
-                "center_manifold", exc, ds_result, qf_result, cm_result
-            )
+            return self._failure("center_manifold", exc, ds_result, qf_result, cm_result)
 
         # —— 步骤 4：表征参数目录变换器 ——
         try:
@@ -171,9 +157,7 @@ class NormalFormPipeline:
             )
             catalog_transformer = LibrationCatalogTransformer(data=data)
         except Exception as exc:
-            return self._failure(
-                "catalog", exc, ds_result, qf_result, cm_result
-            )
+            return self._failure("catalog", exc, ds_result, qf_result, cm_result)
 
         return NormalFormResult(
             context=self.context,
@@ -213,9 +197,7 @@ class NormalFormPipeline:
         else:
             arr = np.asarray(orbit, dtype=float).ravel()
         if arr.shape != (6,):
-            raise ValueError(
-                f"orbit 必须是形状 (6,) 的 rho 状态，得到 {arr.shape}"
-            )
+            raise ValueError(f"orbit 必须是形状 (6,) 的 rho 状态，得到 {arr.shape}")
         return arr
 
     def _failure(

--- a/e2m2e/algorithms/normal_form/polynomial.py
+++ b/e2m2e/algorithms/normal_form/polynomial.py
@@ -1,0 +1,316 @@
+"""多项式 dict 工具：``{pow_tuple: coefficient}`` 的内部表示与运算。
+
+对应 qiao 仓库的 ``poly_operator``（符号 / 混合系数）和
+``list_operator``（数值时间系列系数）两组辅助函数，但只取本切片需要的
+子集——``expr2poly``、``poly2expr``、``poly_poisson``、
+``poly_simplify`` 与对应的 ``polylist_*`` 数值版本。
+
+约定：
+
+- 多项式 dict 的幂次向量固定为 ``(n1, n2, n3, n4, n5, n6)``，
+  对应 ``(q1, q2, q3, p1, p2, p3)``；
+- 系数可以是 sympy 符号、纯数值（``int``/``float``）、或长度为 ``M`` 的
+  一维 ``numpy.ndarray``（数值时间序列）；
+- 零多项式统一表示为 ``{(0, 0, 0, 0, 0, 0): 0}``（或长度 ``M`` 的零数组）。
+
+本模块属于 ``normal_form`` 包内部基础设施，只被同包的
+``legendre`` / ``hamiltonian`` / 后续 ``reducer`` 调用，不对用户
+直接暴露——上游接口请走 ``legendre`` 与 ``hamiltonian``。
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING
+
+import numpy as np
+import numpy.typing as npt
+
+if TYPE_CHECKING:
+    pass
+
+# 对应 (q1, q2, q3, p1, p2, p3)，6 个正则坐标。
+N_VARIABLES: int = 6
+
+
+# ---------------------------------------------------------------------------
+# 类型工具
+# ---------------------------------------------------------------------------
+
+
+def _zero_like(coef: object) -> object:
+    """返回与 ``coef`` 同类型的“零”，支持 sympy、Python 数值与 ndarray。"""
+    if isinstance(coef, np.ndarray):
+        return np.zeros_like(coef)
+    return 0
+
+
+def _is_zero(coef: object, tol: float = 0.0) -> bool:
+    """判断系数是否在数值上为零。
+
+    对 ``ndarray`` 而言，只要存在分量绝对值大于 ``tol`` 即视为非零；
+    对 sympy / Python 数值直接 ``== 0`` 比较。``tol`` 取 ``0`` 时即严格相等。
+    """
+    if isinstance(coef, np.ndarray):
+        if tol <= 0:
+            return not np.any(coef)
+        return not np.any(np.abs(coef) > tol)
+    try:
+        if tol <= 0:
+            return bool(coef == 0)
+        return abs(float(coef)) <= tol
+    except (TypeError, ValueError):
+        # sympy 符号无法直接判等：尝试数值化
+        try:
+            return abs(float(coef)) <= tol
+        except (TypeError, ValueError):
+            return False
+
+
+# ---------------------------------------------------------------------------
+# 幂次向量工具
+# ---------------------------------------------------------------------------
+
+
+def order(pow_tuple: tuple[int, ...]) -> int:
+    """返回幂次向量的总阶数（各分量之和）。"""
+    return int(sum(pow_tuple))
+
+
+def keys_by_order(
+    poly: Mapping[tuple[int, ...], object],
+) -> dict[int, list[tuple[int, ...]]]:
+    """按总阶数分组返回幂次键。"""
+    grouped: dict[int, list[tuple[int, ...]]] = {}
+    for k in poly:
+        grouped.setdefault(order(k), []).append(tuple(k))
+    for k in grouped:
+        grouped[k].sort()
+    return grouped
+
+
+def trim_degree(
+    poly: Mapping[tuple[int, ...], object],
+    max_degree: int,
+) -> dict[tuple[int, ...], object]:
+    """截断总阶数大于 ``max_degree`` 的项。"""
+    if max_degree < 0:
+        raise ValueError(f"max_degree 必须非负，得到 {max_degree}")
+    result: dict[tuple[int, ...], object] = {}
+    for pow_tuple, coef in poly.items():
+        if order(pow_tuple) <= max_degree:
+            result[tuple(pow_tuple)] = coef
+    if not result:
+        result[(0,) * N_VARIABLES] = 0
+    return result
+
+
+# ---------------------------------------------------------------------------
+# sympy 符号 ↔ dict 转换
+# ---------------------------------------------------------------------------
+
+
+def expr2poly(
+    expr: object,
+    variables: tuple[object, ...] | None = None,
+) -> dict[tuple[int, ...], object]:
+    """把 sympy 表达式分解为幂次向量 → 系数 的 dict。
+
+    与 qiao ``expr2poly`` 等价，使用 ``sp.Poly`` 提取单项式系数。
+    零多项式返回 ``{(0,) * 6: 0}``。
+
+    Args:
+        expr: sympy 表达式。
+        variables: 6 个 sympy 符号；默认 ``(q1, q2, q3, p1, p2, p3)``。
+            ``None`` 时从 ``expr`` 中按名 ``q1, q2, q3, p1, p2, p3`` 解析；
+            若 expr 中仍有同名以外的自由符号，多出的会被并入变量顺序中。
+
+    Returns:
+        幂次向量 → 系数 dict。
+    """
+    import sympy as sp
+
+    if expr == 0:
+        return {(0,) * N_VARIABLES: 0}
+
+    if variables is None:
+        # 从 expr.free_symbols 中按名 (q1, q2, q3, p1, p2, p3) 解析
+        # 已有实例；缺失的位补齐（sympy.symbols 默认是 real=True）。
+        name_to_sym = {s.name: s for s in getattr(expr, "free_symbols", set())}
+        variables_list: list[object] = []
+        for name in ("q1", "q2", "q3", "p1", "p2", "p3"):
+            if name in name_to_sym:
+                variables_list.append(name_to_sym[name])
+            else:
+                variables_list.append(sp.Symbol(name, real=True))
+        variables = tuple(variables_list)
+
+    expanded = sp.expand(expr)
+    if expanded == 0:
+        return {(0,) * len(variables): 0}
+
+    poly = sp.Poly(expanded, *variables)
+    raw = poly.as_dict()  # {(e1, ..., e6): coeff}
+    result: dict[tuple[int, ...], object] = {}
+    for monom, coef in raw.items():
+        if coef != 0:
+            result[tuple(int(x) for x in monom)] = coef
+    if not result:
+        result[tuple([0] * len(variables))] = 0
+    return result
+
+
+def poly2expr(
+    poly: Mapping[tuple[int, ...], object],
+    variables: tuple[object, ...] | None = None,
+) -> object:
+    """幂次向量 → 系数 dict 反向组装为 sympy 表达式。
+
+    对应 qiao ``poly2expr``。零项跳过。
+    """
+    import sympy as sp
+
+    if variables is None:
+        variables = sp.symbols("q1 q2 q3 p1 p2 p3")
+
+    expr = sp.Integer(0)
+    for pow_tuple, coef in poly.items():
+        if _is_zero(coef):
+            continue
+        term = sp.sympify(coef)
+        for i, p in enumerate(pow_tuple):
+            if p:
+                term *= variables[i] ** p
+        expr += term
+    return sp.expand(expr)
+
+
+# ---------------------------------------------------------------------------
+# 泊松括号
+# ---------------------------------------------------------------------------
+
+
+def poly_poisson(
+    poly1: Mapping[tuple[int, ...], object],
+    poly2: Mapping[tuple[int, ...], object],
+) -> dict[tuple[int, ...], object]:
+    """计算两个多项式 dict 的泊松括号 ``{poly1, poly2}``。
+
+    6-DOF 辛流形 (q1, q2, q3, p1, p2, p3) 的泊松括号：
+
+        {f, g} = Σ_{k=1}^{3} (∂f/∂q_k · ∂g/∂p_k − ∂f/∂p_k · ∂g/∂q_k)
+
+    对单项式 ``f = c₁ ∏ x_i^{a_i}``, ``g = c₂ ∏ x_i^{b_i}``：
+
+        {f, g} = c₁ c₂ Σ_k (a_k b_{k+3} - b_k a_{k+3}) x^{a+b-e_k-e_{k+3}}
+
+    系数为 sympy 或 ndarray 时均适用。
+    """
+    result: dict[tuple[int, ...], object] = {}
+    for pow1, coef1 in poly1.items():
+        if _is_zero(coef1):
+            continue
+        for pow2, coef2 in poly2.items():
+            if _is_zero(coef2):
+                continue
+            for k in range(3):
+                a_k = pow1[k]
+                a_pk = pow1[k + 3]
+                b_k = pow2[k]
+                b_pk = pow2[k + 3]
+                if not ((a_k and b_pk) or (a_pk and b_k)):
+                    continue
+                new_pow: list[int] = [int(pow1[i]) + int(pow2[i]) for i in range(N_VARIABLES)]
+                new_pow[k] -= 1
+                new_pow[k + 3] -= 1
+                if any(p < 0 for p in new_pow):
+                    continue
+                coef = coef1 * coef2 * (a_k * b_pk - a_pk * b_k)
+                if _is_zero(coef):
+                    continue
+                key = tuple(new_pow)
+                if key in result:
+                    result[key] = result[key] + coef
+                else:
+                    result[key] = coef
+    if not result:
+        result[(0,) * N_VARIABLES] = _zero_like(_sample_coef(poly1, poly2))
+    return result
+
+
+def poly_simplify(
+    poly: Mapping[tuple[int, ...], object],
+    eps: float = 1e-12,
+) -> dict[tuple[int, ...], object]:
+    """合并同幂次项并剔除小于 ``eps`` 的近零项。"""
+    if not poly:
+        return {(0,) * N_VARIABLES: 0}
+
+    merged: dict[tuple[int, ...], object] = {}
+    for pow_tuple, coef in poly.items():
+        key = tuple(int(p) for p in pow_tuple)
+        merged[key] = merged.get(key, 0) + coef
+
+    result: dict[tuple[int, ...], object] = {}
+    for pow_tuple, coef in merged.items():
+        if not _is_zero(coef, tol=eps):
+            result[pow_tuple] = coef
+    if not result:
+        result[(0,) * N_VARIABLES] = _zero_like(_sample_coef(poly))
+    return result
+
+
+def polylist_simplify(
+    poly: Mapping[tuple[int, ...], npt.NDArray[np.floating]],
+    eps: float = 1e-15,
+) -> dict[tuple[int, ...], npt.NDArray[np.floating]]:
+    """数值版 ``poly_simplify``：合并同幂次项，剔除均幅值过小的时间序列。
+
+    与 qiao ``polylist_simplify`` 等价，使用 ``mean abs`` 作为阈值。
+    """
+    if not poly:
+        return {(0,) * N_VARIABLES: np.zeros(1)}
+
+    result: dict[tuple[int, ...], npt.NDArray[np.floating]] = {}
+    for pow_tuple, coef in poly.items():
+        key = tuple(int(p) for p in pow_tuple)
+        mean_abs = float(np.mean(np.abs(coef)))
+        if mean_abs <= eps:
+            continue
+        if key in result:
+            result[key] = result[key] + coef
+        else:
+            result[key] = coef
+    if not result:
+        sample = next(iter(poly.values()))
+        return {(0,) * N_VARIABLES: np.zeros_like(sample)}
+    return result
+
+
+# ---------------------------------------------------------------------------
+# 内部辅助
+# ---------------------------------------------------------------------------
+
+
+def _sample_coef(
+    poly1: Mapping[tuple[int, ...], object],
+    poly2: Mapping[tuple[int, ...], object],
+) -> object:
+    """从两个多项式 dict 中取一个样本系数用于生成零值。"""
+    for poly in (poly1, poly2):
+        if poly:
+            return next(iter(poly.values()))
+    return 0
+
+
+__all__ = [
+    "N_VARIABLES",
+    "order",
+    "keys_by_order",
+    "trim_degree",
+    "expr2poly",
+    "poly2expr",
+    "poly_poisson",
+    "poly_simplify",
+    "polylist_simplify",
+]

--- a/e2m2e/algorithms/normal_form/polynomial.py
+++ b/e2m2e/algorithms/normal_form/polynomial.py
@@ -21,7 +21,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import numpy.typing as npt
@@ -58,11 +58,14 @@ def _is_zero(coef: object, tol: float = 0.0) -> bool:
     try:
         if tol <= 0:
             return bool(coef == 0)
-        return abs(float(coef)) <= tol
+        # coef 可能是 sympy 表达式（动态属性），用 Any 表达 float() 调用。
+        numeric: Any = coef
+        return abs(float(numeric)) <= tol
     except (TypeError, ValueError):
         # sympy 符号无法直接判等：尝试数值化
         try:
-            return abs(float(coef)) <= tol
+            numeric = coef
+            return abs(float(numeric)) <= tol
         except (TypeError, ValueError):
             return False
 
@@ -84,8 +87,8 @@ def keys_by_order(
     grouped: dict[int, list[tuple[int, ...]]] = {}
     for k in poly:
         grouped.setdefault(order(k), []).append(tuple(k))
-    for k in grouped:
-        grouped[k].sort()
+    for deg in grouped:
+        grouped[deg].sort()
     return grouped
 
 
@@ -173,6 +176,8 @@ def poly2expr(
     if variables is None:
         variables = sp.symbols("q1 q2 q3 p1 p2 p3")
 
+    # variables 是 sympy 符号元组（动态属性），用 Any 表达下标与幂运算。
+    vars_any: Any = variables
     expr = sp.Integer(0)
     for pow_tuple, coef in poly.items():
         if _is_zero(coef):
@@ -180,7 +185,7 @@ def poly2expr(
         term = sp.sympify(coef)
         for i, p in enumerate(pow_tuple):
             if p:
-                term *= variables[i] ** p
+                term *= vars_any[i] ** p
         expr += term
     return sp.expand(expr)
 
@@ -225,7 +230,10 @@ def poly_poisson(
                 new_pow[k + 3] -= 1
                 if any(p < 0 for p in new_pow):
                     continue
-                coef = coef1 * coef2 * (a_k * b_pk - a_pk * b_k)
+                # coef1/coef2 为 sympy 表达式或 ndarray（动态属性），用 Any 表达乘法。
+                c1: Any = coef1
+                c2: Any = coef2
+                coef = c1 * c2 * (a_k * b_pk - a_pk * b_k)
                 if _is_zero(coef):
                     continue
                 key = tuple(new_pow)
@@ -249,7 +257,9 @@ def poly_simplify(
     merged: dict[tuple[int, ...], object] = {}
     for pow_tuple, coef in poly.items():
         key = tuple(int(p) for p in pow_tuple)
-        merged[key] = merged.get(key, 0) + coef
+        # coef 为 sympy 表达式或 ndarray（动态属性），用 Any 表达加法。
+        existing: Any = merged.get(key, 0)
+        merged[key] = existing + coef
 
     result: dict[tuple[int, ...], object] = {}
     for pow_tuple, coef in merged.items():
@@ -294,9 +304,12 @@ def polylist_simplify(
 
 def _sample_coef(
     poly1: Mapping[tuple[int, ...], object],
-    poly2: Mapping[tuple[int, ...], object],
+    poly2: Mapping[tuple[int, ...], object] | None = None,
 ) -> object:
-    """从两个多项式 dict 中取一个样本系数用于生成零值。"""
+    """从多项式 dict 中取一个样本系数用于生成零值。
+
+    ``poly2`` 省略或为空时退化为只看 ``poly1``。
+    """
     for poly in (poly1, poly2):
         if poly:
             return next(iter(poly.values()))

--- a/e2m2e/algorithms/normal_form/quasi_floquet.py
+++ b/e2m2e/algorithms/normal_form/quasi_floquet.py
@@ -1,0 +1,548 @@
+"""quasi-Floquet 变换矩阵 ``B(t)``（Code7–Code9）。
+
+对应 qiao ``Code08_QuasiFloquet.py``（矩阵法）与
+``Code08_QuasiFloquet_LA.py``（李代数法）：从动力学替代轨道出发，求解
+
+.. math::
+
+    \\dot{B}(t) = M(t)\\,B(t) - B(t)\\,D,\\qquad B^{T} J B = J,
+
+其中 ``M(t)`` 是替代轨道邻域的时变线性化矩阵，``D`` 是实标准形矩阵
+（一双曲方向 ``±λ``，两中心方向 ``±i ω_p``、``±i ω_v``），``J`` 是 6 维
+辛矩阵。``B(t)`` 把受迫线性化系统化为常系数的 ``Ẏ = D·Y``。
+
+两种实现：
+
+- **矩阵法**（``method="matrix"``）：把 ``B`` 展平为 36 维状态直接积分
+  ``Ḃ = M·B − B·D``，事后用 Newton 迭代把每个采样点的 ``B`` 投影到
+  最近的辛矩阵（qiao ``Code08_QuasiFloquet``）；
+- **李代数法**（``method="lie_algebra"``）：参数化 ``B = B₀·exp(ξ)``，
+  ``ξ ∈ sp(6, R)``（21 维），在李代数里做修正，``B`` 自动保辛（qiao
+  ``Code08_QuasiFloquet_LA``）。
+
+辛保持性的数值保证：当 ``M(t)`` 与 ``D`` 都是 Hamilton 矩阵
+（``MᵀJ + JM = 0``）时，``BᵀJB`` 是 ``Ḃ`` 方程的精确首次积分，因此
+本模块刻意构造 ``M(t) = J·S(t)``（``S`` 对称）以保证辛约束在
+``<1e-12`` 量级成立；矩阵法仍在末尾做一次辛投影兜底。
+
+Public API：
+
+- :class:`QuasiFloquetResult` —— 结果句柄；
+- :class:`QuasiFloquetReducer` —— 上下文绑定的 reducer，通过
+  :meth:`reduce` 给出 :class:`QuasiFloquetResult`。
+
+单位约定：``M(t)``、``D``、``B(t)`` 全部在 qiao 归一化单位（TU）下
+运算；与 SI 之间的换算只能经由 :class:`NormalFormContext` 与
+:mod:`.units` 模块。本模块不暴露 qiao 的 ``QFtrans_mat`` 原始结构。
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import numpy as np
+import numpy.typing as npt
+
+from .dynamical_substitution import DynamicalSubstituteResult
+
+if TYPE_CHECKING:
+    from .context import NormalFormContext
+
+# ---------------------------------------------------------------------------
+# 辛结构与实标准形
+# ---------------------------------------------------------------------------
+
+#: 6 维辛矩阵 ``J = [[0, I₃], [-I₃, 0]]``（位置在前、动量在后）。
+J6: npt.NDArray[np.floating] = np.block(
+    [[np.zeros((3, 3)), np.eye(3)], [-np.eye(3), np.zeros((3, 3))]]
+)
+
+
+def real_normal_form_matrix(
+    lam: float, wp: float, wv: float
+) -> npt.NDArray[np.floating]:
+    """构造 6×6 实标准形矩阵 ``D``。
+
+    对应 qiao ``Global_File`` 中固化的 ``Mat_D``：一双曲方向 ``±λ``、
+    平面内中心方向 ``±i ω_p``、垂直中心方向 ``±i ω_v``。基底顺序与
+    qiao 一致：``[p₁, q₁, q₂, p₂, ...]``——指数 0 双曲、指数 1/4 平面
+    中心对、指数 2/5 垂直中心对。
+
+    Args:
+        lam: 双曲特征指数 λ（>0）。
+        wp: 平面内中心频率 ω_p（>0）。
+        wv: 垂直中心频率 ω_v（>0）。
+
+    Returns:
+        ``(6, 6)`` 实标准形矩阵 ``D``。
+    """
+    D = np.zeros((6, 6), dtype=float)
+    D[0, 0] = lam
+    D[3, 3] = -lam
+    D[1, 4] = wp
+    D[4, 1] = -wp
+    D[2, 5] = wv
+    D[5, 2] = -wv
+    return D
+
+
+# ---------------------------------------------------------------------------
+# sp(6) 李代数工具（迁移自 qiao Calc_Phi_Lie_algebra.py）
+# ---------------------------------------------------------------------------
+
+
+def build_sp6_basis() -> list[npt.NDArray[np.floating]]:
+    """构造 sp(6, R) 的 21 维正交基 ``{E_k}``（Frobenius 归一）。
+
+    三块结构：``A`` 块 ``n²=9``（``E_ij = e_i e_jᵀ − e_{n+j} e_{n+i}ᵀ``）、
+    ``B`` 块 ``n(n+1)/2=6``（右上对称）、``C`` 块 ``n(n+1)/2=6``
+    （左下对称）。对应 qiao ``_build_sp6_basis``。
+    """
+    n = 3
+    E_list: list[npt.NDArray[np.floating]] = []
+    for i in range(n):
+        for j in range(n):
+            tmp = np.zeros((2 * n, 2 * n))
+            tmp[i, j] = 1.0
+            tmp[n + j, n + i] = -1.0
+            E_list.append(tmp / np.linalg.norm(tmp, "fro"))
+    for i in range(n):
+        for j in range(i, n):
+            tmp = np.zeros((2 * n, 2 * n))
+            tmp[i, n + j] = 1.0
+            if i != j:
+                tmp[j, n + i] = 1.0
+            E_list.append(tmp / np.linalg.norm(tmp, "fro"))
+    for i in range(n):
+        for j in range(i, n):
+            tmp = np.zeros((2 * n, 2 * n))
+            tmp[n + i, j] = 1.0
+            if i != j:
+                tmp[n + j, i] = 1.0
+            E_list.append(tmp / np.linalg.norm(tmp, "fro"))
+    return E_list
+
+
+def sp6_to_vector(
+    mat: npt.NDArray[np.floating], basis: list[npt.NDArray[np.floating]]
+) -> npt.NDArray[np.floating]:
+    """sp(6) 矩阵 → 21 维系数向量（Frobenius 内积投影）。"""
+    return np.array([float(np.sum(mat * E_k)) for E_k in basis], dtype=float)
+
+
+def vector_to_sp6(
+    xi: npt.ArrayLike, basis: list[npt.NDArray[np.floating]]
+) -> npt.NDArray[np.floating]:
+    """21 维系数向量 → sp(6) 矩阵 ``M = Σ ξ_k E_k``。"""
+    xi_arr = np.asarray(xi, dtype=float).ravel()
+    out = np.zeros((6, 6), dtype=float)
+    for k, E_k in enumerate(basis):
+        out += xi_arr[k] * E_k
+    return out
+
+
+# ---------------------------------------------------------------------------
+# 结果容器
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class QuasiFloquetResult:
+    """quasi-Floquet 变换结果句柄。
+
+    Attributes:
+        context: 关联 :class:`NormalFormContext`。
+        order: 展开阶数（与 ``context.order`` 一致）。
+        tlist: 采样时间数组 ``(n,)``，归一化 TU。
+        B_samples: ``B(t)`` 在采样点的堆叠，形状 ``(n, 6, 6)``。
+        D: 6×6 实标准形矩阵。
+        method: 实际使用的求解方法（``"matrix"`` 或 ``"lie_algebra"``）。
+        M_samples: 时变线性化矩阵 ``M(t)`` 在采样点的堆叠，形状
+            ``(n, 6, 6)``；诊断用，``None`` 表示未保留。
+        metadata: 自由扩展字段。
+    """
+
+    context: NormalFormContext
+    order: int
+    tlist: npt.NDArray[np.floating]
+    B_samples: npt.NDArray[np.floating]
+    D: npt.NDArray[np.floating]
+    method: str
+    M_samples: npt.NDArray[np.floating] | None = None
+    metadata: dict[str, object] = field(default_factory=dict)
+
+    @property
+    def max_symplectic_error(self) -> float:
+        """所有采样点上 ``‖BᵀJB − J‖∞`` 的最大值。"""
+        if self.B_samples.shape[0] == 0:
+            return float("nan")
+        err = 0.0
+        for B in self.B_samples:
+            e = float(np.max(np.abs(B.T @ J6 @ B - J6)))
+            if e > err:
+                err = e
+        return err
+
+    def B(self, t: float) -> npt.NDArray[np.floating]:
+        """在时刻 ``t`` 处线性插值 ``B(t)``。
+
+        Args:
+            t: 归一化时间 TU。允许 ``tlist`` 之外的端点外推。
+
+        Returns:
+            ``(6, 6)`` 插值矩阵。
+        """
+        t_arr = np.asarray(self.tlist, dtype=float).ravel()
+        if t_arr.size == 0:
+            raise ValueError("tlist 为空，无法插值")
+        if t_arr.size == 1:
+            return np.array(self.B_samples[0], dtype=float)
+        B_flat = np.array(self.B_samples, dtype=float).reshape(t_arr.size, 36)
+        out = np.empty(36, dtype=float)
+        for k in range(36):
+            out[k] = float(np.interp(t, t_arr, B_flat[:, k]))
+        return out.reshape(6, 6)
+
+
+# ---------------------------------------------------------------------------
+# 时变线性化矩阵 M(t)
+# ---------------------------------------------------------------------------
+
+
+def _cr3bp_hessian_symmetric(
+    r: npt.NDArray[np.floating], mu: float
+) -> npt.NDArray[np.floating]:
+    """纯 CR3BP 会合系下二阶导 ``Ω`` 的对称 Hessian（无量纲）。
+
+    返回对称矩阵 ``S = ∂²Ω/∂x_i ∂x_j``，对应
+    ``ρ̈ = −∂Ω/∂ρ`` 在会合系下的二阶导。后续用 ``M = J·S_block`` 拼
+    Hamilton 矩阵（``J`` 的位置/动量顺序与 qiao 一致）。这里只关心围绕
+    替代轨道的线性化，因此位置取 ``r = ρ + 平动点位置``。
+    """
+    mu1 = 1.0 - mu
+    r1 = r - np.array([-mu, 0.0, 0.0])  # 到地球
+    r2 = r - np.array([1.0 - mu, 0.0, 0.0])  # 到月球
+    d1 = float(np.linalg.norm(r1))
+    d2 = float(np.linalg.norm(r2))
+    d1i3 = 1.0 / d1**3
+    d2i3 = 1.0 / d2**3
+    d1i5 = 1.0 / d1**5
+    d2i5 = 1.0 / d2**5
+
+    # 二阶导矩阵：(3/r^5) r⊗r − (1/r^3) I，对每个主天体加权求和
+    S = np.eye(3) * (1.0 - mu1 * d1i3 - mu * d2i3)
+    S += mu1 * 3.0 * d1i5 * np.outer(r1, r1)
+    S += mu * 3.0 * d2i5 * np.outer(r2, r2)
+    return S
+
+
+def _build_M_at(
+    ds_result: DynamicalSubstituteResult,
+) -> tuple[
+    Callable[[float], npt.NDArray[np.floating]],
+    npt.NDArray[np.floating],
+]:
+    """从替代轨道构造 ``M(t)`` 的**连续**求值器与采样点栈。
+
+    会合系 CR3BP 线性化方程为
+    ``δρ̈ = S(ρ)·δρ − 2 Ω×δρ̇``（``S`` 对称、``Ω=ẑ``），写成 Hamilton
+    形 ``[δρ̇; δρ̈] = M·[δρ; δρ̇]`` 即
+    ``M = [[−Ω×, I₃], [S, −Ω×]]``，等价于 ``M = J·[[S, Ω×], [−Ω×, 0]]``
+    仍为 Hamilton 矩阵。
+
+    关键：返回的求值器 ``M_at(t)`` 在任意 ``t`` 上**重新解析地**计算
+    ``S``（先对轨道位置线性插值，再算对称 Hessian），因此在 ODE 的每个
+    自适应步上 ``M(t)`` 都是精确的 Hamilton 矩阵。这避免了「预计算
+    ``M`` 再线性插值」会让 ``MᵀJ+JM=0`` 在节点之间失效、从而破坏辛
+    守恒的问题。
+
+    返回 ``(M_at, M_stack)``：``M_at`` 为连续求值器，``M_stack`` 为
+    在 ``ds_result.tlist`` 采样点上的 ``(n,6,6)`` 数组（诊断用）。
+    """
+    Xlist = np.asarray(ds_result.Xlist, dtype=float)
+    if Xlist.ndim != 2 or Xlist.shape[1] != 6:
+        raise ValueError(f"Xlist 必须是 (n,6)，得到 {Xlist.shape}")
+    n = Xlist.shape[0]
+    mu = float(ds_result.context.mu)
+    r_lp = np.asarray(ds_result.context.libration_position, dtype=float).ravel()
+    t_arr = np.asarray(ds_result.tlist, dtype=float).ravel()
+
+    # 旋转系角速度张量 [[0,-1,0],[1,0,0],[0,0,0]]（对应 Ω×v = Omega_x @ v）
+    omega_x = np.array([[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
+
+    def assemble(rho: npt.NDArray[np.floating]) -> npt.NDArray[np.floating]:
+        S = _cr3bp_hessian_symmetric(rho + r_lp, mu)
+        M = np.zeros((6, 6), dtype=float)
+        M[:3, :3] = -omega_x  # −Ω×（Coriolis 位置块）
+        M[:3, 3:] = np.eye(3)
+        M[3:, :3] = S
+        M[3:, 3:] = -omega_x
+        return M
+
+    def M_at(t: float) -> npt.NDArray[np.floating]:
+        rho = np.array(
+            [float(np.interp(t, t_arr, Xlist[:, k])) for k in range(3)],
+            dtype=float,
+        )
+        return assemble(rho)
+
+    M_stack = np.zeros((n, 6, 6), dtype=float)
+    for i in range(n):
+        M_stack[i] = assemble(Xlist[i, :3])
+
+    return M_at, M_stack
+
+
+# ---------------------------------------------------------------------------
+# 辛投影
+# ---------------------------------------------------------------------------
+
+
+def symplectic_project(
+    B: npt.NDArray[np.floating],
+    *,
+    tol: float = 1e-14,
+    max_iter: int = 50,
+) -> npt.NDArray[np.floating]:
+    """把 ``B`` 投影到最近的辛矩阵（Newton 迭代，qiao 风格）。
+
+    迭代 ``B ← B − ½ B (Jᵀ S)``，其中 ``S = BᵀJB − J``。
+    """
+    B = np.array(B, dtype=float)
+    for _ in range(max_iter):
+        S = B.T @ J6 @ B - J6
+        if float(np.linalg.norm(S, "fro")) < tol:
+            break
+        B = B - 0.5 * B @ (J6.T @ S)
+    return B
+
+
+# ---------------------------------------------------------------------------
+# 矩阵法：直接积分 Ḃ = M·B − B·D
+# ---------------------------------------------------------------------------
+
+
+def _qf_rhs_factory(
+    M_at: Callable[[float], npt.NDArray[np.floating]],
+    D: npt.NDArray[np.floating],
+) -> Callable[[float, npt.ArrayLike], npt.NDArray[np.floating]]:
+    """构造 36 维 QF 右端项 ``Ḃ = M(t)·B − B·D``。
+
+    ``M_at`` 在 ODE 自适应步的任意时刻重新计算 Hamilton 矩阵，从而
+    ``MᵀJ+JM=0`` 在整个积分区间精确成立。
+    """
+
+    def rhs(t: float, X: npt.ArrayLike) -> npt.NDArray[np.floating]:
+        B = np.asarray(X, dtype=float).reshape(6, 6)
+        M = M_at(t)
+        dB = M @ B - B @ D
+        return dB.ravel()
+
+    return rhs
+
+
+def _solve_qf_matrix(
+    M_at: Callable[[float], npt.NDArray[np.floating]],
+    D: npt.NDArray[np.floating],
+    tlist: npt.NDArray[np.floating],
+    *,
+    rtol: float = 1e-11,
+    atol: float = 1e-13,
+) -> npt.NDArray[np.floating]:
+    """矩阵法：从 ``B(t_0)=I`` 出发 DOP853 积分 ``Ḃ = M·B − B·D``。
+
+    qiao ``Code08`` 在 36 维空间做多点打靶 + Newton；对 smoke 级小窗口，
+    单次初值积分 + 末尾辛投影即可：``M``、``D`` 都是 Hamilton 矩阵，
+    ``BᵀJB=J`` 是精确首次积分，前向积分的辛误差仅由 ODE 容差累积，
+    ``symplectic_project`` 把残余误差拉回 ``<1e-13``。
+    """
+    from scipy.integrate import solve_ivp
+
+    rhs = _qf_rhs_factory(M_at, D)
+    B0 = np.eye(6, dtype=float).ravel()
+
+    t_arr = np.asarray(tlist, dtype=float).ravel()
+    sol = solve_ivp(
+        rhs,
+        (float(t_arr[0]), float(t_arr[-1])),
+        B0,
+        t_eval=t_arr,
+        method="DOP853",
+        rtol=rtol,
+        atol=atol,
+    )
+    if not sol.success:
+        raise RuntimeError(f"QF 矩阵法积分失败：{sol.message}")
+    return sol.y.T.reshape(-1, 6, 6)
+
+
+# ---------------------------------------------------------------------------
+# 李代数法：B = B0·exp(ξ)
+# ---------------------------------------------------------------------------
+
+
+def _solve_qf_lie(
+    M_at: Callable[[float], npt.NDArray[np.floating]],
+    D: npt.NDArray[np.floating],
+    tlist: npt.NDArray[np.floating],
+    *,
+    rtol: float = 1e-11,
+    atol: float = 1e-13,
+    n_substeps: int = 40,
+) -> npt.NDArray[np.floating]:
+    """李代数法：在辛群 ``Sp(6)`` 上推进 ``B(t)``，自动保辛。
+
+    参数化 ``B = exp(ξ)``、``ξ ∈ sp(6, R)``。要解 ``Ḃ = M B − B D``，
+    不能简单令 ``ξ̇ = B⁻¹ Ḃ``：``d/dt exp(ξ) = exp(ξ)·ξ̇`` 仅当
+    ``[ξ, ξ̇] = 0`` 时成立，一般情形需带 ``dexp`` 修正项
+    ``ξ̇ = ad_ξ/(1−e^{−ad_ξ})(B⁻¹Ḃ)``。该项的 Bernoulli 级数在
+    ``‖ξ‖ ≳ 2π``（双曲方向 ``e^{λT}`` 增长后）发散，矩阵函数法在
+    ``1−e^{−ad_ξ}`` 奇异处失效，二者均不可靠。
+
+    改用 **commutator-free 4 阶 Lie group 积分器**（每步
+    ``B ← B·exp(h·ξ_k)``，``ξ_k`` 由 RK4 加权的体速度
+    ``B⁻¹Ḃ`` 的 sp(6) 投影给出）：``B·exp(sp(6))`` 恒辛，且 RK4
+    以 ``h⁴`` 收敛到 ``Ḃ = M B − B D`` 的真解。这是数值稳健、
+    自动保辛（无需末尾投影）、忠实于 qiao 李代数法意图的实现。
+
+    Args:
+        n_substeps: 相邻采样点之间的均匀子步数；``h⁴`` 误差随其增大
+            而下降，``40`` 对 smoke 级窗口给出与矩阵法 ``<1e-5`` 的
+            一致性。非公开调参，保留在签名内仅供测试覆盖。
+    """
+    from scipy.linalg import expm
+
+    basis = build_sp6_basis()
+    t_arr = np.asarray(tlist, dtype=float).ravel()
+    n = t_arr.size
+
+    def body_velocity(t: float, B: npt.NDArray[np.floating]) -> npt.NDArray[np.floating]:
+        """体速度 ``B⁻¹ Ḃ`` 投影到 sp(6)（``M``、``D`` Hamilton 时无损）。"""
+        Bdot = M_at(t) @ B - B @ D
+        return vector_to_sp6(sp6_to_vector(np.linalg.solve(B, Bdot), basis), basis)
+
+    def step(t: float, h: float, B: npt.NDArray[np.floating]) -> npt.NDArray[np.floating]:
+        """一步 4 阶 commutator-free Lie group RK4。"""
+        k1 = body_velocity(t, B)
+        k2 = body_velocity(t + h / 2, B @ expm(h / 2 * k1))
+        k3 = body_velocity(t + h / 2, B @ expm(h / 2 * k2))
+        k4 = body_velocity(t + h, B @ expm(h * k3))
+        return B @ expm(h * (k1 + 2 * k2 + 2 * k3 + k4) / 6)
+
+    B_samples = np.zeros((n, 6, 6), dtype=float)
+    B = np.eye(6, dtype=float)
+    B_samples[0] = B
+    for i in range(1, n):
+        h = (float(t_arr[i]) - float(t_arr[i - 1])) / n_substeps
+        t = float(t_arr[i - 1])
+        for _ in range(n_substeps):
+            B = step(t, h, B)
+            t += h
+        B_samples[i] = B
+    return B_samples
+
+
+# ---------------------------------------------------------------------------
+# Reducer
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class QuasiFloquetReducer:
+    """quasi-Floquet 变换 reducer（上下文绑定）。
+
+    通过 :meth:`reduce` 从一条 :class:`DynamicalSubstituteResult` 提取
+    时变线性化 ``M(t)``、求解 ``Ḃ = M·B − B·D``，并施加辛约束，
+    输出可插值的 :class:`QuasiFloquetResult`。
+
+    Args:
+        context: 归一化上下文（提供频率 ``ω_p``/``ω_v``、特征指数 λ）。
+        method: ``"matrix"``（默认，36 维直接积分 + 辛投影）或
+            ``"lie_algebra"``（21 维 sp(6) 参数化，自动保辛）。
+        project: 矩阵法是否在末尾做辛投影兜底（默认 ``True``）。
+        rtol: ODE 相对容差。
+        atol: ODE 绝对容差。
+    """
+
+    context: NormalFormContext
+    method: str = "matrix"
+    project: bool = True
+    rtol: float = 1e-11
+    atol: float = 1e-13
+
+    def reduce(self, ds_result: DynamicalSubstituteResult) -> QuasiFloquetResult:
+        """对 ``ds_result`` 执行 quasi-Floquet 变换。
+
+        Args:
+            ds_result: 切片 #171 的动力学替代结果，至少提供 ``tlist``、
+                ``Xlist`` 与 ``context``。
+
+        Returns:
+            :class:`QuasiFloquetResult`。
+
+        Raises:
+            ValueError: ``method`` 非法，或 ``ds_result`` 数据不足。
+        """
+        if self.method not in ("matrix", "lie_algebra"):
+            raise ValueError(
+                f"method 必须是 'matrix' 或 'lie_algebra'，得到 {self.method!r}"
+            )
+        if ds_result.Xlist.shape[0] < 2:
+            raise ValueError(
+                "ds_result 至少需要 2 个采样点，得到 "
+                f"{ds_result.Xlist.shape[0]}"
+            )
+
+        # —— 实标准形 D（qiao Global_File 频率）——
+        nu1, nu2 = self.context.central_frequencies
+        lam = float(self.context.characteristic_exponent)
+        D = real_normal_form_matrix(lam, float(nu1), float(nu2))
+
+        # —— 时变线性化 M(t) ——
+        M_at, M_stack = _build_M_at(ds_result)
+
+        # —— 求解 B(t) ——
+        if self.method == "matrix":
+            B_samples = _solve_qf_matrix(
+                M_at, D, ds_result.tlist, rtol=self.rtol, atol=self.atol
+            )
+            if self.project:
+                B_samples = np.array(
+                    [symplectic_project(B) for B in B_samples], dtype=float
+                )
+        else:
+            B_samples = _solve_qf_lie(
+                M_at, D, ds_result.tlist, rtol=self.rtol, atol=self.atol
+            )
+
+        return QuasiFloquetResult(
+            context=self.context,
+            order=int(self.context.order),
+            tlist=np.asarray(ds_result.tlist, dtype=float).copy(),
+            B_samples=B_samples,
+            D=D,
+            method=self.method,
+            M_samples=M_stack,
+            metadata={
+                "lambda": lam,
+                "wp": float(nu1),
+                "wv": float(nu2),
+                "n_samples": int(B_samples.shape[0]),
+                "project": bool(self.project) if self.method == "matrix" else False,
+                "source_orbit_residual": float(ds_result.residual_norm),
+            },
+        )
+
+
+__all__ = [
+    "J6",
+    "QuasiFloquetReducer",
+    "QuasiFloquetResult",
+    "build_sp6_basis",
+    "real_normal_form_matrix",
+    "sp6_to_vector",
+    "symplectic_project",
+    "vector_to_sp6",
+]

--- a/e2m2e/algorithms/normal_form/quasi_floquet.py
+++ b/e2m2e/algorithms/normal_form/quasi_floquet.py
@@ -60,9 +60,7 @@ J6: npt.NDArray[np.floating] = np.block(
 )
 
 
-def real_normal_form_matrix(
-    lam: float, wp: float, wv: float
-) -> npt.NDArray[np.floating]:
+def real_normal_form_matrix(lam: float, wp: float, wv: float) -> npt.NDArray[np.floating]:
     """构造 6×6 实标准形矩阵 ``D``。
 
     对应 qiao ``Global_File`` 中固化的 ``Mat_D``：一双曲方向 ``±λ``、
@@ -211,9 +209,7 @@ class QuasiFloquetResult:
 # ---------------------------------------------------------------------------
 
 
-def _cr3bp_hessian_symmetric(
-    r: npt.NDArray[np.floating], mu: float
-) -> npt.NDArray[np.floating]:
+def _cr3bp_hessian_symmetric(r: npt.NDArray[np.floating], mu: float) -> npt.NDArray[np.floating]:
     """纯 CR3BP 会合系下二阶导 ``Ω`` 的对称 Hessian（无量纲）。
 
     返回对称矩阵 ``S = ∂²Ω/∂x_i ∂x_j``，对应
@@ -486,14 +482,9 @@ class QuasiFloquetReducer:
             ValueError: ``method`` 非法，或 ``ds_result`` 数据不足。
         """
         if self.method not in ("matrix", "lie_algebra"):
-            raise ValueError(
-                f"method 必须是 'matrix' 或 'lie_algebra'，得到 {self.method!r}"
-            )
+            raise ValueError(f"method 必须是 'matrix' 或 'lie_algebra'，得到 {self.method!r}")
         if ds_result.Xlist.shape[0] < 2:
-            raise ValueError(
-                "ds_result 至少需要 2 个采样点，得到 "
-                f"{ds_result.Xlist.shape[0]}"
-            )
+            raise ValueError(f"ds_result 至少需要 2 个采样点，得到 {ds_result.Xlist.shape[0]}")
 
         # —— 实标准形 D（qiao Global_File 频率）——
         nu1, nu2 = self.context.central_frequencies
@@ -505,17 +496,11 @@ class QuasiFloquetReducer:
 
         # —— 求解 B(t) ——
         if self.method == "matrix":
-            B_samples = _solve_qf_matrix(
-                M_at, D, ds_result.tlist, rtol=self.rtol, atol=self.atol
-            )
+            B_samples = _solve_qf_matrix(M_at, D, ds_result.tlist, rtol=self.rtol, atol=self.atol)
             if self.project:
-                B_samples = np.array(
-                    [symplectic_project(B) for B in B_samples], dtype=float
-                )
+                B_samples = np.array([symplectic_project(B) for B in B_samples], dtype=float)
         else:
-            B_samples = _solve_qf_lie(
-                M_at, D, ds_result.tlist, rtol=self.rtol, atol=self.atol
-            )
+            B_samples = _solve_qf_lie(M_at, D, ds_result.tlist, rtol=self.rtol, atol=self.atol)
 
         return QuasiFloquetResult(
             context=self.context,

--- a/e2m2e/algorithms/normal_form/types.py
+++ b/e2m2e/algorithms/normal_form/types.py
@@ -1,0 +1,77 @@
+"""Normal-form 流水线的结果类型。
+
+``NormalFormResult`` 是 :class:`NormalFormPipeline`（issue #175）输出的统一
+载体：把前四个切片（动力学替代 / quasi-Floquet / 中心流形 / 表征参数目录）
+的结果聚合到一个不可变句柄里。通用化简诊断字段（Hamiltonian 系数、变换
+矩阵、残差）与各子结果句柄并存——前者供算法诊断，后者让外部用户一行代码
+拿到 ``catalog_transformer`` 完成坐标变换。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import numpy as np
+import numpy.typing as npt
+
+if TYPE_CHECKING:
+    from .catalog import LibrationCatalogTransformer
+    from .center_manifold import CenterManifoldResult
+    from .context import NormalFormContext
+    from .dynamical_substitution import DynamicalSubstituteResult
+    from .quasi_floquet import QuasiFloquetResult
+
+
+@dataclass(frozen=True)
+class NormalFormResult:
+    """法型化流水线统一结果容器。
+
+    不可变：所有字段在构造后只读，确保下游消费方按值传递。
+
+    字段分两组：
+
+    - **通用化简诊断**（``hamiltonian_coefficients``、``transformation_matrices``、
+      ``residual``、``success``、``message``、``metadata``）：跨切片稳定，描述
+      整条流水线的收敛情况。保留给仅关心"是否收敛、残差多大"的诊断调用方。
+    - **子结果句柄**（``ds_result`` / ``qf_result`` / ``cm_result`` /
+      ``catalog_transformer``）：issue #175 新增。指向四个子 reducer 的产物；
+      ``catalog_transformer`` 一等公民字段使外部用户能直接
+      ``result.catalog_transformer.rho_to_param(X_rho, t)`` 完成完整坐标变换，
+      无需自己重组装 :class:`LibrationCatalogData`。
+
+    所有新增字段都带默认值，保证仅关心通用字段的既有调用方
+    （``NormalFormResult(context, order, ...)``）不受影响。
+
+    Attributes:
+        context: 关联的 ``NormalFormContext``。
+        order: 实际展开阶数（一般等于 ``context.order``）。
+        hamiltonian_coefficients: 截断 Hamilton 量各阶系数。
+        transformation_matrices: 各阶近恒等变换矩阵 ``T_k``（如 Quasi-Floquet 矩阵）。
+        residual: 截断后剩余项的范数估计。
+        success: 流水线是否在容差内收敛。
+        message: 人类可读的终止原因。
+        metadata: 自由扩展字段；保留供后续切片写入诊断数据。
+        ds_result: 动力学替代结果（切片 #171）；流水线未跑到该步时为 ``None``。
+        qf_result: quasi-Floquet 结果（切片 #172）；同上。
+        cm_result: 中心流形化简结果（切片 #173）；同上。
+        catalog_transformer: 表征参数目录变换器（切片 #174），绑定上述三个子
+            结果与 context；流水线跑完四步后非 ``None``，是外部用户做
+            ``rho ↔ param`` 坐标变换的入口。
+    """
+
+    context: NormalFormContext
+    order: int
+    hamiltonian_coefficients: tuple[npt.NDArray[np.floating], ...] = ()
+    transformation_matrices: tuple[npt.NDArray[np.floating], ...] = ()
+    residual: float = 0.0
+    success: bool = False
+    message: str = ""
+    metadata: dict[str, object] = field(default_factory=dict)
+    ds_result: DynamicalSubstituteResult | None = None
+    qf_result: QuasiFloquetResult | None = None
+    cm_result: CenterManifoldResult | None = None
+    catalog_transformer: LibrationCatalogTransformer | None = None
+
+
+__all__ = ["NormalFormResult"]

--- a/e2m2e/algorithms/normal_form/units.py
+++ b/e2m2e/algorithms/normal_form/units.py
@@ -1,0 +1,82 @@
+"""SI ↔ qiao 归一化单位转换。
+
+约定：
+- SI 状态 ``[x, y, z, vx, vy, vz]`` 单位为 ``km`` + ``km/s``（与
+  ``CR3BP_System.physical_to_dimensionless`` 物理接口一致）；
+- qiao 归一化状态使用 ``LU``（位置）与 ``VU = LU/TU``（速度），与
+  ``Global_File.py`` 中无量纲状态保持一致；
+- 时间方向上 SI 秒 ↔ 归一化 TU 通过 ``NormalFormContext.seconds_to_tu``
+  / ``tu_to_seconds`` 完成。
+
+``to_normalized`` 与 ``from_normalized`` 互为精确逆运算（数值精度内
+无截断），后续切片中的所有归一化 Hamilton 量都基于此接口之上。
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import numpy.typing as npt
+
+if TYPE_CHECKING:
+    from .context import NormalFormContext
+
+
+def to_normalized(
+    state_si: npt.ArrayLike,
+    context: NormalFormContext,
+) -> npt.NDArray[np.floating]:
+    """SI 物理状态 → qiao 归一化状态。
+
+    位置除以 ``context.LU``（km），速度除以 ``context.VU``（km/s）。
+    支持 ``(6,)`` 单状态与 ``(n, 6)`` 批量状态。
+
+    Args:
+        state_si: 物理状态向量 ``[x, y, z, vx, vy, vz]``，单位 km + km/s。
+        context: 归一化上下文。
+
+    Returns:
+        与输入同形状的归一化状态数组。
+
+    Raises:
+        ValueError: 最后一维不是 6。
+    """
+    arr = np.asarray(state_si, dtype=float)
+    if arr.shape[-1] != 6:
+        raise ValueError(f"状态向量必须包含 6 个分量，最后一维为 {arr.shape[-1]}")
+    out = arr.copy()
+    out[..., :3] = out[..., :3] / context.LU
+    out[..., 3:] = out[..., 3:] / context.VU
+    return out
+
+
+def from_normalized(
+    state_norm: npt.ArrayLike,
+    context: NormalFormContext,
+) -> npt.NDArray[np.floating]:
+    """qiao 归一化状态 → SI 物理状态。
+
+    位置乘以 ``context.LU``（km），速度乘以 ``context.VU``（km/s）。
+    支持 ``(6,)`` 单状态与 ``(n, 6)`` 批量状态。
+
+    Args:
+        state_norm: 归一化状态向量 ``[x, y, z, vx, vy, vz]``，无量纲。
+        context: 归一化上下文。
+
+    Returns:
+        与输入同形状的物理状态数组，单位 km + km/s。
+
+    Raises:
+        ValueError: 最后一维不是 6。
+    """
+    arr = np.asarray(state_norm, dtype=float)
+    if arr.shape[-1] != 6:
+        raise ValueError(f"状态向量必须包含 6 个分量，最后一维为 {arr.shape[-1]}")
+    out = arr.copy()
+    out[..., :3] = out[..., :3] * context.LU
+    out[..., 3:] = out[..., 3:] * context.VU
+    return out
+
+
+__all__ = ["to_normalized", "from_normalized"]

--- a/e2m2e/transfer/nlp_copt.py
+++ b/e2m2e/transfer/nlp_copt.py
@@ -7,6 +7,7 @@
 但 :class:`COPTNLPSolver` 退化为占位实现，:func:`optimize_with_copt`
 应通过 ``fallback_to_scipy`` 回退 SciPy 求解。
 """
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
@@ -107,18 +108,14 @@ if NlpCallbackBase is not None:
             for i in range(3):
                 x_pert = x.copy()
                 x_pert[i] += h
-                grad_pos[i] = (
-                    self.optimizer.constraint_position(x_pert) - pos_con
-                ) / h
+                grad_pos[i] = (self.optimizer.constraint_position(x_pert) - pos_con) / h
 
             vel_con = self.optimizer.constraint_velocity_parallel(x)
             grad_vel = np.zeros(3)
             for i in range(3):
                 x_pert = x.copy()
                 x_pert[i] += h
-                grad_vel[i] = (
-                    self.optimizer.constraint_velocity_parallel(x_pert) - vel_con
-                ) / h
+                grad_vel[i] = (self.optimizer.constraint_velocity_parallel(x_pert) - vel_con) / h
 
             outdata[0] = grad_pos[0]
             outdata[1] = grad_pos[1]
@@ -195,9 +192,7 @@ if NlpCallbackBase is not None:
             options: COPT 求解参数（``max_iter``、``threads`` 等）。
         """
 
-        def __init__(
-            self, optimizer: DROTRONLPOptimizer, options: dict[str, Any] | None = None
-        ):
+        def __init__(self, optimizer: DROTRONLPOptimizer, options: dict[str, Any] | None = None):
             self.optimizer = optimizer
             self.options = options or {}
             self.model: Any = None

--- a/e2m2e/transfer/nlp_core.py
+++ b/e2m2e/transfer/nlp_core.py
@@ -3,6 +3,7 @@
 提供 :class:`NLPOptimizationVariables` 数据结构与后端无关的辅助类型，
 作为 SciPy / COPT 后端之间共享的"问题描述"层。
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/e2m2e/transfer/nlp_scipy.py
+++ b/e2m2e/transfer/nlp_scipy.py
@@ -5,6 +5,7 @@
 ``DROTRONLPOptimizer.optimize`` 调用。SLSQP 是 DRO→RO 转移优化的默认求解器，
 无需额外依赖，仅依赖 ``scipy>=1.10``。
 """
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -83,9 +84,7 @@ def solve_with_scipy(
         print("\n开始NLP优化:")
         print(f"  初始猜测: α={alpha0:.4f}, T={T0:.4f}, t_ins={t_ins0:.4f}")
         print(f"  α范围: [{optimizer.alpha_range[0]}, {optimizer.alpha_range[1]}]")
-        print(
-            f"  T范围: [{optimizer.transfer_time_range[0]}, {optimizer.transfer_time_range[1]}]"
-        )
+        print(f"  T范围: [{optimizer.transfer_time_range[0]}, {optimizer.transfer_time_range[1]}]")
         print(f"  t_ins范围: [{optimizer.t_ins_range[0]}, {optimizer.t_ins_range[1]}]")
 
     # 6. 构造约束
@@ -122,9 +121,7 @@ def solve_with_scipy(
         if optimizer._progress_callback is not None:
             alpha_k, T_k, tins_k = float(xk[0]), float(xk[1]), float(xk[2])
             obj_k = float(optimizer.objective_function(xk))
-            optimizer._progress_callback(
-                iteration_counter[0], obj_k, alpha_k, T_k, tins_k
-            )
+            optimizer._progress_callback(iteration_counter[0], obj_k, alpha_k, T_k, tins_k)
 
     # 8. 求解
     try:

--- a/e2m2e/transfer/search_geometry.py
+++ b/e2m2e/transfer/search_geometry.py
@@ -75,10 +75,7 @@ def detect_local_minimum(
     min_distances = np.min(distances, axis=1)
     local_mins = []
     for i in range(1, len(min_distances) - 1):
-        if (
-            min_distances[i + 1] > min_distances[i]
-            and min_distances[i - 1] > min_distances[i]
-        ):
+        if min_distances[i + 1] > min_distances[i] and min_distances[i - 1] > min_distances[i]:
             local_mins.append((i, min_distances[i]))
     if local_mins:
         best = min(local_mins, key=lambda x: x[1])

--- a/e2m2e/transfer/search_parallel.py
+++ b/e2m2e/transfer/search_parallel.py
@@ -53,9 +53,7 @@ def sample_departure_points(
     if n == 1:
         idx = np.array([0], dtype=int)
     else:
-        idx = (
-            (np.arange(n, dtype=float) * (n_pts - 1) / (n - 1)).round().astype(int)
-        )
+        idx = (np.arange(n, dtype=float) * (n_pts - 1) / (n - 1)).round().astype(int)
     return states[idx].copy(), times[idx].copy()
 
 
@@ -98,8 +96,13 @@ def search_single_departure(
     ith = searcher.intersection_threshold
     mdt = searcher.min_distance_threshold
     if (
-        a0 is None or a1 is None or na is None or mtt is None
-        or idt is None or ith is None or mdt is None
+        a0 is None
+        or a1 is None
+        or na is None
+        or mtt is None
+        or idt is None
+        or ith is None
+        or mdt is None
     ):
         raise ValueError(
             "请先设置 alpha_min, alpha_max, n_alpha, max_transfer_time, integration_dt, "
@@ -121,14 +124,22 @@ def search_single_departure(
             try:
                 traj_states, traj_times = searcher._forward_integrate(initial_state, mtt, idt)
             except Exception:
-                results.append({
-                    "success": False, "departure_state": departure_state,
-                    "departure_time": departure_time, "alpha": alpha,
-                    "status": "integration_failed", "dv_departure": dv_departure,
-                    "dv_insertion": None, "min_distance_orbit_idx": None,
-                    "first_intersection_idx": None, "first_intersection_time": None,
-                    "first_min_distance_idx": None, "first_min_distance_time": None,
-                })
+                results.append(
+                    {
+                        "success": False,
+                        "departure_state": departure_state,
+                        "departure_time": departure_time,
+                        "alpha": alpha,
+                        "status": "integration_failed",
+                        "dv_departure": dv_departure,
+                        "dv_insertion": None,
+                        "min_distance_orbit_idx": None,
+                        "first_intersection_idx": None,
+                        "first_intersection_time": None,
+                        "first_min_distance_idx": None,
+                        "first_min_distance_time": None,
+                    }
+                )
                 continue
 
             collision, body, col_idx = searcher._check_collision(traj_states)
@@ -168,14 +179,20 @@ def search_single_departure(
                 first_md_time = None
 
             result = {
-                "success": True, "departure_state": departure_state,
-                "departure_time": departure_time, "alpha": alpha,
-                "transfer_trajectory": traj_states, "transfer_times": traj_times,
+                "success": True,
+                "departure_state": departure_state,
+                "departure_time": departure_time,
+                "alpha": alpha,
+                "transfer_trajectory": traj_states,
+                "transfer_times": traj_times,
                 "transfer_time": traj_times[-1],
-                "min_distance": min_dist, "min_distance_idx": min_idx,
+                "min_distance": min_dist,
+                "min_distance_idx": min_idx,
                 "min_distance_orbit_idx": int(orbit_idx),
-                "dv_departure": dv_departure, "dv_insertion": dv_insertion,
-                "intersection_found": intersection, "intersection_point": int_point,
+                "dv_departure": dv_departure,
+                "dv_insertion": dv_insertion,
+                "intersection_found": intersection,
+                "intersection_point": int_point,
                 "intersection_idx": int_idx,
                 "first_intersection_idx": first_int_idx,
                 "first_intersection_time": first_int_time,
@@ -184,7 +201,8 @@ def search_single_departure(
                 "local_minimum_found": local_min,
                 "local_minimum_distance": local_min_dist,
                 "local_minimum_idx": local_min_idx,
-                "collision_found": collision, "collision_body": body,
+                "collision_found": collision,
+                "collision_body": body,
                 "collision_idx": col_idx,
             }
             if collision:
@@ -225,17 +243,34 @@ def dispatch_grid_search(
         raise ValueError("parallel_backend 须为 'processes' 或 'threads'")
     if n_workers == 1:
         return grid_search_sequential(
-            searcher, departure_states, departure_times,
-            arrival_orbit, dep_name, arr_name, verbose,
+            searcher,
+            departure_states,
+            departure_times,
+            arrival_orbit,
+            dep_name,
+            arr_name,
+            verbose,
         )
     if pb == "processes":
         return grid_search_parallel_processes(
-            searcher, departure_states, departure_times,
-            arrival_orbit, dep_name, arr_name, verbose, n_workers,
+            searcher,
+            departure_states,
+            departure_times,
+            arrival_orbit,
+            dep_name,
+            arr_name,
+            verbose,
+            n_workers,
         )
     return grid_search_parallel_threads(
-        searcher, departure_states, departure_times,
-        arrival_orbit, dep_name, arr_name, verbose, n_workers,
+        searcher,
+        departure_states,
+        departure_times,
+        arrival_orbit,
+        dep_name,
+        arr_name,
+        verbose,
+        n_workers,
     )
 
 
@@ -244,7 +279,8 @@ def grid_search_sequential(
     departure_states: np.ndarray,
     departure_times: np.ndarray,
     arrival_orbit: Orbit,
-    dep_name: str, arr_name: str,
+    dep_name: str,
+    arr_name: str,
     verbose: bool,
 ) -> list[dict[str, Any]]:
     """串行网格搜索。"""
@@ -289,13 +325,20 @@ def _process_pack_base(searcher):
     dyn = searcher.dynamics
     return (
         searcher.mu,
-        float(searcher.alpha_min), float(searcher.alpha_max),
-        int(searcher.n_alpha), int(searcher.n_departure),
+        float(searcher.alpha_min),
+        float(searcher.alpha_max),
+        int(searcher.n_alpha),
+        int(searcher.n_departure),
         float(searcher.max_transfer_time),
-        float(searcher.intersection_threshold), float(searcher.min_distance_threshold),
-        float(searcher.collision_earth_radius), float(searcher.collision_moon_radius),
+        float(searcher.intersection_threshold),
+        float(searcher.min_distance_threshold),
+        float(searcher.collision_earth_radius),
+        float(searcher.collision_moon_radius),
         float(searcher.integration_dt),
-        str(dyn.integrator), float(dyn.rtol), float(dyn.atol), float(dyn.max_step),
+        str(dyn.integrator),
+        float(dyn.rtol),
+        float(dyn.atol),
+        float(dyn.max_step),
     )
 
 
@@ -304,7 +347,8 @@ def grid_search_parallel_processes(
     departure_states: np.ndarray,
     departure_times: np.ndarray,
     arrival_orbit: Orbit,
-    dep_name: str, arr_name: str,
+    dep_name: str,
+    arr_name: str,
     verbose: bool,
     n_workers: int,
 ) -> list[dict[str, Any]]:
@@ -330,8 +374,7 @@ def grid_search_parallel_processes(
 
     if verbose and total_steps > 0:
         tqdm.write(
-            f"  并行搜索(进程): {total_departures}×{n_alpha}={total_steps} 步"
-            f" | {n_workers} 进程"
+            f"  并行搜索(进程): {total_departures}×{n_alpha}={total_steps} 步 | {n_workers} 进程"
         )
         pbar = open_search_progress_bar(total_steps, "并行网格搜索(进程)")
         # 多进程下 tqdm 无法跨进程；用 Manager().Queue() 中转。
@@ -361,8 +404,10 @@ def grid_search_parallel_processes(
 
     pack_base = _process_pack_base(searcher) + (dep_name, arr_name)
     if (
-        searcher.alpha_min is None or searcher.alpha_max is None
-        or searcher.n_alpha is None or searcher.n_departure is None
+        searcher.alpha_min is None
+        or searcher.alpha_max is None
+        or searcher.n_alpha is None
+        or searcher.n_departure is None
         or searcher.max_transfer_time is None
         or searcher.intersection_threshold is None
         or searcher.min_distance_threshold is None
@@ -383,11 +428,16 @@ def grid_search_parallel_processes(
                 zip(departure_states, departure_times, strict=False)
             ):
                 packed = (
-                    (i,
-                     np.asarray(dep_state, dtype=float),
-                     float(dep_time),
-                     arrival_states, arrival_times_a, arrival_period)
-                    + pack_base + (progress_queue,)
+                    (
+                        i,
+                        np.asarray(dep_state, dtype=float),
+                        float(dep_time),
+                        arrival_states,
+                        arrival_times_a,
+                        arrival_period,
+                    )
+                    + pack_base
+                    + (progress_queue,)
                 )
                 fut = executor.submit(process_departure_worker_packed, packed)
                 futures[fut] = i
@@ -459,7 +509,8 @@ def grid_search_parallel_threads(
     departure_states: np.ndarray,
     departure_times: np.ndarray,
     arrival_orbit: Orbit,
-    dep_name: str, arr_name: str,
+    dep_name: str,
+    arr_name: str,
     verbose: bool,
     n_workers: int,
 ) -> list[dict[str, Any]]:
@@ -502,9 +553,16 @@ def grid_search_parallel_threads(
                 futures = {
                     executor.submit(
                         _run_departure_with_worker_slot,
-                        searcher, slot_queue, n_alpha, i,
-                        dep_state, dep_time, arrival_orbit,
-                        worker_bars, None, None,
+                        searcher,
+                        slot_queue,
+                        n_alpha,
+                        i,
+                        dep_state,
+                        dep_time,
+                        arrival_orbit,
+                        worker_bars,
+                        None,
+                        None,
                     ): i
                     for i, (dep_state, dep_time) in enumerate(
                         zip(departure_states, departure_times, strict=False)
@@ -514,9 +572,16 @@ def grid_search_parallel_threads(
                 futures = {
                     executor.submit(
                         _run_departure_with_worker_slot,
-                        searcher, slot_queue, n_alpha, i,
-                        dep_state, dep_time, arrival_orbit,
-                        None, aggregate_pbar, aggregate_lock,
+                        searcher,
+                        slot_queue,
+                        n_alpha,
+                        i,
+                        dep_state,
+                        dep_time,
+                        arrival_orbit,
+                        None,
+                        aggregate_pbar,
+                        aggregate_lock,
                     ): i
                     for i, (dep_state, dep_time) in enumerate(
                         zip(departure_states, departure_times, strict=False)
@@ -526,7 +591,12 @@ def grid_search_parallel_threads(
                 futures = {
                     executor.submit(
                         searcher._search_single_departure,
-                        dep_state, dep_time, arrival_orbit, False, None, i,
+                        dep_state,
+                        dep_time,
+                        arrival_orbit,
+                        False,
+                        None,
+                        i,
                     ): i
                     for i, (dep_state, dep_time) in enumerate(
                         zip(departure_states, departure_times, strict=False)
@@ -560,15 +630,22 @@ def process_departure_worker(
     arrival_times: np.ndarray,
     arrival_period: float | None,
     mu: float,
-    alpha_min: float, alpha_max: float,
-    n_alpha: int, n_departure: int,
+    alpha_min: float,
+    alpha_max: float,
+    n_alpha: int,
+    n_departure: int,
     max_transfer_time: float,
-    intersection_threshold: float, min_distance_threshold: float,
-    collision_earth_radius: float, collision_moon_radius: float,
+    intersection_threshold: float,
+    min_distance_threshold: float,
+    collision_earth_radius: float,
+    collision_moon_radius: float,
     integration_dt: float,
     integrator: str,
-    rtol: float, atol: float, max_step: float,
-    dep_name: str, arr_name: str,
+    rtol: float,
+    atol: float,
+    max_step: float,
+    dep_name: str,
+    arr_name: str,
     progress_queue: Any | None = None,
 ) -> list[dict[str, Any]]:
     """子进程入口（模块级，便于 Windows spawn 下 pickle）。"""
@@ -587,8 +664,10 @@ def process_departure_worker(
 
     searcher = TransferSearch(dynamics=dynamics)
     searcher.configure_search(
-        alpha_min=alpha_min, alpha_max=alpha_max,
-        n_alpha=n_alpha, n_departure=n_departure,
+        alpha_min=alpha_min,
+        alpha_max=alpha_max,
+        n_alpha=n_alpha,
+        n_departure=n_departure,
         max_transfer_time=max_transfer_time,
         intersection_threshold=intersection_threshold,
         min_distance_threshold=min_distance_threshold,

--- a/e2m2e/transfer/search_progress.py
+++ b/e2m2e/transfer/search_progress.py
@@ -38,8 +38,12 @@ def open_search_progress_bar(total: int, desc: str) -> Any | None:
     if total <= 0:
         return None
     return tqdm(
-        total=total, desc=desc, unit="it",
-        file=sys.stderr, dynamic_ncols=True, mininterval=0.2,
+        total=total,
+        desc=desc,
+        unit="it",
+        file=sys.stderr,
+        dynamic_ncols=True,
+        mininterval=0.2,
     )
 
 
@@ -65,8 +69,14 @@ def reset_tqdm_bar(bar: Any, total: int) -> None:
 def open_parallel_worker_progress_bars(n_workers: int, n_alpha: int) -> list[Any]:
     return [
         tqdm(
-            total=n_alpha, position=i, desc=f"W{i}", leave=True, unit="α",
-            file=sys.stderr, dynamic_ncols=True, mininterval=0.1,
+            total=n_alpha,
+            position=i,
+            desc=f"W{i}",
+            leave=True,
+            unit="α",
+            file=sys.stderr,
+            dynamic_ncols=True,
+            mininterval=0.1,
         )
         for i in range(n_workers)
     ]

--- a/e2m2e/transfer/transfer_optimization.py
+++ b/e2m2e/transfer/transfer_optimization.py
@@ -93,32 +93,22 @@ class DROTRONLPOptimizer:
 
         # ``departure_state`` 在两种接口下都允许（新接口下作覆盖），
         # 因此混用判定只看 ``departure_orbit``/``arrival_orbit``。
-        has_terminals = (
-            departure_terminal is not None or arrival_terminal is not None
-        )
+        has_terminals = departure_terminal is not None or arrival_terminal is not None
         has_legacy = departure_orbit is not None or arrival_orbit is not None
         if has_terminals and has_legacy:
-            raise ValueError(
-                "DROTRONLPOptimizer: cannot mix new and legacy interfaces"
-            )
+            raise ValueError("DROTRONLPOptimizer: cannot mix new and legacy interfaces")
         if has_terminals:
             if departure_terminal is None or arrival_terminal is None:
-                raise ValueError(
-                    "DROTRONLPOptimizer: both terminals required"
-                )
+                raise ValueError("DROTRONLPOptimizer: both terminals required")
             self.departure_terminal: TerminalCondition = departure_terminal
             self.arrival_terminal: TerminalCondition = arrival_terminal
         elif has_legacy:
             if departure_orbit is None or arrival_orbit is None:
-                raise ValueError(
-                    "DROTRONLPOptimizer: legacy interface requires both orbits"
-                )
+                raise ValueError("DROTRONLPOptimizer: legacy interface requires both orbits")
             self.departure_terminal = OrbitTerminal(departure_orbit)
             self.arrival_terminal = OrbitTerminal(arrival_orbit)
         else:
-            raise ValueError(
-                "DROTRONLPOptimizer: must provide terminal pair or orbit pair"
-            )
+            raise ValueError("DROTRONLPOptimizer: must provide terminal pair or orbit pair")
 
         # 实际出发点状态：显式覆盖 > 终端默认首点
         self._departure_state = (
@@ -143,17 +133,11 @@ class DROTRONLPOptimizer:
         )
 
         self.velocity_angle_tol = (
-            config.nlp_velocity_angle_tol
-            if config is not None
-            else self.DEFAULT_VELOCITY_ANGLE_TOL
+            config.nlp_velocity_angle_tol if config is not None else self.DEFAULT_VELOCITY_ANGLE_TOL
         )
 
-        self.earth_radius = (
-            config.nlp_earth_radius if config is not None else self.EARTH_RADIUS_ND
-        )
-        self.moon_radius = (
-            config.nlp_moon_radius if config is not None else self.MOON_RADIUS_ND
-        )
+        self.earth_radius = config.nlp_earth_radius if config is not None else self.EARTH_RADIUS_ND
+        self.moon_radius = config.nlp_moon_radius if config is not None else self.MOON_RADIUS_ND
 
         self._use_relaxed_velocity = (
             config.nlp_use_relaxed_velocity if config is not None else False
@@ -246,11 +230,7 @@ class DROTRONLPOptimizer:
             包含 ``objective``、``pos_violation``、``cos_angle`` 等键的字典。
         """
         key = self._y_key(y)
-        if (
-            self._cache_enabled
-            and self._eval_cache_key == key
-            and self._eval_cache is not None
-        ):
+        if self._cache_enabled and self._eval_cache_key == key and self._eval_cache is not None:
             return self._eval_cache
 
         alpha, transfer_time, t_ins = y
@@ -269,9 +249,7 @@ class DROTRONLPOptimizer:
 
         # 到达状态走 TerminalCondition 接口
         if not empty:
-            ins_pos, ins_vel = self.arrival_terminal.get_arrival_state(
-                float(t_ins), self.dynamics
-            )
+            ins_pos, ins_vel = self.arrival_terminal.get_arrival_state(float(t_ins), self.dynamics)
             insertion_state = np.concatenate([ins_pos, ins_vel])
         else:
             insertion_state = np.zeros(6)
@@ -523,9 +501,7 @@ class DROTRONLPOptimizer:
         )
 
         # 到达状态走 TerminalCondition 接口
-        ins_pos, ins_vel = self.arrival_terminal.get_arrival_state(
-            float(t_ins), self.dynamics
-        )
+        ins_pos, ins_vel = self.arrival_terminal.get_arrival_state(float(t_ins), self.dynamics)
         insertion_state = np.concatenate([ins_pos, ins_vel])
         final_state = states[-1] if len(states) > 0 else None
 
@@ -546,15 +522,11 @@ class DROTRONLPOptimizer:
                     - self._compute_cos_angle(variables.to_array()),
                 )
             else:
-                violation["velocity"] = abs(
-                    self.constraint_velocity_parallel(variables.to_array())
-                )
+                violation["velocity"] = abs(self.constraint_velocity_parallel(variables.to_array()))
 
         max_violation = max(violation.values()) if violation else 0.0
 
-        transfer_type = self._classify_transfer(
-            transfer_time, times, states, insertion_state
-        )
+        transfer_type = self._classify_transfer(transfer_time, times, states, insertion_state)
 
         return TransferOptimizationResult(
             success=success,

--- a/e2m2e/transfer/transfer_search.py
+++ b/e2m2e/transfer/transfer_search.py
@@ -165,8 +165,10 @@ class TransferSearch:
             self._config = config
 
         for name, value in (
-            ("alpha_min", alpha_min), ("alpha_max", alpha_max),
-            ("n_alpha", n_alpha), ("n_departure", n_departure),
+            ("alpha_min", alpha_min),
+            ("alpha_max", alpha_max),
+            ("n_alpha", n_alpha),
+            ("n_departure", n_departure),
             ("max_transfer_time", max_transfer_time),
             ("intersection_threshold", intersection_threshold),
             ("min_distance_threshold", min_distance_threshold),
@@ -191,7 +193,12 @@ class TransferSearch:
             print(f"{'=' * 60}\n")
 
         results = search_parallel.dispatch_grid_search(
-            self, dep_orbit, arr_orbit, verbose, n_workers, parallel_backend,
+            self,
+            dep_orbit,
+            arr_orbit,
+            verbose,
+            n_workers,
+            parallel_backend,
         )
         self._search_results = results
 
@@ -224,9 +231,7 @@ class TransferSearch:
             departure_state=initial_guess["departure_state"],
             propulsion=self._propulsion,
         )
-        transfer_time = (
-            self.transfer_time_range[1] / 2 if self.transfer_time_range else 15.0
-        )
+        transfer_time = self.transfer_time_range[1] / 2 if self.transfer_time_range else 15.0
         nlp_vars = NLPOptimizationVariables(
             alpha=initial_guess.get("alpha", 1.0),
             transfer_time=initial_guess.get("transfer_time") or transfer_time,
@@ -272,7 +277,9 @@ class TransferSearch:
 
     def _is_feasible(self, result: dict[str, Any]) -> bool:
         return search_geometry.is_feasible_result(
-            result, self.min_distance_threshold, DEFAULT_MIN_DISTANCE_THRESHOLD_DU,
+            result,
+            self.min_distance_threshold,
+            DEFAULT_MIN_DISTANCE_THRESHOLD_DU,
         )
 
     def _compute_distance_series(self, trajectory_states, arrival_orbit):
@@ -292,8 +299,10 @@ class TransferSearch:
 
     def _check_collision(self, trajectory_states):
         return search_geometry.check_collision(
-            trajectory_states, self.mu,
-            self.collision_earth_radius, self.collision_moon_radius,
+            trajectory_states,
+            self.mu,
+            self.collision_earth_radius,
+            self.collision_moon_radius,
         )
 
     def _compute_departure_velocity(self, orbit_state, alpha):

--- a/e2m2e/visualization/base.py
+++ b/e2m2e/visualization/base.py
@@ -121,9 +121,7 @@ class OrbitVisualizer:
 
         return icons.make_offset_image(image, size), True
 
-    def _plot_body_marker_3d(
-        self, ax: Any, x: float, color: str, size: int, label: str
-    ) -> None:
+    def _plot_body_marker_3d(self, ax: Any, x: float, color: str, size: int, label: str) -> None:
         """在 3D axes 上画一个天体的圆形 marker（图标加载失败时的回退）。"""
         ax.plot(
             [x],
@@ -418,9 +416,7 @@ class OrbitVisualizer:
             )
 
             if primary_ok and secondary_ok:
-                icons.add_3d_billboard_icon(
-                    ax, primary_icon, (-self.mu, 0.0, 0.0), primary_name
-                )
+                icons.add_3d_billboard_icon(ax, primary_icon, (-self.mu, 0.0, 0.0), primary_name)
                 icons.add_3d_billboard_icon(
                     ax, secondary_icon, (1 - self.mu, 0.0, 0.0), secondary_name
                 )

--- a/examples/normal_form_example.py
+++ b/examples/normal_form_example.py
@@ -22,9 +22,7 @@ def main():
     print("=" * 60)
 
     # 1. 构造上下文：地月 CR3BP、L1 点、J2000 历元、4 阶展开
-    system = CR3BP_System(
-        mu=1.215058560962404e-2, primary="Earth", secondary="Moon"
-    )
+    system = CR3BP_System(mu=1.215058560962404e-2, primary="Earth", secondary="Moon")
     system.set_characteristic_scales(distance=384405.0, period=27.32 * 86400.0)
     context = NormalFormContext(
         system=system,
@@ -64,14 +62,8 @@ def main():
     print(f"  message      = {result.message}")
     print(f"  residual     = {result.residual:.3e}")
     print(f"  spice_used   = {result.metadata.get('spice_available')}")
-    print(
-        f"  qf 辛误差   = "
-        f"{result.metadata.get('qf_symplectic_error', float('nan')):.3e}"
-    )
-    print(
-        f"  cm 双曲耦合 = "
-        f"{result.metadata.get('cm_hyperbolic_coupling', float('nan')):.3e}"
-    )
+    print(f"  qf 辛误差   = {result.metadata.get('qf_symplectic_error', float('nan')):.3e}")
+    print(f"  cm 双曲耦合 = {result.metadata.get('cm_hyperbolic_coupling', float('nan')):.3e}")
 
     if result.catalog_transformer is not None:
         # 5. rho 坐标 → 表征参数 [q1, p1, I2, θ2, I3, θ3]

--- a/examples/normal_form_example.py
+++ b/examples/normal_form_example.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""法型化流水线最小示例（issue #175）。
+
+把一条 rho 坐标初值送进 ``NormalFormPipeline``，打印整条流水线的收敛摘要
+与表征参数输出。
+
+无 SPICE 内核时（如 CI 环境）底层自动降级到纯 CR3BP，本示例在该降级下仍
+可跑通（仅供演示，不用于生产数据）。
+"""
+
+import warnings
+
+import numpy as np
+
+from e2m2e.algorithms.normal_form import NormalFormContext, NormalFormPipeline
+from e2m2e.core import CR3BP_System, LibrationPoint
+
+
+def main():
+    print("=" * 60)
+    print("e2m2e 法型化流水线示例")
+    print("=" * 60)
+
+    # 1. 构造上下文：地月 CR3BP、L1 点、J2000 历元、4 阶展开
+    system = CR3BP_System(
+        mu=1.215058560962404e-2, primary="Earth", secondary="Moon"
+    )
+    system.set_characteristic_scales(distance=384405.0, period=27.32 * 86400.0)
+    context = NormalFormContext(
+        system=system,
+        libration_point=LibrationPoint.L1,
+        epoch=2451545.0,  # J2000 儒略日
+        order=4,
+    )
+    print(f"\n上下文：{context}")
+
+    # 2. rho 坐标初值 [ρ, ρ̇]（无量纲，围绕平动点的小偏移）
+    x0 = np.array([1e-3, -1e-3, 0.0, 0.0, 1e-4, -1e-4])
+    print(f"初值 x0 = {x0}")
+
+    # 3. 一行流水线：星历轨道 → 表征参数
+    #    小窗口 + 低阶中心流形，让示例在数秒内跑完（非生产配置）。
+    pipeline = NormalFormPipeline(
+        context=context,
+        quasi_floquet_method="matrix",
+        center_max_order=5,
+        dynamical_kwargs={
+            "t_total": 4.0,
+            "node_step": 0.8,
+            "dense_step": 0.2,
+            "max_iter": 3,
+            "tolerance": 1e-6,
+            "prefer": "fft",
+        },
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")  # 屏蔽 SPICE 降级警告
+        result = pipeline.reduce(x0)
+
+    # 4. 打印流水线摘要
+    print("\n流水线摘要")
+    print("-" * 40)
+    print(f"  success      = {result.success}")
+    print(f"  message      = {result.message}")
+    print(f"  residual     = {result.residual:.3e}")
+    print(f"  spice_used   = {result.metadata.get('spice_available')}")
+    print(
+        f"  qf 辛误差   = "
+        f"{result.metadata.get('qf_symplectic_error', float('nan')):.3e}"
+    )
+    print(
+        f"  cm 双曲耦合 = "
+        f"{result.metadata.get('cm_hyperbolic_coupling', float('nan')):.3e}"
+    )
+
+    if result.catalog_transformer is not None:
+        # 5. rho 坐标 → 表征参数 [q1, p1, I2, θ2, I3, θ3]
+        param = result.catalog_transformer.rho_to_param(x0, t=0.0)
+        print("\n表征参数（t=0）")
+        print("-" * 40)
+        labels = ["q1 (双曲)", "p1 (双曲)", "I2 (平面)", "θ2 (平面)", "I3 (垂直)", "θ3 (垂直)"]
+        for label, value in zip(labels, param, strict=True):
+            print(f"  {label:14s} = {value:+.6e}")
+
+        # 6. 往返自检：param → rho 应还原初值
+        back = result.catalog_transformer.param_to_rho(param, t=0.0)
+        print(f"\n往返误差 ‖param→rho − x0‖∞ = {np.max(np.abs(back - x0)):.3e}")
+    else:
+        print("\n流水线未跑完，无表征参数输出。")
+
+    print("\n" + "=" * 60)
+    print("示例完成")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "e2m2e"
-version = "5.0.0"
+version = "5.1.0"
 description = "Earth to Moon, Moon to Earth — 地月空间转移轨道设计库"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -42,6 +42,14 @@ dependencies = [
     "spiceypy>=8.1.0",
     "pydantic>=2.0",
     "pyerfa>=2.0.1.5",
+]
+
+[project.optional-dependencies]
+# 法型化流水线（normal-form 切片）所需的符号计算与并行工具，
+# 在化简器内部惰性导入，不阻塞基础 ``e2m2e.algorithms`` 加载。
+normal-form = [
+    "sympy>=1.12",
+    "joblib>=1.3",
 ]
 
 [project.urls]

--- a/tests/algorithms/normal_form/conftest.py
+++ b/tests/algorithms/normal_form/conftest.py
@@ -1,0 +1,31 @@
+"""Normal-form 切片测试的共享 fixture。
+
+提供与 qiao Global_File 约定一致的地月 CR3BP 系统（已设置特征尺度），
+供 ``test_context``、``test_units`` 等模块复用。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from e2m2e.core import CR3BP_System
+
+
+@pytest.fixture
+def earth_moon_cr3bp() -> CR3BP_System:
+    """与 conftest.earth_moon_system 等价的 CR3BP 系统实例。
+
+    本测试目录不复用根 conftest 的 fixture，避免与其他切片在 mu 默认值上
+    耦合（本切片以 qiao 的 mu 为权威值）。
+    """
+    return CR3BP_System(mu=1.215058560962404e-2, primary="Earth", secondary="Moon")
+
+
+@pytest.fixture
+def earth_moon_system(earth_moon_cr3bp: CR3BP_System) -> CR3BP_System:
+    """已设置特征尺度的地月 CR3BP 系统（与库内其它测试一致）。"""
+    earth_moon_cr3bp.set_characteristic_scales(
+        distance=384405.0,
+        period=27.32 * 86400.0,
+    )
+    return earth_moon_cr3bp

--- a/tests/algorithms/normal_form/test_catalog.py
+++ b/tests/algorithms/normal_form/test_catalog.py
@@ -425,9 +425,7 @@ def test_w_series_interp_uses_real_tlist(l1_context):
     tlist = np.asarray(qf.tlist, dtype=float).ravel()
     expected = float(np.interp(t, tlist, arr))  # 真实网格解析值
     wrong = float(np.interp(t, np.arange(arr.size) * 0.1, arr))  # 兜底网格错误值
-    assert abs(expected - wrong) > 1e-3, (
-        "测试前提不成立：真实网格与兜底网格在该点应明显不同"
-    )
+    assert abs(expected - wrong) > 1e-3, "测试前提不成立：真实网格与兜底网格在该点应明显不同"
 
     coeffs = _interp_W_series_at_t(cm, qf, t)
     got = coeffs[order][pow_tuple].real
@@ -526,12 +524,8 @@ def test_end_to_end_roundtrip_trivial(catalog_data, l1_context):
     rng = np.random.default_rng(101)
     X_rho = 1e-3 * rng.standard_normal(6)
     t = 1.35
-    X_param = rho_to_param(
-        X_rho, t, l1_context, data.ds_result, data.qf_result, data.cm_result
-    )
-    X_back = param_to_rho(
-        X_param, t, l1_context, data.ds_result, data.qf_result, data.cm_result
-    )
+    X_param = rho_to_param(X_rho, t, l1_context, data.ds_result, data.qf_result, data.cm_result)
+    X_back = param_to_rho(X_param, t, l1_context, data.ds_result, data.qf_result, data.cm_result)
     # 线性段全程：机器精度
     np.testing.assert_allclose(X_back, X_rho, atol=1e-12)
 
@@ -545,12 +539,20 @@ def test_end_to_end_roundtrip_with_high_order(catalog_data, l1_context):
     X_rho = 1e-3 * rng.standard_normal(6)
     t = 1.35
     X_param = rho_to_param(
-        X_rho, t, l1_context,
-        catalog_data.ds_result, catalog_data.qf_result, catalog_data.cm_result,
+        X_rho,
+        t,
+        l1_context,
+        catalog_data.ds_result,
+        catalog_data.qf_result,
+        catalog_data.cm_result,
     )
     X_back = param_to_rho(
-        X_param, t, l1_context,
-        catalog_data.ds_result, catalog_data.qf_result, catalog_data.cm_result,
+        X_param,
+        t,
+        l1_context,
+        catalog_data.ds_result,
+        catalog_data.qf_result,
+        catalog_data.cm_result,
     )
     np.testing.assert_allclose(X_back, X_rho, atol=1e-7)
 
@@ -561,12 +563,20 @@ def test_end_to_end_at_multiple_times(catalog_data, l1_context):
     X_rho = 1e-3 * rng.standard_normal(6)
     for t in [0.0, 0.5, 1.0, 2.0, 2.9]:
         X_param = rho_to_param(
-            X_rho, t, l1_context,
-            catalog_data.ds_result, catalog_data.qf_result, catalog_data.cm_result,
+            X_rho,
+            t,
+            l1_context,
+            catalog_data.ds_result,
+            catalog_data.qf_result,
+            catalog_data.cm_result,
         )
         X_back = param_to_rho(
-            X_param, t, l1_context,
-            catalog_data.ds_result, catalog_data.qf_result, catalog_data.cm_result,
+            X_param,
+            t,
+            l1_context,
+            catalog_data.ds_result,
+            catalog_data.qf_result,
+            catalog_data.cm_result,
         )
         np.testing.assert_allclose(X_back, X_rho, atol=1e-7, err_msg=f"t={t}")
 
@@ -592,8 +602,12 @@ def test_transformer_methods_match_functional(catalog_data, l1_context):
 
     X_param_oo = tr.rho_to_param(X_rho, t)
     X_param_fn = rho_to_param(
-        X_rho, t, l1_context,
-        catalog_data.ds_result, catalog_data.qf_result, catalog_data.cm_result,
+        X_rho,
+        t,
+        l1_context,
+        catalog_data.ds_result,
+        catalog_data.qf_result,
+        catalog_data.cm_result,
     )
     np.testing.assert_allclose(X_param_oo, X_param_fn, atol=1e-14)
 

--- a/tests/algorithms/normal_form/test_catalog.py
+++ b/tests/algorithms/normal_form/test_catalog.py
@@ -1,0 +1,651 @@
+"""``normal_form.coord_trans`` + ``catalog`` 测试。
+
+覆盖（issue #174，切片 5）：
+
+- :mod:`coord_trans` 5 段叶子函数各自的往返（``rho↔em``、``em↔ds``、
+  ``ds↔qf``、``qf↔cm``、``cm↔param``）；
+- 端到端链 ``rho → param → rho`` 误差在容差内（**硬性数值约束**）：
+  线性段（rho↔em、em↔ds、ds↔qf、cm↔param）接近机器精度（~1e-12），
+  高阶 Lie 级数段（qf↔cm）允许稍宽（~1e-8），分开断言；
+- :class:`LibrationCatalogTransformer` 可绑定预计算系数表做 OO 入口；
+- qiao ``.npz`` fixture 不可用时 ``pytest.skip`` 守卫。
+
+输入三个子结果（DS / QF / CM）的构造沿用 ``test_center_manifold.py`` /
+``test_quasi_floquet.py`` 的范式：本切片的变换链只读 ``W_poly``、
+``B_at(t)``、``W_series``，故用 ``B=I`` 的最小 QF 结果 + 注入高阶项的
+CM 结果 + 构造的小 DS 结果。SPICE 不可用时 rho↔em 段退化到纯 CR3BP
+（``p = ρ̇``），往返仍为机器精度。
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from e2m2e.algorithms.normal_form.catalog import (
+    LibrationCatalogData,
+    LibrationCatalogTransformer,
+)
+from e2m2e.algorithms.normal_form.center_manifold import (
+    CenterManifoldReducer,
+)
+from e2m2e.algorithms.normal_form.coord_trans import (
+    cm_to_param,
+    cm_to_qf,
+    ds_to_em,
+    ds_to_qf,
+    em_to_ds,
+    em_to_rho,
+    param_to_cm,
+    param_to_rho,
+    qf_to_cm,
+    qf_to_ds,
+    rho_to_em,
+    rho_to_param,
+)
+from e2m2e.algorithms.normal_form.dynamical_substitution import (
+    DynamicalSubstituteResult,
+)
+from e2m2e.algorithms.normal_form.quasi_floquet import (
+    QuasiFloquetResult,
+    real_normal_form_matrix,
+)
+from e2m2e.core import LibrationPoint
+
+# ---------------------------------------------------------------------------
+# 公共 fixture（沿用 test_center_manifold / test_quasi_floquet 的范式）
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def l1_context(earth_moon_system):
+    """L1 共线点上下文。"""
+    from e2m2e.algorithms.normal_form import NormalFormContext
+    from e2m2e.algorithms.normal_form.constants import JD0_J2000
+
+    return NormalFormContext(
+        system=earth_moon_system,
+        libration_point=LibrationPoint.L1,
+        epoch=JD0_J2000,
+        order=4,
+    )
+
+
+def _make_ds_result(l1_context, *, n: int = 96, T: float = 3.0):
+    """构造最小 :class:`DynamicalSubstituteResult`。
+
+    用一条围绕原点的小正弦轨道作为 ``Xlist``，由其数值微分得 ``W_poly``
+    （6 个线性项系数时间序列）。本切片变换链只读 ``W_poly`` 与 ``tlist``，
+    故 ``Kamiltonian``/``fft_components`` 等字段留默认/空。
+    """
+    tlist = np.linspace(0.0, T, n)
+    amp = 1e-3
+    # 简单正弦轨道（rho, rhodot）
+    A = amp * np.cos(tlist)[:, None] * np.array([[1.0, 0.5, -0.3]])
+    Adot = -amp * np.sin(tlist)[:, None] * np.array([[1.0, 0.5, -0.3]])
+    B = amp * 0.8 * np.sin(tlist)[:, None] * np.array([[0.2, -0.6, 0.4]])
+    Bdot = amp * 0.8 * np.cos(tlist)[:, None] * np.array([[0.2, -0.6, 0.4]])
+    Xlist = np.concatenate([A, B], axis=1)  # (n,6): [A,B]（位置在 0:3、动量在 3:6）
+
+    # W_poly: 前 3 线性项 = A（位置层），后 3 = B（动量层），与
+    # DynamicalSubstituteCorrector._build_W 的 pow_units 约定一致。
+    pow_units = [
+        (1, 0, 0, 0, 0, 0),
+        (0, 1, 0, 0, 0, 0),
+        (0, 0, 1, 0, 0, 0),
+        (0, 0, 0, 1, 0, 0),
+        (0, 0, 0, 0, 1, 0),
+        (0, 0, 0, 0, 0, 1),
+    ]
+    W_poly = {}
+    Wdot_poly = {}
+    for k, p in enumerate(pow_units):
+        W_poly[p] = Xlist[:, k]
+        Wdot_poly[p] = (Adot if k < 3 else Bdot)[:, k - (3 if k >= 3 else 0)]
+
+    return DynamicalSubstituteResult(
+        context=l1_context,
+        order=int(l1_context.order),
+        substitute_orbit=Xlist,
+        tlist=tlist,
+        Xlist=Xlist,
+        W_poly=W_poly,
+        Wdot_poly=Wdot_poly,
+        Kamiltonian=None,
+    )
+
+
+def _make_qf_result(l1_context, *, n: int = 96, T: float = 3.0, B_identity: bool = True):
+    """构造最小 :class:`QuasiFloquetResult`。
+
+    ``B_identity=True`` 时 ``B(t)=I``（DS↔QF 退化为恒等，便于把往返误差
+    归因到其他段）；``False`` 时用一组随机辛接近的矩阵。本切片变换链只
+    读 ``B_at(t)``。
+    """
+    lam = float(l1_context.characteristic_exponent)
+    nu1, nu2 = l1_context.central_frequencies
+    D = real_normal_form_matrix(lam, float(nu1), float(nu2))
+    tlist = np.linspace(0.0, T, n)
+    if B_identity:
+        B_samples = np.stack([np.eye(6, dtype=float) for _ in range(n)])
+    else:
+        rng = np.random.default_rng(0)
+        B_samples = np.stack([np.eye(6) + 1e-2 * rng.standard_normal((6, 6)) for _ in range(n)])
+    return QuasiFloquetResult(
+        context=l1_context,
+        order=int(l1_context.order),
+        tlist=tlist,
+        B_samples=B_samples,
+        D=D,
+        method="matrix",
+    )
+
+
+def _make_cm_result(l1_context, qf_result, *, max_order: int = 5, with_terms: bool = True):
+    """构造 :class:`CenterManifoldResult`（注入高阶 Hamiltonian 项后化简）。
+
+    注入双曲-中心交叉项使 ``W_series`` 非平凡——这是 QF↔CM 高阶 Lie 级数
+    的数值内容。``with_terms=False`` 时退化到平凡（无高阶项，W_series 全空，
+    qf↔cm 段退化为恒等）。
+    """
+    reducer = CenterManifoldReducer(context=l1_context, max_order=max_order)
+    n = qf_result.tlist.size
+    if not with_terms:
+        return reducer.reduce(qf_result)
+    terms = {
+        (2, 1, 0, 1, 0, 0): 0.1 * np.ones(n),
+        (1, 2, 0, 2, 0, 0): 0.05 * np.ones(n),
+        (0, 3, 0, 0, 1, 0): 0.08 * np.ones(n),
+    }
+    return reducer.reduce(qf_result, hamiltonian_terms=terms)
+
+
+def _interp_W_series_at_t(cm_result, qf_result, t):
+    """测试用镜像：在 t 处插值 CM 的 W_series（与 coord_trans.__init__ 一致）。
+
+    时间网格用 ``qf_result.tlist``（与 ``CenterManifoldReducer.reduce`` 生成
+    W_series 的时间轴一致），而非任意兜底网格——这是 issue #174 的正向数值
+    正确性关键（往返测试因正逆相消掩盖不了正向错误）。
+    """
+    t_arr = np.asarray(qf_result.tlist, dtype=float).ravel()
+    out: dict[int, dict[tuple[int, ...], complex]] = {}
+    for step_data in cm_result.W_series.values():
+        for order, poly in step_data.items():
+            if not poly:
+                continue
+            out.setdefault(order, {})
+            for pow_tuple, coef_arr in poly.items():
+                arr = np.asarray(coef_arr, dtype=complex).ravel()
+                if arr.size == 0:
+                    continue
+                if arr.size == 1:
+                    val = complex(arr[0])
+                else:
+                    re = float(np.interp(t, t_arr, arr.real))
+                    im = float(np.interp(t, t_arr, arr.imag))
+                    val = complex(re, im)
+                out[order][pow_tuple] = out[order].get(pow_tuple, 0j) + val
+    return out
+
+
+# ---------------------------------------------------------------------------
+# rho ↔ EM
+# ---------------------------------------------------------------------------
+
+
+def test_rho_em_roundtrip_machine_precision(l1_context):
+    """rho → EM → rho 在纯 CR3BP 退路下为机器精度（p = ρ̇）。"""
+    rng = np.random.default_rng(42)
+    X_rho = 1e-3 * rng.standard_normal(6)
+    t = 1.23
+    X_em = rho_to_em(X_rho, t, l1_context)
+    X_back = em_to_rho(X_em, t, l1_context)
+    np.testing.assert_allclose(X_back, X_rho, atol=1e-14)
+
+
+def test_rho_em_rejects_bad_shape(l1_context):
+    """非 (6,) 输入报 ValueError。"""
+    with pytest.raises(ValueError, match="X_rho"):
+        rho_to_em(np.zeros(7), 0.0, l1_context)
+    with pytest.raises(ValueError, match="X_em"):
+        em_to_rho(np.zeros(3), 0.0, l1_context)
+
+
+# ---------------------------------------------------------------------------
+# EM ↔ DS
+# ---------------------------------------------------------------------------
+
+
+def test_em_ds_roundtrip_machine_precision(l1_context):
+    """EM → DS → EM 平移往返为机器精度。"""
+    ds = _make_ds_result(l1_context)
+    rng = np.random.default_rng(7)
+    X_em = 1e-3 * rng.standard_normal(6)
+    t = 1.5
+    # 内联插值 W(t) 以便单元隔离
+    from e2m2e.algorithms.normal_form.coord_trans.em_ds import _interp_W_at
+
+    W_at_t = _interp_W_at(ds.W_poly, np.asarray(ds.tlist).ravel(), t)
+    X_ds = em_to_ds(X_em, W_at_t)
+    X_back = ds_to_em(X_ds, W_at_t)
+    np.testing.assert_allclose(X_back, X_em, atol=1e-14)
+
+
+def test_em_ds_translation_correctness():
+    """平移关系正确：Q = q − B、P = p + A，[A,B]=W。"""
+    W = np.array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6])  # A=[.1,.2,.3], B=[.4,.5,.6]
+    X_em = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+    X_ds = em_to_ds(X_em, W)
+    # Q = q - B
+    np.testing.assert_allclose(X_ds[:3], [0.6, 1.5, 2.4])
+    # P = p + A
+    np.testing.assert_allclose(X_ds[3:], [4.1, 5.2, 6.3])
+
+
+# ---------------------------------------------------------------------------
+# DS ↔ QF
+# ---------------------------------------------------------------------------
+
+
+def test_ds_qf_roundtrip_identity(l1_context):
+    """B=I 时 DS↔QF 恒等；往返机器精度。"""
+    B = np.eye(6)
+    rng = np.random.default_rng(11)
+    X_ds = 1e-3 * rng.standard_normal(6)
+    X_qf = ds_to_qf(X_ds, B)
+    np.testing.assert_allclose(X_qf, X_ds, atol=1e-14)
+    X_back = qf_to_ds(X_qf, B)
+    np.testing.assert_allclose(X_back, X_ds, atol=1e-14)
+
+
+def test_ds_qf_roundtrip_general_matrix():
+    """一般可逆 B 的往返机器精度。"""
+    rng = np.random.default_rng(23)
+    B = np.eye(6) + 1e-2 * rng.standard_normal((6, 6))
+    assert abs(np.linalg.det(B)) > 0.1  # 可逆
+    X_ds = 1e-3 * rng.standard_normal(6)
+    X_qf = ds_to_qf(X_ds, B)
+    X_back = qf_to_ds(X_qf, B)
+    np.testing.assert_allclose(X_back, X_ds, atol=1e-12)
+
+
+def test_ds_qf_relation_correctness():
+    """X_QF = B⁻¹·X_DS 数学关系正确。"""
+    B = 2.0 * np.eye(6)
+    X_ds = np.ones(6)
+    X_qf = ds_to_qf(X_ds, B)
+    np.testing.assert_allclose(X_qf, 0.5 * np.ones(6))
+
+
+# ---------------------------------------------------------------------------
+# QF ↔ CM（高阶 Lie 级数）
+# ---------------------------------------------------------------------------
+
+
+def test_qf_cm_roundtrip_trivial_no_W(l1_context):
+    """无高阶项（W_series 全空）时 QF↔CM 恒等；往返机器精度。"""
+    qf = _make_qf_result(l1_context)
+    cm = _make_cm_result(l1_context, qf, with_terms=False)
+    W_at_t = _interp_W_series_at_t(cm, qf, 1.0)
+    rng = np.random.default_rng(5)
+    X_qf = 1e-3 * rng.standard_normal(6)
+    X_cm = qf_to_cm(X_qf, W_at_t)
+    X_back = cm_to_qf(X_cm, W_at_t)
+    np.testing.assert_allclose(X_back, X_qf, atol=1e-12)
+
+
+def test_qf_cm_roundtrip_with_high_order(l1_context):
+    """有非平凡 W_series 时 QF↔CM 往返在 1e-8 内（高阶 Lie 级数容差）。"""
+    qf = _make_qf_result(l1_context)
+    cm = _make_cm_result(l1_context, qf, with_terms=True, max_order=5)
+    # 确认 W_series 非平凡
+    nonempty = sum(
+        1
+        for step in cm.W_series.values()
+        for poly in step.values()
+        for v in poly.values()
+        if np.any(np.asarray(v) != 0)
+    )
+    assert nonempty > 0, "注入高阶项后 W_series 应非平凡"
+
+    W_at_t = _interp_W_series_at_t(cm, qf, 1.0)
+    rng = np.random.default_rng(13)
+    X_qf = 1e-3 * rng.standard_normal(6)
+    X_cm = qf_to_cm(X_qf, W_at_t)
+    X_back = cm_to_qf(X_cm, W_at_t)
+    # 高阶 Lie 级数往返：允许稍宽
+    np.testing.assert_allclose(X_back, X_qf, atol=1e-8)
+
+
+def test_qf_cm_re_basis_change_is_involution():
+    """实/复基底变换 D 是对合：D⁻¹·D = I（逐元素验证）。"""
+    from e2m2e.algorithms.normal_form.coord_trans.qf_cm import _D, _D_INV
+
+    np.testing.assert_allclose(_D @ _D_INV, np.eye(6), atol=1e-14)
+    np.testing.assert_allclose(_D_INV @ _D, np.eye(6), atol=1e-14)
+
+
+def test_hamilton_flow_rhs_matches_termwise():
+    """向量化 Hamilton 流右端与逐项 oracle 逐位一致（含 0^0=1 边界）。
+
+    对应 qiao ``qpQF2qpCM.__main__`` 的自检逻辑。
+    """
+    from e2m2e.algorithms.normal_form.coord_trans.qf_cm import (
+        _hamilton_flow_rhs,
+        _pack_wpoly,
+    )
+
+    W = {
+        (0, 0, 0, 0, 0, 0): 0.5 + 0.0j,
+        (2, 0, 0, 0, 0, 0): 1.3 + 0.2j,
+        (0, 0, 0, 1, 0, 0): 0.7 - 0.4j,
+        (1, 1, 0, 1, 1, 0): -0.6 + 1.1j,
+        (0, 0, 2, 0, 0, 3): 2.0 + 0.0j,
+        (1, 2, 3, 4, 5, 6): 0.3 - 0.7j,
+    }
+    rng = np.random.default_rng(0)
+    test_X = [
+        np.zeros(6, dtype=complex),
+        np.array([1.0, 0, 0, 0, 0.5, 0], dtype=complex),
+        np.array([0.3, -0.2, 0.1, -0.4, 0.6, 0.9], dtype=complex),
+        rng.standard_normal(6) + 1j * rng.standard_normal(6),
+        rng.standard_normal(6) + 1j * rng.standard_normal(6),
+    ]
+    exps, coefs = _pack_wpoly(W)
+
+    def termwise(X, W_poly):
+        q1, q2, q3, p1, p2, p3 = X
+        dX = np.zeros(6, dtype=complex)
+        for (n1, n2, n3, n4, n5, n6), val in W_poly.items():
+            if n4 > 0:
+                dX[0] += val * n4 * q1**n1 * q2**n2 * q3**n3 * p1 ** (n4 - 1) * p2**n5 * p3**n6
+            if n5 > 0:
+                dX[1] += val * n5 * q1**n1 * q2**n2 * q3**n3 * p1**n4 * p2 ** (n5 - 1) * p3**n6
+            if n6 > 0:
+                dX[2] += val * n6 * q1**n1 * q2**n2 * q3**n3 * p1**n4 * p2**n5 * p3 ** (n6 - 1)
+            if n1 > 0:
+                dX[3] -= val * n1 * q1 ** (n1 - 1) * q2**n2 * q3**n3 * p1**n4 * p2**n5 * p3**n6
+            if n2 > 0:
+                dX[4] -= val * n2 * q1**n1 * q2 ** (n2 - 1) * q3**n3 * p1**n4 * p2**n5 * p3**n6
+            if n3 > 0:
+                dX[5] -= val * n3 * q1**n1 * q2**n2 * q3 ** (n3 - 1) * p1**n4 * p2**n5 * p3**n6
+        return dX
+
+    worst = 0.0
+    for X in test_X:
+        v = _hamilton_flow_rhs(X.astype(complex), exps, coefs)
+        ref = termwise(X.astype(complex), W)
+        worst = max(worst, float(np.max(np.abs(v - ref))))
+    assert worst < 1e-12, f"向量化与逐项偏差 {worst:.3e}"
+
+
+def test_w_series_interp_uses_real_tlist(l1_context):
+    """W_series 插值必须用 ``qf_result.tlist``，而非任意兜底网格。
+
+    回归守卫：``CenterManifoldResult`` 不存 tlist，``_interp_W_series_at_t``
+    若退回 ``dt=0.1`` 兜底网格，会在非采样点上给出错误系数（差异可达 ~1），
+    导致正向 ``rho_to_param`` 数值错误——而往返测试因正逆相消掩盖该错误。
+    本测试注入一项随时间线性变化的 Hamiltonian 项，使化简后的 W_series
+    含随时间变化的系数，在非采样点上断言插值值等于用真实 ``qf.tlist``
+    的解析值，且与 ``dt=0.1`` 兜底值明显不同。这是 issue #174 "rho_to_param
+    与 qiao fixture 一致" 的前提保障。
+    """
+    from e2m2e.algorithms.normal_form.center_manifold import CenterManifoldReducer
+    from e2m2e.algorithms.normal_form.coord_trans import _interp_W_series_at_t
+
+    qf = _make_qf_result(l1_context, n=96, T=3.0)
+    # 注入一项随时间线性变化的 Hamiltonian 项，使 W_series 非常值
+    n = qf.tlist.size
+    terms = {
+        (2, 1, 0, 1, 0, 0): np.linspace(0.05, 0.15, n),
+        (1, 2, 0, 2, 0, 0): 0.05 * np.ones(n),
+        (0, 3, 0, 0, 1, 0): 0.08 * np.ones(n),
+    }
+    reducer = CenterManifoldReducer(context=l1_context, max_order=5)
+    cm = reducer.reduce(qf, hamiltonian_terms=terms)
+
+    # 取一个随时间显著变化的 (step, order, pow) 项
+    target = None
+    for step_data in cm.W_series.values():
+        for order, poly in step_data.items():
+            for pow_tuple, arr in poly.items():
+                a = np.asarray(arr, dtype=float).ravel()
+                if a.size > 2 and float(np.ptp(a)) > 1e-6:
+                    target = (order, pow_tuple, a)
+                    break
+            if target:
+                break
+        if target:
+            break
+    assert target is not None, "W_series 应有随时间变化的项"
+
+    order, pow_tuple, arr = target
+    # 非采样点：真实网格 dt≈0.0316，兜底 dt=0.1，t=1.0 上两者插值明显不同
+    t = 1.0
+    tlist = np.asarray(qf.tlist, dtype=float).ravel()
+    expected = float(np.interp(t, tlist, arr))  # 真实网格解析值
+    wrong = float(np.interp(t, np.arange(arr.size) * 0.1, arr))  # 兜底网格错误值
+    assert abs(expected - wrong) > 1e-3, (
+        "测试前提不成立：真实网格与兜底网格在该点应明显不同"
+    )
+
+    coeffs = _interp_W_series_at_t(cm, qf, t)
+    got = coeffs[order][pow_tuple].real
+    np.testing.assert_allclose(got, expected, atol=1e-12)
+    assert abs(got - wrong) > 1e-3, "插值不应使用 dt=0.1 兜底网格"
+
+
+# ---------------------------------------------------------------------------
+# CM ↔ param
+# ---------------------------------------------------------------------------
+
+
+def test_cm_param_roundtrip_machine_precision():
+    """CM → param → CM 往返机器精度（作用量-角变量）。"""
+    rng = np.random.default_rng(29)
+    X_cm = 1e-3 * rng.standard_normal(6)
+    # 保证中心对幅值非零（避免 atan2(0,0) 退化）
+    X_cm[1] += 0.05
+    X_cm[4] += 0.03
+    X_cm[2] += 0.04
+    X_cm[5] += 0.02
+    X_param = cm_to_param(X_cm)
+    X_back = param_to_cm(X_param)
+    np.testing.assert_allclose(X_back, X_cm, atol=1e-14)
+
+
+def test_cm_param_action_angle_correctness():
+    """作用量-角变量公式正确：I2=(q2²+p2²)/2, θ2=atan2(p2,q2)。"""
+    X_cm = np.array([1.0, 0.3, -0.4, 2.0, 0.5, 0.6])
+    q1, q2, q3, p1, p2, p3 = X_cm
+    X_param = cm_to_param(X_cm)
+    # 双曲方向原样
+    np.testing.assert_allclose(X_param[0], q1)
+    np.testing.assert_allclose(X_param[1], p1)
+    # 作用量
+    np.testing.assert_allclose(X_param[2], 0.5 * (q2**2 + p2**2))
+    np.testing.assert_allclose(X_param[4], 0.5 * (q3**2 + p3**2))
+    # 角变量
+    np.testing.assert_allclose(X_param[3], np.arctan2(p2, q2))
+    np.testing.assert_allclose(X_param[5], np.arctan2(p3, q3))
+
+
+def test_cm_param_rejects_bad_shape():
+    """非 (6,) 输入报 ValueError。"""
+    with pytest.raises(ValueError, match="X_cm"):
+        cm_to_param(np.zeros(4))
+    with pytest.raises(ValueError, match="X_param"):
+        param_to_cm(np.zeros(8))
+
+
+def test_param_to_cm_zero_action():
+    """I2=I3=0 时中心对还原为 0（√(2I)·cos/sin = 0）。"""
+    X_param = np.array([1.0, 2.0, 0.0, 0.5, 0.0, 0.7])
+    X_cm = param_to_cm(X_param)
+    np.testing.assert_allclose(X_cm[1], 0.0)
+    np.testing.assert_allclose(X_cm[2], 0.0)
+    np.testing.assert_allclose(X_cm[4], 0.0)
+    np.testing.assert_allclose(X_cm[5], 0.0)
+    # 双曲方向原样
+    np.testing.assert_allclose(X_cm[0], 1.0)
+    np.testing.assert_allclose(X_cm[3], 2.0)
+
+
+# ---------------------------------------------------------------------------
+# 端到端链：rho → param → rho
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def catalog_data(l1_context):
+    """聚合三个子结果的 :class:`LibrationCatalogData`（B=I + 非平凡 W_series）。"""
+    ds = _make_ds_result(l1_context)
+    qf = _make_qf_result(l1_context)
+    cm = _make_cm_result(l1_context, qf, with_terms=True, max_order=5)
+    return LibrationCatalogData(
+        context=l1_context,
+        ds_result=ds,
+        qf_result=qf,
+        cm_result=cm,
+    )
+
+
+def test_end_to_end_roundtrip_trivial(catalog_data, l1_context):
+    """端到端 rho → param → rho：B=I + 无高阶项时机器精度。
+
+    用平凡 CM（无高阶项）替换 catalog_data 的 cm_result，隔离线性段误差。
+    """
+    qf = catalog_data.qf_result
+    cm_trivial = _make_cm_result(l1_context, qf, with_terms=False)
+    data = LibrationCatalogData(
+        context=l1_context,
+        ds_result=catalog_data.ds_result,
+        qf_result=qf,
+        cm_result=cm_trivial,
+    )
+    rng = np.random.default_rng(101)
+    X_rho = 1e-3 * rng.standard_normal(6)
+    t = 1.35
+    X_param = rho_to_param(
+        X_rho, t, l1_context, data.ds_result, data.qf_result, data.cm_result
+    )
+    X_back = param_to_rho(
+        X_param, t, l1_context, data.ds_result, data.qf_result, data.cm_result
+    )
+    # 线性段全程：机器精度
+    np.testing.assert_allclose(X_back, X_rho, atol=1e-12)
+
+
+def test_end_to_end_roundtrip_with_high_order(catalog_data, l1_context):
+    """端到端 rho → param → rho：含高阶 Lie 级数时在 1e-7 内。
+
+    硬性数值约束：高阶 Lie 级数段误差主导，整体放宽到 ~1e-7。
+    """
+    rng = np.random.default_rng(202)
+    X_rho = 1e-3 * rng.standard_normal(6)
+    t = 1.35
+    X_param = rho_to_param(
+        X_rho, t, l1_context,
+        catalog_data.ds_result, catalog_data.qf_result, catalog_data.cm_result,
+    )
+    X_back = param_to_rho(
+        X_param, t, l1_context,
+        catalog_data.ds_result, catalog_data.qf_result, catalog_data.cm_result,
+    )
+    np.testing.assert_allclose(X_back, X_rho, atol=1e-7)
+
+
+def test_end_to_end_at_multiple_times(catalog_data, l1_context):
+    """端到端往返在多个时刻都成立（插值路径覆盖）。"""
+    rng = np.random.default_rng(303)
+    X_rho = 1e-3 * rng.standard_normal(6)
+    for t in [0.0, 0.5, 1.0, 2.0, 2.9]:
+        X_param = rho_to_param(
+            X_rho, t, l1_context,
+            catalog_data.ds_result, catalog_data.qf_result, catalog_data.cm_result,
+        )
+        X_back = param_to_rho(
+            X_param, t, l1_context,
+            catalog_data.ds_result, catalog_data.qf_result, catalog_data.cm_result,
+        )
+        np.testing.assert_allclose(X_back, X_rho, atol=1e-7, err_msg=f"t={t}")
+
+
+# ---------------------------------------------------------------------------
+# LibrationCatalogTransformer（OO 入口）
+# ---------------------------------------------------------------------------
+
+
+def test_transformer_constructible(catalog_data):
+    """``LibrationCatalogTransformer`` 可用聚合句柄构造。"""
+    tr = LibrationCatalogTransformer(data=catalog_data)
+    assert tr.data is catalog_data
+    assert tr.context is catalog_data.context
+
+
+def test_transformer_methods_match_functional(catalog_data, l1_context):
+    """OO 入口 ``rho_to_param``/``param_to_rho`` 与函数式结果一致。"""
+    tr = LibrationCatalogTransformer(data=catalog_data)
+    rng = np.random.default_rng(404)
+    X_rho = 1e-3 * rng.standard_normal(6)
+    t = 0.8
+
+    X_param_oo = tr.rho_to_param(X_rho, t)
+    X_param_fn = rho_to_param(
+        X_rho, t, l1_context,
+        catalog_data.ds_result, catalog_data.qf_result, catalog_data.cm_result,
+    )
+    np.testing.assert_allclose(X_param_oo, X_param_fn, atol=1e-14)
+
+    X_rho_back_oo = tr.param_to_rho(X_param_oo, t)
+    np.testing.assert_allclose(X_rho_back_oo, X_rho, atol=1e-7)
+
+
+def test_transformer_roundtrip(catalog_data):
+    """``LibrationCatalogTransformer`` 端到端 OO 往返。"""
+    tr = LibrationCatalogTransformer(data=catalog_data)
+    rng = np.random.default_rng(505)
+    X_rho = 1e-3 * rng.standard_normal(6)
+    t = 1.5
+    X_param = tr.rho_to_param(X_rho, t)
+    X_back = tr.param_to_rho(X_param, t)
+    np.testing.assert_allclose(X_back, X_rho, atol=1e-7)
+
+
+def test_catalog_data_is_frozen(catalog_data, l1_context):
+    """``LibrationCatalogData`` 不可变（frozen dataclass）。"""
+    import dataclasses
+
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        catalog_data.context = l1_context  # type: ignore[misc]
+
+
+def test_lazy_export_via_package(l1_context):
+    """``LibrationCatalogTransformer`` 经包顶层 lazy export 可导入。"""
+    from e2m2e.algorithms.normal_form import (
+        LibrationCatalogData,
+        LibrationCatalogTransformer,
+    )
+
+    assert LibrationCatalogData is not None
+    assert LibrationCatalogTransformer is not None
+
+
+# ---------------------------------------------------------------------------
+# qiao .npz 回归 fixture（本仓库没有，skip 守卫）
+# ---------------------------------------------------------------------------
+
+
+def test_qiao_npz_regression_is_skipped_without_fixture():
+    """qiao ``data_array``/``W_series`` fixture 在本仓库不存在，必须 skip。
+
+    本测试验证 skip 守卫生效；外部 fixture 引入后可替换为与 qiao
+    ``rho2param``/``param2rho`` 输出的真实数值比对。
+    """
+    from pathlib import Path
+
+    fixture = Path(__file__).parent / "data" / "L1_rho2param_data.npz"
+    if not fixture.exists():
+        pytest.skip(f"qiao .npz fixture 不存在：{fixture}")
+    data = np.load(fixture, allow_pickle=True)
+    assert "data_array" in data

--- a/tests/algorithms/normal_form/test_catalog.py
+++ b/tests/algorithms/normal_form/test_catalog.py
@@ -22,6 +22,9 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
+# sympy 是 normal-form optional dep；未安装时整个文件 skip（不 error）。
+pytest.importorskip("sympy")
+
 from e2m2e.algorithms.normal_form.catalog import (
     LibrationCatalogData,
     LibrationCatalogTransformer,

--- a/tests/algorithms/normal_form/test_center_manifold.py
+++ b/tests/algorithms/normal_form/test_center_manifold.py
@@ -1,0 +1,464 @@
+"""``normal_form.center_manifold`` 测试。
+
+覆盖（issue #173，切片 4）：
+
+- :class:`CenterManifoldReducer` 可用，``reduce`` 返回
+  :class:`CenterManifoldResult`；
+- 两步化简（``invariant`` / ``center``）的判别条件忠实迁移 qiao
+  Code10/Code11；
+- **化简效果硬性断言**：注入双曲-中心交叉项后，``max_hyperbolic_coupling``
+  显著低于化简前；化简后剩余 Hamiltonian 只含作用量项；
+- 单步可独立执行（``steps=("invariant",)`` / ``("center",)``）；
+- 频域 ODE 求解器、MAD 离群抑制、高阶数值微分单元测试；
+- qiao ``.npz`` 回归 fixture 用 ``pytest.skip`` 守卫（本仓库没有）。
+
+输入 :class:`QuasiFloquetResult` 的构造沿用
+``test_quasi_floquet.py`` 的范式：本切片的 reducer 只读 ``tlist``、
+``D``（频率）；高阶 Hamiltonian 项经 ``hamiltonian_terms`` 注入
+（对应 qiao Code09 的 ``L?_QF_Hamilton.npz``）。注入项刻意构造为
+物理上明确的「双曲-中心交叉项」，用以直接断言化简效果。
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from e2m2e.algorithms.normal_form.center_manifold import (
+    DEFAULT_MAX_ORDER,
+    CenterManifoldReducer,
+    CenterManifoldResult,
+    list_deriv,
+)
+from e2m2e.algorithms.normal_form.quasi_floquet import (
+    QuasiFloquetResult,
+    real_normal_form_matrix,
+)
+from e2m2e.core import LibrationPoint
+
+# ---------------------------------------------------------------------------
+# 公共 fixture（沿用 test_quasi_floquet 的范式）
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def l1_context(earth_moon_system):
+    """L1 共线点上下文。"""
+    from e2m2e.algorithms.normal_form import NormalFormContext
+    from e2m2e.algorithms.normal_form.constants import JD0_J2000
+
+    return NormalFormContext(
+        system=earth_moon_system,
+        libration_point=LibrationPoint.L1,
+        epoch=JD0_J2000,
+        order=4,
+    )
+
+
+def _make_qf_result(l1_context, *, n: int = 96, T: float = 3.0) -> QuasiFloquetResult:
+    """构造一个最小 :class:`QuasiFloquetResult`（B(t)=I，仅用于承载 tlist/D）。
+
+    本切片 reducer 只读 ``tlist`` 与实标准形 ``D``（频率）；``B_samples``
+    不参与化简，故用单位矩阵占位即可。这与 qiao Code10 的实际输入
+    （Code09 已把 Hamiltonian 投到 QF 坐标、留下时变系数）等价：
+    系数时变性已包含在注入的 ``hamiltonian_terms`` 中。
+    """
+    lam = float(l1_context.characteristic_exponent)
+    nu1, nu2 = l1_context.central_frequencies
+    D = real_normal_form_matrix(lam, float(nu1), float(nu2))
+    tlist = np.linspace(0.0, T, n)
+    B = np.stack([np.eye(6, dtype=float) for _ in range(n)])
+    return QuasiFloquetResult(
+        context=l1_context,
+        order=int(l1_context.order),
+        tlist=tlist,
+        B_samples=B,
+        D=D,
+        method="matrix",
+    )
+
+
+def _hyper_center_terms(tlist, scale: float = 0.1):
+    """注入一批双曲-中心交叉项（``q_1``/``p_1`` 与 ``q_2``/``p_2`` 耦合）。
+
+    这些项是 Step 1（``invariant``）应当消去的对象：判别条件
+    ``pow(1) != pow(4)``（双曲方向不平衡）即不满足保留判据。
+    """
+    ones = np.ones_like(tlist)
+    return {
+        (2, 1, 0, 1, 0, 0): scale * ones,  # q1²·q2·p1（pow1=2≠pow4=1）
+        (1, 2, 0, 2, 0, 0): scale * 0.5 * ones,  # q1·q2²·p1²（pow1=1≠pow4=2）
+        (1, 0, 1, 2, 0, 0): scale * 0.3 * ones,  # q1·q3·p1²（双曲-垂直交叉）
+    }
+
+
+def _center_cross_terms(tlist, scale: float = 0.08):
+    """注入一批中心方向间非共振耦合项（``q_2``/``p_2`` 与 ``q_3``/``p_3``）。
+
+    这些项双曲方向平衡（``pow1==pow4==0``）但中心方向不平衡，是 Step 2
+    （``center``）应当消去的对象。
+    """
+    ones = np.ones_like(tlist)
+    return {
+        (0, 3, 0, 0, 1, 0): scale * ones,  # q2³·p2（pow2=3≠pow5=1）
+        (0, 1, 2, 0, 1, 2): scale * 0.5 * ones,  # q2·q3²·p2·p3²
+    }
+
+
+# ---------------------------------------------------------------------------
+# 构造与接口
+# ---------------------------------------------------------------------------
+
+
+def test_reducer_is_constructible(l1_context):
+    """``CenterManifoldReducer`` 可用上下文构造，默认 max_order=10。"""
+    reducer = CenterManifoldReducer(context=l1_context)
+    assert reducer.context is l1_context
+    assert reducer.max_order == DEFAULT_MAX_ORDER == 10
+
+
+def test_reducer_rejects_unknown_step(l1_context):
+    """``steps`` 含非法名时抛 :class:`ValueError`。"""
+    reducer = CenterManifoldReducer(context=l1_context, max_order=5)
+    qf = _make_qf_result(l1_context)
+    with pytest.raises(ValueError, match="非法值"):
+        reducer.reduce(qf, steps=("bogus",))
+
+
+def test_reducer_rejects_nonpositive_max_order(l1_context):
+    """``max_order`` 非正时抛 :class:`ValueError`。"""
+    reducer = CenterManifoldReducer(context=l1_context, max_order=0)
+    qf = _make_qf_result(l1_context)
+    with pytest.raises(ValueError, match="max_order"):
+        reducer.reduce(qf)
+
+
+def test_reduce_returns_result_with_required_fields(l1_context):
+    """``reduce`` 返回 :class:`CenterManifoldResult`，字段齐备。"""
+    reducer = CenterManifoldReducer(context=l1_context, max_order=5)
+    qf = _make_qf_result(l1_context)
+    terms = _hyper_center_terms(qf.tlist)
+    result = reducer.reduce(qf, hamiltonian_terms=terms)
+
+    assert isinstance(result, CenterManifoldResult)
+    assert result.context is l1_context
+    assert result.order == 5
+    # 默认两步都执行
+    assert result.steps_performed == ("invariant", "center")
+    # metadata 记录频率
+    assert {"lambda", "wp", "wv", "n_samples", "pre_hyperbolic_center_coupling"} <= set(
+        result.metadata
+    )
+    # W_series 封装了每步每阶的系数表
+    assert "invariant" in result.W_series
+    assert "center" in result.W_series
+
+
+# ---------------------------------------------------------------------------
+# smoke：端到端跑通小输入
+# ---------------------------------------------------------------------------
+
+
+def test_smoke_end_to_end_runs(l1_context):
+    """端到端：构造 QF 结果 + 注入高阶项 → reduce 跑通不报错。"""
+    reducer = CenterManifoldReducer(context=l1_context, max_order=6)
+    qf = _make_qf_result(l1_context)
+    terms = _hyper_center_terms(qf.tlist)
+    result = reducer.reduce(qf, hamiltonian_terms=terms)
+    # 结果非空
+    assert len(result.hamiltonian_terms) > 0
+    # W_series 两步都有内容
+    assert any(result.W_series["invariant"].values())
+    # hamiltonian_terms 系数都是有限实数
+    for coef in result.hamiltonian_terms.values():
+        assert np.all(np.isfinite(coef))
+
+
+# ---------------------------------------------------------------------------
+# 化简效果硬性断言：交叉项系数下降
+# ---------------------------------------------------------------------------
+
+
+def test_invariant_step_reduces_hyperbolic_center_coupling(l1_context):
+    """Step 1（invariant）消去双曲-中心交叉项。
+
+    注入 ``q_1``/``p_1`` 与中心方向耦合的项后，化简后
+    ``max_hyperbolic_coupling`` 应远小于化简前 ``pre_coupling``。
+    """
+    reducer = CenterManifoldReducer(context=l1_context, max_order=6)
+    qf = _make_qf_result(l1_context)
+    terms = _hyper_center_terms(qf.tlist, scale=0.1)
+    pre = 0.1  # _hyper_center_terms 最大幅值
+
+    result = reducer.reduce(qf, hamiltonian_terms=terms, steps=("invariant",))
+    post = result.max_hyperbolic_coupling
+    assert post < 1e-3 * pre, (
+        f"Step 1 化简后双曲-中心耦合 {post:.2e} 未显著低于化简前 {pre:.2e}"
+    )
+    # 化简后保留的项（3 阶以上）要么是纯双曲（pow1==pow4）要么纯中心；
+    # 二阶实标准形项不参与断言。
+    for pow_tuple in result.hamiltonian_terms:
+        if sum(pow_tuple) < 3:
+            continue
+        assert pow_tuple[0] == pow_tuple[3], (
+            f"Step 1 后 3+ 阶仍含双曲不平衡项 {pow_tuple}"
+        )
+
+
+def test_center_step_leaves_only_action_terms(l1_context):
+    """Step 1 + Step 2 后 Hamiltonian 只剩作用量项。
+
+    两步完成后，保留的项必须满足三对共轭全部平衡
+    （``pow1==pow4 && pow2==pow5 && pow3==pow6``）——即仅依赖作用量
+    ``I_1``、``I_2``、``I_3``。
+    """
+    reducer = CenterManifoldReducer(context=l1_context, max_order=6)
+    qf = _make_qf_result(l1_context)
+    terms = {}
+    terms.update(_hyper_center_terms(qf.tlist, scale=0.1))
+    terms.update(_center_cross_terms(qf.tlist, scale=0.08))
+
+    result = reducer.reduce(qf, hamiltonian_terms=terms)  # 两步都跑
+    # 二阶实标准形项（如 q2²）是 H₂ 的分量，Lie 变换不处理；只对 ≥3 阶
+    # 项断言三对全平衡（作用量形式）。
+    for pow_tuple in result.hamiltonian_terms:
+        if sum(pow_tuple) < 3:
+            continue
+        is_action = (
+            pow_tuple[0] == pow_tuple[3]
+            and pow_tuple[1] == pow_tuple[4]
+            and pow_tuple[2] == pow_tuple[5]
+        )
+        assert is_action, f"两步化简后 3+ 阶仍含非作用量项 {pow_tuple}"
+
+
+def test_max_hyperbolic_coupling_decreases_after_full_reduction(l1_context):
+    """两步化简后 ``max_hyperbolic_coupling`` 严格小于化简前。"""
+    reducer = CenterManifoldReducer(context=l1_context, max_order=6)
+    qf = _make_qf_result(l1_context)
+    terms = _hyper_center_terms(qf.tlist, scale=0.1)
+    pre = 0.1  # _hyper_center_terms 最大注入幅值
+
+    result = reducer.reduce(qf, hamiltonian_terms=terms)
+    assert result.max_hyperbolic_coupling < pre
+    assert result.metadata["pre_hyperbolic_center_coupling"] == pytest.approx(pre)
+
+
+# ---------------------------------------------------------------------------
+# 单步独立执行
+# ---------------------------------------------------------------------------
+
+
+def test_single_step_invariant(l1_context):
+    """``steps=("invariant",)`` 只跑 Step 1。"""
+    reducer = CenterManifoldReducer(context=l1_context, max_order=5)
+    qf = _make_qf_result(l1_context)
+    terms = _hyper_center_terms(qf.tlist)
+    result = reducer.reduce(qf, hamiltonian_terms=terms, steps=("invariant",))
+    assert result.steps_performed == ("invariant",)
+    assert "invariant" in result.W_series
+    assert "center" not in result.W_series
+
+
+def test_single_step_center(l1_context):
+    """``steps=("center",)`` 只跑 Step 2。
+
+    无高阶项注入时 Step 2 退化为只处理二阶实标准形（平凡），仍应跑通。
+    """
+    reducer = CenterManifoldReducer(context=l1_context, max_order=5)
+    qf = _make_qf_result(l1_context)
+    result = reducer.reduce(qf, steps=("center",))
+    assert result.steps_performed == ("center",)
+    assert "center" in result.W_series
+    assert "invariant" not in result.W_series
+
+
+def test_center_step_produces_nonzero_complex_W(l1_context):
+    """Step 2 对中心非共振项真正求出**非零复值** W。
+
+    回归守卫：注入双曲方向已平衡（``pow1==pow4==0``）但中心方向不平衡
+    （``pow2!=pow5``）的纯中心项，Step 2 必须对它们求解同调方程、产出
+    非零 W。中心方向特征频率为纯虚 ``iω``，故 W 为纯虚（实部≈0）。
+
+    此前曾存在两个互相叠加的退化：(1) ``_limit_fft_outliers_mad`` 在
+    ``MAD=0``（常系数输入）时把唯一非零的零频当离群点缩到 0，使 W 归零；
+    (2) ``reduce`` 对 W 取实部，丢弃 Step 2 纯虚 W 的全部内容。任一退化
+    复发，本测试的 ``nonzero_W`` 断言即失败。
+    """
+    reducer = CenterManifoldReducer(context=l1_context, max_order=6)
+    qf = _make_qf_result(l1_context)
+    ones = np.ones_like(qf.tlist)
+    # 纯中心非共振项：双曲平衡，中心不平衡 → 仅 Step 2 处理
+    center_terms = {
+        (0, 3, 0, 0, 1, 0): 0.08 * ones,  # pow2=3 ≠ pow5=1
+        (0, 2, 1, 0, 1, 1): 0.05 * ones,  # pow2=2 ≠ pow5=1
+    }
+    result = reducer.reduce(
+        qf, hamiltonian_terms=center_terms, steps=("center",)
+    )
+    # W_series["center"] 必须含至少一个非零项
+    nonzero_W = any(
+        np.any(np.abs(v)) > 1e-9
+        for poly in result.W_series["center"].values()
+        for v in poly.values()
+    )
+    assert nonzero_W, "Step 2 未对中心非共振项求出非零 W（退化复发？）"
+    # Step 2 的 W 是复值（中心方向在复域操作）
+    for poly in result.W_series["center"].values():
+        for v in poly.values():
+            assert np.iscomplexobj(v)
+            assert v.dtype == np.complex128
+
+
+def test_center_step_reduces_center_coupling(l1_context):
+    """Step 2 消去中心方向间非共振耦合，使 Hamiltonian 只剩作用量项。
+
+    回归守卫：注入纯中心非共振项后，Step 2 化简结果中 ≥3 阶项必须全部
+    满足三对共轭平衡（``pow1==pow4 && pow2==pow5 && pow3==pow6``），即
+    仅依赖作用量 ``I_2``/``I_3``。此前 Step 2 因 W 归零退化而是 no-op，
+    本测试直接断言化简效果，不依赖正逆相消。
+    """
+    reducer = CenterManifoldReducer(context=l1_context, max_order=6)
+    qf = _make_qf_result(l1_context)
+    ones = np.ones_like(qf.tlist)
+    center_terms = {
+        (0, 3, 0, 0, 1, 0): 0.08 * ones,
+        (0, 2, 1, 0, 1, 1): 0.05 * ones,
+    }
+    result = reducer.reduce(
+        qf, hamiltonian_terms=center_terms, steps=("center",)
+    )
+    for pow_tuple in result.hamiltonian_terms:
+        if sum(pow_tuple) < 3:
+            continue
+        is_action = (
+            pow_tuple[0] == pow_tuple[3]
+            and pow_tuple[1] == pow_tuple[4]
+            and pow_tuple[2] == pow_tuple[5]
+        )
+        assert is_action, (
+            f"Step 2 后 3+ 阶仍含中心非作用量项 {pow_tuple}"
+        )
+
+
+def test_W_for_accessor_and_keyerror(l1_context):
+    """``W_for(step, order)`` 封装访问器正确返回；非法 step 抛 KeyError。"""
+    reducer = CenterManifoldReducer(context=l1_context, max_order=5)
+    qf = _make_qf_result(l1_context)
+    result = reducer.reduce(qf, hamiltonian_terms=_hyper_center_terms(qf.tlist))
+    w3 = result.W_for("invariant", 3)
+    assert isinstance(w3, dict)
+    with pytest.raises(KeyError, match="未执行"):
+        result.W_for("bogus", 3)
+
+
+def test_trivial_input_no_higher_order_terms(l1_context):
+    """不注入高阶项时 reducer 退化为只含二阶实标准形（仍跑通）。"""
+    reducer = CenterManifoldReducer(context=l1_context, max_order=4)
+    qf = _make_qf_result(l1_context)
+    result = reducer.reduce(qf)  # hamiltonian_terms=None
+    # 只剩二阶实标准形 5 项
+    lam = float(l1_context.characteristic_exponent)
+    nu1, nu2 = l1_context.central_frequencies
+    expected = {
+        (1, 0, 0, 1, 0, 0): lam,
+        (0, 2, 0, 0, 0, 0): float(nu1) / 2,
+        (0, 0, 0, 0, 2, 0): float(nu1) / 2,
+        (0, 0, 2, 0, 0, 0): float(nu2) / 2,
+        (0, 0, 0, 0, 0, 2): float(nu2) / 2,
+    }
+    assert set(result.hamiltonian_terms.keys()) == set(expected.keys())
+    for k, v in expected.items():
+        np.testing.assert_allclose(result.hamiltonian_terms[k][0], v, atol=1e-10)
+
+
+def test_coefficient_length_mismatch_raises(l1_context):
+    """``hamiltonian_terms`` 系数长度与 ``tlist`` 不一致时报错。"""
+    reducer = CenterManifoldReducer(context=l1_context, max_order=4)
+    qf = _make_qf_result(l1_context)
+    bad_terms = {(2, 1, 0, 1, 0, 0): np.ones(7)}  # 长度 7 ≠ tlist 长度
+    with pytest.raises(ValueError, match="不一致"):
+        reducer.reduce(qf, hamiltonian_terms=bad_terms)
+
+
+# ---------------------------------------------------------------------------
+# 频域 ODE 求解器与数值微分单元测试
+# ---------------------------------------------------------------------------
+
+
+def test_solve_wfunc_fft_recovers_exponential_forcing():
+    """``_solve_wfunc_fft`` 对 ``f(t)=e^{αt}``、``k=-α`` 应近似恢复 ``t+c``。
+
+    ``ẏ = -α·y + e^{αt}`` 的一个特解是 ``y = e^{αt}/(2α)``；此处只验证
+    求解器返回有限复值数组、且与解析特解量级一致。
+    """
+    from e2m2e.algorithms.normal_form.center_manifold import _solve_wfunc_fft
+
+    tlist = np.linspace(0, 2.0, 128)
+    alpha = 1.7
+    forcing = np.exp(alpha * tlist)
+    k = complex(-alpha, 0.0)
+    y = _solve_wfunc_fft(tlist, forcing, k)
+    assert y.shape == tlist.shape
+    assert np.all(np.isfinite(y))
+
+
+def test_list_deriv_recovers_linear_function():
+    """``list_deriv`` 对线性函数 ``y=t`` 应精确返回常数 1。"""
+    tlist = np.linspace(0, 1.0, 40)
+    h = float(tlist[1] - tlist[0])
+    y = 2.5 * tlist + 1.0
+    dy = list_deriv(y, h, n=8)
+    # 内部点应精确（端点因差分阶降低误差略大，放宽）
+    np.testing.assert_allclose(dy[8:-8], np.full(dy[8:-8].shape, 2.5), atol=1e-10)
+
+
+def test_list_deriv_handles_complex():
+    """``list_deriv`` 对复值输入分别处理实/虚部。"""
+    tlist = np.linspace(0, 2.0, 50)
+    h = float(tlist[1] - tlist[0])
+    y = np.cos(tlist) + 1j * np.sin(tlist)
+    dy = list_deriv(y, h, n=8)
+    # d/dt[cos+isin] = -sin + i cos
+    np.testing.assert_allclose(dy.real[6:-6], -np.sin(tlist[6:-6]), atol=1e-8)
+    np.testing.assert_allclose(dy.imag[6:-6], np.cos(tlist[6:-6]), atol=1e-8)
+
+
+def test_keep_criteria_predicates():
+    """判别条件忠实迁移 qiao Code10/Code11。"""
+    from e2m2e.algorithms.normal_form.center_manifold import (
+        _is_center_term,
+        _is_invariant_term,
+    )
+
+    # invariant：只看 pow(1)==pow(4)
+    assert _is_invariant_term((2, 1, 0, 2, 0, 0))  # pow1==pow4==2，保留
+    assert not _is_invariant_term((2, 1, 0, 1, 0, 0))  # pow1=2≠pow4=1，消去
+    # center：三对共轭全部平衡
+    assert _is_center_term((2, 1, 0, 2, 1, 0))  # 全平衡
+    assert not _is_center_term((2, 1, 0, 2, 0, 0))  # pow2=1≠pow5=0
+    assert not _is_center_term((2, 1, 0, 1, 1, 0))  # pow1=2≠pow4=1
+    # invariant 保留的项未必满足 center（center 更严）
+    assert _is_invariant_term((0, 3, 0, 0, 1, 0))  # pow1==pow4==0
+    assert not _is_center_term((0, 3, 0, 0, 1, 0))  # 但 pow2=3≠pow5=1
+
+
+# ---------------------------------------------------------------------------
+# qiao .npz 回归 fixture（本仓库没有，skip 守卫）
+# ---------------------------------------------------------------------------
+
+
+def test_qiao_npz_regression_is_skipped_without_fixture():
+    """qiao ``L1_QF_Hamilton.npz`` fixture 在本仓库不存在，必须 skip。
+
+    本测试验证 skip 守卫生效；外部 fixture 引入后可替换为与 qiao
+    Code10/Code11 输出的真实数值比对（``L1_InvarManifold.npz`` /
+    ``L1_CenterManifold.npz``）。
+    """
+    from pathlib import Path
+
+    fixture = Path(__file__).parent / "data" / "L1_QF_Hamilton.npz"
+    if not fixture.exists():
+        pytest.skip(f"qiao .npz fixture 不存在：{fixture}")
+    data = np.load(fixture, allow_pickle=True)
+    assert "powers" in data and "coefficients" in data

--- a/tests/algorithms/normal_form/test_center_manifold.py
+++ b/tests/algorithms/normal_form/test_center_manifold.py
@@ -24,6 +24,9 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
+# sympy 是 normal-form optional dep；未安装时整个文件 skip（不 error）。
+pytest.importorskip("sympy")
+
 from e2m2e.algorithms.normal_form.center_manifold import (
     DEFAULT_MAX_ORDER,
     CenterManifoldReducer,

--- a/tests/algorithms/normal_form/test_center_manifold.py
+++ b/tests/algorithms/normal_form/test_center_manifold.py
@@ -192,17 +192,13 @@ def test_invariant_step_reduces_hyperbolic_center_coupling(l1_context):
 
     result = reducer.reduce(qf, hamiltonian_terms=terms, steps=("invariant",))
     post = result.max_hyperbolic_coupling
-    assert post < 1e-3 * pre, (
-        f"Step 1 化简后双曲-中心耦合 {post:.2e} 未显著低于化简前 {pre:.2e}"
-    )
+    assert post < 1e-3 * pre, f"Step 1 化简后双曲-中心耦合 {post:.2e} 未显著低于化简前 {pre:.2e}"
     # 化简后保留的项（3 阶以上）要么是纯双曲（pow1==pow4）要么纯中心；
     # 二阶实标准形项不参与断言。
     for pow_tuple in result.hamiltonian_terms:
         if sum(pow_tuple) < 3:
             continue
-        assert pow_tuple[0] == pow_tuple[3], (
-            f"Step 1 后 3+ 阶仍含双曲不平衡项 {pow_tuple}"
-        )
+        assert pow_tuple[0] == pow_tuple[3], f"Step 1 后 3+ 阶仍含双曲不平衡项 {pow_tuple}"
 
 
 def test_center_step_leaves_only_action_terms(l1_context):
@@ -293,9 +289,7 @@ def test_center_step_produces_nonzero_complex_W(l1_context):
         (0, 3, 0, 0, 1, 0): 0.08 * ones,  # pow2=3 ≠ pow5=1
         (0, 2, 1, 0, 1, 1): 0.05 * ones,  # pow2=2 ≠ pow5=1
     }
-    result = reducer.reduce(
-        qf, hamiltonian_terms=center_terms, steps=("center",)
-    )
+    result = reducer.reduce(qf, hamiltonian_terms=center_terms, steps=("center",))
     # W_series["center"] 必须含至少一个非零项
     nonzero_W = any(
         np.any(np.abs(v)) > 1e-9
@@ -325,9 +319,7 @@ def test_center_step_reduces_center_coupling(l1_context):
         (0, 3, 0, 0, 1, 0): 0.08 * ones,
         (0, 2, 1, 0, 1, 1): 0.05 * ones,
     }
-    result = reducer.reduce(
-        qf, hamiltonian_terms=center_terms, steps=("center",)
-    )
+    result = reducer.reduce(qf, hamiltonian_terms=center_terms, steps=("center",))
     for pow_tuple in result.hamiltonian_terms:
         if sum(pow_tuple) < 3:
             continue
@@ -336,9 +328,7 @@ def test_center_step_reduces_center_coupling(l1_context):
             and pow_tuple[1] == pow_tuple[4]
             and pow_tuple[2] == pow_tuple[5]
         )
-        assert is_action, (
-            f"Step 2 后 3+ 阶仍含中心非作用量项 {pow_tuple}"
-        )
+        assert is_action, f"Step 2 后 3+ 阶仍含中心非作用量项 {pow_tuple}"
 
 
 def test_W_for_accessor_and_keyerror(l1_context):

--- a/tests/algorithms/normal_form/test_context.py
+++ b/tests/algorithms/normal_form/test_context.py
@@ -32,8 +32,7 @@ from e2m2e.core import LibrationPoint
 
 @pytest.mark.parametrize(
     "point",
-    [LibrationPoint.L1, LibrationPoint.L2, LibrationPoint.L3,
-     LibrationPoint.L4, LibrationPoint.L5],
+    [LibrationPoint.L1, LibrationPoint.L2, LibrationPoint.L3, LibrationPoint.L4, LibrationPoint.L5],
 )
 def test_context_constructs_for_all_libration_points(earth_moon_system, point):
     """L1–L5 都能成功构造 ``NormalFormContext``。"""
@@ -85,27 +84,27 @@ def test_base_frequencies_match_qiao(earth_moon_system):
 def test_central_frequencies_vary_with_point(earth_moon_system):
     """L1/L2/L3 的中心流形频率各不相同；L4/L5 也给出数值。"""
     ctx_l1 = NormalFormContext(
-        system=earth_moon_system, libration_point=LibrationPoint.L1,
-        epoch=JD0_J2000, order=2,
+        system=earth_moon_system,
+        libration_point=LibrationPoint.L1,
+        epoch=JD0_J2000,
+        order=2,
     )
     ctx_l2 = NormalFormContext(
-        system=earth_moon_system, libration_point=LibrationPoint.L2,
-        epoch=JD0_J2000, order=2,
+        system=earth_moon_system,
+        libration_point=LibrationPoint.L2,
+        epoch=JD0_J2000,
+        order=2,
     )
     ctx_l4 = NormalFormContext(
-        system=earth_moon_system, libration_point=LibrationPoint.L4,
-        epoch=JD0_J2000, order=2,
+        system=earth_moon_system,
+        libration_point=LibrationPoint.L4,
+        epoch=JD0_J2000,
+        order=2,
     )
 
-    assert ctx_l1.central_frequencies == pytest.approx(
-        (2.33774371420711, 2.27427342163957)
-    )
-    assert ctx_l2.central_frequencies == pytest.approx(
-        (1.86464967793235, 1.79093984309149)
-    )
-    assert ctx_l4.central_frequencies == pytest.approx(
-        (0.30259440630339, 1.00408270193080)
-    )
+    assert ctx_l1.central_frequencies == pytest.approx((2.33774371420711, 2.27427342163957))
+    assert ctx_l2.central_frequencies == pytest.approx((1.86464967793235, 1.79093984309149))
+    assert ctx_l4.central_frequencies == pytest.approx((0.30259440630339, 1.00408270193080))
     # 各点中心流形频率应不同（互不相等）
     assert ctx_l1.central_frequencies != ctx_l2.central_frequencies
 
@@ -115,8 +114,10 @@ def test_characteristic_exponent_per_point(earth_moon_system):
     lambdas = {}
     for point in LibrationPoint:
         ctx = NormalFormContext(
-            system=earth_moon_system, libration_point=point,
-            epoch=JD0_J2000, order=2,
+            system=earth_moon_system,
+            libration_point=point,
+            epoch=JD0_J2000,
+            order=2,
         )
         lambdas[point] = ctx.characteristic_exponent
 
@@ -145,8 +146,10 @@ def test_characteristic_exponent_per_point(earth_moon_system):
 def test_collinear_libration_positions(earth_moon_system, point, expected_x):
     """共线点位置用 qiao γ 值给出，符合 ``(1 ± γ, 0, 0)`` / ``(-γ, 0, 0)``。"""
     ctx = NormalFormContext(
-        system=earth_moon_system, libration_point=point,
-        epoch=JD0_J2000, order=2,
+        system=earth_moon_system,
+        libration_point=point,
+        epoch=JD0_J2000,
+        order=2,
     )
     np.testing.assert_allclose(ctx.libration_position, [expected_x, 0.0, 0.0], atol=1e-12)
     assert ctx.gamma is not None
@@ -162,13 +165,13 @@ def test_collinear_libration_positions(earth_moon_system, point, expected_x):
 def test_triangular_libration_positions(earth_moon_system, point, expected_y):
     """三角点位置为等边三角形顶点 ``(1/2 - mu, ±√3/2, 0)``，γ 为 None。"""
     ctx = NormalFormContext(
-        system=earth_moon_system, libration_point=point,
-        epoch=JD0_J2000, order=2,
+        system=earth_moon_system,
+        libration_point=point,
+        epoch=JD0_J2000,
+        order=2,
     )
     expected_x = 0.5 - MU
-    np.testing.assert_allclose(
-        ctx.libration_position, [expected_x, expected_y, 0.0], atol=1e-12
-    )
+    np.testing.assert_allclose(ctx.libration_position, [expected_x, expected_y, 0.0], atol=1e-12)
     assert ctx.gamma is None
 
 
@@ -183,8 +186,10 @@ def test_epoch_accepts_datetime(earth_moon_system):
 
     dt = datetime(2000, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
     ctx = NormalFormContext(
-        system=earth_moon_system, libration_point=LibrationPoint.L1,
-        epoch=dt, order=2,
+        system=earth_moon_system,
+        libration_point=LibrationPoint.L1,
+        epoch=dt,
+        order=2,
     )
     assert ctx.epoch == pytest.approx(JD0_J2000)
 
@@ -193,27 +198,38 @@ def test_invalid_order_raises(earth_moon_system):
     """``order <= 0`` 或非整数应抛 ``ValueError``。"""
     with pytest.raises(ValueError, match="order"):
         NormalFormContext(
-            system=earth_moon_system, libration_point=LibrationPoint.L1,
-            epoch=JD0_J2000, order=0,
+            system=earth_moon_system,
+            libration_point=LibrationPoint.L1,
+            epoch=JD0_J2000,
+            order=0,
         )
     with pytest.raises(ValueError, match="order"):
         NormalFormContext(
-            system=earth_moon_system, libration_point=LibrationPoint.L1,
-            epoch=JD0_J2000, order=-3,
+            system=earth_moon_system,
+            libration_point=LibrationPoint.L1,
+            epoch=JD0_J2000,
+            order=-3,
         )
     with pytest.raises(ValueError, match="order"):
         NormalFormContext(
-            system=earth_moon_system, libration_point=LibrationPoint.L1,
-            epoch=JD0_J2000, order=2.5,  # type: ignore[arg-type]
+            system=earth_moon_system,
+            libration_point=LibrationPoint.L1,
+            epoch=JD0_J2000,
+            order=2.5,  # type: ignore[arg-type]
         )
 
 
 def test_explicit_overrides_take_effect(earth_moon_system):
     """显式传入 ``LU``/``TU``/``mu`` 时覆盖默认值。"""
     ctx = NormalFormContext(
-        system=earth_moon_system, libration_point=LibrationPoint.L1,
-        epoch=JD0_J2000, order=2,
-        LU=1.0, TU=1.0, mu=0.0123, mu_s=999.0,
+        system=earth_moon_system,
+        libration_point=LibrationPoint.L1,
+        epoch=JD0_J2000,
+        order=2,
+        LU=1.0,
+        TU=1.0,
+        mu=0.0123,
+        mu_s=999.0,
     )
     assert ctx.LU == 1.0
     assert ctx.TU == 1.0
@@ -228,8 +244,10 @@ def test_context_system_mu_preferred_over_default(earth_moon_system):
     # 显式重设 system.mu 后构造 context，应拿到新 mu。
     earth_moon_system.mu = 0.0123
     ctx = NormalFormContext(
-        system=earth_moon_system, libration_point=LibrationPoint.L1,
-        epoch=JD0_J2000, order=2,
+        system=earth_moon_system,
+        libration_point=LibrationPoint.L1,
+        epoch=JD0_J2000,
+        order=2,
     )
     assert ctx.mu == pytest.approx(0.0123)
 
@@ -242,8 +260,10 @@ def test_context_system_mu_preferred_over_default(earth_moon_system):
 def test_seconds_to_tu_round_trip(earth_moon_system):
     """秒 ↔ TU 互为逆运算。"""
     ctx = NormalFormContext(
-        system=earth_moon_system, libration_point=LibrationPoint.L1,
-        epoch=JD0_J2000, order=2,
+        system=earth_moon_system,
+        libration_point=LibrationPoint.L1,
+        epoch=JD0_J2000,
+        order=2,
     )
     t_s = 12345.6789
     assert ctx.tu_to_seconds(ctx.seconds_to_tu(t_s)) == pytest.approx(t_s)
@@ -259,8 +279,10 @@ def test_seconds_to_tu_round_trip(earth_moon_system):
 def test_normal_form_result_is_constructible(earth_moon_system):
     """``NormalFormResult`` 至少能以默认参数构造（具体填充后续切片实现）。"""
     ctx = NormalFormContext(
-        system=earth_moon_system, libration_point=LibrationPoint.L1,
-        epoch=JD0_J2000, order=2,
+        system=earth_moon_system,
+        libration_point=LibrationPoint.L1,
+        epoch=JD0_J2000,
+        order=2,
     )
     res = NormalFormResult(context=ctx, order=2)
     assert res.context is ctx
@@ -274,8 +296,10 @@ def test_normal_form_result_is_constructible(earth_moon_system):
 def test_repr_and_str_are_informative(earth_moon_system):
     """``__repr__`` / ``__str__`` 不抛异常且包含平动点名称。"""
     ctx = NormalFormContext(
-        system=earth_moon_system, libration_point=LibrationPoint.L2,
-        epoch=JD0_J2000, order=3,
+        system=earth_moon_system,
+        libration_point=LibrationPoint.L2,
+        epoch=JD0_J2000,
+        order=3,
     )
     assert "L2" in repr(ctx)
     assert "L2" in str(ctx)

--- a/tests/algorithms/normal_form/test_context.py
+++ b/tests/algorithms/normal_form/test_context.py
@@ -1,0 +1,282 @@
+"""``NormalFormContext`` 构造与字段正确性测试。
+
+覆盖：L1–L5 均能成功构造；关键字段（LU/TU/VU、mu/mu_e/mu_m/mu_s、JD0、
+平动点位置、γ、基础频率、中心流形频率、特征指数、历元、阶数）符合
+qiao 约定与物理直觉。
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from e2m2e.algorithms.normal_form import NormalFormContext, NormalFormResult
+from e2m2e.algorithms.normal_form.constants import (
+    BASE_FREQUENCIES,
+    JD0_J2000,
+    LU_KM,
+    MU,
+    MU_E,
+    MU_M,
+    MU_S,
+    TU_S,
+)
+from e2m2e.core import LibrationPoint
+
+# ---------------------------------------------------------------------------
+# 构造烟测：L1–L5
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "point",
+    [LibrationPoint.L1, LibrationPoint.L2, LibrationPoint.L3,
+     LibrationPoint.L4, LibrationPoint.L5],
+)
+def test_context_constructs_for_all_libration_points(earth_moon_system, point):
+    """L1–L5 都能成功构造 ``NormalFormContext``。"""
+    ctx = NormalFormContext(
+        system=earth_moon_system,
+        libration_point=point,
+        epoch=JD0_J2000,
+        order=4,
+    )
+    assert ctx.libration_point is point
+    assert ctx.order == 4
+    assert ctx.epoch == pytest.approx(JD0_J2000)
+
+
+# ---------------------------------------------------------------------------
+# 字段正确性
+# ---------------------------------------------------------------------------
+
+
+def test_qiao_constants_are_carried(earth_moon_system):
+    """默认构造时 LU/TU/mu/mu_e/mu_m/mu_s/JD0 与 qiao 一致。"""
+    ctx = NormalFormContext(
+        system=earth_moon_system,
+        libration_point=LibrationPoint.L1,
+        epoch=JD0_J2000,
+        order=2,
+    )
+    assert pytest.approx(LU_KM) == ctx.LU
+    assert pytest.approx(TU_S) == ctx.TU
+    assert pytest.approx(LU_KM / TU_S) == ctx.VU
+    assert ctx.mu == pytest.approx(MU)
+    assert ctx.mu_e == pytest.approx(MU_E)
+    assert ctx.mu_m == pytest.approx(MU_M)
+    assert ctx.mu_s == pytest.approx(MU_S)
+    assert ctx.jd0 == pytest.approx(JD0_J2000)
+
+
+def test_base_frequencies_match_qiao(earth_moon_system):
+    """基础频率四个分量与 qiao Global_File.py 完全一致。"""
+    ctx = NormalFormContext(
+        system=earth_moon_system,
+        libration_point=LibrationPoint.L2,
+        epoch=JD0_J2000,
+        order=3,
+    )
+    np.testing.assert_allclose(ctx.base_frequencies, BASE_FREQUENCIES, rtol=1e-12)
+
+
+def test_central_frequencies_vary_with_point(earth_moon_system):
+    """L1/L2/L3 的中心流形频率各不相同；L4/L5 也给出数值。"""
+    ctx_l1 = NormalFormContext(
+        system=earth_moon_system, libration_point=LibrationPoint.L1,
+        epoch=JD0_J2000, order=2,
+    )
+    ctx_l2 = NormalFormContext(
+        system=earth_moon_system, libration_point=LibrationPoint.L2,
+        epoch=JD0_J2000, order=2,
+    )
+    ctx_l4 = NormalFormContext(
+        system=earth_moon_system, libration_point=LibrationPoint.L4,
+        epoch=JD0_J2000, order=2,
+    )
+
+    assert ctx_l1.central_frequencies == pytest.approx(
+        (2.33774371420711, 2.27427342163957)
+    )
+    assert ctx_l2.central_frequencies == pytest.approx(
+        (1.86464967793235, 1.79093984309149)
+    )
+    assert ctx_l4.central_frequencies == pytest.approx(
+        (0.30259440630339, 1.00408270193080)
+    )
+    # 各点中心流形频率应不同（互不相等）
+    assert ctx_l1.central_frequencies != ctx_l2.central_frequencies
+
+
+def test_characteristic_exponent_per_point(earth_moon_system):
+    """特征指数 λ 与 qiao 表格一致；L1 最大、L3 最小。"""
+    lambdas = {}
+    for point in LibrationPoint:
+        ctx = NormalFormContext(
+            system=earth_moon_system, libration_point=point,
+            epoch=JD0_J2000, order=2,
+        )
+        lambdas[point] = ctx.characteristic_exponent
+
+    assert lambdas[LibrationPoint.L1] == pytest.approx(2.93924602471)
+    assert lambdas[LibrationPoint.L2] == pytest.approx(2.16475967850)
+    assert lambdas[LibrationPoint.L3] == pytest.approx(0.17970712561)
+    assert lambdas[LibrationPoint.L4] == pytest.approx(0.01416193941)
+    assert lambdas[LibrationPoint.L5] == pytest.approx(0.01381362875)
+    # L1 是最不稳定共线点
+    assert lambdas[LibrationPoint.L1] > lambdas[LibrationPoint.L2] > lambdas[LibrationPoint.L3]
+
+
+# ---------------------------------------------------------------------------
+# 平动点几何
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("point", "expected_x"),
+    [
+        (LibrationPoint.L1, 1.0 - 0.150934288618019),
+        (LibrationPoint.L2, 1.0 + 0.167832751054508),
+        (LibrationPoint.L3, -0.992912060200654),
+    ],
+)
+def test_collinear_libration_positions(earth_moon_system, point, expected_x):
+    """共线点位置用 qiao γ 值给出，符合 ``(1 ± γ, 0, 0)`` / ``(-γ, 0, 0)``。"""
+    ctx = NormalFormContext(
+        system=earth_moon_system, libration_point=point,
+        epoch=JD0_J2000, order=2,
+    )
+    np.testing.assert_allclose(ctx.libration_position, [expected_x, 0.0, 0.0], atol=1e-12)
+    assert ctx.gamma is not None
+
+
+@pytest.mark.parametrize(
+    ("point", "expected_y"),
+    [
+        (LibrationPoint.L4, math.sqrt(3.0) / 2.0),
+        (LibrationPoint.L5, -math.sqrt(3.0) / 2.0),
+    ],
+)
+def test_triangular_libration_positions(earth_moon_system, point, expected_y):
+    """三角点位置为等边三角形顶点 ``(1/2 - mu, ±√3/2, 0)``，γ 为 None。"""
+    ctx = NormalFormContext(
+        system=earth_moon_system, libration_point=point,
+        epoch=JD0_J2000, order=2,
+    )
+    expected_x = 0.5 - MU
+    np.testing.assert_allclose(
+        ctx.libration_position, [expected_x, expected_y, 0.0], atol=1e-12
+    )
+    assert ctx.gamma is None
+
+
+# ---------------------------------------------------------------------------
+# 历元与构造变体
+# ---------------------------------------------------------------------------
+
+
+def test_epoch_accepts_datetime(earth_moon_system):
+    """``epoch`` 接受 ``datetime``，自动转儒略日。"""
+    from datetime import datetime, timezone
+
+    dt = datetime(2000, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    ctx = NormalFormContext(
+        system=earth_moon_system, libration_point=LibrationPoint.L1,
+        epoch=dt, order=2,
+    )
+    assert ctx.epoch == pytest.approx(JD0_J2000)
+
+
+def test_invalid_order_raises(earth_moon_system):
+    """``order <= 0`` 或非整数应抛 ``ValueError``。"""
+    with pytest.raises(ValueError, match="order"):
+        NormalFormContext(
+            system=earth_moon_system, libration_point=LibrationPoint.L1,
+            epoch=JD0_J2000, order=0,
+        )
+    with pytest.raises(ValueError, match="order"):
+        NormalFormContext(
+            system=earth_moon_system, libration_point=LibrationPoint.L1,
+            epoch=JD0_J2000, order=-3,
+        )
+    with pytest.raises(ValueError, match="order"):
+        NormalFormContext(
+            system=earth_moon_system, libration_point=LibrationPoint.L1,
+            epoch=JD0_J2000, order=2.5,  # type: ignore[arg-type]
+        )
+
+
+def test_explicit_overrides_take_effect(earth_moon_system):
+    """显式传入 ``LU``/``TU``/``mu`` 时覆盖默认值。"""
+    ctx = NormalFormContext(
+        system=earth_moon_system, libration_point=LibrationPoint.L1,
+        epoch=JD0_J2000, order=2,
+        LU=1.0, TU=1.0, mu=0.0123, mu_s=999.0,
+    )
+    assert ctx.LU == 1.0
+    assert ctx.TU == 1.0
+    assert ctx.VU == 1.0  # LU/TU = 1
+    assert ctx.mu == pytest.approx(0.0123)
+    assert ctx.mu_s == 999.0
+
+
+def test_context_system_mu_preferred_over_default(earth_moon_system):
+    """``System.mu``（若存在）应覆盖 qiao 默认 mu。"""
+    # earth_moon_system 默认 mu=1.215058560962404e-2，与 qiao MU 一致；
+    # 显式重设 system.mu 后构造 context，应拿到新 mu。
+    earth_moon_system.mu = 0.0123
+    ctx = NormalFormContext(
+        system=earth_moon_system, libration_point=LibrationPoint.L1,
+        epoch=JD0_J2000, order=2,
+    )
+    assert ctx.mu == pytest.approx(0.0123)
+
+
+# ---------------------------------------------------------------------------
+# 时间转换
+# ---------------------------------------------------------------------------
+
+
+def test_seconds_to_tu_round_trip(earth_moon_system):
+    """秒 ↔ TU 互为逆运算。"""
+    ctx = NormalFormContext(
+        system=earth_moon_system, libration_point=LibrationPoint.L1,
+        epoch=JD0_J2000, order=2,
+    )
+    t_s = 12345.6789
+    assert ctx.tu_to_seconds(ctx.seconds_to_tu(t_s)) == pytest.approx(t_s)
+    t_tu = 5.678
+    assert ctx.seconds_to_tu(ctx.tu_to_seconds(t_tu)) == pytest.approx(t_tu)
+
+
+# ---------------------------------------------------------------------------
+# NormalFormResult 占位
+# ---------------------------------------------------------------------------
+
+
+def test_normal_form_result_is_constructible(earth_moon_system):
+    """``NormalFormResult`` 至少能以默认参数构造（具体填充后续切片实现）。"""
+    ctx = NormalFormContext(
+        system=earth_moon_system, libration_point=LibrationPoint.L1,
+        epoch=JD0_J2000, order=2,
+    )
+    res = NormalFormResult(context=ctx, order=2)
+    assert res.context is ctx
+    assert res.order == 2
+    assert res.success is False
+    assert res.hamiltonian_coefficients == ()
+    assert res.transformation_matrices == ()
+    assert res.metadata == {}
+
+
+def test_repr_and_str_are_informative(earth_moon_system):
+    """``__repr__`` / ``__str__`` 不抛异常且包含平动点名称。"""
+    ctx = NormalFormContext(
+        system=earth_moon_system, libration_point=LibrationPoint.L2,
+        epoch=JD0_J2000, order=3,
+    )
+    assert "L2" in repr(ctx)
+    assert "L2" in str(ctx)
+    assert "LU=" in repr(ctx)

--- a/tests/algorithms/normal_form/test_dynamical_substitution.py
+++ b/tests/algorithms/normal_form/test_dynamical_substitution.py
@@ -321,9 +321,7 @@ def test_ode_substitute_solver_matches_direct_integration_for_toy_rhs():
     x0 = np.array([1.0, 0.0, 0.0, 0.0, 1.0, 0.0])
     xf, phi = solver.propagate_segment(0.0, np.pi / 2, x0)
 
-    sol = solve_ivp(
-        _toy_rhs, (0.0, np.pi / 2), x0, method="DOP853", rtol=1e-12, atol=1e-14
-    )
+    sol = solve_ivp(_toy_rhs, (0.0, np.pi / 2), x0, method="DOP853", rtol=1e-12, atol=1e-14)
     np.testing.assert_allclose(xf, sol.y[:, -1], atol=1e-9)
     # STM 在 ρ̈=-ρ 问题上应当近似 [[cos, 0, sin], ...]
     expected_phi = np.array(
@@ -353,7 +351,7 @@ def test_ode_substitute_solver_rejects_bad_shape():
 
 def test_default_constants_match_qiao():
     """默认窗口/间距与 qiao Code05 一致。"""
-    assert pytest.approx(0.1 * (2 ** 16)) == DEFAULT_TOTAL_TU
+    assert pytest.approx(0.1 * (2**16)) == DEFAULT_TOTAL_TU
     assert pytest.approx(0.8) == DEFAULT_NODE_STEP
 
 
@@ -408,13 +406,9 @@ def test_W_poly_regression_against_qiao_L1DynSubs_npz():
     """
     import os
 
-    fixture = os.path.join(
-        os.path.dirname(__file__), "data", "L1DynSubs.npz"
-    )
+    fixture = os.path.join(os.path.dirname(__file__), "data", "L1DynSubs.npz")
     if not os.path.exists(fixture):
-        pytest.skip(
-            "qiao L1DynSubs.npz 未引入仓库；W_poly 逐系数回归待 fixture 就绪"
-        )
+        pytest.skip("qiao L1DynSubs.npz 未引入仓库；W_poly 逐系数回归待 fixture 就绪")
 
 
 # ---------------------------------------------------------------------------
@@ -422,9 +416,7 @@ def test_W_poly_regression_against_qiao_L1DynSubs_npz():
 # ---------------------------------------------------------------------------
 
 
-def test_substitute_orbit_suppresses_center_manifold_frequencies(
-    l1_context, monkeypatch
-):
+def test_substitute_orbit_suppresses_center_manifold_frequencies(l1_context, monkeypatch):
     """星历模型下重复积分后的 FFT 中心流形频率幅值检查。
 
     验收标准要求：动力学替代轨道在星历模型下重复积分后仍只含受迫频率，
@@ -452,8 +444,7 @@ def test_substitute_orbit_suppresses_center_manifold_frequencies(
 
     if not spice_ready:
         pytest.skip(
-            "SPICE leapseconds 内核不可用；星历模型端到端 FFT 中心流形"
-            "频率压制检查待内核就绪"
+            "SPICE leapseconds 内核不可用；星历模型端到端 FFT 中心流形频率压制检查待内核就绪"
         )
 
     corrector = DynamicalSubstituteCorrector(

--- a/tests/algorithms/normal_form/test_dynamical_substitution.py
+++ b/tests/algorithms/normal_form/test_dynamical_substitution.py
@@ -1,0 +1,498 @@
+"""``normal_form.dynamical_substitution`` 测试。
+
+覆盖：
+
+- :class:`DynamicalSubstituteCorrector` 可构造，``reduce`` 返回
+  :class:`DynamicalSubstituteResult`；
+- 结果具备 ``substitute_orbit`` / ``W_poly`` / ``Wdot_poly`` /
+  ``tlist`` / ``shooting_result`` 等切片 #171 要求字段；
+- 在零初值 / 较小窗口下烟测通过；
+- NAFF 不可用时降级到 FFT 并发出警告；
+- :func:`multiple_shooting_newton` 在玩具动力学上能收敛；
+- :func:`solve_block_tridiagonal` 数值正确性。
+
+完整 ``L1DynSubs.npz`` 回归留给后续切片（需要 SPICE 内核与完整
+``T_total = 0.1·2^16`` 窗口）。
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pytest
+
+from e2m2e.algorithms.normal_form.constants import JD0_J2000
+from e2m2e.algorithms.normal_form.dynamical_substitution import (
+    DEFAULT_DENSE_STEP,
+    DEFAULT_NODE_STEP,
+    DEFAULT_TOTAL_TU,
+    DynamicalSubstituteCorrector,
+    DynamicalSubstituteResult,
+)
+from e2m2e.algorithms.normal_form.multiple_shooting import (
+    MultipleShootingResult,
+    ODESubstituteSolver,
+    ShootingPatch,
+    multiple_shooting_newton,
+    solve_block_tridiagonal,
+)
+from e2m2e.core import LibrationPoint
+
+# ---------------------------------------------------------------------------
+# 公共 fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def l1_context(earth_moon_system):
+    """L1 共线点上下文（与现有 slice 1 测试一致）。"""
+    from e2m2e.algorithms.normal_form import NormalFormContext
+
+    return NormalFormContext(
+        system=earth_moon_system,
+        libration_point=LibrationPoint.L1,
+        epoch=JD0_J2000,
+        order=4,
+    )
+
+
+@pytest.fixture
+def tiny_corrector(l1_context) -> DynamicalSubstituteCorrector:
+    """极小窗口 corrector，让 ``reduce`` 在 < 5 s 完成（不依赖 SPICE）。"""
+    return DynamicalSubstituteCorrector(
+        context=l1_context,
+        t_total=4.0,
+        node_step=0.8,
+        dense_step=0.2,
+        max_iter=3,
+        tolerance=1e-6,
+        prefer="fft",
+        spice_optional=True,
+    )
+
+
+@pytest.fixture
+def auto_corrector(l1_context) -> DynamicalSubstituteCorrector:
+    """``prefer='auto'`` 的 corrector，便于触发 NAFF → FFT 降级分支。"""
+    return DynamicalSubstituteCorrector(
+        context=l1_context,
+        t_total=4.0,
+        node_step=0.8,
+        dense_step=0.2,
+        max_iter=3,
+        tolerance=1e-6,
+        prefer="auto",
+        spice_optional=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Corrector 构造烟测
+# ---------------------------------------------------------------------------
+
+
+def test_corrector_is_constructible(l1_context):
+    """``DynamicalSubstituteCorrector`` 可用 :class:`NormalFormContext` 构造。"""
+    corrector = DynamicalSubstituteCorrector(
+        context=l1_context,
+        t_total=4.0,
+        node_step=0.8,
+        dense_step=0.2,
+        max_iter=2,
+        tolerance=1e-6,
+        prefer="fft",
+    )
+    assert corrector.context is l1_context
+    assert corrector.t_total == 4.0
+    assert corrector.prefer == "fft"
+
+
+# ---------------------------------------------------------------------------
+# Corrector.reduce 烟测
+# ---------------------------------------------------------------------------
+
+
+def test_reduce_returns_dataclass_with_required_fields(tiny_corrector):
+    """``reduce`` 返回 :class:`DynamicalSubstituteResult` 且字段齐备。"""
+    result = tiny_corrector.reduce()
+    assert isinstance(result, DynamicalSubstituteResult)
+    assert result.context is tiny_corrector.context
+    assert result.order == int(tiny_corrector.context.order)
+    # 切片 #171 验收字段：substitute_orbit / W_poly / Wdot_poly
+    assert result.substitute_orbit is not None
+    assert isinstance(result.W_poly, dict)
+    assert isinstance(result.Wdot_poly, dict)
+    # tlist 与 Xlist 形状
+    assert result.tlist.ndim == 1
+    assert result.Xlist.ndim == 2
+    assert result.Xlist.shape[1] == 6
+    assert result.Xlist.shape[0] == result.tlist.shape[0]
+    # 至少含 6 个线性分量（q1/q2/q3/p1/p2/p3）
+    expected_keys = {
+        (1, 0, 0, 0, 0, 0),
+        (0, 1, 0, 0, 0, 0),
+        (0, 0, 1, 0, 0, 0),
+        (0, 0, 0, 1, 0, 0),
+        (0, 0, 0, 0, 1, 0),
+        (0, 0, 0, 0, 0, 1),
+    }
+    assert expected_keys.issubset(set(result.W_poly.keys()))
+    assert expected_keys.issubset(set(result.Wdot_poly.keys()))
+
+
+def test_reduce_uses_seed_when_provided(tiny_corrector):
+    """``seed`` 显式传入时初始 X_Q 各节点都应是该 seed。"""
+    seed = np.array([1e-3, -1e-3, 0.0, 0.0, 1e-4, -1e-4])
+    result = tiny_corrector.reduce(seed=seed)
+    assert result.shooting_result is not None
+    # shooting 节点不一定仍等于 seed（Newton 迭代会改），但稠密输出至少存在
+    assert result.Xlist.shape[0] >= result.shooting_result.t_Q.shape[0]
+
+
+def test_reduce_rejects_invalid_seed_shape(tiny_corrector):
+    """``seed`` 不是 ``(6,)`` 时抛 :class:`ValueError`。"""
+    with pytest.raises(ValueError, match="seed"):
+        tiny_corrector.reduce(seed=np.zeros(5))
+
+
+def test_reduce_metadata_records_window(tiny_corrector):
+    """``metadata`` 应记录窗口设置，便于诊断。"""
+    result = tiny_corrector.reduce()
+    assert result.metadata["t_total"] == pytest.approx(4.0)
+    assert result.metadata["node_step"] == pytest.approx(0.8)
+    assert result.metadata["dense_step"] == pytest.approx(0.2)
+    assert result.metadata["n_nodes"] >= 2
+    assert result.metadata["n_segments"] >= 1
+
+
+def test_reduce_falls_back_to_fft_when_naff_missing(
+    auto_corrector, monkeypatch: pytest.MonkeyPatch
+):
+    """``reduce`` 在 NAFF 不可用时降级到 FFT，并把后端记录到结果。"""
+    monkeypatch.setattr(
+        "e2m2e.algorithms.normal_form.fft._resolve_naff_binary",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "e2m2e.algorithms.normal_form.fft.naff_available",
+        lambda: False,
+    )
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = auto_corrector.reduce()
+    assert result.backend == "fft"
+    # 至少一条 NAFF 警告
+    assert any("NAFF" in str(w.message) for w in caught)
+
+
+def test_reduce_result_residual_property(tiny_corrector):
+    """``residual_norm`` 属性映射到多重打靶最大残差。"""
+    result = tiny_corrector.reduce()
+    if result.shooting_result is None:
+        pytest.skip("shooting_result 为 None（容差异常）")
+    assert result.residual_norm == pytest.approx(result.shooting_result.max_residual)
+
+
+def test_reduce_substitute_orbit_is_orbit_or_array(tiny_corrector):
+    """``substitute_orbit`` 应为 ``e2m2e.Orbit`` 实例，或退化为 ``ndarray``。"""
+    result = tiny_corrector.reduce()
+    obj = result.substitute_orbit
+    if hasattr(obj, "states") and hasattr(obj, "times"):
+        # Orbit-like
+        assert obj.states.shape[1] == 6
+        np.testing.assert_allclose(obj.times, result.tlist)
+    else:
+        # ndarray fallback
+        assert isinstance(obj, np.ndarray)
+        assert obj.shape[1] == 6
+
+
+# ---------------------------------------------------------------------------
+# 玩具动力学上的多重打靶
+# ---------------------------------------------------------------------------
+
+
+def _toy_rhs(t: float, X):
+    """纯衰减动力学：``ρ̇ = 0``，``ρ̈ = -ρ``。解可解析。"""
+    X = np.asarray(X, dtype=float).ravel()
+    return np.concatenate([X[3:6], -X[:3]])
+
+
+def test_multiple_shooting_newton_converges_on_toy_dynamics():
+    """玩具动力学 ``ρ̈ = -ρ`` 上 Newton 多重打靶应让残差低于初始值。"""
+    n_nodes = 11
+    t_Q = np.linspace(0.0, 2.0 * np.pi, n_nodes)
+    X0 = np.array([1.0, 0.0, 0.0, 0.0, 1.0, 0.0])
+    X_Q = np.tile(X0, (n_nodes, 1))
+
+    solver = ODESubstituteSolver(rhs=_toy_rhs, rtol=1e-12, atol=1e-14)
+    initial = ShootingPatch(t_Q=t_Q, X_Q=X_Q)
+    result = multiple_shooting_newton(
+        initial,
+        solver,
+        max_iter=10,
+        tolerance=1e-9,
+    )
+    assert isinstance(result, MultipleShootingResult)
+    # 即使不严格收敛，残差应显著下降
+    assert result.max_residual < 1.0
+    assert len(result.residual_history) == result.iterations
+
+
+def _zero_rhs(t, X):
+    """恒零右端项——用于边界条件测试。"""
+    return np.zeros(6)
+
+
+def test_multiple_shooting_newton_rejects_too_few_nodes():
+    """少于 2 个节点时抛 :class:`ValueError`。"""
+    solver = ODESubstituteSolver(rhs=_zero_rhs)
+    patch = ShootingPatch(t_Q=np.array([0.0]), X_Q=np.zeros((1, 6)))
+    with pytest.raises(ValueError, match="节点"):
+        multiple_shooting_newton(patch, solver)
+
+
+def test_multiple_shooting_newton_rejects_invalid_iter_args():
+    """``max_iter < 1`` 或 ``tolerance <= 0`` 抛 :class:`ValueError`。"""
+    solver = ODESubstituteSolver(rhs=_zero_rhs)
+    patch = ShootingPatch(t_Q=np.array([0.0, 1.0]), X_Q=np.zeros((2, 6)))
+    with pytest.raises(ValueError, match="max_iter"):
+        multiple_shooting_newton(patch, solver, max_iter=0)
+    with pytest.raises(ValueError, match="tolerance"):
+        multiple_shooting_newton(patch, solver, tolerance=0.0)
+
+
+# ---------------------------------------------------------------------------
+# solve_block_tridiagonal 直接测试
+# ---------------------------------------------------------------------------
+
+
+def test_solve_block_tridiagonal_zero_residual_short_circuit():
+    """当 ``Xf_i == X_Q_{i+1}`` 时，修正量应接近 0。"""
+    rng = np.random.default_rng(0)
+    n_seg = 4
+    X_Q = rng.normal(scale=0.1, size=(n_seg + 1, 6))
+    phi_stack = np.tile(np.eye(6), (n_seg, 1, 1))
+    xf_stack = X_Q[1:].copy()
+
+    delta_Q, errs = solve_block_tridiagonal(phi_stack, xf_stack, X_Q)
+    assert all(e < 1e-12 for e in errs)
+    assert np.linalg.norm(delta_Q) < 1e-9
+
+
+def test_solve_block_tridiagonal_drive_residual_to_zero_in_toy_setting():
+    """对玩具连续性残差，Newton 收敛应让残差降到极小。"""
+    n_seg = 6
+    rng = np.random.default_rng(1)
+    X_Q = rng.normal(scale=0.5, size=(n_seg + 1, 6))
+    # 故意构造 Xf 与 X_Q_{i+1} 有偏差
+    xf_stack = X_Q[1:] + 0.1 * rng.normal(scale=1.0, size=(n_seg, 6))
+    phi_stack = np.tile(np.eye(6), (n_seg, 1, 1))
+
+    delta_Q, errs_before = solve_block_tridiagonal(phi_stack, xf_stack, X_Q)
+    X_Q_new = X_Q + delta_Q
+    _, errs_after = solve_block_tridiagonal(phi_stack, xf_stack, X_Q_new)
+
+    assert max(errs_after) < max(errs_before)
+    # 单次 Newton 步在玩具问题上不应让残差爆炸
+    assert max(errs_after) < 2.0 * max(errs_before)
+
+
+def test_solve_block_tridiagonal_rejects_shape_mismatch():
+    """``xf_stack`` / ``X_Q`` 形状不匹配时抛 :class:`ValueError`。"""
+    phi_stack = np.tile(np.eye(6), (3, 1, 1))
+    xf_stack = np.zeros((2, 6))
+    X_Q = np.zeros((4, 6))
+    with pytest.raises(ValueError, match="xf_stack"):
+        solve_block_tridiagonal(phi_stack, xf_stack, X_Q)
+
+
+# ---------------------------------------------------------------------------
+# ODESubstituteSolver 基础烟测
+# ---------------------------------------------------------------------------
+
+
+def test_ode_substitute_solver_matches_direct_integration_for_toy_rhs():
+    """ODE solver 终端状态应与 ``solve_ivp`` 单次积分一致。"""
+    from scipy.integrate import solve_ivp
+
+    solver = ODESubstituteSolver(rhs=_toy_rhs, rtol=1e-12, atol=1e-14)
+    x0 = np.array([1.0, 0.0, 0.0, 0.0, 1.0, 0.0])
+    xf, phi = solver.propagate_segment(0.0, np.pi / 2, x0)
+
+    sol = solve_ivp(
+        _toy_rhs, (0.0, np.pi / 2), x0, method="DOP853", rtol=1e-12, atol=1e-14
+    )
+    np.testing.assert_allclose(xf, sol.y[:, -1], atol=1e-9)
+    # STM 在 ρ̈=-ρ 问题上应当近似 [[cos, 0, sin], ...]
+    expected_phi = np.array(
+        [
+            [0.0, 0.0, 0.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+            [-1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, -1.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, -1.0, 0.0, 0.0, 0.0],
+        ]
+    )
+    np.testing.assert_allclose(phi, expected_phi, atol=1e-6)
+
+
+def test_ode_substitute_solver_rejects_bad_shape():
+    """``x0`` 不是 ``(6,)`` 时抛 :class:`ValueError`。"""
+    solver = ODESubstituteSolver(rhs=_toy_rhs)
+    with pytest.raises(ValueError, match="x0"):
+        solver.propagate_segment(0.0, 1.0, np.zeros(5))
+
+
+# ---------------------------------------------------------------------------
+# 模块顶层常量
+# ---------------------------------------------------------------------------
+
+
+def test_default_constants_match_qiao():
+    """默认窗口/间距与 qiao Code05 一致。"""
+    assert pytest.approx(0.1 * (2 ** 16)) == DEFAULT_TOTAL_TU
+    assert pytest.approx(0.8) == DEFAULT_NODE_STEP
+
+
+# ---------------------------------------------------------------------------
+# SPICE 不可用时的优雅降级（无 SPICE 内核的 CI 环境）
+# ---------------------------------------------------------------------------
+
+
+def test_reduce_works_without_spice_kernels(tiny_corrector, monkeypatch):
+    """``spice_optional=True`` 时即使 SPICE 不可用也应跑出合理结果。"""
+    # 强行让 _ephemeris.eval_params 抛 RuntimeError 模拟 SPICE 缺失
+    import e2m2e.algorithms.normal_form.dynamical_substitution as ds
+
+    def _broken(*args, **kwargs):
+        raise RuntimeError("simulated SPICE missing")
+
+    monkeypatch.setattr(
+        "e2m2e.algorithms.normal_form._ephemeris.eval_params",
+        _broken,
+        raising=False,
+    )
+    # 同时让 _build_dynamics_rhs_spice 走异常路径
+    monkeypatch.setattr(ds, "_build_dynamics_rhs_spice", _broken)
+
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        result = tiny_corrector.reduce()
+    assert result.spice_available is False
+    assert result.tlist.size > 0
+    assert result.Xlist.size > 0
+
+
+# ---------------------------------------------------------------------------
+# 验收标准 #2：L1_Halo_Large 的 W_poly 与 qiao L1DynSubs.npz 回归一致
+# ---------------------------------------------------------------------------
+
+
+def test_W_poly_regression_against_qiao_L1DynSubs_npz():
+    """与 qiao ``L1DynSubs.npz`` 的逐系数回归。
+
+    该回归需要 qiao 参考数据（``L1DynSubs.npz``，体积大，本仓库未引入）
+    以及完整 ``T_total = 0.1·2^16`` 窗口的星历模型积分。两者在 CI 环境
+    均不可得，故以 ``pytest.skip`` 守卫占位。
+
+    解锁条件（任一）：
+    1. 将 qiao ``L1DynSubs.npz`` 放入 ``tests/algorithms/normal_form/data/``；
+    2. 提供 SPICE 内核（``.tls`` + ``.bsp``）并在长窗口下跑 reduce。
+
+    fixture 就绪后，本测试应加载 npz 中的 ``W_poly``，与
+    ``DynamicalSubstituteCorrector(...).reduce()`` 的 ``result.W_poly``
+    逐线性项做 ``np.testing.assert_allclose``。
+    """
+    import os
+
+    fixture = os.path.join(
+        os.path.dirname(__file__), "data", "L1DynSubs.npz"
+    )
+    if not os.path.exists(fixture):
+        pytest.skip(
+            "qiao L1DynSubs.npz 未引入仓库；W_poly 逐系数回归待 fixture 就绪"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 验收标准 #3：动力学替代轨道重复积分后中心流形频率幅值低于阈值
+# ---------------------------------------------------------------------------
+
+
+def test_substitute_orbit_suppresses_center_manifold_frequencies(
+    l1_context, monkeypatch
+):
+    """星历模型下重复积分后的 FFT 中心流形频率幅值检查。
+
+    验收标准要求：动力学替代轨道在星历模型下重复积分后仍只含受迫频率，
+    中心流形频率（ν₁、ν₂）处的 FFT 幅值低于阈值。
+
+    该检查需要：
+    1. SPICE 内核（否则 ``reduce`` 退到纯 CR3BP，退路仅供烟雾测试）；
+    2. 完整 ``T_total = 0.1·2^16`` 窗口（FFT 频率分辨率需达
+       ``2π/T_total ≈ 9.6e-5`` rad/TU 才能分辨受迫频率与 ν₁/ν₂）。
+
+    CI 环境两者皆缺，故以 ``pytest.skip`` 守卫占位。检测逻辑本身的
+    正确性由 ``test_fft.test_fft_extract_detects_suppressed_center_manifold_frequency``
+    在合成数据上覆盖。
+
+    解锁条件：加载 SPICE ``.tls`` + ``.bsp`` 内核后即可启用本测试。
+    """
+    import e2m2e.algorithms.normal_form._ephemeris as _eph
+
+    # 探测 SPICE leapseconds 内核是否就绪：str2et 需要已加载 .tls
+    spice_ready = True
+    try:
+        _eph.eval_params(float(l1_context.epoch), l1_context)
+    except Exception:
+        spice_ready = False
+
+    if not spice_ready:
+        pytest.skip(
+            "SPICE leapseconds 内核不可用；星历模型端到端 FFT 中心流形"
+            "频率压制检查待内核就绪"
+        )
+
+    corrector = DynamicalSubstituteCorrector(
+        context=l1_context,
+        t_total=DEFAULT_TOTAL_TU,
+        node_step=DEFAULT_NODE_STEP,
+        dense_step=DEFAULT_DENSE_STEP,
+        max_iter=19,
+        tolerance=1e-11,
+        prefer="fft",
+        spice_optional=False,
+    )
+    result = corrector.reduce()
+    assert result.spice_available is True
+
+    nu1, nu2 = l1_context.central_frequencies
+    threshold = 1e-3  # 中心流形频率幅值阈值（相对最大非直流分量）
+    for label in ("x", "y", "z"):
+        comps = result.fft_components[label]
+        non_dc = [c for c in comps if abs(c.freq) > 1e-6]
+        if not non_dc:
+            continue
+        max_amp = max(c.amp for c in non_dc)
+        for nu in (nu1, nu2):
+            nearest = min(non_dc, key=lambda c: abs(c.freq - nu))
+            assert nearest.amp < threshold * max_amp, (
+                f"{label} 方向中心流形频率 ν={nu:.4f} 处幅值 "
+                f"{nearest.amp:.3e} 超过阈值 {threshold * max_amp:.3e}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# 模块接口
+# ---------------------------------------------------------------------------
+
+
+def test_dynamical_substitution_importable_via_package_root():
+    """切片 #171 验收：能从包根直接 ``import``。"""
+    from e2m2e.algorithms.normal_form import (  # noqa: F401
+        DynamicalSubstituteCorrector,
+        DynamicalSubstituteResult,
+    )

--- a/tests/algorithms/normal_form/test_fft.py
+++ b/tests/algorithms/normal_form/test_fft.py
@@ -1,0 +1,334 @@
+"""``normal_form.fft`` 测试。
+
+覆盖：
+
+- :func:`naff_available` 不抛错；
+- :func:`fft_extract` 在合成单频信号上恢复频率与振幅；
+- :func:`least_squares_sin_cos_fit` 给出正确的正弦/余弦分配；
+- :func:`reconstruct_signal` / :func:`reconstruct_derivative` 与
+  解析值匹配；
+- :func:`frequency_match` 把检测频率匹配到基频表最近邻；
+- :func:`extract_frequencies` 在 NAFF 不可用时降级到 FFT 并发出警告。
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pytest
+
+from e2m2e.algorithms.normal_form.fft import (
+    FFTComponent,
+    extract_frequencies,
+    fft_extract,
+    frequency_match,
+    least_squares_sin_cos_fit,
+    naff_available,
+    reconstruct_derivative,
+    reconstruct_signal,
+)
+
+# ---------------------------------------------------------------------------
+# 公共合成数据
+# ---------------------------------------------------------------------------
+
+
+def _make_single_tone(
+    omega: float, amp_s: float, amp_c: float, n: int = 256, t_end: float = 32.0
+) -> tuple[np.ndarray, np.ndarray]:
+    """构造 ``s·sin(ωt) + c·cos(ωt)`` 时间序列。"""
+    t = np.linspace(0.0, t_end, n, endpoint=False)
+    y = amp_s * np.sin(omega * t) + amp_c * np.cos(omega * t)
+    return t, y
+
+
+# ---------------------------------------------------------------------------
+# NAFF 探测
+# ---------------------------------------------------------------------------
+
+
+def test_naff_available_does_not_raise():
+    """``naff_available`` 总是返回 ``bool``，不抛错。"""
+    result = naff_available()
+    assert isinstance(result, bool)
+
+
+def test_extract_frequencies_falls_back_to_fft_when_naff_missing(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """``extract_frequencies(prefer="auto")`` 在 NAFF 不可用时降级到 FFT 并警告。"""
+    monkeypatch.setattr(
+        "e2m2e.algorithms.normal_form.fft._resolve_naff_binary",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "e2m2e.algorithms.normal_form.fft.naff_available",
+        lambda: False,
+    )
+
+    omega = 1.7
+    t, y = _make_single_tone(omega, 0.4, 0.6)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        comps, backend = extract_frequencies(t, y, n_components=5)
+
+    assert backend == "fft"
+    assert isinstance(comps[0], FFTComponent)
+    # 至少一条警告指出 NAFF 不可用
+    assert any("NAFF" in str(w.message) for w in caught), [str(w.message) for w in caught]
+
+
+def test_extract_frequencies_prefer_naff_falls_back_on_runtime_error(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """``prefer="naff"`` 但 NAFF 调用失败时也降级到 FFT。"""
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("simulated NAFF crash")
+
+    monkeypatch.setattr(
+        "e2m2e.algorithms.normal_form.fft._resolve_naff_binary",
+        lambda: "/bin/true",
+    )
+    monkeypatch.setattr(
+        "e2m2e.algorithms.normal_form.fft.naff_available",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "e2m2e.algorithms.normal_form.fft.detect_naff",
+        _boom,
+    )
+
+    omega = 1.7
+    t, y = _make_single_tone(omega, 0.4, 0.6)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        comps, backend = extract_frequencies(t, y, n_components=5)
+
+    assert backend == "fft"
+    assert any("NAFF" in str(w.message) for w in caught)
+
+
+def test_extract_frequencies_prefer_fft_skips_naff():
+    """``prefer="fft"`` 时即使 NAFF 可用也走 FFT。"""
+    omega = 1.7
+    t, y = _make_single_tone(omega, 0.4, 0.6)
+    comps, backend = extract_frequencies(t, y, n_components=3, prefer="fft")
+    assert backend == "fft"
+
+
+def test_extract_frequencies_rejects_bad_prefer():
+    """``prefer`` 取值非法时抛 :class:`ValueError`。"""
+    t, y = _make_single_tone(1.0, 0.0, 1.0)
+    with pytest.raises(ValueError, match="prefer"):
+        extract_frequencies(t, y, prefer="nonsense")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# FFT 提取
+# ---------------------------------------------------------------------------
+
+
+def test_fft_extract_recovers_single_tone_frequency():
+    """合成单频信号的 FFT 提取应给出与真值接近的频率。"""
+    omega = 1.7
+    t, y = _make_single_tone(omega, 0.4, 0.6, n=512, t_end=64.0)
+    comps = fft_extract(t, y, n_components=5)
+    # 直流分量排第一，剩下按振幅降序——主峰应非常接近真频率
+    non_dc = [c for c in comps if abs(c.freq) > 1e-6]
+    assert non_dc, "至少应有一个非零频率分量"
+    top_amp, top_freq = max((c.amp, c.freq) for c in non_dc)
+    # Hanning 窗 + 二次谱插值：典型精度 ~0.5% 频率分辨率
+    assert top_freq == pytest.approx(omega, rel=5e-3)
+
+
+def test_fft_extract_handles_short_series():
+    """极短序列（< 4 点）应安全返回。"""
+    t = np.array([0.0, 1.0])
+    y = np.array([0.5, -0.5])
+    assert fft_extract(t, y) == []
+    t = np.array([0.0, 1.0, 2.0])
+    y = np.array([1.0, 0.0, -1.0])
+    comps = fft_extract(t, y, n_components=2)
+    assert all(isinstance(c, FFTComponent) for c in comps)
+
+
+def test_fft_extract_rejects_shape_mismatch():
+    """``times`` 与 ``data`` 形状不一致时抛 :class:`ValueError`。"""
+    t = np.linspace(0.0, 1.0, 10)
+    y = np.zeros(11)
+    with pytest.raises(ValueError, match="形状"):
+        fft_extract(t, y)
+
+
+def test_fft_extract_rejects_non_monotonic_time():
+    """时间序列非单调递增时抛 :class:`ValueError`。"""
+    t = np.array([0.0, 0.5, 0.4, 0.9])
+    y = np.zeros(4)
+    with pytest.raises(ValueError, match="单调递增"):
+        fft_extract(t, y)
+
+
+# ---------------------------------------------------------------------------
+# 最小二乘 sin/cos 拟合
+# ---------------------------------------------------------------------------
+
+
+def test_least_squares_fit_recovers_amp_split():
+    """对已知 ``s, c`` 的信号，最小二乘应复原 ``amp_s, amp_c``。"""
+    omega = 2.4
+    amp_s, amp_c = 0.31, -0.47
+    t, y = _make_single_tone(omega, amp_s, amp_c, n=512, t_end=64.0)
+
+    comps = least_squares_sin_cos_fit(t, y, [omega])
+    assert len(comps) == 1
+    c = comps[0]
+    assert c.freq == pytest.approx(omega, abs=1e-12)
+    assert c.amp_s == pytest.approx(amp_s, abs=1e-2)
+    assert c.amp_c == pytest.approx(amp_c, abs=1e-2)
+
+
+def test_least_squares_fit_includes_dc_component():
+    """频率集合含 0 时应给出直流分量。"""
+    t = np.linspace(0.0, 4.0, 64)
+    y = np.full_like(t, 1.23)
+    comps = least_squares_sin_cos_fit(t, y, [0.0])
+    assert comps[0].freq == 0.0
+    assert comps[0].amp_c == pytest.approx(1.23, abs=1e-12)
+
+
+def test_least_squares_fit_rejects_shape_mismatch():
+    """形状不一致时抛 :class:`ValueError`。"""
+    t = np.zeros(8)
+    y = np.zeros(7)
+    with pytest.raises(ValueError, match="形状"):
+        least_squares_sin_cos_fit(t, y, [1.0])
+
+
+# ---------------------------------------------------------------------------
+# 信号重构
+# ---------------------------------------------------------------------------
+
+
+def test_reconstruct_signal_recovers_synthetic_combo():
+    """``reconstruct_signal`` 应回放 ``Σ s·sin + c·cos``。"""
+    omega1, omega2 = 1.1, 2.3
+    t = np.linspace(0.0, 6.0, 200)
+
+    components = [
+        FFTComponent(freq=omega1, amp_s=0.3, amp_c=0.4),
+        FFTComponent(freq=omega2, amp_s=-0.2, amp_c=0.5),
+    ]
+
+    expected = (
+        0.3 * np.sin(omega1 * t)
+        + 0.4 * np.cos(omega1 * t)
+        + (-0.2) * np.sin(omega2 * t)
+        + 0.5 * np.cos(omega2 * t)
+    )
+    np.testing.assert_allclose(reconstruct_signal(t, components), expected, atol=1e-12)
+
+
+def test_reconstruct_signal_empty_returns_zero():
+    """空频域分量应返回零数组。"""
+    t = np.array([0.0, 1.0, 2.0])
+    out = reconstruct_signal(t, [])
+    np.testing.assert_array_equal(out, np.zeros_like(t))
+
+
+def test_reconstruct_derivative_matches_analytical():
+    """``reconstruct_derivative`` 应解析地对信号求导。"""
+    omega = 1.5
+    t = np.linspace(0.0, 4.0, 100)
+    components = [
+        FFTComponent(freq=omega, amp_s=0.3, amp_c=0.4),
+    ]
+    expected = -0.3 * omega * np.sin(omega * t) - 0.4 * omega * np.sin(omega * t) * 0.0 + (
+        0.3 * omega * np.cos(omega * t) - 0.4 * omega * np.sin(omega * t)
+    )
+    # 重写 expected = s·ω·cos − c·ω·sin
+    s, c = 0.3, 0.4
+    expected = s * omega * np.cos(omega * t) - c * omega * np.sin(omega * t)
+    np.testing.assert_allclose(
+        reconstruct_derivative(t, components), expected, atol=1e-12
+    )
+
+
+# ---------------------------------------------------------------------------
+# 频率匹配
+# ---------------------------------------------------------------------------
+
+
+def test_fft_extract_detects_suppressed_center_manifold_frequency():
+    """验收标准 #3 的检测逻辑：强受迫频率 + 弱中心流形频率时，
+    FFT 能定位到中心流形频率且其幅值远低于受迫主峰。
+
+    合成信号 ``cos(ω_forced·t) + ε·cos(ω_cm·t)``，其中 ``ω_cm`` 取
+    L1 中心流形频率 ν₁≈2.3377，受迫分量幅值是中心流形的 100 倍。
+    FFT 提取后，离 ν₁ 最近的分量幅值应低于主峰的 5%（即中心流形
+    频率被压制）。该测试覆盖"幅值低于阈值"的判定逻辑本身；端到端
+    的动力学替代轨道 FFT 检查（依赖 SPICE + 完整窗口）见
+    ``test_dynamical_substitution``。
+    """
+    omega_forced = 0.9  # 受迫基频量级
+    omega_cm = 2.33774371420711  # L1 中心流形频率 ν₁
+    amp_forced, amp_cm = 1.0, 0.01  # 中心流形被压制 100 倍
+
+    t = np.linspace(0.0, 200.0, 4000, endpoint=False)
+    y = amp_forced * np.cos(omega_forced * t) + amp_cm * np.cos(omega_cm * t)
+
+    comps = fft_extract(t, y, n_components=8)
+    non_dc = [c for c in comps if abs(c.freq) > 1e-6]
+    assert non_dc
+
+    max_amp = max(c.amp for c in non_dc)
+    nearest_cm = min(non_dc, key=lambda c: abs(c.freq - omega_cm))
+    # 检测到的中心流形频率应接近真值
+    assert nearest_cm.freq == pytest.approx(omega_cm, abs=0.05)
+    # 其幅值应远低于受迫主峰（中心流形被压制）
+    assert nearest_cm.amp < 0.05 * max_amp
+
+
+def test_frequency_match_assigns_nearest_basis():
+    """``frequency_match`` 把检测频率匹配到基频表最近邻。"""
+    basis_freqs = np.array([0.991548, 0.074801, 0.925199, 1.004022])
+    basis_coefs = np.array(
+        [[1, 0, 0, 0, 0, 0], [0, 1, 0, 0, 0, 0], [0, 0, 1, 0, 0, 0], [0, 0, 0, 1, 0, 0]],
+        dtype=int,
+    )
+    components = [
+        FFTComponent(freq=0.99, amp_s=0.1, amp_c=0.0, amp=0.1),
+        FFTComponent(freq=0.075, amp_s=0.0, amp_c=0.2, amp=0.2),
+        FFTComponent(freq=0.0, amp_s=0.0, amp_c=0.05, amp=0.05),
+    ]
+    matched = frequency_match(components, basis_freqs, basis_coefs)
+    matched_non_dc = [c for c in matched if c.match_freq != 0.0]
+    # 两个非零分量应分别匹配到 0.991548 与 0.074801
+    matched_freqs = {round(c.match_freq, 6) for c in matched_non_dc}
+    assert 0.991548 in matched_freqs
+    assert 0.074801 in matched_freqs
+
+
+def test_frequency_match_rejects_empty_basis():
+    """空基频表必须抛 :class:`ValueError`。"""
+    components = [FFTComponent(freq=1.0, amp=1.0)]
+    with pytest.raises(ValueError, match="basis_freqs"):
+        frequency_match(components, [])
+
+
+def test_frequency_match_handles_dc_only():
+    """仅含直流分量时也返回占位匹配项。"""
+    components = [FFTComponent(freq=0.0, amp_s=0.0, amp_c=1.0, amp=1.0)]
+    matched = frequency_match(components, [0.0], np.zeros((1, 6), dtype=int))
+    assert matched[0].match_freq == 0.0
+    assert matched[0].coef == (0, 0, 0, 0, 0, 0)
+
+
+def test_frequency_match_rejects_coef_row_mismatch():
+    """``basis_coefs`` 行数与 ``basis_freqs`` 不一致时报错。"""
+    components = [FFTComponent(freq=1.0, amp=1.0)]
+    with pytest.raises(ValueError, match="basis_coefs"):
+        frequency_match(components, [1.0, 2.0], np.zeros((1, 6), dtype=int))

--- a/tests/algorithms/normal_form/test_fft.py
+++ b/tests/algorithms/normal_form/test_fft.py
@@ -246,15 +246,15 @@ def test_reconstruct_derivative_matches_analytical():
     components = [
         FFTComponent(freq=omega, amp_s=0.3, amp_c=0.4),
     ]
-    expected = -0.3 * omega * np.sin(omega * t) - 0.4 * omega * np.sin(omega * t) * 0.0 + (
-        0.3 * omega * np.cos(omega * t) - 0.4 * omega * np.sin(omega * t)
+    expected = (
+        -0.3 * omega * np.sin(omega * t)
+        - 0.4 * omega * np.sin(omega * t) * 0.0
+        + (0.3 * omega * np.cos(omega * t) - 0.4 * omega * np.sin(omega * t))
     )
     # 重写 expected = s·ω·cos − c·ω·sin
     s, c = 0.3, 0.4
     expected = s * omega * np.cos(omega * t) - c * omega * np.sin(omega * t)
-    np.testing.assert_allclose(
-        reconstruct_derivative(t, components), expected, atol=1e-12
-    )
+    np.testing.assert_allclose(reconstruct_derivative(t, components), expected, atol=1e-12)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/algorithms/normal_form/test_hamiltonian.py
+++ b/tests/algorithms/normal_form/test_hamiltonian.py
@@ -1,0 +1,324 @@
+"""``normal_form.hamiltonian`` 测试。"""
+
+from __future__ import annotations
+
+import os
+import time
+
+import numpy as np
+import pytest
+
+from e2m2e.algorithms.normal_form import NormalFormContext
+from e2m2e.algorithms.normal_form.constants import JD0_J2000
+from e2m2e.algorithms.normal_form.hamiltonian import (
+    DYNAMIC_PARAM_NAMES,
+    Hamiltonian,
+    build_hamiltonian,
+    evaluate_hamiltonian,
+    hamiltonian_constant_term,
+)
+from e2m2e.algorithms.normal_form.legendre import expand_legendre_1_over_r
+from e2m2e.core import LibrationPoint
+
+# ---------------------------------------------------------------------------
+# 公共 fixture：可复用的上下文与 Legendre 展开
+# ---------------------------------------------------------------------------
+
+_QIAO_FIXTURE_L1 = os.path.join(
+    "/home/ouyangjiahong/codes/qiao",
+    "Results/Result_HamiltonFunc/1_Ephemeris_Model/L1_EM_Hamilton.mat",
+)
+
+
+@pytest.fixture
+def l1_context(earth_moon_system) -> NormalFormContext:
+    """L1 共线点 :class:`NormalFormContext`（不含 SPICE 依赖）。"""
+    return NormalFormContext(
+        system=earth_moon_system,
+        libration_point=LibrationPoint.L1,
+        epoch=JD0_J2000,
+        order=4,
+    )
+
+
+@pytest.fixture
+def l1_legendre():
+    """L1 共线点 4 阶 Legendre 展开——评估时间 < 1 s。"""
+    return expand_legendre_1_over_r(4)
+
+
+@pytest.fixture
+def l1_hamiltonian(l1_context, l1_legendre) -> Hamiltonian:
+    """符号 Hamilton 量（仅 sympy 系数，未数值化）。"""
+    return build_hamiltonian(l1_context, l1_legendre, max_degree=4)
+
+
+# ---------------------------------------------------------------------------
+# SPICE 与 qiao fixture 可用性检测
+# ---------------------------------------------------------------------------
+
+_SPICE_KERNEL_DIR = os.environ.get(
+    "SPICE_KERNEL_DIR",
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "..", "kernels"),
+)
+
+
+def _has_spice_kernels() -> bool:
+    """检查 SPICE ``.tls`` + ``.bsp`` 都可用。"""
+    if not os.path.isdir(_SPICE_KERNEL_DIR):
+        return False
+    has_tls = any(f.endswith(".tls") for f in os.listdir(_SPICE_KERNEL_DIR))
+    has_bsp = any(f.endswith(".bsp") for f in os.listdir(_SPICE_KERNEL_DIR))
+    return has_tls and has_bsp
+
+
+_has_spice = _has_spice_kernels()
+_has_qiao_fixture = os.path.exists(_QIAO_FIXTURE_L1)
+
+requires_spice = pytest.mark.skipif(
+    not _has_spice,
+    reason="SPICE kernels (.tls + .bsp) not available",
+)
+
+requires_qiao = pytest.mark.skipif(
+    not (_has_spice and _has_qiao_fixture),
+    reason="SPICE kernels or qiao L1_EM_Hamilton.mat not available",
+)
+
+
+@pytest.fixture
+def spice_loaded():
+    """加载 leapseconds + 任一可用 SPK；不可用时跳过。"""
+    if not _has_spice:
+        pytest.skip("SPICE kernels not available")
+    import spiceypy as spice
+
+    for fname in ("naif0012.tls", "naif0011.tls"):
+        path = os.path.join(_SPICE_KERNEL_DIR, fname)
+        if os.path.exists(path):
+            spice.furnsh(path)
+    for fname in ("de440.bsp", "de440s.bsp", "de438.bsp", "de435.bsp", "de430.bsp"):
+        path = os.path.join(_SPICE_KERNEL_DIR, fname)
+        if os.path.exists(path):
+            spice.furnsh(path)
+            return path
+    pytest.skip("No SPICE ephemeris kernel (.bsp) found")
+
+
+# ---------------------------------------------------------------------------
+# 构造烟测（纯符号，不需 SPICE）
+# ---------------------------------------------------------------------------
+
+
+def test_build_hamiltonian_returns_dataclass(l1_context, l1_legendre):
+    """``build_hamiltonian`` 必须返回 :class:`Hamiltonian`。"""
+    h = build_hamiltonian(l1_context, l1_legendre, max_degree=4)
+    assert isinstance(h, Hamiltonian)
+    assert isinstance(h.coefficients, dict)
+    assert h.n_terms > 0
+    assert h.max_degree == 4
+    assert not h.is_evaluated
+
+
+def test_build_hamiltonian_powers_match_coefficients(l1_hamiltonian):
+    """幂次向量数组与系数 dict 一一对应。"""
+    assert l1_hamiltonian.n_terms == len(l1_hamiltonian.coefficients)
+    keys_in_dict = set(l1_hamiltonian.coefficients.keys())
+    keys_in_array = {
+        tuple(int(p) for p in row) for row in l1_hamiltonian.powers
+    }
+    assert keys_in_dict == keys_in_array
+
+
+def test_build_hamiltonian_max_degree_filters_terms(l1_context, l1_legendre):
+    """阶数截断必须生效。"""
+    h = build_hamiltonian(l1_context, l1_legendre, max_degree=2)
+    for pow_tuple in h.coefficients:
+        assert sum(int(p) for p in pow_tuple) <= 2
+
+
+def test_build_hamiltonian_rejects_invalid_max_degree(l1_context, l1_legendre):
+    """``max_degree < 1`` 报 :class:`ValueError`。"""
+    with pytest.raises(ValueError, match="max_degree"):
+        build_hamiltonian(l1_context, l1_legendre, max_degree=0)
+
+
+def test_build_hamiltonian_sources_are_recorded(l1_hamiltonian):
+    """``store_sources=True`` 时输出含 6 块组成的诊断 dict。"""
+    sources = l1_hamiltonian.sources
+    expected_keys = {
+        "force", "kinetic", "coriolis", "centrifugal",
+        "pot_earth", "pot_moon", "pot_sun",
+    }
+    assert expected_keys.issubset(set(sources.keys()))
+
+
+def test_hamiltonian_contains_kinetic_diagonal_terms(l1_hamiltonian):
+    """动能 ½‖p‖² 对角项必为 ½。"""
+    diag = (
+        l1_hamiltonian.coefficients[(0, 0, 0, 2, 0, 0)],
+        l1_hamiltonian.coefficients[(0, 0, 0, 0, 2, 0)],
+        l1_hamiltonian.coefficients[(0, 0, 0, 0, 0, 2)],
+    )
+    for c in diag:
+        assert c == pytest.approx(0.5, abs=1e-12)
+
+
+def test_dynamic_param_names_cover_eval_params_keys():
+    """动态参数名集合至少包含 Eval_expr 主要项。"""
+    needed = {
+        "Cpq1", "Cpq5", "Cqq5",
+        "f1", "f2", "f3",
+        "rex", "rey", "rez", "re0",
+        "rmx", "rmy", "rmz", "rm0",
+        "rsx", "rsy", "rsz", "rs0",
+        "mu_e", "mu_m", "mu_s",
+    }
+    assert needed.issubset(set(DYNAMIC_PARAM_NAMES))
+
+
+# ---------------------------------------------------------------------------
+# 数值化与已知值（需要 SPICE 内核）
+# ---------------------------------------------------------------------------
+
+
+@requires_spice
+def test_evaluate_hamiltonian_runs(spice_loaded, l1_hamiltonian, l1_context):
+    """对一组时刻求值 Hamilton 量，运行无异常。"""
+    times = np.linspace(0.0, 5.0, 6)
+    evaled = evaluate_hamiltonian(l1_hamiltonian, times, l1_context)
+    assert evaled.is_evaluated
+    assert isinstance(evaled.coefficients, np.ndarray)
+    assert evaled.coefficients.shape == (len(times), evaled.n_terms)
+    # 常数项应在 J2000 附近 ≈ -862.5
+    target = (0, 0, 0, 0, 0, 0)
+    for j in range(evaled.n_terms):
+        if tuple(int(p) for p in evaled.powers[j]) == target:
+            assert evaled.coefficients[0, j] == pytest.approx(-862.5, abs=0.5)
+            break
+    else:
+        pytest.fail("常数项 (0,0,0,0,0,0) 不在 evaled.powers 中")
+
+
+@requires_spice
+def test_hamiltonian_constant_term_matches_qiao_value(
+    spice_loaded, l1_hamiltonian, l1_context
+):
+    """L1 Hamilton 常数项与 qiao ``L1_EM_Hamilton.mat`` 在 t=0 一致。"""
+    times = np.array([0.0])
+    h0 = hamiltonian_constant_term(l1_hamiltonian, times, l1_context)
+    assert h0[0] == pytest.approx(-862.50648692, abs=1e-6)
+
+
+@requires_qiao
+def test_evaluate_hamiltonian_against_qiao_fixture(
+    spice_loaded, l1_context, l1_legendre
+):
+    """与 qiao ``L1_EM_Hamilton.mat`` 在 t=0 处逐项比对。
+
+    qiao fixture 在 N=15 上有 687 项；本测试只用 order=4，因此 qiao 中
+    高阶项不在我们这边。匹配率衡量我们 order=4 内能重现的那部分。
+    """
+    import scipy.io as sio
+
+    qiao_data = sio.loadmat(_QIAO_FIXTURE_L1, squeeze_me=False)
+    qiao_h_poly = qiao_data["H_poly"]
+
+    qiao_lookup: dict[tuple[int, ...], float] = {}
+    for i in range(qiao_h_poly.shape[0]):
+        pv = qiao_h_poly[i, 0].ravel().astype(int)
+        col = qiao_h_poly[i, 1].ravel()
+        qiao_lookup[tuple(int(x) for x in pv)] = float(col[0])
+
+    h = build_hamiltonian(l1_context, l1_legendre, max_degree=4)
+    times = np.array([0.0])
+    evaled = evaluate_hamiltonian(h, times, l1_context)
+    arr = evaled.coefficients
+    our_lookup = {
+        tuple(int(x) for x in evaled.powers[j]): float(arr[0, j])
+        for j in range(evaled.n_terms)
+    }
+
+    n_match = 0
+    n_total = 0
+    for k, v in qiao_lookup.items():
+        ours = our_lookup.get(k)
+        if ours is None:
+            continue
+        n_total += 1
+        if abs(v) < 1e-12 and abs(ours) < 1e-12:
+            n_match += 1
+            continue
+        tol = max(1e-7, abs(v) * 1e-6)
+        if abs(ours - v) < tol:
+            n_match += 1
+
+    # order=4 至少匹配 30 项；qiao N=15 多出来的 600+ 项不在我们这边
+    assert n_total >= 30, f"我们的项数太少：{n_total}（qiao={len(qiao_lookup)}）"
+    assert n_match >= n_total - 5, f"匹配数 {n_match}/{n_total}"
+
+
+@requires_spice
+def test_evaluate_hamiltonian_time_series_bounded(
+    spice_loaded, l1_hamiltonian, l1_context
+):
+    """时间序列的常数项 H_0(t) 在 [0, 10] TU 内单调有界（不应发散）。"""
+    times = np.linspace(0.0, 10.0, 11)
+    h0 = hamiltonian_constant_term(l1_hamiltonian, times, l1_context)
+    assert h0.min() > -1100.0
+    assert h0.max() < -700.0
+    assert h0.std() < 50.0
+
+
+@requires_spice
+def test_build_evaluate_l1_order4_within_timeout(spice_loaded, l1_context):
+    """构造 + 一次 evaluate 不应超过 30 s（SPICE 内核已加载）。"""
+    leg = expand_legendre_1_over_r(4)
+    t0 = time.time()
+    h = build_hamiltonian(l1_context, leg, max_degree=4)
+    _ = evaluate_hamiltonian(h, np.linspace(0.0, 5.0, 5), l1_context)
+    elapsed = time.time() - t0
+    assert elapsed < 30.0, f"耗时 {elapsed:.1f} s 过长"
+
+
+# ---------------------------------------------------------------------------
+# 不需要 SPICE 的解析/接口测试
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_hamiltonian_over_invalid_times_fails(l1_hamiltonian):
+    """非一维 ``times`` 必须报 :class:`ValueError`。"""
+    bad_times = np.zeros((3, 3))
+    with pytest.raises(ValueError, match="times"):
+        evaluate_hamiltonian(l1_hamiltonian, bad_times, None)  # type: ignore[arg-type]
+
+
+def test_polylist_simplify_zero_epsilon_drops_only_zero_columns():
+    """``polylist_simplify`` 在 ``eps=0`` 仍保留所有非零列。"""
+    from e2m2e.algorithms.normal_form.polynomial import polylist_simplify
+
+    powers = {
+        (0, 0, 0, 0, 0, 0): np.array([1.0]),
+        (0, 1, 0, 0, 0, 0): np.array([0.0]),
+        (1, 0, 0, 0, 0, 0): np.array([2.0]),
+    }
+    simplified = polylist_simplify(powers, eps=0.0)
+    assert set(simplified.keys()) == {
+        (0, 0, 0, 0, 0, 0),
+        (1, 0, 0, 0, 0, 0),
+    }
+
+
+def test_evaluate_hamiltonian_requires_sympy_coefficients():
+    """无 sympy 系数的 :class:`Hamiltonian` 报 :class:`ValueError`。"""
+    from e2m2e.algorithms.normal_form.hamiltonian import Hamiltonian
+
+    powers = np.zeros((1, 6), dtype=np.int64)
+    h = Hamiltonian(
+        powers=powers,
+        coefficients=None,
+        sources={},
+        max_degree=1,
+    )
+    with pytest.raises(ValueError, match="sympy"):
+        evaluate_hamiltonian(h, np.array([0.0]), None)  # type: ignore[arg-type]

--- a/tests/algorithms/normal_form/test_hamiltonian.py
+++ b/tests/algorithms/normal_form/test_hamiltonian.py
@@ -124,9 +124,7 @@ def test_build_hamiltonian_powers_match_coefficients(l1_hamiltonian):
     """幂次向量数组与系数 dict 一一对应。"""
     assert l1_hamiltonian.n_terms == len(l1_hamiltonian.coefficients)
     keys_in_dict = set(l1_hamiltonian.coefficients.keys())
-    keys_in_array = {
-        tuple(int(p) for p in row) for row in l1_hamiltonian.powers
-    }
+    keys_in_array = {tuple(int(p) for p in row) for row in l1_hamiltonian.powers}
     assert keys_in_dict == keys_in_array
 
 
@@ -147,8 +145,13 @@ def test_build_hamiltonian_sources_are_recorded(l1_hamiltonian):
     """``store_sources=True`` 时输出含 6 块组成的诊断 dict。"""
     sources = l1_hamiltonian.sources
     expected_keys = {
-        "force", "kinetic", "coriolis", "centrifugal",
-        "pot_earth", "pot_moon", "pot_sun",
+        "force",
+        "kinetic",
+        "coriolis",
+        "centrifugal",
+        "pot_earth",
+        "pot_moon",
+        "pot_sun",
     }
     assert expected_keys.issubset(set(sources.keys()))
 
@@ -167,12 +170,27 @@ def test_hamiltonian_contains_kinetic_diagonal_terms(l1_hamiltonian):
 def test_dynamic_param_names_cover_eval_params_keys():
     """动态参数名集合至少包含 Eval_expr 主要项。"""
     needed = {
-        "Cpq1", "Cpq5", "Cqq5",
-        "f1", "f2", "f3",
-        "rex", "rey", "rez", "re0",
-        "rmx", "rmy", "rmz", "rm0",
-        "rsx", "rsy", "rsz", "rs0",
-        "mu_e", "mu_m", "mu_s",
+        "Cpq1",
+        "Cpq5",
+        "Cqq5",
+        "f1",
+        "f2",
+        "f3",
+        "rex",
+        "rey",
+        "rez",
+        "re0",
+        "rmx",
+        "rmy",
+        "rmz",
+        "rm0",
+        "rsx",
+        "rsy",
+        "rsz",
+        "rs0",
+        "mu_e",
+        "mu_m",
+        "mu_s",
     }
     assert needed.issubset(set(DYNAMIC_PARAM_NAMES))
 
@@ -201,9 +219,7 @@ def test_evaluate_hamiltonian_runs(spice_loaded, l1_hamiltonian, l1_context):
 
 
 @requires_spice
-def test_hamiltonian_constant_term_matches_qiao_value(
-    spice_loaded, l1_hamiltonian, l1_context
-):
+def test_hamiltonian_constant_term_matches_qiao_value(spice_loaded, l1_hamiltonian, l1_context):
     """L1 Hamilton 常数项与 qiao ``L1_EM_Hamilton.mat`` 在 t=0 一致。"""
     times = np.array([0.0])
     h0 = hamiltonian_constant_term(l1_hamiltonian, times, l1_context)
@@ -211,9 +227,7 @@ def test_hamiltonian_constant_term_matches_qiao_value(
 
 
 @requires_qiao
-def test_evaluate_hamiltonian_against_qiao_fixture(
-    spice_loaded, l1_context, l1_legendre
-):
+def test_evaluate_hamiltonian_against_qiao_fixture(spice_loaded, l1_context, l1_legendre):
     """与 qiao ``L1_EM_Hamilton.mat`` 在 t=0 处逐项比对。
 
     qiao fixture 在 N=15 上有 687 项；本测试只用 order=4，因此 qiao 中
@@ -235,8 +249,7 @@ def test_evaluate_hamiltonian_against_qiao_fixture(
     evaled = evaluate_hamiltonian(h, times, l1_context)
     arr = evaled.coefficients
     our_lookup = {
-        tuple(int(x) for x in evaled.powers[j]): float(arr[0, j])
-        for j in range(evaled.n_terms)
+        tuple(int(x) for x in evaled.powers[j]): float(arr[0, j]) for j in range(evaled.n_terms)
     }
 
     n_match = 0
@@ -259,9 +272,7 @@ def test_evaluate_hamiltonian_against_qiao_fixture(
 
 
 @requires_spice
-def test_evaluate_hamiltonian_time_series_bounded(
-    spice_loaded, l1_hamiltonian, l1_context
-):
+def test_evaluate_hamiltonian_time_series_bounded(spice_loaded, l1_hamiltonian, l1_context):
     """时间序列的常数项 H_0(t) 在 [0, 10] TU 内单调有界（不应发散）。"""
     times = np.linspace(0.0, 10.0, 11)
     h0 = hamiltonian_constant_term(l1_hamiltonian, times, l1_context)

--- a/tests/algorithms/normal_form/test_hamiltonian.py
+++ b/tests/algorithms/normal_form/test_hamiltonian.py
@@ -8,6 +8,9 @@ import time
 import numpy as np
 import pytest
 
+# sympy 是 normal-form optional dep；未安装时整个文件 skip（不 error）。
+pytest.importorskip("sympy")
+
 from e2m2e.algorithms.normal_form import NormalFormContext
 from e2m2e.algorithms.normal_form.constants import JD0_J2000
 from e2m2e.algorithms.normal_form.hamiltonian import (

--- a/tests/algorithms/normal_form/test_legendre.py
+++ b/tests/algorithms/normal_form/test_legendre.py
@@ -6,6 +6,9 @@ import math
 
 import pytest
 
+# sympy 是 normal-form optional dep；未安装时整个文件 skip（不 error）。
+pytest.importorskip("sympy")
+
 from e2m2e.algorithms.normal_form.legendre import (
     DEFAULT_COLLINEAR_ORDER,
     DEFAULT_TRIANGULAR_ORDER,

--- a/tests/algorithms/normal_form/test_legendre.py
+++ b/tests/algorithms/normal_form/test_legendre.py
@@ -1,0 +1,161 @@
+"""``normal_form.legendre`` 测试。"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from e2m2e.algorithms.normal_form.legendre import (
+    DEFAULT_COLLINEAR_ORDER,
+    DEFAULT_TRIANGULAR_ORDER,
+    LegendreExpansionResult,
+    expand_legendre_1_over_r,
+    expand_legendre_for_body,
+)
+
+# ---------------------------------------------------------------------------
+# 基本烟测
+# ---------------------------------------------------------------------------
+
+
+def test_expand_legendre_returns_dataclass_with_required_fields():
+    """结果类型为 :class:`LegendreExpansionResult`，含必要字段。"""
+    res = expand_legendre_1_over_r(3)
+    assert isinstance(res, LegendreExpansionResult)
+    assert res.max_degree == 3
+    assert res.term_count > 0
+    assert isinstance(res.polynomial, dict)
+    assert res.max_degree == 3
+
+
+def test_expand_legendre_rejects_invalid_order():
+    """``max_degree < 1`` 报 :class:`ValueError`。"""
+    with pytest.raises(ValueError, match="max_degree"):
+        expand_legendre_1_over_r(0)
+    with pytest.raises(ValueError, match="max_degree"):
+        expand_legendre_1_over_r(-2)
+
+
+def test_expand_legendre_order_1_is_simple():
+    """一阶展开只有线性 q 项 + 1/r0 常数项。"""
+    res = expand_legendre_1_over_r(1)
+    # 一阶 Legendre 中 6 元 dict 仅出现 (0,0,0,0,0,0)、(1,0,0,...)、(0,1,0,...)、(0,0,1,...)
+    keys = set(res.polynomial.keys())
+    assert (0, 0, 0, 0, 0, 0) in keys
+    assert len(keys) >= 4
+
+
+def test_expand_legendre_term_count_grows_monotonically():
+    """更高阶展开会引入更多项（物理直觉：每个角度余弦多贡献一份齐次多项式）。"""
+    n1 = expand_legendre_1_over_r(3).term_count
+    n2 = expand_legendre_1_over_r(4).term_count
+    n3 = expand_legendre_1_over_r(5).term_count
+    assert n1 < n2 < n3
+
+
+def test_default_orders_have_recommended_values():
+    """默认阶数与 qiao/Legendre 切片约定一致。"""
+    assert DEFAULT_COLLINEAR_ORDER == 10
+    assert DEFAULT_TRIANGULAR_ORDER == 8
+
+
+# ---------------------------------------------------------------------------
+# 符号正确性
+# ---------------------------------------------------------------------------
+
+
+def test_expand_legendre_does_not_depend_on_p():
+    """1/r 是标量场；``p1, p2, p3`` 系数恒为 0。"""
+    res = expand_legendre_1_over_r(4)
+    for pow_tuple, coef in res.polynomial.items():
+        p_exponents = pow_tuple[3:]
+        if any(p > 0 for p in p_exponents):
+            assert coef == 0, (
+                f"1/r 标量场不应含 p 依赖；幂次 {pow_tuple} 系数 = {coef}"
+            )
+
+
+def test_expand_legendre_constant_term_is_inverse_r0():
+    """常数项应为 ``1/r0``（无量纲距离 ``r0 = |r|`` 的 L₀ 项）。"""
+    import sympy as sp
+
+    res = expand_legendre_1_over_r(3)
+    const_coef = res.polynomial[(0, 0, 0, 0, 0, 0)]
+    # 把所有其他符号替换为 1 后，常数项应该 = 1 (即 sum(1/r0 = 1/1 = 1))
+    sub_map = {}
+    for s in const_coef.free_symbols:
+        sub_map[s] = sp.Integer(1)
+    value = float(const_coef.subs(sub_map))
+    assert value == pytest.approx(1.0, abs=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# 数值正确性
+# ---------------------------------------------------------------------------
+
+
+def _build_subs(coef, rx, ry, rz, r0_val) -> dict:
+    """按 :func:`sympy` 表达式的 ``free_symbols`` 名字构造替换表。"""
+
+    vals = {"rx": rx, "ry": ry, "rz": rz, "r0": r0_val}
+    sub: dict[object, float] = {}
+    for s in coef.free_symbols:
+        name = getattr(s, "name", None)
+        if name in vals:
+            sub[s] = float(vals[name])
+    return sub
+
+
+@pytest.mark.parametrize("max_degree", [3, 4])
+def test_legendre_reproduces_1_over_r_numerically(max_degree):
+    """对一系列参考点，多项式重建必须逼近闭式 ``1/|r − q|``。
+
+    q 在 L1 附近的 ``~0.05 LU`` 量级小偏移下，3 阶 Legendre 截断即可
+    提供 ``|recon − exact| < 1e-4`` 的精度；4 阶进一步收敛。
+    """
+    res = expand_legendre_1_over_r(max_degree)
+    rx, ry, rz = 1.0, 0.0, 0.0
+    r0_val = math.sqrt(rx * rx + ry * ry + rz * rz)
+
+    test_qs = [
+        (0.05, 0.03, 0.02),
+        (-0.04, 0.02, -0.01),
+        (0.01, 0.0, 0.0),
+    ]
+    tolerance = 1e-4 if max_degree == 3 else 1e-5
+    for q1, q2, q3 in test_qs:
+        exact = 1.0 / math.sqrt(
+            (rx - q1) ** 2 + (ry - q2) ** 2 + (rz - q3) ** 2
+        )
+        recon = 0.0
+        for pow_tuple, coef in res.polynomial.items():
+            n1, n2, n3 = pow_tuple[:3]
+            sub = _build_subs(coef, rx, ry, rz, r0_val)
+            recon += float(coef.subs(sub)) * (q1**n1) * (q2**n2) * (q3**n3)
+        assert recon == pytest.approx(exact, abs=tolerance), (
+            f"order={max_degree} q=({q1},{q2},{q3}) exact={exact} recon={recon}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# expand_legendre_for_body
+# ---------------------------------------------------------------------------
+
+
+def test_expand_legendre_for_body_negates_and_scales_coefficients():
+    """``expand_legendre_for_body`` 把每个系数乘 ``-mu``，但不改幂次。"""
+    res = expand_legendre_1_over_r(3)
+    mu = 0.012
+    body = expand_legendre_for_body(res, mu=mu)
+    assert set(body.keys()) == set(res.polynomial.keys())
+    for pow_tuple in res.polynomial:
+        if res.polynomial[pow_tuple] == 0:
+            continue
+        # 注意：Legendre 系数可能仍有 (rx, ry, rz, r0) 自由符号；
+        # 此处对比两个 dict 在同一符号替换下的差值。
+        sample = res.polynomial[pow_tuple]
+        subs = _build_subs(sample, 1.0, 0.0, 0.0, 1.0)
+        original_val = float(sample.subs(subs))
+        body_val = float(body[pow_tuple].subs(subs))
+        assert body_val == pytest.approx(-mu * original_val, abs=1e-12)

--- a/tests/algorithms/normal_form/test_legendre.py
+++ b/tests/algorithms/normal_form/test_legendre.py
@@ -71,9 +71,7 @@ def test_expand_legendre_does_not_depend_on_p():
     for pow_tuple, coef in res.polynomial.items():
         p_exponents = pow_tuple[3:]
         if any(p > 0 for p in p_exponents):
-            assert coef == 0, (
-                f"1/r 标量场不应含 p 依赖；幂次 {pow_tuple} 系数 = {coef}"
-            )
+            assert coef == 0, f"1/r 标量场不应含 p 依赖；幂次 {pow_tuple} 系数 = {coef}"
 
 
 def test_expand_legendre_constant_term_is_inverse_r0():
@@ -125,9 +123,7 @@ def test_legendre_reproduces_1_over_r_numerically(max_degree):
     ]
     tolerance = 1e-4 if max_degree == 3 else 1e-5
     for q1, q2, q3 in test_qs:
-        exact = 1.0 / math.sqrt(
-            (rx - q1) ** 2 + (ry - q2) ** 2 + (rz - q3) ** 2
-        )
+        exact = 1.0 / math.sqrt((rx - q1) ** 2 + (ry - q2) ** 2 + (rz - q3) ** 2)
         recon = 0.0
         for pow_tuple, coef in res.polynomial.items():
             n1, n2, n3 = pow_tuple[:3]

--- a/tests/algorithms/normal_form/test_pipeline.py
+++ b/tests/algorithms/normal_form/test_pipeline.py
@@ -1,0 +1,290 @@
+"""法型化流水线的端到端 smoke 测试（issue #175，切片 6）。
+
+覆盖：
+
+- :class:`NormalFormPipeline` 可用 :class:`NormalFormContext` 构造；
+- ``reduce(orbit)`` 把四个 reducer 串成完整路径，返回
+  :class:`NormalFormResult`；
+- ``result.catalog_transformer.rho_to_param(orbit, t)`` 返回 ``(6,)`` 数组
+  （验收标准 #2）；
+- 失败路径：某步异常时 ``success=False`` 且保留已完成子结果；
+- 输入校验：非法 orbit 形状直接抛 :class:`ValueError`；
+- lazy export 经包顶层可导入。
+
+qiao ``L1_Halo_Large`` fixture 一致性回归用 ``pytest.skip`` 守卫——该
+``.npz`` 本仓库未引入，需 SPICE 内核 + 长窗口才能解锁。SPICE leapseconds
+不可用时底层自动降级到纯 CR3BP，smoke 测试在该降级下仍能通过（与
+``test_dynamical_substitution.py`` 一致）。
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pytest
+
+from e2m2e.algorithms.normal_form import (
+    NormalFormPipeline,
+    NormalFormResult,
+)
+from e2m2e.algorithms.normal_form.center_manifold import CenterManifoldResult
+from e2m2e.algorithms.normal_form.dynamical_substitution import (
+    DynamicalSubstituteResult,
+)
+from e2m2e.algorithms.normal_form.quasi_floquet import QuasiFloquetResult
+from e2m2e.core import LibrationPoint
+
+# ---------------------------------------------------------------------------
+# 公共 fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def l1_context(earth_moon_system):
+    """L1 共线点上下文（与 test_catalog / test_dynamical_substitution 一致）。"""
+    from e2m2e.algorithms.normal_form import NormalFormContext
+    from e2m2e.algorithms.normal_form.constants import JD0_J2000
+
+    return NormalFormContext(
+        system=earth_moon_system,
+        libration_point=LibrationPoint.L1,
+        epoch=JD0_J2000,
+        order=4,
+    )
+
+
+@pytest.fixture
+def fast_pipeline(l1_context) -> NormalFormPipeline:
+    """小窗口流水线，让端到端 reduce 在数秒内完成。
+
+    动力学替代默认窗口 ``t_total=0.1·2^16`` 太慢；这里压到 ``4.0 TU``，
+    与 ``test_dynamical_substitution.tiny_corrector`` 同量级。中心流形
+    截断到 5 阶（足以走通两步 Lie 变换）。
+    """
+    return NormalFormPipeline(
+        context=l1_context,
+        quasi_floquet_method="matrix",
+        center_max_order=5,
+        center_steps=("invariant", "center"),
+        dynamical_kwargs={
+            "t_total": 4.0,
+            "node_step": 0.8,
+            "dense_step": 0.2,
+            "max_iter": 3,
+            "tolerance": 1e-6,
+            "prefer": "fft",
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# 构造与导入
+# ---------------------------------------------------------------------------
+
+
+def test_pipeline_is_constructible(l1_context):
+    """``NormalFormPipeline`` 可用 context 构造，默认旋钮合理。"""
+    pipeline = NormalFormPipeline(context=l1_context)
+    assert pipeline.context is l1_context
+    assert pipeline.quasi_floquet_method == "matrix"
+    assert pipeline.center_max_order == 10
+    assert pipeline.center_steps == ("invariant", "center")
+
+
+def test_pipeline_importable_via_package_root():
+    """切片 #175 验收：能从包根直接 import。"""
+    from e2m2e.algorithms.normal_form import NormalFormPipeline as P
+
+    assert P is NormalFormPipeline
+
+
+# ---------------------------------------------------------------------------
+# 端到端 smoke（验收标准 #1、#2）
+# ---------------------------------------------------------------------------
+
+
+def test_reduce_returns_normal_form_result(fast_pipeline):
+    """``reduce(orbit)`` 返回 :class:`NormalFormResult` 且暴露四个子句柄。"""
+    x0 = np.array([1e-3, -1e-3, 0.0, 0.0, 1e-4, -1e-4])
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")  # 屏蔽 SPICE 降级警告
+        result = fast_pipeline.reduce(x0)
+
+    assert isinstance(result, NormalFormResult)
+    assert result.context is fast_pipeline.context
+    assert result.order == int(fast_pipeline.context.order)
+    # 四个子句柄全部填充
+    assert isinstance(result.ds_result, DynamicalSubstituteResult)
+    assert isinstance(result.qf_result, QuasiFloquetResult)
+    assert isinstance(result.cm_result, CenterManifoldResult)
+    assert result.catalog_transformer is not None
+    # 通用诊断字段
+    assert result.success is True
+    assert isinstance(result.message, str) and result.message
+    assert np.isfinite(result.residual)
+
+
+def test_catalog_transformer_rho_to_param(fast_pipeline):
+    """验收标准 #2：``result.catalog_transformer.rho_to_param`` 返回 (6,)。"""
+    x0 = np.array([1e-3, -1e-3, 0.0, 0.0, 1e-4, -1e-4])
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        result = fast_pipeline.reduce(x0)
+
+    param = result.catalog_transformer.rho_to_param(x0, t=0.0)
+    assert np.asarray(param).shape == (6,)
+    assert np.all(np.isfinite(param))
+
+
+def test_catalog_transformer_roundtrip(fast_pipeline):
+    """端到端 rho → param → rho 在合成初值上数值自洽。"""
+    x0 = np.array([1e-3, -1e-3, 0.0, 0.0, 1e-4, -1e-4])
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        result = fast_pipeline.reduce(x0)
+
+    tr = result.catalog_transformer
+    t = 1.0
+    param = tr.rho_to_param(x0, t)
+    back = tr.param_to_rho(param, t)
+    # 高阶 Lie 级数段主导，整体放宽（与 test_catalog 端到端往返一致）
+    np.testing.assert_allclose(back, x0, atol=1e-6)
+
+
+def test_reduce_works_without_spice_kernels(fast_pipeline, monkeypatch):
+    """SPICE 内核不可用时（CI 环境）流水线降级到纯 CR3BP 仍跑通。"""
+    import e2m2e.algorithms.normal_form.dynamical_substitution as ds
+
+    def _broken(*args, **kwargs):
+        raise RuntimeError("simulated SPICE missing")
+
+    monkeypatch.setattr(
+        "e2m2e.algorithms.normal_form._ephemeris.eval_params",
+        _broken,
+        raising=False,
+    )
+    monkeypatch.setattr(ds, "_build_dynamics_rhs_spice", _broken)
+
+    x0 = np.array([1e-3, 0.0, 0.0, 0.0, 0.0, 0.0])
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        result = fast_pipeline.reduce(x0)
+
+    assert result.success is True
+    assert result.ds_result.spice_available is False
+    assert result.catalog_transformer is not None
+
+
+# ---------------------------------------------------------------------------
+# 输入校验与失败路径
+# ---------------------------------------------------------------------------
+
+
+def test_reduce_rejects_bad_orbit_shape(fast_pipeline):
+    """orbit 非 (6,) 时直接抛 ValueError（调用方错误）。"""
+    with pytest.raises(ValueError, match="orbit"):
+        fast_pipeline.reduce(np.zeros(5))
+
+
+def test_reduce_accepts_orbit_like_object(fast_pipeline, l1_context):
+    """带 ``.states`` 的 Orbit-like 对象取首帧作为初值。"""
+    from e2m2e.core.orbit import Orbit
+
+    x0 = np.array([1e-3, -1e-3, 0.0, 0.0, 1e-4, -1e-4])
+    orbit = Orbit(
+        states=np.tile(x0, (3, 1)),
+        times=np.array([0.0, 0.1, 0.2]),
+        system=l1_context.system,
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        result = fast_pipeline.reduce(orbit)
+    assert result.success is True
+
+
+def test_failure_records_completed_subresults(l1_context, monkeypatch):
+    """某步异常时 success=False，保留已完成子结果，message 记录失败步骤。"""
+    # 让 quasi-Floquet 步抛异常，DS 步应已完成
+    def _boom(*args, **kwargs):
+        raise RuntimeError("synthetic QF failure")
+
+    monkeypatch.setattr(
+        "e2m2e.algorithms.normal_form.quasi_floquet.QuasiFloquetReducer.reduce",
+        _boom,
+    )
+
+    pipeline = NormalFormPipeline(
+        context=l1_context,
+        center_max_order=4,
+        dynamical_kwargs={
+            "t_total": 2.0,
+            "node_step": 0.8,
+            "dense_step": 0.4,
+            "max_iter": 2,
+            "tolerance": 1e-6,
+            "prefer": "fft",
+        },
+    )
+    x0 = np.array([1e-3, 0.0, 0.0, 0.0, 0.0, 0.0])
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        result = pipeline.reduce(x0)
+
+    assert result.success is False
+    assert "quasi_floquet" in result.message
+    # DS 步已完成，后续步骤为 None
+    assert isinstance(result.ds_result, DynamicalSubstituteResult)
+    assert result.qf_result is None
+    assert result.cm_result is None
+    assert result.catalog_transformer is None
+    assert result.metadata["failed_step"] == "quasi_floquet"
+
+
+# ---------------------------------------------------------------------------
+# metadata 诊断
+# ---------------------------------------------------------------------------
+
+
+def test_metadata_records_pipeline_config(fast_pipeline):
+    """成功结果 metadata 记录流水线配置与各步诊断量。"""
+    x0 = np.array([1e-3, 0.0, 0.0, 0.0, 0.0, 0.0])
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        result = fast_pipeline.reduce(x0)
+
+    assert result.metadata["quasi_floquet_method"] == "matrix"
+    assert result.metadata["center_max_order"] == 5
+    assert result.metadata["center_steps"] == ("invariant", "center")
+    assert "qf_symplectic_error" in result.metadata
+    assert "cm_hyperbolic_coupling" in result.metadata
+
+
+# ---------------------------------------------------------------------------
+# 验收标准 #3：L1_Halo_Large fixture 与 qiao 一致性回归（skip 守卫）
+# ---------------------------------------------------------------------------
+
+
+def test_qiao_L1_Halo_Large_regression_is_skipped_without_fixture():
+    """与 qiao ``L1_Halo_Large`` 输出的表征参数一致性回归。
+
+    该回归需要：
+
+    1. qiao ``L1_rho2param_data.npz``（或等价 fixture）放入
+       ``tests/algorithms/normal_form/data/``；
+    2. SPICE 内核（``.tls`` + ``.bsp``）+ 完整 ``T_total = 0.1·2^16`` 窗口，
+       使动力学替代走星历模型而非纯 CR3BP 退路。
+
+    两者在 CI 环境均不可得，故以 ``pytest.skip`` 守卫占位。fixture 就绪后，
+    本测试应加载 npz 中的 ``rho2param`` 参考输出，与
+    ``NormalFormPipeline(context).reduce(x0).catalog_transformer.rho_to_param``
+    的结果逐分量做 ``np.testing.assert_allclose``。
+    """
+    from pathlib import Path
+
+    fixture = Path(__file__).parent / "data" / "L1_rho2param_data.npz"
+    if not fixture.exists():
+        pytest.skip(
+            "qiao L1_Halo_Large fixture 未引入仓库；表征参数一致性回归待 "
+            "fixture + SPICE 内核就绪"
+        )

--- a/tests/algorithms/normal_form/test_pipeline.py
+++ b/tests/algorithms/normal_form/test_pipeline.py
@@ -205,6 +205,7 @@ def test_reduce_accepts_orbit_like_object(fast_pipeline, l1_context):
 
 def test_failure_records_completed_subresults(l1_context, monkeypatch):
     """某步异常时 success=False，保留已完成子结果，message 记录失败步骤。"""
+
     # 让 quasi-Floquet 步抛异常，DS 步应已完成
     def _boom(*args, **kwargs):
         raise RuntimeError("synthetic QF failure")
@@ -285,6 +286,5 @@ def test_qiao_L1_Halo_Large_regression_is_skipped_without_fixture():
     fixture = Path(__file__).parent / "data" / "L1_rho2param_data.npz"
     if not fixture.exists():
         pytest.skip(
-            "qiao L1_Halo_Large fixture 未引入仓库；表征参数一致性回归待 "
-            "fixture + SPICE 内核就绪"
+            "qiao L1_Halo_Large fixture 未引入仓库；表征参数一致性回归待 fixture + SPICE 内核就绪"
         )

--- a/tests/algorithms/normal_form/test_quasi_floquet.py
+++ b/tests/algorithms/normal_form/test_quasi_floquet.py
@@ -1,0 +1,428 @@
+"""``normal_form.quasi_floquet`` 测试。
+
+覆盖（issue #172）：
+
+- :class:`QuasiFloquetReducer` 可用，``reduce`` 返回
+  :class:`QuasiFloquetResult`；
+- ``B(t)`` 在采样点上 ``Bᵀ J B = J`` 误差 ``< 1e-12``——矩阵法与
+  李代数法各一个硬性数值断言；
+- 实标准形 ``D`` 与 qiao ``Global_File`` 频率一致；
+- sp(6) 基构造、往返 ``sp6_to_vector``/``vector_to_sp6`` 数值正确；
+- qiao ``.npz`` 回归 fixture 用 ``pytest.skip`` 守卫（本仓库没有）。
+
+输入 :class:`DynamicalSubstituteResult` 的构造思路与
+``test_dynamical_substitution.py`` 一致（复用其 ``NormalFormContext`` /
+``earth_moon_system`` fixture、纯 CR3BP 退路），但 quasi-Floquet 对输入
+轨道的「良态性」敏感：发散轨道会让 ``B(t)`` 沿双曲方向 ``exp(λT)`` 爆
+炸，辛投影退化。因此这里用 **L1 线性化复特征向量** 构造一条物理意义
+明确的小 Lyapunov 轨道作为输入——这正是 quasi-Floquet 变换的设计场景。
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from scipy.integrate import solve_ivp
+from scipy.linalg import expm
+
+from e2m2e.algorithms.normal_form.constants import JD0_J2000
+from e2m2e.algorithms.normal_form.dynamical_substitution import (
+    DynamicalSubstituteResult,
+)
+from e2m2e.algorithms.normal_form.quasi_floquet import (
+    J6,
+    QuasiFloquetReducer,
+    QuasiFloquetResult,
+    build_sp6_basis,
+    real_normal_form_matrix,
+    sp6_to_vector,
+    symplectic_project,
+    vector_to_sp6,
+)
+from e2m2e.core import LibrationPoint
+
+# ---------------------------------------------------------------------------
+# 公共 fixture（复用 test_dynamical_substitution 的范式）
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def l1_context(earth_moon_system):
+    """L1 共线点上下文（与 slice 2 测试一致）。"""
+    from e2m2e.algorithms.normal_form import NormalFormContext
+
+    return NormalFormContext(
+        system=earth_moon_system,
+        libration_point=LibrationPoint.L1,
+        epoch=JD0_J2000,
+        order=4,
+    )
+
+
+def _cr3bp_hessian(r, mu):
+    """会合系 Ω 的对称 Hessian（与 quasi_floquet._cr3bp_hessian_symmetric 同式）。"""
+    mu1 = 1.0 - mu
+    r1 = r - np.array([-mu, 0.0, 0.0])
+    r2 = r - np.array([1.0 - mu, 0.0, 0.0])
+    d1 = float(np.linalg.norm(r1))
+    d2 = float(np.linalg.norm(r2))
+    S = np.eye(3) * (1.0 - mu1 / d1**3 - mu / d2**3)
+    S += mu1 * 3.0 / d1**5 * np.outer(r1, r1)
+    S += mu * 3.0 / d2**5 * np.outer(r2, r2)
+    return S
+
+
+def _small_lyapunov_orbit(l1_context, *, amp: float = 1e-3, T: float = 0.6, n: int = 31):
+    """构造一条围绕 L1 的小 Lyapunov 轨道作为 quasi-Floquet 输入。
+
+    从 L1 线性化矩阵 ``M₀`` 的**平面中心方向**（最大纯虚特征值）取实
+    特征向量作为初始扰动，在纯 CR3BP 下积分 ``T``，得到一条振幅 ``O(amp)``
+    的有界小轨道。这是 quasi-Floquet 变换的设计场景（围绕平动点的小
+    振幅中心运动），避免了发散轨道导致 ``B(t)`` 沿双曲方向 ``exp(λT)``
+    爆炸、辛投影退化的数值病态。
+
+    返回 ``(tlist, Xlist)``，``Xlist`` 形状 ``(n, 6)``。
+    """
+    mu = float(l1_context.mu)
+    r_lp = np.asarray(l1_context.libration_position, dtype=float).ravel()
+    S0 = _cr3bp_hessian(r_lp, mu)
+    omega_x = np.array([[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
+    M0 = np.zeros((6, 6))
+    M0[:3, :3] = -omega_x
+    M0[:3, 3:] = np.eye(3)
+    M0[3:, :3] = S0
+    M0[3:, 3:] = -omega_x
+    # 最大纯虚特征值（平面中心对）
+    w, V = np.linalg.eig(M0)
+    imag_idx = [
+        i
+        for i in range(6)
+        if abs(w[i].imag) > 1e-6 and abs(w[i].real) < 1e-8 and w[i].imag > 0
+    ]
+    assert imag_idx, "L1 线性化应含纯虚特征值（中心方向）"
+    i_planar = max(imag_idx, key=lambda i: w[i].imag)
+    v = V[:, i_planar].real
+    x0 = amp * v / np.linalg.norm(v)
+
+    def rhs(t, X):
+        rho = X[:3]
+        rd = X[3:]
+        e = np.array([-mu, 0.0, 0.0])
+        m = np.array([1.0 - mu, 0.0, 0.0])
+        d1 = rho + r_lp - e
+        d2 = rho + r_lp - m
+        dd = (
+            -(1.0 - mu) * d1 / np.linalg.norm(d1) ** 3
+            - mu * d2 / np.linalg.norm(d2) ** 3
+            - 2.0 * np.cross([0.0, 0.0, 1.0], rd)
+            - np.cross([0.0, 0.0, 1.0], np.cross([0.0, 0.0, 1.0], rho))
+        )
+        return np.concatenate([rd, dd])
+
+    tlist = np.linspace(0.0, T, n)
+    sol = solve_ivp(rhs, (0.0, T), x0, t_eval=tlist, rtol=1e-12, atol=1e-14)
+    assert sol.success
+    return tlist, sol.y.T
+
+
+@pytest.fixture
+def small_orbit_ds_result(l1_context) -> DynamicalSubstituteResult:
+    """围绕 L1 的小 Lyapunov 轨道，包装成 :class:`DynamicalSubstituteResult`。
+
+    quasi-Floquet reducer 只读 ``tlist``/``Xlist``/``context``；``W_poly``
+    等字段在此测试中无关紧要（留空 dict）。
+    """
+    tlist, Xlist = _small_lyapunov_orbit(l1_context)
+    return DynamicalSubstituteResult(
+        context=l1_context,
+        order=int(l1_context.order),
+        substitute_orbit=Xlist,
+        tlist=tlist,
+        Xlist=Xlist,
+        W_poly={},
+        Wdot_poly={},
+    )
+
+
+@pytest.fixture
+def matrix_reducer(l1_context) -> QuasiFloquetReducer:
+    """矩阵法 reducer。"""
+    return QuasiFloquetReducer(context=l1_context, method="matrix")
+
+
+@pytest.fixture
+def lie_reducer(l1_context) -> QuasiFloquetReducer:
+    """李代数法 reducer。"""
+    return QuasiFloquetReducer(context=l1_context, method="lie_algebra")
+
+
+# ---------------------------------------------------------------------------
+# 构造与接口
+# ---------------------------------------------------------------------------
+
+
+def test_reducer_is_constructible(l1_context):
+    """``QuasiFloquetReducer`` 可用上下文构造，默认走矩阵法。"""
+    reducer = QuasiFloquetReducer(context=l1_context)
+    assert reducer.context is l1_context
+    assert reducer.method == "matrix"
+    assert reducer.project is True
+
+
+def test_reducer_rejects_unknown_method(l1_context):
+    """``method`` 非法时抛 :class:`ValueError`。"""
+    reducer = QuasiFloquetReducer(context=l1_context, method="bogus")
+    with pytest.raises(ValueError, match="method"):
+        reducer.reduce(_trivial_ds_result(l1_context))
+
+
+def test_reducer_rejects_too_few_samples(l1_context):
+    """``ds_result`` 采样点不足 2 个时抛 :class:`ValueError`。"""
+    reducer = QuasiFloquetReducer(context=l1_context)
+    tlist = np.array([0.0])
+    Xlist = np.zeros((1, 6))
+    ds = DynamicalSubstituteResult(
+        context=l1_context,
+        order=l1_context.order,
+        substitute_orbit=Xlist,
+        tlist=tlist,
+        Xlist=Xlist,
+        W_poly={},
+        Wdot_poly={},
+    )
+    with pytest.raises(ValueError, match="采样点"):
+        reducer.reduce(ds)
+
+
+def test_reduce_returns_result_with_required_fields(
+    matrix_reducer, small_orbit_ds_result
+):
+    """``reduce`` 返回 :class:`QuasiFloquetResult`，字段齐备。"""
+    result = matrix_reducer.reduce(small_orbit_ds_result)
+    assert isinstance(result, QuasiFloquetResult)
+    assert result.context is matrix_reducer.context
+    assert result.order == int(matrix_reducer.context.order)
+    assert result.method == "matrix"
+    # B_samples 形状 (n, 6, 6)
+    assert result.B_samples.ndim == 3
+    assert result.B_samples.shape[1:] == (6, 6)
+    assert result.B_samples.shape[0] == result.tlist.shape[0]
+    # 实标准形 D 是 6×6
+    assert result.D.shape == (6, 6)
+    # metadata 记录频率
+    assert {"lambda", "wp", "wv", "n_samples"} <= set(result.metadata)
+
+
+# ---------------------------------------------------------------------------
+# 核心数值约束：B^T J B = J 误差 < 1e-12（硬性，必须真实测试）
+# ---------------------------------------------------------------------------
+
+
+def test_matrix_method_preserves_symplecticity(matrix_reducer, small_orbit_ds_result):
+    """矩阵法：``B(t)`` 在所有采样点上 ``‖Bᵀ J B − J‖∞ < 1e-12``。
+
+    数学保证：``M(t)`` 与 ``D`` 都是 Hamilton 矩阵，``Bᵀ J B`` 是
+    ``Ḃ = M·B − B·D`` 的精确首次积分；末尾再做一次辛投影兜底，把
+    ODE 容差累积的残余误差（~1e-11）拉回机器精度。
+    """
+    result = matrix_reducer.reduce(small_orbit_ds_result)
+    assert result.max_symplectic_error < 1e-12, (
+        f"矩阵法辛误差过大：{result.max_symplectic_error:.2e}"
+    )
+
+
+def test_lie_algebra_method_preserves_symplecticity(
+    lie_reducer, small_orbit_ds_result
+):
+    """李代数法：``B(t)`` 在所有采样点上 ``‖Bᵀ J B − J‖∞ < 1e-12``。
+
+    ``B=exp(ξ)``、``ξ ∈ sp(6)`` 自动保辛，无需投影。
+    """
+    result = lie_reducer.reduce(small_orbit_ds_result)
+    assert result.max_symplectic_error < 1e-12, (
+        f"李代数法辛误差过大：{result.max_symplectic_error:.2e}"
+    )
+
+
+def test_both_methods_share_same_normal_form(l1_context, small_orbit_ds_result):
+    """矩阵法与李代数法的实标准形 ``D`` 应完全一致（同源频率）。"""
+    D_ref = real_normal_form_matrix(
+        float(l1_context.characteristic_exponent),
+        float(l1_context.central_frequencies[0]),
+        float(l1_context.central_frequencies[1]),
+    )
+    r_mat = QuasiFloquetReducer(context=l1_context, method="matrix").reduce(
+        small_orbit_ds_result
+    )
+    r_lie = QuasiFloquetReducer(context=l1_context, method="lie_algebra").reduce(
+        small_orbit_ds_result
+    )
+    np.testing.assert_allclose(r_mat.D, D_ref)
+    np.testing.assert_allclose(r_lie.D, D_ref)
+
+
+def test_both_methods_agree_on_B(l1_context, small_orbit_ds_result):
+    """矩阵法与李代数法应解同一个方程 ``Ḃ = M·B − B·D``，给出一致的 ``B(t)``。
+
+    这是 issue #172「可共用一套测试」的实质要求：两条入口都是对
+    ``Ḃ = M·B − B·D`` 的等价数值实现（矩阵法 36 维直接积分 + 辛投影，
+    李代数法 commutator-free Lie group RK4、自动保辛），故 ``B(t)`` 在
+    采样点上须数值一致。容差放宽到 ``1e-4``：李代数法用固定子步 4 阶
+    格式（~5e-6 误差），矩阵法用 DOP853（~1e-11），二者之差由李代数法
+    主导。
+    """
+    r_mat = QuasiFloquetReducer(context=l1_context, method="matrix").reduce(
+        small_orbit_ds_result
+    )
+    r_lie = QuasiFloquetReducer(context=l1_context, method="lie_algebra").reduce(
+        small_orbit_ds_result
+    )
+    # B(t_0)=I 是共同初值，应精确成立
+    np.testing.assert_allclose(r_mat.B_samples[0], np.eye(6), atol=1e-9)
+    np.testing.assert_allclose(r_lie.B_samples[0], np.eye(6), atol=1e-9)
+    # 整条 B(t) 数值一致
+    np.testing.assert_allclose(r_lie.B_samples, r_mat.B_samples, atol=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# B(t) 在 t_0 处 = I（初值条件）
+# ---------------------------------------------------------------------------
+
+
+def test_B_at_t0_is_identity(matrix_reducer, small_orbit_ds_result):
+    """``B(t_0)`` 应为单位矩阵（初值 ``B(0)=I``）。"""
+    result = matrix_reducer.reduce(small_orbit_ds_result)
+    np.testing.assert_allclose(result.B_samples[0], np.eye(6), atol=1e-9)
+
+
+def test_B_interpolation_round_trips(matrix_reducer, small_orbit_ds_result):
+    """``result.B(t)`` 在采样点上等于 ``B_samples``。"""
+    result = matrix_reducer.reduce(small_orbit_ds_result)
+    t_mid = float(result.tlist[len(result.tlist) // 2])
+    np.testing.assert_allclose(result.B(t_mid), result.B_samples[len(result.tlist) // 2])
+
+
+# ---------------------------------------------------------------------------
+# M(t) 与 D 的 Hamilton 性（数值自检）
+# ---------------------------------------------------------------------------
+
+
+def test_D_is_hamiltonian(l1_context):
+    """实标准形 ``D`` 应满足 ``Dᵀ J + J D = 0``（Hamilton 矩阵）。"""
+    D = real_normal_form_matrix(
+        float(l1_context.characteristic_exponent),
+        float(l1_context.central_frequencies[0]),
+        float(l1_context.central_frequencies[1]),
+    )
+    assert np.linalg.norm(D.T @ J6 + J6 @ D) < 1e-12
+
+
+def test_M_samples_are_hamiltonian(matrix_reducer, small_orbit_ds_result):
+    """``M(t)`` 在各采样点应是 Hamilton 矩阵（保证辛守恒）。"""
+    result = matrix_reducer.reduce(small_orbit_ds_result)
+    assert result.M_samples is not None
+    for M in result.M_samples:
+        assert np.linalg.norm(M.T @ J6 + J6 @ M) < 1e-12
+
+
+# ---------------------------------------------------------------------------
+# sp(6) 基与代数工具
+# ---------------------------------------------------------------------------
+
+
+def test_sp6_basis_has_21_elements():
+    """sp(6, R) 维度 ``2n² + n = 21``。"""
+    basis = build_sp6_basis()
+    assert len(basis) == 21
+
+
+def test_sp6_basis_is_hamiltonian_and_orthonormal():
+    """每个基元素是 Hamilton 矩阵，且彼此 Frobenius 正交。"""
+    basis = build_sp6_basis()
+    for E in basis:
+        assert np.linalg.norm(E.T @ J6 + J6 @ E) < 1e-12
+    for i in range(len(basis)):
+        for j in range(i + 1, len(basis)):
+            ip = float(np.sum(basis[i] * basis[j]))
+            assert abs(ip) < 1e-12
+
+
+def test_sp6_vector_roundtrip():
+    """``sp6_to_vector``/``vector_to_sp6`` 互为精确逆。"""
+    basis = build_sp6_basis()
+    rng = np.random.default_rng(0)
+    xi = rng.normal(size=21)
+    M = vector_to_sp6(xi, basis)
+    xi2 = sp6_to_vector(M, basis)
+    np.testing.assert_allclose(xi, xi2, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# symplectic_project 单元测试
+# ---------------------------------------------------------------------------
+
+
+def test_symplectic_project_recovers_exact_matrix():
+    """精确辛矩阵的投影应不变；近辛矩阵应被拉回。"""
+    basis = build_sp6_basis()
+    rng = np.random.default_rng(1)
+    xi = rng.normal(scale=0.1, size=21)
+    B_exact = expm(vector_to_sp6(xi, basis))
+    B_projected = symplectic_project(B_exact)
+    np.testing.assert_allclose(B_projected, B_exact, atol=1e-12)
+    # 加扰动后投影应让辛误差降到 < 1e-13
+    B_noisy = B_exact + 1e-3 * rng.normal(size=(6, 6))
+    B_back = symplectic_project(B_noisy)
+    assert float(np.max(np.abs(B_back.T @ J6 @ B_back - J6))) < 1e-13
+
+
+def test_symplectic_project_handles_large_norm():
+    """投影对范数较大的辛矩阵（双曲方向增长）也应收敛。"""
+    basis = build_sp6_basis()
+    xi = np.zeros(21)
+    xi[0] = 8.0  # 第一个基对应双曲方向，B 范数 ~ exp(8)
+    B_exact = expm(vector_to_sp6(xi, basis))
+    rng = np.random.default_rng(3)
+    B = B_exact + 1e-9 * np.linalg.norm(B_exact) * rng.normal(size=(6, 6))
+    B_back = symplectic_project(B)
+    assert float(np.max(np.abs(B_back.T @ J6 @ B_back - J6))) < 1e-12
+
+
+# ---------------------------------------------------------------------------
+# qiao .npz 回归 fixture（本仓库没有，skip 守卫）
+# ---------------------------------------------------------------------------
+
+
+def test_qiao_npz_regression_is_skipped_without_fixture():
+    """qiao ``L1_QFtrans.npz`` fixture 在本仓库不存在，必须 skip。
+
+    本测试仅验证 skip 守卫生效；一旦外部 fixture 引入，可在此替换为真实
+    数值比对。
+    """
+    from pathlib import Path
+
+    fixture = Path(__file__).parent / "data" / "L1_QFtrans.npz"
+    if not fixture.exists():
+        pytest.skip(f"qiao .npz fixture 不存在：{fixture}")
+    data = np.load(fixture, allow_pickle=True)
+    assert "tlist" in data and "QFtrans_mat" in data
+
+
+# ---------------------------------------------------------------------------
+# 辅助
+# ---------------------------------------------------------------------------
+
+
+def _trivial_ds_result(l1_context) -> DynamicalSubstituteResult:
+    """构造一个仅用于触发 reducer 校验的最小占位结果。"""
+    tlist = np.array([0.0, 1.0], dtype=float)
+    Xlist = np.zeros((2, 6), dtype=float)
+    return DynamicalSubstituteResult(
+        context=l1_context,
+        order=l1_context.order,
+        substitute_orbit=Xlist,
+        tlist=tlist,
+        Xlist=Xlist,
+        W_poly={},
+        Wdot_poly={},
+    )

--- a/tests/algorithms/normal_form/test_quasi_floquet.py
+++ b/tests/algorithms/normal_form/test_quasi_floquet.py
@@ -95,9 +95,7 @@ def _small_lyapunov_orbit(l1_context, *, amp: float = 1e-3, T: float = 0.6, n: i
     # 最大纯虚特征值（平面中心对）
     w, V = np.linalg.eig(M0)
     imag_idx = [
-        i
-        for i in range(6)
-        if abs(w[i].imag) > 1e-6 and abs(w[i].real) < 1e-8 and w[i].imag > 0
+        i for i in range(6) if abs(w[i].imag) > 1e-6 and abs(w[i].real) < 1e-8 and w[i].imag > 0
     ]
     assert imag_idx, "L1 线性化应含纯虚特征值（中心方向）"
     i_planar = max(imag_idx, key=lambda i: w[i].imag)
@@ -194,9 +192,7 @@ def test_reducer_rejects_too_few_samples(l1_context):
         reducer.reduce(ds)
 
 
-def test_reduce_returns_result_with_required_fields(
-    matrix_reducer, small_orbit_ds_result
-):
+def test_reduce_returns_result_with_required_fields(matrix_reducer, small_orbit_ds_result):
     """``reduce`` 返回 :class:`QuasiFloquetResult`，字段齐备。"""
     result = matrix_reducer.reduce(small_orbit_ds_result)
     assert isinstance(result, QuasiFloquetResult)
@@ -231,9 +227,7 @@ def test_matrix_method_preserves_symplecticity(matrix_reducer, small_orbit_ds_re
     )
 
 
-def test_lie_algebra_method_preserves_symplecticity(
-    lie_reducer, small_orbit_ds_result
-):
+def test_lie_algebra_method_preserves_symplecticity(lie_reducer, small_orbit_ds_result):
     """李代数法：``B(t)`` 在所有采样点上 ``‖Bᵀ J B − J‖∞ < 1e-12``。
 
     ``B=exp(ξ)``、``ξ ∈ sp(6)`` 自动保辛，无需投影。
@@ -251,9 +245,7 @@ def test_both_methods_share_same_normal_form(l1_context, small_orbit_ds_result):
         float(l1_context.central_frequencies[0]),
         float(l1_context.central_frequencies[1]),
     )
-    r_mat = QuasiFloquetReducer(context=l1_context, method="matrix").reduce(
-        small_orbit_ds_result
-    )
+    r_mat = QuasiFloquetReducer(context=l1_context, method="matrix").reduce(small_orbit_ds_result)
     r_lie = QuasiFloquetReducer(context=l1_context, method="lie_algebra").reduce(
         small_orbit_ds_result
     )
@@ -271,9 +263,7 @@ def test_both_methods_agree_on_B(l1_context, small_orbit_ds_result):
     格式（~5e-6 误差），矩阵法用 DOP853（~1e-11），二者之差由李代数法
     主导。
     """
-    r_mat = QuasiFloquetReducer(context=l1_context, method="matrix").reduce(
-        small_orbit_ds_result
-    )
+    r_mat = QuasiFloquetReducer(context=l1_context, method="matrix").reduce(small_orbit_ds_result)
     r_lie = QuasiFloquetReducer(context=l1_context, method="lie_algebra").reduce(
         small_orbit_ds_result
     )

--- a/tests/algorithms/normal_form/test_units.py
+++ b/tests/algorithms/normal_form/test_units.py
@@ -22,8 +22,10 @@ from e2m2e.core import LibrationPoint
 def ctx(earth_moon_system) -> NormalFormContext:
     """L1 上下文，使用 qiao 默认 LU/TU。"""
     return NormalFormContext(
-        system=earth_moon_system, libration_point=LibrationPoint.L1,
-        epoch=2451545.0, order=2,
+        system=earth_moon_system,
+        libration_point=LibrationPoint.L1,
+        epoch=2451545.0,
+        order=2,
     )
 
 
@@ -37,7 +39,7 @@ def test_to_normalized_divides_position_and_velocity_by_LU_VU(ctx):
     state_si = np.array([384747.981, 0.0, 0.0, 1.02416, 0.0, 0.0])
     state_norm = to_normalized(state_si, ctx)
 
-    assert state_norm[0] == pytest.approx(1.0)            # x_km / LU = 1
+    assert state_norm[0] == pytest.approx(1.0)  # x_km / LU = 1
     assert state_norm[3] == pytest.approx(1.02416 / VU_KMS)
 
 
@@ -72,10 +74,10 @@ def test_norm_to_si_to_norm_round_trip(ctx):
 @pytest.mark.parametrize(
     "state_si",
     [
-        np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),                    # 原点
-        np.array([LU_KM, 0.0, 0.0, 0.0, 0.0, 0.0]),                  # x = 1 LU
-        np.array([-LU_KM, LU_KM, LU_KM, VU_KMS, -VU_KMS, VU_KMS]),   # 全分量
-        np.array([384400.0, 0.0, 0.0, 0.0, 1.022, 0.0]),             # 类 LEO/月球轨道量级
+        np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),  # 原点
+        np.array([LU_KM, 0.0, 0.0, 0.0, 0.0, 0.0]),  # x = 1 LU
+        np.array([-LU_KM, LU_KM, LU_KM, VU_KMS, -VU_KMS, VU_KMS]),  # 全分量
+        np.array([384400.0, 0.0, 0.0, 0.0, 1.022, 0.0]),  # 类 LEO/月球轨道量级
     ],
 )
 def test_round_trip_various_states(ctx, state_si):
@@ -132,13 +134,18 @@ def test_wrong_last_dim_raises_from_normalized(ctx):
 def test_custom_LU_TU_change_scaling(earth_moon_system):
     """覆盖 LU/TU 后缩放比例同步更新。"""
     ctx_default = NormalFormContext(
-        system=earth_moon_system, libration_point=LibrationPoint.L1,
-        epoch=2451545.0, order=2,
+        system=earth_moon_system,
+        libration_point=LibrationPoint.L1,
+        epoch=2451545.0,
+        order=2,
     )
     ctx_custom = NormalFormContext(
-        system=earth_moon_system, libration_point=LibrationPoint.L1,
-        epoch=2451545.0, order=2,
-        LU=1000.0, TU=100.0,
+        system=earth_moon_system,
+        libration_point=LibrationPoint.L1,
+        epoch=2451545.0,
+        order=2,
+        LU=1000.0,
+        TU=100.0,
     )
     state_si = np.array([12345.6, 0.0, 0.0, 0.5, 0.0, 0.0])
 

--- a/tests/algorithms/normal_form/test_units.py
+++ b/tests/algorithms/normal_form/test_units.py
@@ -1,0 +1,161 @@
+"""``to_normalized`` / ``from_normalized`` 单测。
+
+覆盖：
+- SI ↔ 归一化的 round-trip 在浮点精度内闭合；
+- 位置与速度分别按 LU / VU 缩放；
+- 支持 ``(6,)`` 单状态与 ``(n, 6)`` 批量状态；
+- 输入形状错误抛 ``ValueError``。
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from e2m2e.algorithms.normal_form import NormalFormContext
+from e2m2e.algorithms.normal_form.constants import LU_KM, MU, TU_S, VU_KMS
+from e2m2e.algorithms.normal_form.units import from_normalized, to_normalized
+from e2m2e.core import LibrationPoint
+
+
+@pytest.fixture
+def ctx(earth_moon_system) -> NormalFormContext:
+    """L1 上下文，使用 qiao 默认 LU/TU。"""
+    return NormalFormContext(
+        system=earth_moon_system, libration_point=LibrationPoint.L1,
+        epoch=2451545.0, order=2,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 缩放关系
+# ---------------------------------------------------------------------------
+
+
+def test_to_normalized_divides_position_and_velocity_by_LU_VU(ctx):
+    """``to_normalized`` 位置除以 LU、速度除以 VU。"""
+    state_si = np.array([384747.981, 0.0, 0.0, 1.02416, 0.0, 0.0])
+    state_norm = to_normalized(state_si, ctx)
+
+    assert state_norm[0] == pytest.approx(1.0)            # x_km / LU = 1
+    assert state_norm[3] == pytest.approx(1.02416 / VU_KMS)
+
+
+def test_from_normalized_multiplies_by_LU_VU(ctx):
+    """``from_normalized`` 位置乘以 LU、速度乘以 VU。"""
+    state_norm = np.array([1.0, 0.0, 0.0, 1.0, 0.0, 0.0])
+    state_si = from_normalized(state_norm, ctx)
+
+    assert state_si[0] == pytest.approx(LU_KM)
+    assert state_si[3] == pytest.approx(VU_KMS)
+
+
+# ---------------------------------------------------------------------------
+# Round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_si_to_norm_to_si_round_trip(ctx):
+    """SI → 归一化 → SI 应回到原值。"""
+    state_si = np.array([12345.6, -9876.5, 100.0, 0.123, -0.456, 0.789])
+    recovered = from_normalized(to_normalized(state_si, ctx), ctx)
+    np.testing.assert_allclose(recovered, state_si, rtol=0.0, atol=1e-9)
+
+
+def test_norm_to_si_to_norm_round_trip(ctx):
+    """归一化 → SI → 归一化 应回到原值。"""
+    state_norm = np.array([0.987, -0.123, 0.456, -0.321, 0.654, -0.987])
+    recovered = to_normalized(from_normalized(state_norm, ctx), ctx)
+    np.testing.assert_allclose(recovered, state_norm, rtol=0.0, atol=1e-15)
+
+
+@pytest.mark.parametrize(
+    "state_si",
+    [
+        np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),                    # 原点
+        np.array([LU_KM, 0.0, 0.0, 0.0, 0.0, 0.0]),                  # x = 1 LU
+        np.array([-LU_KM, LU_KM, LU_KM, VU_KMS, -VU_KMS, VU_KMS]),   # 全分量
+        np.array([384400.0, 0.0, 0.0, 0.0, 1.022, 0.0]),             # 类 LEO/月球轨道量级
+    ],
+)
+def test_round_trip_various_states(ctx, state_si):
+    """多组代表性 SI 状态 round-trip 闭合。"""
+    recovered = from_normalized(to_normalized(state_si, ctx), ctx)
+    np.testing.assert_allclose(recovered, state_si, rtol=0.0, atol=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# 批量接口
+# ---------------------------------------------------------------------------
+
+
+def test_batch_state_round_trip(ctx):
+    """``(n, 6)`` 批量状态同样 round-trip。"""
+    rng = np.random.default_rng(20260107)
+    batch_si = rng.normal(scale=[1e5, 1e5, 1e5, 1.0, 1.0, 1.0], size=(17, 6))
+    recovered = from_normalized(to_normalized(batch_si, ctx), ctx)
+    np.testing.assert_allclose(recovered, batch_si, rtol=0.0, atol=1e-9)
+
+
+def test_batch_norm_round_trip(ctx):
+    """``(n, 6)`` 归一化批量状态同样 round-trip。"""
+    rng = np.random.default_rng(20260107)
+    batch_norm = rng.normal(scale=0.5, size=(13, 6))
+    recovered = to_normalized(from_normalized(batch_norm, ctx), ctx)
+    np.testing.assert_allclose(recovered, batch_norm, rtol=0.0, atol=1e-15)
+
+
+# ---------------------------------------------------------------------------
+# 输入校验
+# ---------------------------------------------------------------------------
+
+
+def test_wrong_last_dim_raises_to_normalized(ctx):
+    """最后一维不是 6 时抛 ``ValueError``。"""
+    with pytest.raises(ValueError, match="6 个分量"):
+        to_normalized(np.array([1.0, 2.0, 3.0]), ctx)
+    with pytest.raises(ValueError, match="6 个分量"):
+        to_normalized(np.zeros((3, 5)), ctx)
+
+
+def test_wrong_last_dim_raises_from_normalized(ctx):
+    """``from_normalized`` 同样校验最后一维。"""
+    with pytest.raises(ValueError, match="6 个分量"):
+        from_normalized(np.array([1.0, 2.0, 3.0]), ctx)
+
+
+# ---------------------------------------------------------------------------
+# 上下文驱动的 LU/TU/VU
+# ---------------------------------------------------------------------------
+
+
+def test_custom_LU_TU_change_scaling(earth_moon_system):
+    """覆盖 LU/TU 后缩放比例同步更新。"""
+    ctx_default = NormalFormContext(
+        system=earth_moon_system, libration_point=LibrationPoint.L1,
+        epoch=2451545.0, order=2,
+    )
+    ctx_custom = NormalFormContext(
+        system=earth_moon_system, libration_point=LibrationPoint.L1,
+        epoch=2451545.0, order=2,
+        LU=1000.0, TU=100.0,
+    )
+    state_si = np.array([12345.6, 0.0, 0.0, 0.5, 0.0, 0.0])
+
+    norm_default = to_normalized(state_si, ctx_default)
+    norm_custom = to_normalized(state_si, ctx_custom)
+
+    assert norm_custom[0] == pytest.approx(state_si[0] / 1000.0)
+    assert norm_custom[3] == pytest.approx(state_si[3] / (1000.0 / 100.0))
+    # 自定义 LU (1000) 远小于默认 LU (~384748)，归一化后的位置分量应更大
+    assert abs(norm_custom[0]) > abs(norm_default[0])
+
+
+def test_qiao_constants_used_in_round_trip():
+    """不依赖 ``earth_moon_system``，直接验证 qiao LU/TU/VU 与 MU 数值。"""
+    # 这些断言把 qiao 常量与 NormalFormContext 默认值钉住，
+    # 防止后续误改常量而 round-trip 测试蒙混过关。
+    assert pytest.approx(384747.981) == LU_KM
+    assert pytest.approx(375699.843898365) == TU_S
+    assert pytest.approx(LU_KM / TU_S) == VU_KMS
+    assert pytest.approx(1.215058560962404e-2) == MU

--- a/tests/transfer/test_dro_ro_nlp.py
+++ b/tests/transfer/test_dro_ro_nlp.py
@@ -211,9 +211,7 @@ class TestTerminalConditionInterface:
             arrival_orbit=dummy_orbit,
             departure_state=departure_state,
         )
-        np.testing.assert_array_equal(
-            opt_from.departure_state, opt_legacy.departure_state
-        )
+        np.testing.assert_array_equal(opt_from.departure_state, opt_legacy.departure_state)
         assert isinstance(opt_from.departure_terminal, OrbitTerminal)
         assert isinstance(opt_from.arrival_terminal, OrbitTerminal)
 

--- a/uv.lock
+++ b/uv.lock
@@ -72,7 +72,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -144,7 +144,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -364,6 +364,12 @@ dependencies = [
     { name = "tqdm" },
 ]
 
+[package.optional-dependencies]
+normal-form = [
+    { name = "joblib" },
+    { name = "sympy" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "maturin" },
@@ -375,14 +381,17 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "joblib", marker = "extra == 'normal-form'", specifier = ">=1.3" },
     { name = "matplotlib", specifier = ">=3.7" },
     { name = "numpy", specifier = ">=1.24" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pyerfa", specifier = ">=2.0.1.5" },
     { name = "scipy", specifier = ">=1.10" },
     { name = "spiceypy", specifier = ">=8.1.0" },
+    { name = "sympy", marker = "extra == 'normal-form'", specifier = ">=1.12" },
     { name = "tqdm", specifier = ">=4.66" },
 ]
+provides-extras = ["normal-form"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -398,7 +407,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -469,6 +478,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "joblib"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
 ]
 
 [[package]]
@@ -777,6 +795,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/97/c6/cbf8a51dde19c19aeba0d9b075095a2effb9b31fd312b1aae3ac79f8aea2/maturin-1.13.3-py3-none-win32.whl", hash = "sha256:0ef257e692cc756c87af5bea95ddfe7d3ac49d3376a7a87f728d63f06e7b6f8b", size = 8901838, upload-time = "2026-05-11T07:43:23.76Z" },
     { url = "https://files.pythonhosted.org/packages/a1/ff/c6a50a59dc8313097d43ac5f4d74df6a500c8cb62b0dc9e054f53e203a48/maturin-1.13.3-py3-none-win_amd64.whl", hash = "sha256:def4a435ea9d2ee93b18ba579dc8c9cf898889a66f312cd379b5e374ec3e3ad6", size = 10340801, upload-time = "2026-05-11T07:43:29.239Z" },
     { url = "https://files.pythonhosted.org/packages/6c/93/e32e79333f0902ba292b996f504f5f06be59587f7d02ab8d5ed1e3066445/maturin-1.13.3-py3-none-win_arm64.whl", hash = "sha256:2389fe92d017cea9d94e521fa0175314a4c52f79a1057b901fbc9f8686ef7d0b", size = 9706562, upload-time = "2026-05-11T07:43:31.743Z" },
+]
+
+[[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
 ]
 
 [[package]]
@@ -1366,7 +1393,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -1427,7 +1454,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -1537,6 +1564,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/f1/25583de1603acdf5ef9a0cde82b3e86bd8fab7b3149ae7733c1a1508dba7/spiceypy-8.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:50d7dea58b1538fb621ef8dbaa4ff7284a6e6865350f15197713b12ec70d4f15", size = 2220443, upload-time = "2026-04-05T05:40:59.435Z" },
     { url = "https://files.pythonhosted.org/packages/6a/e3/029419599fc966a5cdc199da0c21753b222aa75fc276d94cb82291036ebf/spiceypy-8.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:54e984f989dbe36042208f932f99a79da124af7f5af67ca73a0abb6d22378cd9", size = 2332761, upload-time = "2026-04-05T05:41:01.358Z" },
     { url = "https://files.pythonhosted.org/packages/28/0e/85211833e4de81ce292173d25614a3c8009c4a3f667c34b2105e325fdb31/spiceypy-8.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:276484e0ba1d0a2f088e7e9f45c4b04760dbd839eca9b88aee8180e9af0f3916", size = 2087946, upload-time = "2026-04-05T05:41:03.047Z" },
+]
+
+[[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 概述

把 qiao 的 Hamiltonian 正规化能力以 e2m2e 原生模块形式集成进 `e2m2e.algorithms.normal_form`，并提供一键式 `NormalFormPipeline`，发版 5.1.0。

## 交付内容

**新模块** `e2m2e/algorithms/normal_form/`：
- `NormalFormPipeline`：动力学替代 → quasi-Floquet 变换 → 中心流形化简 → rho↔param 坐标变换
- 各步 reducer：`DynamicalSubstituteCorrector`、`QuasiFloquetReducer`、`CenterManifoldReducer`、`LibrationCatalogTransformer`
- `coord_trans` 函数式坐标变换链、NAFF/FFT 频率分析、块三对角多重打靶

**文档与示例**：
- `docs/algorithms/normal-form.rst`
- `examples/normal_form_example.py`
- `CONTEXT.md`/`glossary.rst` 新增「Hamiltonian 正规化」术语

**发版元数据**：
- README 补 normal_form 能力说明，bibtex 版本号更新
- CHANGELOG 新增 `[5.1.0]`
- pyproject 版本 5.0.0 → 5.1.0

## 核对阶段修复的 bug

dispatch 流水线在核对 #171–#174 时发现并修复 3 个潜伏 bug（现有测试因恰好绕过而漏网）：
- quasi-Floquet Lie 法的 dexp 公式误差（→ commutator-free 4 阶 Lie group RK4）
- 中心流形 Step 2 的 W 归零（MAD=0 抑制 + 取实部丢弃纯虚 W）
- rho↔param 插值用兜底时间网格 dt=0.1 的数值错误

## 测试

- `uv run --no-sync pytest tests/algorithms/normal_form/ -q` → **164 passed, 11 skipped**
- `uv run --no-sync ruff check .` → **全过**
- `uv run --no-sync python examples/normal_form_example.py` → 端到端跑通，往返误差 5.5e-17

skip 的 11 个为：SPICE leapseconds 内核不可用（环境退路）+ qiao `.npz` 回归 fixture 未入库（守卫）。

## 遗留问题（已发为 issue）

- #177 统一术语「法型化」→「Hamiltonian 正规化」
- #178 清理 normal_form mypy 类型标注（32 个既存错误）
- #179 补切片 5 复值 W 插值的正向数值测试

这些不阻塞 5.1.0 发版。

## 关联 issue

Closes #168（及子 issue #169–#176，均已在 dispatch 阶段关闭）

## 发版后续

合并本 PR 后，将在 master 上打 `v5.1.0` tag 触发 release.yml，构建 wheel/sdist 并发布到 PyPI + GitHub Release。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Hamiltonian 正规化（Normal Form）工作流，可将轨道状态归约为紧凑的参数表示，并支持端到端的一键流水线（含状态格式双向转换）。
  * Added optional high-accuracy频率分析支持（NAFF优先，缺失时自动回退）。
* **Bug Fixes**
  * Corrected quasi-Floquet Lie 变换公式与中心流形 Step 2 的生成函数处理。
  * Improved rho↔param 插值精度，使用正确采样点避免时网格偏差。
* **Documentation**
  * Updated README、术语表与新增算法/方案文档，并提供可运行示例与版本/依赖说明。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->