### PR TITLE
feat(propagation): Python 层对接 Rust STM 传播器

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,4 @@ scripts/*.png
 # agent/工具会话产物
 .mimocode/
 .zcode/
+*.pdb

--- a/crates/e2m2e-integrators/src/lib.rs
+++ b/crates/e2m2e-integrators/src/lib.rs
@@ -6,9 +6,9 @@
 //! [`crate::cowell`] 的模块文档。
 
 use pyo3::prelude::*;
-#[cfg(feature = "spice")]
-use pyo3::types::PyDict;
 use pyo3::types::PyList;
+#[cfg(feature = "spice")]
+use pyo3::types::{PyDict, PyTuple};
 
 pub(crate) mod abm;
 pub(crate) mod butcher;

--- a/e2m2e/constants.py
+++ b/e2m2e/constants.py
@@ -1,0 +1,25 @@
+"""共享物理常量（单一来源）。
+
+所有力模型与系统统一从此模块引用地球半径、天文单位等共享物理常量，
+避免各模块重复定义导致取值漂移（历史上 ``drag`` 用 6378.137 km 而
+``shadow``/``gravity_file`` 等用 6378.1363 km；``srp`` 用
+149597870.691 km 而 ``cr3bp_system`` 用 149597870.7 km）。
+
+取值统一采用 GMAT/WGS84 标准，与 GMAT R2026a 默认值及多数既有代码一致。
+"""
+
+from __future__ import annotations
+
+# 地球赤道半径（km）。
+# 取 GMAT PCK / IAU 2015 常用值 6378.1363 km，与 gravity_file、shadow、
+# relativistic_correction 等力模型一致。注意 drag 模型旧值 6378.137 km
+# (WGS84) 已统一至此标准，地心高度差 0.0007 km，对大气密度影响可忽略。
+R_EARTH: float = 6378.1363
+
+# 天文单位（km）。
+# 取 GMAT nominalSun 值 149597870.7 km（GMAT R2026a
+# SolarRadiationPressure 默认），与 cr3bp_system 一致。
+AU: float = 149597870.7
+
+# 千米 → 米换算因子。
+KM_TO_M: float = 1000.0

--- a/e2m2e/core/dynamics.py
+++ b/e2m2e/core/dynamics.py
@@ -81,7 +81,7 @@ class Dynamics:
 
         # 缓存最近一次积分结果
         self.last_trajectory: tuple[np.ndarray, np.ndarray] | None = None
-        self.last_stm = None  # STM 矩阵数组
+        self.last_stm: np.ndarray | None = None  # STM 矩阵数组
 
         # 截面检测参数
         self.cross_section_tolerance = 1e-8

--- a/e2m2e/core/ephemeris_dynamics.py
+++ b/e2m2e/core/ephemeris_dynamics.py
@@ -33,12 +33,20 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import Callable
+from typing import Any
 
 import numpy as np
 import numpy.typing as npt
 
 from .dynamics import Dynamics
 from .ephemeris_system import EphemerisSystem
+
+try:
+    from e2m2e._integrators import propagate_with_stm_py
+
+    _HAS_RUST_STM = True
+except ImportError:
+    _HAS_RUST_STM = False
 
 
 class EphemerisDynamics(Dynamics):
@@ -78,6 +86,69 @@ class EphemerisDynamics(Dynamics):
         if span_duration > 0:
             return min(self.max_step, span_duration / 10.0)
         return self.max_step
+
+    def _propagate_with_stm(
+        self,
+        initial_state: np.ndarray,
+        t_span: tuple[float, float],
+        t_eval: npt.ArrayLike | None,
+        max_step: float,
+        with_jacobi: bool,
+    ) -> dict[str, Any]:
+        """增广状态积分（含 STM），优先走 Rust 快速路径。"""
+        if _HAS_RUST_STM:
+            return self._propagate_with_stm_rust(
+                initial_state,
+                t_span,
+                t_eval,
+                max_step,
+            )
+        return super()._propagate_with_stm(
+            initial_state,
+            t_span,
+            t_eval,
+            max_step,
+            with_jacobi,
+        )
+
+    def _propagate_with_stm_rust(
+        self,
+        initial_state: np.ndarray,
+        t_span: tuple[float, float],
+        t_eval: npt.ArrayLike | None,
+        max_step: float,
+    ) -> dict[str, Any]:
+        """Rust 快速路径：调用 propagate_with_stm_py 完成 STM 传播。"""
+        system: EphemerisSystem = self.system
+        bodies = list(system.bodies)
+        origin = system.origin
+        gm_values = [float(gm) for gm in system.get_gm_values()]
+
+        if t_eval is not None:
+            t_eval_list = [float(t) for t in np.asarray(t_eval, dtype=float).ravel()]
+        else:
+            t_eval_list = [float(t_span[0]), float(t_span[1])]
+
+        result = propagate_with_stm_py(
+            bodies=bodies,
+            origin=origin,
+            gm_values=gm_values,
+            t_span=(float(t_span[0]), float(t_span[1])),
+            t_eval=t_eval_list,
+            initial_state=[float(x) for x in initial_state[:6]],
+            rtol=self.rtol,
+            atol=self.atol,
+            max_step=float(max_step),
+        )
+
+        states = np.array(result["states"])
+        stm = np.array(result["stm"]).reshape(-1, 6, 6)
+        time = np.array(result["time"])
+
+        self.last_trajectory = (time, states)
+        self.last_stm = stm
+
+        return {"time": time, "states": states, "stm": stm}
 
     def _compute_acc_and_jacobian(
         self,

--- a/e2m2e/dynamics/forces/relativistic_correction.py
+++ b/e2m2e/dynamics/forces/relativistic_correction.py
@@ -7,7 +7,8 @@ from typing import Any
 import numpy as np
 import numpy.typing as npt
 
-from ..constants import R_EARTH
+from e2m2e.constants import R_EARTH
+
 from ..coordinate_system import CoordinateSystem
 from ..standard_axes import ICRSAxes, ITRFSpiceAxes
 from ..standard_origins import CelestialBodyOrigin

--- a/e2m2e/dynamics/forces/shadow.py
+++ b/e2m2e/dynamics/forces/shadow.py
@@ -17,7 +17,8 @@ from typing import TYPE_CHECKING
 import numpy as np
 import numpy.typing as npt
 
-from ..constants import R_EARTH
+from e2m2e.constants import R_EARTH
+
 from .physical_model import require_inertial_frame
 
 if TYPE_CHECKING:

--- a/e2m2e/dynamics/forces/srp.py
+++ b/e2m2e/dynamics/forces/srp.py
@@ -23,7 +23,8 @@ from typing import TYPE_CHECKING
 import numpy as np
 import numpy.typing as npt
 
-from ..constants import AU, KM_TO_M
+from e2m2e.constants import AU, KM_TO_M
+
 from .physical_model import PhysicalModel, require_inertial_frame
 
 if TYPE_CHECKING:

--- a/e2m2e/dynamics/propagation/cr3bp_system.py
+++ b/e2m2e/dynamics/propagation/cr3bp_system.py
@@ -14,8 +14,9 @@ import numpy as np
 import numpy.typing as npt
 from scipy.optimize import fsolve
 
-from .constants import AU as _AU_KM
-from .enums import ReferenceFrame, UnitSystem
+from e2m2e.constants import AU as _AU_KM
+from e2m2e.enums import ReferenceFrame, UnitSystem
+
 from .potential import pseudo_potential_hessian
 from .system import System
 

--- a/e2m2e/dynamics/propagation/dynamics.py
+++ b/e2m2e/dynamics/propagation/dynamics.py
@@ -81,7 +81,7 @@ class Dynamics:
 
         # 缓存最近一次积分结果
         self.last_trajectory: tuple[np.ndarray, np.ndarray] | None = None
-        self.last_stm = None  # STM 矩阵数组
+        self.last_stm: np.ndarray | None = None  # STM 矩阵数组
 
         # 截面检测参数
         self.cross_section_tolerance = 1e-8

--- a/e2m2e/dynamics/propagation/ephemeris_dynamics.py
+++ b/e2m2e/dynamics/propagation/ephemeris_dynamics.py
@@ -33,12 +33,20 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import Callable
+from typing import Any
 
 import numpy as np
 import numpy.typing as npt
 
 from .dynamics import Dynamics
 from .ephemeris_system import EphemerisSystem
+
+try:
+    from e2m2e._integrators import propagate_with_stm_py
+
+    _HAS_RUST_STM = True
+except ImportError:
+    _HAS_RUST_STM = False
 
 
 class EphemerisDynamics(Dynamics):
@@ -78,6 +86,69 @@ class EphemerisDynamics(Dynamics):
         if span_duration > 0:
             return min(self.max_step, span_duration / 10.0)
         return self.max_step
+
+    def _propagate_with_stm(
+        self,
+        initial_state: np.ndarray,
+        t_span: tuple[float, float],
+        t_eval: npt.ArrayLike | None,
+        max_step: float,
+        with_jacobi: bool,
+    ) -> dict[str, Any]:
+        """增广状态积分（含 STM），优先走 Rust 快速路径。"""
+        if _HAS_RUST_STM:
+            return self._propagate_with_stm_rust(
+                initial_state,
+                t_span,
+                t_eval,
+                max_step,
+            )
+        return super()._propagate_with_stm(
+            initial_state,
+            t_span,
+            t_eval,
+            max_step,
+            with_jacobi,
+        )
+
+    def _propagate_with_stm_rust(
+        self,
+        initial_state: np.ndarray,
+        t_span: tuple[float, float],
+        t_eval: npt.ArrayLike | None,
+        max_step: float,
+    ) -> dict[str, Any]:
+        """Rust 快速路径：调用 propagate_with_stm_py 完成 STM 传播。"""
+        system: EphemerisSystem = self.system
+        bodies = list(system.bodies)
+        origin = system.origin
+        gm_values = [float(gm) for gm in system.get_gm_values()]
+
+        if t_eval is not None:
+            t_eval_list = [float(t) for t in np.asarray(t_eval, dtype=float).ravel()]
+        else:
+            t_eval_list = [float(t_span[0]), float(t_span[1])]
+
+        result = propagate_with_stm_py(
+            bodies=bodies,
+            origin=origin,
+            gm_values=gm_values,
+            t_span=(float(t_span[0]), float(t_span[1])),
+            t_eval=t_eval_list,
+            initial_state=[float(x) for x in initial_state[:6]],
+            rtol=self.rtol,
+            atol=self.atol,
+            max_step=float(max_step),
+        )
+
+        states = np.array(result["states"])
+        stm = np.array(result["stm"]).reshape(-1, 6, 6)
+        time = np.array(result["time"])
+
+        self.last_trajectory = (time, states)
+        self.last_stm = stm
+
+        return {"time": time, "states": states, "stm": stm}
 
     def _compute_acc_and_jacobian(
         self,

--- a/e2m2e/dynamics/propagation/ephemeris_system.py
+++ b/e2m2e/dynamics/propagation/ephemeris_system.py
@@ -9,8 +9,9 @@ from __future__ import annotations
 import numpy as np
 import numpy.typing as npt
 
+from e2m2e.enums import ReferenceFrame, UnitSystem
+
 from .coordinate.coordinate_system import CoordinateSystem
-from .enums import ReferenceFrame, UnitSystem
 from .spice import SPICEManager
 from .system import System
 

--- a/e2m2e/dynamics/propagation/system.py
+++ b/e2m2e/dynamics/propagation/system.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import abc
 
-from .enums import ReferenceFrame, UnitSystem
+from e2m2e.enums import ReferenceFrame, UnitSystem
 
 
 class System(abc.ABC):

--- a/e2m2e/enums.py
+++ b/e2m2e/enums.py
@@ -1,0 +1,70 @@
+"""共享领域枚举
+
+存放被 core / algorithms / transfer / visualization 等多层引用的基础领域枚举。
+仅 mbse 内部使用的追溯性枚举仍保留在 ``e2m2e.mbse.data.enums``。
+
+此处定义的枚举也经 ``e2m2e.mbse.data.enums`` 重导出，以保持向后兼容。
+"""
+
+from __future__ import annotations
+
+import enum
+
+
+class ReferenceFrame(enum.Enum):
+    """参考坐标系"""
+
+    ROTATING = "rotating"  # CR3BP 旋转坐标系
+    INERTIAL = "inertial"  # 惯性坐标系
+    BARYCENTRIC = "barycentric"  # 质心坐标系
+    PRIMARY_CENTERED = "primary_centered"  # 主天体中心坐标系
+    SECONDARY_CENTERED = "secondary_centered"  # 次天体中心坐标系
+    SYNODIC = "synodic"  # 会合坐标系
+    J2000 = "J2000"  # J2000 惯性系
+
+
+class UnitSystem(enum.Enum):
+    """单位系统"""
+
+    DIMENSIONLESS = "dimensionless"  # 无量纲单位（如 CR3BP）
+    SI = "si"  # 国际单位制（km, s, km/s）
+
+
+class ProjectionPlane(enum.Enum):
+    """投影平面"""
+
+    XY = "xy"
+    XZ = "xz"
+    YZ = "yz"
+
+
+class TransferType(enum.Enum):
+    """转移类型"""
+
+    DIRECT = "direct"
+    LGA = "lga"  # Lunar Gravity Assist
+    EXTERNAL = "external"
+
+
+class BoundaryMode(enum.Enum):
+    """两层多重打靶的边界条件。"""
+
+    FIXED_ENDPOINTS = "fixed_endpoints"
+
+
+class TwoLevelMultipleShootingStatus(enum.Enum):
+    """两层多重打靶的结果状态。"""
+
+    CONVERGED = "converged"
+    MAX_ITERATIONS = "max_iterations"
+    LEVEL1_FAILED = "level1_failed"
+
+
+class ConvergenceState(enum.Enum):
+    """算法收敛状态（用于状态机图）"""
+
+    ITERATING = "iterating"
+    CONVERGED = "converged"
+    DIVERGED = "diverged"
+    STAGNATED = "stagnated"
+    MAX_ITERATIONS = "max_iterations"

--- a/tests/core/dynamics/test_rust_stm_propagation.py
+++ b/tests/core/dynamics/test_rust_stm_propagation.py
@@ -1,0 +1,137 @@
+"""Rust propagate_with_stm_py 对接测试。
+
+验证 EphemerisDynamics 的 Rust 快速路径与 SciPy 路径
+在 LEO 一个周期内的 STM 一致性。
+"""
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+pytestmark = pytest.mark.spice
+
+
+@pytest.fixture
+def leo_state():
+    """近地轨道初始状态 (J2000, km, km/s)"""
+    r = 6778  # 地球半径 + 400 km
+    v = np.sqrt(398600.436 / r)  # 圆轨道速度
+    return np.array([r, 0, 0, 0, v, 0])
+
+
+@pytest.fixture
+def reference_et(spice_manager, reference_epoch):
+    """参考历元的 ET 秒数"""
+    return spice_manager.utc_to_et(reference_epoch)
+
+
+class TestRustStmAvailability:
+    """测试 Rust STM 模块是否可用"""
+
+    def test_rust_stm_import_flag(self):
+        """应能检测到 propagate_with_stm_py 是否可用"""
+        from e2m2e.core.ephemeris_dynamics import _HAS_RUST_STM
+
+        # 无论是否安装了 spice wheel，flag 都应该是 bool
+        assert isinstance(_HAS_RUST_STM, bool)
+
+
+class TestRustStmPropagation:
+    """测试 Rust STM 传播的正确性"""
+
+    def test_rust_propagate_with_stm_shape(self, spice_eph_dynamics, reference_et, leo_state):
+        """Rust 路径应返回正确形状的 states/stm/time"""
+        from e2m2e.core.ephemeris_dynamics import _HAS_RUST_STM
+
+        if not _HAS_RUST_STM:
+            pytest.skip("propagate_with_stm_py 不可用（未安装 spice wheel）")
+
+        t_span = (reference_et, reference_et + 5400)  # 1.5 小时
+        t_eval = np.linspace(t_span[0], t_span[1], 50)
+        result = spice_eph_dynamics._propagate_with_stm_rust(
+            leo_state, t_span, t_eval, max_step=60.0
+        )
+
+        assert result["states"].shape == (50, 6)
+        assert result["stm"].shape == (50, 6, 6)
+        assert result["time"].shape == (50,)
+
+    def test_rust_stm_initial_is_identity(self, spice_eph_dynamics, reference_et, leo_state):
+        """Rust 路径的初始 STM 应为单位矩阵"""
+        from e2m2e.core.ephemeris_dynamics import _HAS_RUST_STM
+
+        if not _HAS_RUST_STM:
+            pytest.skip("propagate_with_stm_py 不可用（未安装 spice wheel）")
+
+        t_span = (reference_et, reference_et + 3600)
+        t_eval = np.linspace(t_span[0], t_span[1], 100)
+        result = spice_eph_dynamics._propagate_with_stm_rust(
+            leo_state, t_span, t_eval, max_step=60.0
+        )
+
+        assert_allclose(result["stm"][0], np.eye(6), atol=1e-6)
+
+    def test_rust_vs_python_stm_leo_one_period(self, spice_eph_dynamics, reference_et, leo_state):
+        """Rust 与 Python STM 在 LEO 一个周期内一致性"""
+        from e2m2e.core.ephemeris_dynamics import _HAS_RUST_STM
+
+        if not _HAS_RUST_STM:
+            pytest.skip("propagate_with_stm_py 不可用（未安装 spice wheel）")
+
+        # LEO 约 90 分钟
+        period = 2 * np.pi * np.sqrt(6778**3 / 398600.436)
+        t_span = (reference_et, reference_et + period)
+        t_eval = np.linspace(t_span[0], t_span[1], 20)
+        max_step = spice_eph_dynamics._get_max_step(t_span)
+
+        # Rust 路径
+        rust_result = spice_eph_dynamics._propagate_with_stm_rust(
+            leo_state, t_span, t_eval, max_step
+        )
+
+        # Python 路径（基类 SciPy）
+        from e2m2e.core.dynamics import Dynamics
+
+        python_result = Dynamics._propagate_with_stm(
+            spice_eph_dynamics,
+            leo_state,
+            t_span,
+            t_eval,
+            max_step,
+            with_jacobi=False,
+        )
+
+        # 状态对比：用 atol 1e-3 km（1 米），因为接近零的分量相对误差无意义
+        assert_allclose(
+            rust_result["states"],
+            python_result["states"],
+            atol=1e-3,
+            err_msg="Rust 与 Python 状态传播结果不一致",
+        )
+
+        # STM 对比：独立 DOP853 实现累积差异，max abs diff ~1e-4
+        assert_allclose(
+            rust_result["stm"],
+            python_result["stm"],
+            atol=1e-3,
+            err_msg="Rust 与 Python STM 结果不一致",
+        )
+
+    def test_rust_propagate_api_entry(self, spice_eph_dynamics, reference_et, leo_state):
+        """通过 propagate(with_stm=True) 入口应自动走 Rust 路径"""
+        from e2m2e.core.ephemeris_dynamics import _HAS_RUST_STM
+
+        if not _HAS_RUST_STM:
+            pytest.skip("propagate_with_stm_py 不可用（未安装 spice wheel）")
+
+        t_span = (reference_et, reference_et + 3600)
+        result = spice_eph_dynamics.propagate(leo_state, t_span, with_stm=True)
+
+        assert "stm" in result
+        assert result["stm"].shape[1:] == (6, 6)
+        assert np.all(np.isfinite(result["states"]))
+        assert np.all(np.isfinite(result["stm"]))
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## 概述

完成阶段 D 的第一步：让 `EphemerisDynamics.propagate(with_stm=True)` 自动走 Rust `propagate_with_stm_py` 快速路径。

## 改动

### Commit 1: fix(dynamics) — constants/enums import 断裂修复

PR #243 的 `core → dynamics` 迁移遗留了 `dynamics` 模块的相对 import 断裂（指向不存在的 `dynamics/constants.py`、`dynamics/enums.py`）。新增两个顶层模块作为单一来源：

- `e2m2e/constants.py`：`R_EARTH`、`AU`、`KM_TO_M`
- `e2m2e/enums.py`：`ReferenceFrame`、`UnitSystem` 等

修复 `dynamics/propagation/`（3 个文件）和 `dynamics/forces/`（3 个文件）的 import。

### Commit 2: feat(propagation) — Rust STM 对接

在 `EphemerisDynamics` 中覆写 `_propagate_with_stm`：

- `_HAS_RUST_STM` flag：try/except 检测 `propagate_with_stm_py` 是否可用
- `_propagate_with_stm_rust`：提取 system.bodies/origin/gm_values，调 Rust，转换返回格式
- 无 spice wheel 时自动回退 SciPy，上层 `MultipleShooting.correct()` 零改动

附带修复：
- `crates/e2m2e-integrators/src/lib.rs`：添加 `PyTuple` import（PyO3 编译修复）
- `e2m2e/core/dynamics.py`：`last_stm` 类型注解（mypy 修复）

## 测试

新增 `tests/core/dynamics/test_rust_stm_propagation.py`（5 个测试）：

| 测试 | 验证内容 |
|------|---------|
| `test_rust_stm_import_flag` | `_HAS_RUST_STM` 为 bool |
| `test_rust_propagate_with_stm_shape` | 返回 states(50,6) + stm(50,6,6) |
| `test_rust_stm_initial_is_identity` | 初始 STM ≈ I₆ |
| `test_rust_vs_python_stm_leo_one_period` | Rust vs Python LEO 一圈差异 < 1e-3 |
| `test_rust_propagate_api_entry` | `propagate(with_stm=True)` 入口自动走 Rust |

原有 28 个 ephemeris_dynamics 测试零回归（72/72 全通过）。

## 验收标准

- [x] Rust STM 初始值 = 单位矩阵
- [x] Rust vs Python LEO 一圈状态差异 < 1e-3 km
- [x] `MultipleShooting.correct()` 的传播入口自动走 Rust（无代码改动）
- [x] 无 spice wheel 时自动回退 SciPy

## 下一步

任务 2：DRO→GEO 端到端验证（`transfer-orbit-design` 仓库）