### PR TITLE
feat(stm): 将 compiled STM 合并到 integrators crate，消除 cspice 隔离

### DIFF
--- a/crates/e2m2e-forces/src/forces/compiled.rs
+++ b/crates/e2m2e-forces/src/forces/compiled.rs
@@ -78,7 +78,11 @@ impl CompiledForce {
                 let r_norm_sq = r[0] * r[0] + r[1] * r[1] + r[2] * r[2];
                 let r_norm = r_norm_sq.sqrt().max(1e-6);
                 let inv_r3 = 1.0 / (r_norm * r_norm * r_norm);
-                Ok([-mu * r[0] * inv_r3, -mu * r[1] * inv_r3, -mu * r[2] * inv_r3])
+                Ok([
+                    -mu * r[0] * inv_r3,
+                    -mu * r[1] * inv_r3,
+                    -mu * r[2] * inv_r3,
+                ])
             }
             Self::GravityField {
                 c_flat,
@@ -218,7 +222,11 @@ pub fn acceleration_and_jacobian(
             let r_norm = r_norm_sq.sqrt().max(1e-6);
             let inv_r3 = 1.0 / (r_norm * r_norm * r_norm);
             let inv_r5 = inv_r3 / (r_norm * r_norm);
-            let acc = [-mu * r[0] * inv_r3, -mu * r[1] * inv_r3, -mu * r[2] * inv_r3];
+            let acc = [
+                -mu * r[0] * inv_r3,
+                -mu * r[1] * inv_r3,
+                -mu * r[2] * inv_r3,
+            ];
             let mut jac = [[0.0_f64; 3]; 3];
             for i in 0..3 {
                 for j in 0..3 {
@@ -229,9 +237,19 @@ pub fn acceleration_and_jacobian(
             Ok((acc, jac))
         }
         CompiledForce::GravityField {
-            c_flat, s_flat, mu, radius, degree, order,
-            input_frame, propagation_frame, body, propagation_origin,
-            tide_mode, k_love_flat, k_plus_flat,
+            c_flat,
+            s_flat,
+            mu,
+            radius,
+            degree,
+            order,
+            input_frame,
+            propagation_frame,
+            body,
+            propagation_origin,
+            tide_mode,
+            k_love_flat,
+            k_plus_flat,
         } => {
             let r_sc = [state[0], state[1], state[2]];
             let tide = TideConfig {
@@ -240,9 +258,20 @@ pub fn acceleration_and_jacobian(
                 k_plus_flat: k_plus_flat.clone(),
             };
             let ctx = gravity_field::GravityFieldContext::build(
-                et, c_flat, s_flat, *mu, *radius, *degree, *order,
-                input_frame, propagation_frame, body, propagation_origin, &tide,
-            ).map_err(|e| format!("{:?}", e))?;
+                et,
+                c_flat,
+                s_flat,
+                *mu,
+                *radius,
+                *degree,
+                *order,
+                input_frame,
+                propagation_frame,
+                body,
+                propagation_origin,
+                &tide,
+            )
+            .map_err(|e| format!("{:?}", e))?;
             let acc = ctx.accel(&r_sc).map_err(|e| format!("{:?}", e))?;
             let jac = ctx.jacobian_fd(&r_sc).map_err(|e| format!("{:?}", e))?;
             Ok((acc, jac))
@@ -251,7 +280,8 @@ pub fn acceleration_and_jacobian(
             let sc_pos = [state[0], state[1], state[2]];
             let (acc, jac) = spk_accel::third_body_acceleration_and_jacobian(
                 et, body, observer, &sc_pos, *mu, 1e-6,
-            ).map_err(|e| format!("{:?}", e))?;
+            )
+            .map_err(|e| format!("{:?}", e))?;
             Ok((acc, jac))
         }
         CompiledForce::IndirectTerm { .. } => {

--- a/crates/e2m2e-forces/src/forces/compiled.rs
+++ b/crates/e2m2e-forces/src/forces/compiled.rs
@@ -15,6 +15,9 @@ use e2m2e_spice::spk_accel;
 /// 每个 variant 持有该 force 的全部配置。Python 侧用元组序列化（见
 /// `force_from_tuple`）。
 pub enum CompiledForce {
+    PointMass {
+        mu: f64,
+    },
     GravityField {
         c_flat: Vec<f64>,
         s_flat: Vec<f64>,
@@ -70,6 +73,13 @@ impl CompiledForce {
         observer: &str,
     ) -> Result<[f64; 3], String> {
         match self {
+            Self::PointMass { mu } => {
+                let r = [state[0], state[1], state[2]];
+                let r_norm_sq = r[0] * r[0] + r[1] * r[1] + r[2] * r[2];
+                let r_norm = r_norm_sq.sqrt().max(1e-6);
+                let inv_r3 = 1.0 / (r_norm * r_norm * r_norm);
+                Ok([-mu * r[0] * inv_r3, -mu * r[1] * inv_r3, -mu * r[2] * inv_r3])
+            }
             Self::GravityField {
                 c_flat,
                 s_flat,
@@ -175,4 +185,100 @@ pub fn compute_total_acceleration(
         total[2] += a[2];
     }
     Ok(total)
+}
+
+/// 单个 force 是否支持解析/Rust FD 雅可比。
+pub fn supports_jacobian(force: &CompiledForce) -> bool {
+    matches!(
+        force,
+        CompiledForce::PointMass { .. }
+            | CompiledForce::GravityField { .. }
+            | CompiledForce::ThirdBody { .. }
+            | CompiledForce::IndirectTerm { .. }
+    )
+}
+
+/// 计算单个 force 的加速度 + 雅可比（3×3）。
+///
+/// - PointMass：解析 `-μ(I/r³ − 3rrᵀ/r⁵)`
+/// - GravityField：body-fixed 系 FD + R·J·Rᵀ（需 SPICE）
+/// - ThirdBody：spk_accel 解析
+/// - IndirectTerm：零矩阵（不依赖航天器位置）
+/// - SRP/Relativistic：返回 Err
+pub fn acceleration_and_jacobian(
+    force: &CompiledForce,
+    et: f64,
+    state: &[f64; 6],
+    observer: &str,
+) -> Result<([f64; 3], [[f64; 3]; 3]), String> {
+    match force {
+        CompiledForce::PointMass { mu } => {
+            let r = [state[0], state[1], state[2]];
+            let r_norm_sq = r[0] * r[0] + r[1] * r[1] + r[2] * r[2];
+            let r_norm = r_norm_sq.sqrt().max(1e-6);
+            let inv_r3 = 1.0 / (r_norm * r_norm * r_norm);
+            let inv_r5 = inv_r3 / (r_norm * r_norm);
+            let acc = [-mu * r[0] * inv_r3, -mu * r[1] * inv_r3, -mu * r[2] * inv_r3];
+            let mut jac = [[0.0_f64; 3]; 3];
+            for i in 0..3 {
+                for j in 0..3 {
+                    let delta = if i == j { 1.0 } else { 0.0 };
+                    jac[i][j] = -mu * (delta * inv_r3 - 3.0 * r[i] * r[j] * inv_r5);
+                }
+            }
+            Ok((acc, jac))
+        }
+        CompiledForce::GravityField {
+            c_flat, s_flat, mu, radius, degree, order,
+            input_frame, propagation_frame, body, propagation_origin,
+            tide_mode, k_love_flat, k_plus_flat,
+        } => {
+            let r_sc = [state[0], state[1], state[2]];
+            let tide = TideConfig {
+                mode: tide_mode.clone(),
+                k_love_flat: k_love_flat.clone(),
+                k_plus_flat: k_plus_flat.clone(),
+            };
+            let ctx = gravity_field::GravityFieldContext::build(
+                et, c_flat, s_flat, *mu, *radius, *degree, *order,
+                input_frame, propagation_frame, body, propagation_origin, &tide,
+            ).map_err(|e| format!("{:?}", e))?;
+            let acc = ctx.accel(&r_sc).map_err(|e| format!("{:?}", e))?;
+            let jac = ctx.jacobian_fd(&r_sc).map_err(|e| format!("{:?}", e))?;
+            Ok((acc, jac))
+        }
+        CompiledForce::ThirdBody { body, mu } => {
+            let sc_pos = [state[0], state[1], state[2]];
+            let (acc, jac) = spk_accel::third_body_acceleration_and_jacobian(
+                et, body, observer, &sc_pos, *mu, 1e-6,
+            ).map_err(|e| format!("{:?}", e))?;
+            Ok((acc, jac))
+        }
+        CompiledForce::IndirectTerm { .. } => {
+            let acc = force.acceleration(et, state, observer)?;
+            Ok((acc, [[0.0; 3]; 3]))
+        }
+        _ => Err(format!("Jacobian not supported for this force type")),
+    }
+}
+
+/// 计算所有 force 的总加速度 + 总雅可比（逐力叠加）。
+pub fn compute_total_acceleration_and_jacobian(
+    forces: &[CompiledForce],
+    et: f64,
+    state: &[f64; 6],
+    observer: &str,
+) -> Result<([f64; 3], [[f64; 3]; 3]), String> {
+    let mut total_acc = [0.0_f64; 3];
+    let mut total_jac = [[0.0_f64; 3]; 3];
+    for force in forces {
+        let (acc, jac) = acceleration_and_jacobian(force, et, state, observer)?;
+        for i in 0..3 {
+            total_acc[i] += acc[i];
+            for j in 0..3 {
+                total_jac[i][j] += jac[i][j];
+            }
+        }
+    }
+    Ok((total_acc, total_jac))
 }

--- a/crates/e2m2e-forces/src/forces/compiled_stm.rs
+++ b/crates/e2m2e-forces/src/forces/compiled_stm.rs
@@ -6,9 +6,7 @@
 //!
 //! 复用 `nbody_stm` 的 `compute_jacobian_A` + `stm_derivative`。
 
-use crate::forces::compiled::{
-    CompiledForce, compute_total_acceleration_and_jacobian,
-};
+use crate::forces::compiled::{compute_total_acceleration_and_jacobian, CompiledForce};
 use crate::forces::nbody_stm;
 use e2m2e_propagation::butcher::{explicit_rk_step, suggest_next_step};
 use e2m2e_propagation::pd45::PD45_TABLE;
@@ -38,8 +36,14 @@ fn augmented_eom(
     et: f64,
     augmented: &[f64],
 ) -> Result<Vec<f64>, String> {
-    let state6 = [augmented[0], augmented[1], augmented[2],
-                  augmented[3], augmented[4], augmented[5]];
+    let state6 = [
+        augmented[0],
+        augmented[1],
+        augmented[2],
+        augmented[3],
+        augmented[4],
+        augmented[5],
+    ];
     let mut stm = [0.0_f64; 36];
     stm.copy_from_slice(&augmented[6..42]);
 
@@ -61,7 +65,12 @@ fn augmented_eom(
 }
 
 /// 预检：在 t0 做一次加速度 + 雅可比计算，SPICE 配置错误立即显式失败。
-pub fn precheck(forces: &[CompiledForce], observer: &str, et: f64, state: &[f64; 6]) -> Result<(), String> {
+pub fn precheck(
+    forces: &[CompiledForce],
+    observer: &str,
+    et: f64,
+    state: &[f64; 6],
+) -> Result<(), String> {
     compute_total_acceleration_and_jacobian(forces, et, state, observer)?;
     Ok(())
 }
@@ -119,11 +128,19 @@ pub fn propagate_compiled_stm(
     let mut n_rejected = 0usize;
 
     let mut times = vec![t_span.0];
-    let mut states = vec![[initial_state[0], initial_state[1], initial_state[2],
-                           initial_state[3], initial_state[4], initial_state[5]]];
+    let mut states = vec![[
+        initial_state[0],
+        initial_state[1],
+        initial_state[2],
+        initial_state[3],
+        initial_state[4],
+        initial_state[5],
+    ]];
     let mut stms = {
         let mut stm0 = [0.0_f64; 36];
-        for i in 0..6 { stm0[i * 6 + i] = 1.0; }
+        for i in 0..6 {
+            stm0[i * 6 + i] = 1.0;
+        }
         vec![stm0]
     };
 
@@ -139,7 +156,10 @@ pub fn propagate_compiled_stm(
         }
         h = h.min(h_max);
         if h < MIN_STEP * (t_span.1 - t_span.0).abs() {
-            return Err(format!("step size collapsed below minimum after {} steps", n_steps));
+            return Err(format!(
+                "step size collapsed below minimum after {} steps",
+                n_steps
+            ));
         }
 
         let forces_ref = forces;
@@ -178,9 +198,16 @@ pub fn propagate_compiled_stm(
     if times.len() != t_eval.len() {
         return Err(format!(
             "output length mismatch: got {} time points, expected {}",
-            times.len(), t_eval.len()
+            times.len(),
+            t_eval.len()
         ));
     }
 
-    Ok(CompiledStmResult { states, stms, times, n_steps, n_rejected })
+    Ok(CompiledStmResult {
+        states,
+        stms,
+        times,
+        n_steps,
+        n_rejected,
+    })
 }

--- a/crates/e2m2e-forces/src/forces/compiled_stm.rs
+++ b/crates/e2m2e-forces/src/forces/compiled_stm.rs
@@ -1,0 +1,186 @@
+//! 编译型力模型 + STM 变分方程的 PD45 传播。
+//!
+//! 镜像 `nbody_stm.rs` 的 42 维增广状态布局，但用 PD45 循环
+//! （与 `propagate_compiled` 同一 RK 表/控制器），使 with_stm=True/False
+//! 的 states 逐位一致。
+//!
+//! 复用 `nbody_stm` 的 `compute_jacobian_A` + `stm_derivative`。
+
+use crate::forces::compiled::{
+    CompiledForce, compute_total_acceleration_and_jacobian,
+};
+use crate::forces::nbody_stm;
+use e2m2e_propagation::butcher::{explicit_rk_step, suggest_next_step};
+use e2m2e_propagation::pd45::PD45_TABLE;
+
+/// PD45 嵌入误差估计的阶数（p=4 嵌入, 误差 ~ O(h^5)）。
+const PD45_EMBEDDED_ORDER: usize = 4;
+
+/// 最小步长（秒），防止步长坍缩。
+const MIN_STEP: f64 = 1e-12;
+
+/// 传播结果：状态轨迹 + STM 序列。
+pub struct CompiledStmResult {
+    pub states: Vec<[f64; 6]>,
+    pub stms: Vec<[f64; 36]>,
+    pub times: Vec<f64>,
+    pub n_steps: usize,
+    pub n_rejected: usize,
+}
+
+/// 42 维增广右端项：[v(3), a(3), dΦ/dt(36)]。
+///
+/// 从编译型力模型获取加速度 + 雅可比，组装 A 矩阵，
+/// 计算 STM 变分方程。
+fn augmented_eom(
+    forces: &[CompiledForce],
+    observer: &str,
+    et: f64,
+    augmented: &[f64],
+) -> Result<Vec<f64>, String> {
+    let state6 = [augmented[0], augmented[1], augmented[2],
+                  augmented[3], augmented[4], augmented[5]];
+    let mut stm = [0.0_f64; 36];
+    stm.copy_from_slice(&augmented[6..42]);
+
+    let (acc, jac_da_dr) = compute_total_acceleration_and_jacobian(forces, et, &state6, observer)?;
+    let dstm = nbody_stm::stm_derivative(&stm, &jac_da_dr);
+
+    let mut result = vec![0.0_f64; 42];
+    // dr/dt = v
+    result[0] = state6[3];
+    result[1] = state6[4];
+    result[2] = state6[5];
+    // dv/dt = a
+    result[3] = acc[0];
+    result[4] = acc[1];
+    result[5] = acc[2];
+    // dΦ/dt
+    result[6..42].copy_from_slice(&dstm);
+    Ok(result)
+}
+
+/// 预检：在 t0 做一次加速度 + 雅可比计算，SPICE 配置错误立即显式失败。
+pub fn precheck(forces: &[CompiledForce], observer: &str, et: f64, state: &[f64; 6]) -> Result<(), String> {
+    compute_total_acceleration_and_jacobian(forces, et, state, observer)?;
+    Ok(())
+}
+
+/// PD45 42 维增广状态传播（状态 + STM）。
+///
+/// 与 `nbody_stm::propagate_with_stm` 物理等价，但用 PD45 循环
+/// （与 `propagate_compiled` 同一 RK 表/控制器），
+/// 保证 with_stm=True/False 的 states 逐位一致。
+///
+/// # 参数
+/// - `forces`: 编译型力模型列表
+/// - `observer`: 传播系 origin 天体名
+/// - `t_span`: (t_start, t_end) 积分区间（SPICE et 秒）
+/// - `t_eval`: 输出时间点（必须在 t_span 内且单调递增）
+/// - `initial_state`: 初始状态 [x,y,z,vx,vy,vz]（km, km/s）
+/// - `rtol`, `atol`: 积分容差（合并为 tol = rtol）
+/// - `max_step`: 最大步长（秒），None 则不限制
+/// - `max_steps`: 最大步数
+pub fn propagate_compiled_stm(
+    forces: &[CompiledForce],
+    observer: &str,
+    t_span: (f64, f64),
+    t_eval: &[f64],
+    initial_state: &[f64; 6],
+    rtol: f64,
+    _atol: f64,
+    max_step: Option<f64>,
+    max_steps: Option<usize>,
+) -> Result<CompiledStmResult, String> {
+    if t_eval.is_empty() {
+        return Err("t_eval must not be empty".to_string());
+    }
+
+    // 预检
+    precheck(forces, observer, t_span.0, initial_state)?;
+
+    let tol = rtol;
+    let h_max = max_step.unwrap_or(f64::INFINITY);
+    let s_max = max_steps.unwrap_or(500_000);
+
+    // 构造 42 维增广状态
+    let mut augmented0 = vec![0.0_f64; 42];
+    augmented0[..6].copy_from_slice(initial_state);
+    // 单位 STM
+    for i in 0..6 {
+        augmented0[6 + i * 6 + i] = 1.0;
+    }
+
+    let mut y = augmented0;
+    let mut t = t_span.0;
+    let mut h = (t_span.1 - t_span.0).min(h_max);
+    let mut eval_idx = 1usize; // t_eval[0] == t0 已记录
+    let mut n_steps = 0usize;
+    let mut n_rejected = 0usize;
+
+    let mut times = vec![t_span.0];
+    let mut states = vec![[initial_state[0], initial_state[1], initial_state[2],
+                           initial_state[3], initial_state[4], initial_state[5]]];
+    let mut stms = {
+        let mut stm0 = [0.0_f64; 36];
+        for i in 0..6 { stm0[i * 6 + i] = 1.0; }
+        vec![stm0]
+    };
+
+    while t < t_eval[t_eval.len() - 1] && n_steps < s_max {
+        n_steps += 1;
+
+        // 限制步长不超过下一个评估点
+        if eval_idx < t_eval.len() {
+            let t_next_eval = t_eval[eval_idx];
+            if t + h > t_next_eval {
+                h = t_next_eval - t;
+            }
+        }
+        h = h.min(h_max);
+        if h < MIN_STEP * (t_span.1 - t_span.0).abs() {
+            return Err(format!("step size collapsed below minimum after {} steps", n_steps));
+        }
+
+        let forces_ref = forces;
+        let observer_ref = observer;
+        let callback = |ti: f64, yi: &[f64]| -> Result<Vec<f64>, String> {
+            augmented_eom(forces_ref, observer_ref, ti, yi)
+        };
+
+        let (y_new, error) = explicit_rk_step(&PD45_TABLE, t, &y, h, callback, Some(6))
+            .map_err(|e: String| format!("RK step error at t={}: {}", t, e))?;
+
+        if error <= tol {
+            t += h;
+            y = y_new;
+
+            // 输出落在 t_eval 的点
+            while eval_idx < t_eval.len() && t >= t_eval[eval_idx] - 1e-9 {
+                times.push(t_eval[eval_idx]);
+                let mut s = [0.0_f64; 6];
+                s.copy_from_slice(&y[..6]);
+                states.push(s);
+                let mut stm = [0.0_f64; 36];
+                stm.copy_from_slice(&y[6..42]);
+                stms.push(stm);
+                eval_idx += 1;
+            }
+
+            h = suggest_next_step(h, error, tol, PD45_EMBEDDED_ORDER);
+        } else {
+            n_rejected += 1;
+            h = suggest_next_step(h, error, tol, PD45_EMBEDDED_ORDER);
+        }
+    }
+
+    // 校验输出长度
+    if times.len() != t_eval.len() {
+        return Err(format!(
+            "output length mismatch: got {} time points, expected {}",
+            times.len(), t_eval.len()
+        ));
+    }
+
+    Ok(CompiledStmResult { states, stms, times, n_steps, n_rejected })
+}

--- a/crates/e2m2e-forces/src/forces/gravity_field.rs
+++ b/crates/e2m2e-forces/src/forces/gravity_field.rs
@@ -314,13 +314,21 @@ impl GravityFieldContext {
     ) -> Result<Self, SpiceFfiError> {
         // 1. 查天体位置（平移偏移）
         let (prop_origin_state_ssb, _) = e2m2e_spice::spice_ffi::spkezr(
-            propagation_origin, et, propagation_frame, "NONE", "SOLAR SYSTEM BARYCENTER",
+            propagation_origin,
+            et,
+            propagation_frame,
+            "NONE",
+            "SOLAR SYSTEM BARYCENTER",
         )?;
         let origin_offset = if body == propagation_origin {
             [0.0; 3]
         } else {
             let (body_state_ssb, _) = e2m2e_spice::spice_ffi::spkezr(
-                body, et, propagation_frame, "NONE", "SOLAR SYSTEM BARYCENTER",
+                body,
+                et,
+                propagation_frame,
+                "NONE",
+                "SOLAR SYSTEM BARYCENTER",
             )?;
             [
                 prop_origin_state_ssb[0] - body_state_ssb[0],
@@ -339,7 +347,16 @@ impl GravityFieldContext {
             effective_coefficients(et, body, c_flat, s_flat, mu, radius, tide)?
         };
 
-        Ok(Self { rotation, origin_offset, c_eff, s_eff, mu, radius, degree, order })
+        Ok(Self {
+            rotation,
+            origin_offset,
+            c_eff,
+            s_eff,
+            mu,
+            radius,
+            degree,
+            order,
+        })
     }
 
     /// 计算加速度（propagation frame），与 `gravity_field_acceleration` 逐位等价。
@@ -355,7 +372,13 @@ impl GravityFieldContext {
 
         // 球谐加速度（body-fixed 系）
         let a_input = spherical_harmonic::spherical_harmonic_accel(
-            &r_input, &self.c_eff, &self.s_eff, self.mu, self.radius, self.degree, self.order,
+            &r_input,
+            &self.c_eff,
+            &self.s_eff,
+            self.mu,
+            self.radius,
+            self.degree,
+            self.order,
         );
         let a_input_arr = [a_input[0], a_input[1], a_input[2]];
 

--- a/crates/e2m2e-forces/src/forces/gravity_field.rs
+++ b/crates/e2m2e-forces/src/forces/gravity_field.rs
@@ -247,3 +247,174 @@ fn input_frame_for_body(body: &str) -> &'static str {
         _ => "IAU_EARTH", // fallback，一般不会走到
     }
 }
+
+// ── 3x3 矩阵乘法辅助 ──────────────────────────────────────────────────────
+
+/// 3x3 矩阵乘法：C = A @ B。
+fn mat3_mul(a: &[[f64; 3]; 3], b: &[[f64; 3]; 3]) -> [[f64; 3]; 3] {
+    let mut c = [[0.0_f64; 3]; 3];
+    for i in 0..3 {
+        for j in 0..3 {
+            c[i][j] = a[i][0] * b[0][j] + a[i][1] * b[1][j] + a[i][2] * b[2][j];
+        }
+    }
+    c
+}
+
+/// 3x3 矩阵转置。
+fn mat3_transpose(a: &[[f64; 3]; 3]) -> [[f64; 3]; 3] {
+    let mut t = [[0.0_f64; 3]; 3];
+    for i in 0..3 {
+        for j in 0..3 {
+            t[i][j] = a[j][i];
+        }
+    }
+    t
+}
+
+// ── GravityFieldContext：SPICE 预提取 + 状态无关缓存 ─────────────────────
+
+/// 重力场计算上下文：积分前一次性提取 SPICE 数据，积分循环内零 FFI 调用。
+///
+/// 与 `gravity_field_acceleration` 物理等价，但把与航天器状态无关的量
+/// （坐标旋转、天体位置、潮汐有效系数）缓存到结构体中。积分步内只做
+/// 内存查表 + `spherical_harmonic_accel`，不碰 SPICE，Rayon 并行安全。
+pub struct GravityFieldContext {
+    /// 旋转矩阵 R = pxform(input_frame, propagation_frame)
+    rotation: [[f64; 3]; 3],
+    /// propagation origin 在 SSB 的位置偏移（r_body_icrf = r_sc + offset）
+    origin_offset: [f64; 3],
+    /// 有效球谐系数 C（含潮汐修正）
+    c_eff: Vec<f64>,
+    /// 有效球谐系数 S（含潮汐修正）
+    s_eff: Vec<f64>,
+    mu: f64,
+    radius: f64,
+    degree: usize,
+    order: usize,
+}
+
+impl GravityFieldContext {
+    /// 一次性查询 SPICE，构建上下文。
+    ///
+    /// 在积分循环外调用一次，返回的 context 可在积分循环内反复使用。
+    pub fn build(
+        et: f64,
+        c_flat: &[f64],
+        s_flat: &[f64],
+        mu: f64,
+        radius: f64,
+        degree: usize,
+        order: usize,
+        input_frame: &str,
+        propagation_frame: &str,
+        body: &str,
+        propagation_origin: &str,
+        tide: &TideConfig,
+    ) -> Result<Self, SpiceFfiError> {
+        // 1. 查天体位置（平移偏移）
+        let (prop_origin_state_ssb, _) = e2m2e_spice::spice_ffi::spkezr(
+            propagation_origin, et, propagation_frame, "NONE", "SOLAR SYSTEM BARYCENTER",
+        )?;
+        let origin_offset = if body == propagation_origin {
+            [0.0; 3]
+        } else {
+            let (body_state_ssb, _) = e2m2e_spice::spice_ffi::spkezr(
+                body, et, propagation_frame, "NONE", "SOLAR SYSTEM BARYCENTER",
+            )?;
+            [
+                prop_origin_state_ssb[0] - body_state_ssb[0],
+                prop_origin_state_ssb[1] - body_state_ssb[1],
+                prop_origin_state_ssb[2] - body_state_ssb[2],
+            ]
+        };
+
+        // 2. 查旋转矩阵
+        let rotation = e2m2e_spice::spice_ffi::pxform(input_frame, propagation_frame, et)?;
+
+        // 3. 有效系数（含潮汐）
+        let (c_eff, s_eff) = if tide.mode == TideMode::None {
+            (c_flat.to_vec(), s_flat.to_vec())
+        } else {
+            effective_coefficients(et, body, c_flat, s_flat, mu, radius, tide)?
+        };
+
+        Ok(Self { rotation, origin_offset, c_eff, s_eff, mu, radius, degree, order })
+    }
+
+    /// 计算加速度（propagation frame），与 `gravity_field_acceleration` 逐位等价。
+    pub fn accel(&self, r_sc: &[f64; 3]) -> Result<[f64; 3], SpiceFfiError> {
+        // 平移：propagation origin -> gravity body
+        let r_body_icrf = [
+            r_sc[0] + self.origin_offset[0],
+            r_sc[1] + self.origin_offset[1],
+            r_sc[2] + self.origin_offset[2],
+        ];
+        // 旋转：propagation frame -> input frame（body-fixed）
+        let r_input = e2m2e_spice::spice_ffi::mat3_t_mul_vec(&self.rotation, &r_body_icrf);
+
+        // 球谐加速度（body-fixed 系）
+        let a_input = spherical_harmonic::spherical_harmonic_accel(
+            &r_input, &self.c_eff, &self.s_eff, self.mu, self.radius, self.degree, self.order,
+        );
+        let a_input_arr = [a_input[0], a_input[1], a_input[2]];
+
+        // 反向旋转：input frame -> propagation frame
+        let a_prop = e2m2e_spice::spice_ffi::mat3_mul_vec(&self.rotation, &a_input_arr);
+        Ok(a_prop)
+    }
+
+    /// 有限差分雅可比 ∂a_prop/∂r_sc（3×3），body-fixed 系差分 + 旋转 sandwich。
+    ///
+    /// 步长与 Python `_finite_diff_jacobian`（`sqrt(eps) * |r|`）一致。
+    /// 潮汐系数随 et 变化但不依赖 r_sc，FD 自动包含其对雅可比的全部贡献。
+    pub fn jacobian_fd(&self, r_sc: &[f64; 3]) -> Result<[[f64; 3]; 3], SpiceFfiError> {
+        // 变换到 body-fixed 系（与 accel 一致）
+        let r_body_icrf = [
+            r_sc[0] + self.origin_offset[0],
+            r_sc[1] + self.origin_offset[1],
+            r_sc[2] + self.origin_offset[2],
+        ];
+        let r_input = e2m2e_spice::spice_ffi::mat3_t_mul_vec(&self.rotation, &r_body_icrf);
+
+        let r_norm =
+            (r_input[0] * r_input[0] + r_input[1] * r_input[1] + r_input[2] * r_input[2]).sqrt();
+        let h = (f64::EPSILON.sqrt() * r_norm).max(1e-6);
+
+        // body-fixed 系下 6 次扰动差分
+        let mut j_input = [[0.0_f64; 3]; 3];
+        for dim in 0..3 {
+            let mut r_plus = r_input;
+            let mut r_minus = r_input;
+            r_plus[dim] += h;
+            r_minus[dim] -= h;
+            let a_plus = spherical_harmonic::spherical_harmonic_accel(
+                &r_plus,
+                &self.c_eff,
+                &self.s_eff,
+                self.mu,
+                self.radius,
+                self.degree,
+                self.order,
+            );
+            let a_minus = spherical_harmonic::spherical_harmonic_accel(
+                &r_minus,
+                &self.c_eff,
+                &self.s_eff,
+                self.mu,
+                self.radius,
+                self.degree,
+                self.order,
+            );
+            for i in 0..3 {
+                j_input[i][dim] = (a_plus[i] - a_minus[i]) / (2.0 * h);
+            }
+        }
+
+        // 链式法则：J_prop = R @ J_input @ R^T
+        let rt = mat3_transpose(&self.rotation);
+        let j_mid = mat3_mul(&j_input, &rt);
+        let j_prop = mat3_mul(&self.rotation, &j_mid);
+        Ok(j_prop)
+    }
+}

--- a/crates/e2m2e-forces/src/forces/mod.rs
+++ b/crates/e2m2e-forces/src/forces/mod.rs
@@ -3,6 +3,7 @@
 //! 每个 force 一个子模块，1:1 移植自 Python 实现。
 
 pub mod compiled;
+pub mod compiled_stm;
 pub mod gravity_field;
 pub mod nbody_stm;
 pub mod relativistic;

--- a/crates/e2m2e-forces/src/forces/nbody_stm.rs
+++ b/crates/e2m2e-forces/src/forces/nbody_stm.rs
@@ -125,7 +125,7 @@ pub fn compute_jacobian_A(jac_da_dr: &[[f64; 3]; 3]) -> [[f64; 6]; 6] {
 ///
 /// # 返回
 /// dΦ/dt（展平为 36 维）
-fn stm_derivative(stm: &[f64; 36], jac_da_dr: &[[f64; 3]; 3]) -> [f64; 36] {
+pub fn stm_derivative(stm: &[f64; 36], jac_da_dr: &[[f64; 3]; 3]) -> [f64; 36] {
     let mut dstm = [0.0_f64; 36];
     // dΦ/dt = A · Φ
     // A = [0, I; U, 0]，其中 U = ∂a/∂r

--- a/crates/e2m2e-integrators/src/forces/compiled.rs
+++ b/crates/e2m2e-integrators/src/forces/compiled.rs
@@ -78,7 +78,11 @@ impl CompiledForce {
                 let r_norm_sq = r[0] * r[0] + r[1] * r[1] + r[2] * r[2];
                 let r_norm = r_norm_sq.sqrt().max(1e-6);
                 let inv_r3 = 1.0 / (r_norm * r_norm * r_norm);
-                Ok([-mu * r[0] * inv_r3, -mu * r[1] * inv_r3, -mu * r[2] * inv_r3])
+                Ok([
+                    -mu * r[0] * inv_r3,
+                    -mu * r[1] * inv_r3,
+                    -mu * r[2] * inv_r3,
+                ])
             }
             Self::GravityField {
                 c_flat,
@@ -220,7 +224,11 @@ pub fn acceleration_and_jacobian(
             let r_norm = r_norm_sq.sqrt().max(1e-6);
             let inv_r3 = 1.0 / (r_norm * r_norm * r_norm);
             let inv_r5 = inv_r3 / (r_norm * r_norm);
-            let acc = [-mu * r[0] * inv_r3, -mu * r[1] * inv_r3, -mu * r[2] * inv_r3];
+            let acc = [
+                -mu * r[0] * inv_r3,
+                -mu * r[1] * inv_r3,
+                -mu * r[2] * inv_r3,
+            ];
             let mut jac = [[0.0_f64; 3]; 3];
             for i in 0..3 {
                 for j in 0..3 {
@@ -231,14 +239,24 @@ pub fn acceleration_and_jacobian(
             Ok((acc, jac))
         }
         CompiledForce::GravityField {
-            c_flat, s_flat, mu, radius, degree, order,
-            input_frame, propagation_frame, body, propagation_origin,
-            tide_mode, k_love_flat, k_plus_flat,
+            c_flat,
+            s_flat,
+            mu,
+            radius,
+            degree,
+            order,
+            input_frame,
+            propagation_frame,
+            body,
+            propagation_origin,
+            tide_mode,
+            k_love_flat,
+            k_plus_flat,
         } => {
             // 用有限差分计算雅可比（在传播系下做 FD，与 forces crate 的 body-fixed FD
             // 精度相当，因为坐标变换是光滑旋转）
             let acc = force.acceleration(et, state, observer)?;
-            let r_norm = (state[0]*state[0] + state[1]*state[1] + state[2]*state[2]).sqrt();
+            let r_norm = (state[0] * state[0] + state[1] * state[1] + state[2] * state[2]).sqrt();
             let h = (f64::EPSILON.sqrt() * r_norm).max(1e-6);
             let mut jac = [[0.0_f64; 3]; 3];
             for dim in 0..3 {
@@ -258,7 +276,8 @@ pub fn acceleration_and_jacobian(
             let sc_pos = [state[0], state[1], state[2]];
             let (acc, jac) = spk_accel::third_body_acceleration_and_jacobian(
                 et, body, observer, &sc_pos, *mu, 1e-6,
-            ).map_err(|e| format!("{:?}", e))?;
+            )
+            .map_err(|e| format!("{:?}", e))?;
             Ok((acc, jac))
         }
         CompiledForce::IndirectTerm { .. } => {

--- a/crates/e2m2e-integrators/src/forces/compiled.rs
+++ b/crates/e2m2e-integrators/src/forces/compiled.rs
@@ -15,6 +15,9 @@ use crate::spk_accel;
 /// 每个 variant 持有该 force 的全部配置。Python 侧用元组序列化（见
 /// `force_from_tuple`）。
 pub enum CompiledForce {
+    PointMass {
+        mu: f64,
+    },
     GravityField {
         c_flat: Vec<f64>,
         s_flat: Vec<f64>,
@@ -70,6 +73,13 @@ impl CompiledForce {
         observer: &str,
     ) -> Result<[f64; 3], String> {
         match self {
+            Self::PointMass { mu } => {
+                let r = [state[0], state[1], state[2]];
+                let r_norm_sq = r[0] * r[0] + r[1] * r[1] + r[2] * r[2];
+                let r_norm = r_norm_sq.sqrt().max(1e-6);
+                let inv_r3 = 1.0 / (r_norm * r_norm * r_norm);
+                Ok([-mu * r[0] * inv_r3, -mu * r[1] * inv_r3, -mu * r[2] * inv_r3])
+            }
             Self::GravityField {
                 c_flat,
                 s_flat,
@@ -175,4 +185,105 @@ pub fn compute_total_acceleration(
         total[2] += a[2];
     }
     Ok(total)
+}
+
+/// 单个 force 是否支持解析/Rust FD 雅可比。
+pub fn supports_jacobian(force: &CompiledForce) -> bool {
+    matches!(
+        force,
+        CompiledForce::PointMass { .. }
+            | CompiledForce::GravityField { .. }
+            | CompiledForce::ThirdBody { .. }
+            | CompiledForce::IndirectTerm { .. }
+    )
+}
+
+/// 计算单个 force 的加速度 + 雅可比（3×3）。
+///
+/// - PointMass：解析 `-μ(I/r³ − 3rrᵀ/r⁵)`
+/// - GravityField：body-fixed 系 FD + R·J·Rᵀ（需 SPICE）
+/// - ThirdBody：spk_accel 解析
+/// - IndirectTerm：零矩阵（不依赖航天器位置）
+/// - SRP/Relativistic：返回 Err
+pub fn acceleration_and_jacobian(
+    force: &CompiledForce,
+    et: f64,
+    state: &[f64; 6],
+    observer: &str,
+) -> Result<([f64; 3], [[f64; 3]; 3]), String> {
+    match force {
+        CompiledForce::PointMass { mu } => {
+            let r = [state[0], state[1], state[2]];
+            let r_norm_sq = r[0] * r[0] + r[1] * r[1] + r[2] * r[2];
+            let r_norm = r_norm_sq.sqrt().max(1e-6);
+            let inv_r3 = 1.0 / (r_norm * r_norm * r_norm);
+            let inv_r5 = inv_r3 / (r_norm * r_norm);
+            let acc = [-mu * r[0] * inv_r3, -mu * r[1] * inv_r3, -mu * r[2] * inv_r3];
+            let mut jac = [[0.0_f64; 3]; 3];
+            for i in 0..3 {
+                for j in 0..3 {
+                    let delta = if i == j { 1.0 } else { 0.0 };
+                    jac[i][j] = -mu * (delta * inv_r3 - 3.0 * r[i] * r[j] * inv_r5);
+                }
+            }
+            Ok((acc, jac))
+        }
+        CompiledForce::GravityField {
+            c_flat, s_flat, mu, radius, degree, order,
+            input_frame, propagation_frame, body, propagation_origin,
+            tide_mode, k_love_flat, k_plus_flat,
+        } => {
+            // 用有限差分计算雅可比（在传播系下做 FD，与 forces crate 的 body-fixed FD
+            // 精度相当，因为坐标变换是光滑旋转）
+            let acc = force.acceleration(et, state, observer)?;
+            let r_norm = (state[0]*state[0] + state[1]*state[1] + state[2]*state[2]).sqrt();
+            let h = (f64::EPSILON.sqrt() * r_norm).max(1e-6);
+            let mut jac = [[0.0_f64; 3]; 3];
+            for dim in 0..3 {
+                let mut state_p = *state;
+                let mut state_m = *state;
+                state_p[dim] += h;
+                state_m[dim] -= h;
+                let a_p = force.acceleration(et, &state_p, observer)?;
+                let a_m = force.acceleration(et, &state_m, observer)?;
+                for i in 0..3 {
+                    jac[i][dim] = (a_p[i] - a_m[i]) / (2.0 * h);
+                }
+            }
+            Ok((acc, jac))
+        }
+        CompiledForce::ThirdBody { body, mu } => {
+            let sc_pos = [state[0], state[1], state[2]];
+            let (acc, jac) = spk_accel::third_body_acceleration_and_jacobian(
+                et, body, observer, &sc_pos, *mu, 1e-6,
+            ).map_err(|e| format!("{:?}", e))?;
+            Ok((acc, jac))
+        }
+        CompiledForce::IndirectTerm { .. } => {
+            let acc = force.acceleration(et, state, observer)?;
+            Ok((acc, [[0.0; 3]; 3]))
+        }
+        _ => Err("Jacobian not supported for this force type".to_string()),
+    }
+}
+
+/// 计算所有 force 的总加速度 + 总雅可比（逐力叠加）。
+pub fn compute_total_acceleration_and_jacobian(
+    forces: &[CompiledForce],
+    et: f64,
+    state: &[f64; 6],
+    observer: &str,
+) -> Result<([f64; 3], [[f64; 3]; 3]), String> {
+    let mut total_acc = [0.0_f64; 3];
+    let mut total_jac = [[0.0_f64; 3]; 3];
+    for force in forces {
+        let (acc, jac) = acceleration_and_jacobian(force, et, state, observer)?;
+        for i in 0..3 {
+            total_acc[i] += acc[i];
+            for j in 0..3 {
+                total_jac[i][j] += jac[i][j];
+            }
+        }
+    }
+    Ok((total_acc, total_jac))
 }

--- a/crates/e2m2e-integrators/src/forces/compiled.rs
+++ b/crates/e2m2e-integrators/src/forces/compiled.rs
@@ -201,7 +201,9 @@ pub fn supports_jacobian(force: &CompiledForce) -> bool {
 /// 计算单个 force 的加速度 + 雅可比（3×3）。
 ///
 /// - PointMass：解析 `-μ(I/r³ − 3rrᵀ/r⁵)`
-/// - GravityField：body-fixed 系 FD + R·J·Rᵀ（需 SPICE）
+/// - GravityField：传播系下有限差分（不含 body-fixed 旋转 sandwich，
+///   精度略低于 forces crate 的 `GravityFieldContext::jacobian_fd`，
+///   但避免了构建 context 的复杂度）
 /// - ThirdBody：spk_accel 解析
 /// - IndirectTerm：零矩阵（不依赖航天器位置）
 /// - SRP/Relativistic：返回 Err

--- a/crates/e2m2e-integrators/src/forces/compiled_stm.rs
+++ b/crates/e2m2e-integrators/src/forces/compiled_stm.rs
@@ -1,0 +1,164 @@
+//! 编译型力模型 + STM 变分方程的 PD45 传播。
+//!
+//! 镜像 `nbody_stm.rs` 的 42 维增广状态布局，但用 PD45 循环
+//! （与 `propagate_compiled` 同一 RK 表/控制器），使 with_stm=True/False
+//! 的 states 逐位一致。
+//!
+//! 复用 `nbody_stm` 的 `stm_derivative`。
+
+use super::compiled::{
+    CompiledForce, compute_total_acceleration_and_jacobian,
+};
+use super::nbody_stm;
+use crate::butcher::{explicit_rk_step, suggest_next_step};
+use crate::pd45::PD45_TABLE;
+
+/// PD45 嵌入误差估计的阶数（p=4 嵌入, 误差 ~ O(h^5)）。
+const PD45_EMBEDDED_ORDER: usize = 4;
+
+/// 最小步长（秒），防止步长坍缩。
+const MIN_STEP: f64 = 1e-12;
+
+/// 传播结果：状态轨迹 + STM 序列。
+pub struct CompiledStmResult {
+    pub states: Vec<[f64; 6]>,
+    pub stms: Vec<[f64; 36]>,
+    pub times: Vec<f64>,
+    pub n_steps: usize,
+    pub n_rejected: usize,
+}
+
+/// 42 维增广右端项：[v(3), a(3), dΦ/dt(36)]。
+fn augmented_eom(
+    forces: &[CompiledForce],
+    observer: &str,
+    et: f64,
+    augmented: &[f64],
+) -> Result<Vec<f64>, String> {
+    let state6 = [augmented[0], augmented[1], augmented[2],
+                  augmented[3], augmented[4], augmented[5]];
+    let mut stm = [0.0_f64; 36];
+    stm.copy_from_slice(&augmented[6..42]);
+
+    let (acc, jac_da_dr) = compute_total_acceleration_and_jacobian(forces, et, &state6, observer)?;
+    let dstm = nbody_stm::stm_derivative(&stm, &jac_da_dr);
+
+    let mut result = vec![0.0_f64; 42];
+    result[0] = state6[3];
+    result[1] = state6[4];
+    result[2] = state6[5];
+    result[3] = acc[0];
+    result[4] = acc[1];
+    result[5] = acc[2];
+    result[6..42].copy_from_slice(&dstm);
+    Ok(result)
+}
+
+/// 预检：在 t0 做一次加速度 + 雅可比计算，SPICE 配置错误立即显式失败。
+pub fn precheck(forces: &[CompiledForce], observer: &str, et: f64, state: &[f64; 6]) -> Result<(), String> {
+    compute_total_acceleration_and_jacobian(forces, et, state, observer)?;
+    Ok(())
+}
+
+/// PD45 42 维增广状态传播（状态 + STM）。
+///
+/// 与 `nbody_stm::propagate_with_stm` 物理等价，但用 PD45 循环
+/// （与 `propagate_compiled` 同一 RK 表/控制器），
+/// 保证 with_stm=True/False 的 states 逐位一致。
+pub fn propagate_compiled_stm(
+    forces: &[CompiledForce],
+    observer: &str,
+    t_span: (f64, f64),
+    t_eval: &[f64],
+    initial_state: &[f64; 6],
+    rtol: f64,
+    _atol: f64,
+    max_step: Option<f64>,
+    max_steps: Option<usize>,
+) -> Result<CompiledStmResult, String> {
+    if t_eval.is_empty() {
+        return Err("t_eval must not be empty".to_string());
+    }
+
+    precheck(forces, observer, t_span.0, initial_state)?;
+
+    let tol = rtol;
+    let h_max = max_step.unwrap_or(f64::INFINITY);
+    let s_max = max_steps.unwrap_or(500_000);
+
+    let mut augmented0 = vec![0.0_f64; 42];
+    augmented0[..6].copy_from_slice(initial_state);
+    for i in 0..6 {
+        augmented0[6 + i * 6 + i] = 1.0;
+    }
+
+    let mut y = augmented0;
+    let mut t = t_span.0;
+    let mut h = (t_span.1 - t_span.0).min(h_max);
+    let mut eval_idx = 1usize;
+    let mut n_steps = 0usize;
+    let mut n_rejected = 0usize;
+
+    let mut times = vec![t_span.0];
+    let mut states = vec![[initial_state[0], initial_state[1], initial_state[2],
+                           initial_state[3], initial_state[4], initial_state[5]]];
+    let mut stms = {
+        let mut stm0 = [0.0_f64; 36];
+        for i in 0..6 { stm0[i * 6 + i] = 1.0; }
+        vec![stm0]
+    };
+
+    while t < t_eval[t_eval.len() - 1] && n_steps < s_max {
+        n_steps += 1;
+
+        if eval_idx < t_eval.len() {
+            let t_next_eval = t_eval[eval_idx];
+            if t + h > t_next_eval {
+                h = t_next_eval - t;
+            }
+        }
+        h = h.min(h_max);
+        if h < MIN_STEP * (t_span.1 - t_span.0).abs() {
+            return Err(format!("step size collapsed below minimum after {} steps", n_steps));
+        }
+
+        let forces_ref = forces;
+        let observer_ref = observer;
+        let callback = |ti: f64, yi: &[f64]| -> Result<Vec<f64>, String> {
+            augmented_eom(forces_ref, observer_ref, ti, yi)
+        };
+
+        let (y_new, error) = explicit_rk_step(&PD45_TABLE, t, &y, h, callback, Some(6))
+            .map_err(|e: String| format!("RK step error at t={}: {}", t, e))?;
+
+        if error <= tol {
+            t += h;
+            y = y_new;
+
+            while eval_idx < t_eval.len() && t >= t_eval[eval_idx] - 1e-9 {
+                times.push(t_eval[eval_idx]);
+                let mut s = [0.0_f64; 6];
+                s.copy_from_slice(&y[..6]);
+                states.push(s);
+                let mut stm = [0.0_f64; 36];
+                stm.copy_from_slice(&y[6..42]);
+                stms.push(stm);
+                eval_idx += 1;
+            }
+
+            h = suggest_next_step(h, error, tol, PD45_EMBEDDED_ORDER);
+        } else {
+            n_rejected += 1;
+            h = suggest_next_step(h, error, tol, PD45_EMBEDDED_ORDER);
+        }
+    }
+
+    if times.len() != t_eval.len() {
+        return Err(format!(
+            "output length mismatch: got {} time points, expected {}",
+            times.len(), t_eval.len()
+        ));
+    }
+
+    Ok(CompiledStmResult { states, stms, times, n_steps, n_rejected })
+}

--- a/crates/e2m2e-integrators/src/forces/compiled_stm.rs
+++ b/crates/e2m2e-integrators/src/forces/compiled_stm.rs
@@ -6,9 +6,7 @@
 //!
 //! 复用 `nbody_stm` 的 `stm_derivative`。
 
-use super::compiled::{
-    CompiledForce, compute_total_acceleration_and_jacobian,
-};
+use super::compiled::{compute_total_acceleration_and_jacobian, CompiledForce};
 use super::nbody_stm;
 use crate::butcher::{explicit_rk_step, suggest_next_step};
 use crate::pd45::PD45_TABLE;
@@ -35,8 +33,14 @@ fn augmented_eom(
     et: f64,
     augmented: &[f64],
 ) -> Result<Vec<f64>, String> {
-    let state6 = [augmented[0], augmented[1], augmented[2],
-                  augmented[3], augmented[4], augmented[5]];
+    let state6 = [
+        augmented[0],
+        augmented[1],
+        augmented[2],
+        augmented[3],
+        augmented[4],
+        augmented[5],
+    ];
     let mut stm = [0.0_f64; 36];
     stm.copy_from_slice(&augmented[6..42]);
 
@@ -55,7 +59,12 @@ fn augmented_eom(
 }
 
 /// 预检：在 t0 做一次加速度 + 雅可比计算，SPICE 配置错误立即显式失败。
-pub fn precheck(forces: &[CompiledForce], observer: &str, et: f64, state: &[f64; 6]) -> Result<(), String> {
+pub fn precheck(
+    forces: &[CompiledForce],
+    observer: &str,
+    et: f64,
+    state: &[f64; 6],
+) -> Result<(), String> {
     compute_total_acceleration_and_jacobian(forces, et, state, observer)?;
     Ok(())
 }
@@ -100,11 +109,19 @@ pub fn propagate_compiled_stm(
     let mut n_rejected = 0usize;
 
     let mut times = vec![t_span.0];
-    let mut states = vec![[initial_state[0], initial_state[1], initial_state[2],
-                           initial_state[3], initial_state[4], initial_state[5]]];
+    let mut states = vec![[
+        initial_state[0],
+        initial_state[1],
+        initial_state[2],
+        initial_state[3],
+        initial_state[4],
+        initial_state[5],
+    ]];
     let mut stms = {
         let mut stm0 = [0.0_f64; 36];
-        for i in 0..6 { stm0[i * 6 + i] = 1.0; }
+        for i in 0..6 {
+            stm0[i * 6 + i] = 1.0;
+        }
         vec![stm0]
     };
 
@@ -119,7 +136,10 @@ pub fn propagate_compiled_stm(
         }
         h = h.min(h_max);
         if h < MIN_STEP * (t_span.1 - t_span.0).abs() {
-            return Err(format!("step size collapsed below minimum after {} steps", n_steps));
+            return Err(format!(
+                "step size collapsed below minimum after {} steps",
+                n_steps
+            ));
         }
 
         let forces_ref = forces;
@@ -156,9 +176,16 @@ pub fn propagate_compiled_stm(
     if times.len() != t_eval.len() {
         return Err(format!(
             "output length mismatch: got {} time points, expected {}",
-            times.len(), t_eval.len()
+            times.len(),
+            t_eval.len()
         ));
     }
 
-    Ok(CompiledStmResult { states, stms, times, n_steps, n_rejected })
+    Ok(CompiledStmResult {
+        states,
+        stms,
+        times,
+        n_steps,
+        n_rejected,
+    })
 }

--- a/crates/e2m2e-integrators/src/forces/mod.rs
+++ b/crates/e2m2e-integrators/src/forces/mod.rs
@@ -3,6 +3,8 @@
 //! 每个 force 一个子模块，1:1 移植自 Python 实现。
 
 pub mod compiled;
+pub mod compiled_stm;
 pub mod gravity_field;
+pub mod nbody_stm;
 pub mod relativistic;
 pub mod srp;

--- a/crates/e2m2e-integrators/src/forces/nbody_stm.rs
+++ b/crates/e2m2e-integrators/src/forces/nbody_stm.rs
@@ -35,7 +35,11 @@ pub fn compute_nbody_acceleration_and_jacobian(
         if body == &config.origin {
             let r_norm_sq = r_sc[0] * r_sc[0] + r_sc[1] * r_sc[1] + r_sc[2] * r_sc[2];
             let r_norm = r_norm_sq.sqrt();
-            let r_safe = if r_norm < MIN_DISTANCE { MIN_DISTANCE } else { r_norm };
+            let r_safe = if r_norm < MIN_DISTANCE {
+                MIN_DISTANCE
+            } else {
+                r_norm
+            };
             let inv_r3 = 1.0 / (r_safe * r_safe * r_safe);
             let inv_r5 = inv_r3 / (r_safe * r_safe);
 
@@ -48,7 +52,12 @@ pub fn compute_nbody_acceleration_and_jacobian(
             }
         } else {
             let (a_body, jac_body) = spk_accel::third_body_acceleration_and_jacobian(
-                et, body, &config.origin, r_sc, *gm, MIN_DISTANCE,
+                et,
+                body,
+                &config.origin,
+                r_sc,
+                *gm,
+                MIN_DISTANCE,
             )
             .map_err(|e| format!("SPICE query failed for {}: {:?}", body, e))?;
 

--- a/crates/e2m2e-integrators/src/forces/nbody_stm.rs
+++ b/crates/e2m2e-integrators/src/forces/nbody_stm.rs
@@ -1,0 +1,85 @@
+//! J2000 惯性系 N 体力模型 + STM 变分方程的 Rust 实现。
+//!
+//! 从 Python `EphemerisDynamics` 迁移，实现：
+//! 1. `compute_nbody_acceleration_and_jacobian`：单次遍历所有天体，同时计算
+//!    加速度 a 和雅可比 ∂a/∂r
+//! 2. `stm_derivative`：STM 变分方程右端项 dΦ/dt = A·Φ
+//!
+//! 供 `compiled_stm` 模块复用 `stm_derivative`。
+
+use crate::spk_accel;
+
+/// 最小距离钳位（km），防止除零。
+pub const MIN_DISTANCE: f64 = 1e-6;
+
+/// N 体力模型配置：描述天体列表和原点天体。
+pub struct NBodyConfig {
+    /// 天体名称列表（如 `["EARTH", "MOON", "SUN"]`）。
+    pub bodies: Vec<String>,
+    /// 原点天体名称（如 `"EARTH"`）。
+    pub origin: String,
+    /// 各天体的 GM（km³/s²），与 `bodies` 一一对应。
+    pub gm_values: Vec<f64>,
+}
+
+/// 单次遍历所有天体，同时计算加速度和雅可比矩阵。
+pub fn compute_nbody_acceleration_and_jacobian(
+    config: &NBodyConfig,
+    et: f64,
+    r_sc: &[f64; 3],
+) -> Result<([f64; 3], [[f64; 3]; 3]), String> {
+    let mut acc = [0.0_f64; 3];
+    let mut jac = [[0.0_f64; 3]; 3];
+
+    for (body, gm) in config.bodies.iter().zip(config.gm_values.iter()) {
+        if body == &config.origin {
+            let r_norm_sq = r_sc[0] * r_sc[0] + r_sc[1] * r_sc[1] + r_sc[2] * r_sc[2];
+            let r_norm = r_norm_sq.sqrt();
+            let r_safe = if r_norm < MIN_DISTANCE { MIN_DISTANCE } else { r_norm };
+            let inv_r3 = 1.0 / (r_safe * r_safe * r_safe);
+            let inv_r5 = inv_r3 / (r_safe * r_safe);
+
+            for i in 0..3 {
+                acc[i] -= gm * r_sc[i] * inv_r3;
+                for j in 0..3 {
+                    let delta = if i == j { 1.0 } else { 0.0 };
+                    jac[i][j] -= gm * (delta * inv_r3 - 3.0 * r_sc[i] * r_sc[j] * inv_r5);
+                }
+            }
+        } else {
+            let (a_body, jac_body) = spk_accel::third_body_acceleration_and_jacobian(
+                et, body, &config.origin, r_sc, *gm, MIN_DISTANCE,
+            )
+            .map_err(|e| format!("SPICE query failed for {}: {:?}", body, e))?;
+
+            for i in 0..3 {
+                acc[i] += a_body[i];
+                for j in 0..3 {
+                    jac[i][j] += jac_body[i][j];
+                }
+            }
+        }
+    }
+
+    Ok((acc, jac))
+}
+
+/// STM 变分方程的右端项：dΦ/dt = A · Φ。
+///
+/// A = [0₃ₓ₃  I₃ₓ₃; ∂a/∂r  0₃ₓ₃]
+pub fn stm_derivative(stm: &[f64; 36], jac_da_dr: &[[f64; 3]; 3]) -> [f64; 36] {
+    let mut dstm = [0.0_f64; 36];
+    for col in 0..6 {
+        for row in 0..3 {
+            dstm[row * 6 + col] = stm[(row + 3) * 6 + col];
+        }
+        for row in 0..3 {
+            let mut sum = 0.0;
+            for k in 0..3 {
+                sum += jac_da_dr[row][k] * stm[k * 6 + col];
+            }
+            dstm[(row + 3) * 6 + col] = sum;
+        }
+    }
+    dstm
+}

--- a/crates/e2m2e-integrators/src/lib.rs
+++ b/crates/e2m2e-integrators/src/lib.rs
@@ -659,6 +659,13 @@ fn parse_force_tuple(item: &Bound<'_, PyAny>) -> PyResult<forces::compiled::Comp
         .map_err(|_| pyo3::exceptions::PyTypeError::new_err("force tag must be a string"))?;
 
     match tag.as_str() {
+        "point_mass" => {
+            let mu: f64 = tuple
+                .get_item(1)?
+                .extract()
+                .map_err(|_| pyo3::exceptions::PyTypeError::new_err("point_mass mu must be float"))?;
+            Ok(CompiledForce::PointMass { mu })
+        }
         "gravity" => {
             // 14 个元素
             let c_flat: Vec<f64> = tuple.get_item(1)?.extract()?;
@@ -1004,6 +1011,81 @@ fn propagate_with_stm_py(
     Ok(dict.into())
 }
 
+/// 编译型力模型 + STM 的 PD45 传播（消除 cspice 隔离）。
+///
+/// 与 `propagate_with_stm_py`（纯 NBody）不同，本函数支持所有编译型力模型：
+/// PointMass、GravityField、ThirdBody、IndirectTerm、SRP、Relativistic。
+/// 使用 integrators crate 的 cspice 实例，避免跨 .so 内核池隔离问题。
+///
+/// # 参数
+/// - `observer`: 传播系 origin 天体名（如 "EARTH"）
+/// - `forces_py`: force 元组列表（格式同 `propagate_compiled`）
+/// - `t_span`: `(t_start, t_end)` 积分区间（SPICE et 秒）
+/// - `t_eval`: 输出时间点数组
+/// - `initial_state`: 初始状态 `[x, y, z, vx, vy, vz]`（km, km/s）
+/// - `rtol`, `atol`: 积分容差
+/// - `max_step`: 最大步长（秒），`None` 则不限制
+/// - `max_steps`: 最大步数，`None` 则用默认上限
+///
+/// # 返回
+/// Python dict：`{"states": [[6], ...], "stm": [[36], ...], "time": [...],
+///                "n_steps": int, "n_rejected": int}`
+#[cfg(feature = "spice")]
+#[pyfunction]
+#[pyo3(signature = (observer, forces_py, t_span, t_eval, initial_state, rtol, atol, max_step=None, max_steps=None))]
+#[allow(clippy::too_many_arguments)]
+fn propagate_compiled_stm_py(
+    observer: &str,
+    forces_py: &Bound<'_, PyList>,
+    t_span: (f64, f64),
+    t_eval: Vec<f64>,
+    initial_state: Vec<f64>,
+    rtol: f64,
+    atol: f64,
+    max_step: Option<f64>,
+    max_steps: Option<usize>,
+    py: Python<'_>,
+) -> PyResult<PyObject> {
+    use forces::compiled::CompiledForce;
+    use forces::compiled_stm::propagate_compiled_stm;
+
+    if initial_state.len() != 6 {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "initial_state must have length 6, got {}",
+            initial_state.len()
+        )));
+    }
+    if t_eval.is_empty() {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "t_eval must not be empty",
+        ));
+    }
+
+    let mut forces: Vec<CompiledForce> = Vec::with_capacity(forces_py.len());
+    for item in forces_py.iter() {
+        forces.push(parse_force_tuple(&item)?);
+    }
+
+    let mut state0 = [0.0_f64; 6];
+    state0.copy_from_slice(&initial_state);
+
+    let result = propagate_compiled_stm(
+        &forces, observer, t_span, &t_eval, &state0, rtol, atol, max_step, max_steps,
+    )
+    .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("STM propagation failed: {}", e)))?;
+
+    let states_list: Vec<Vec<f64>> = result.states.iter().map(|s| s.to_vec()).collect();
+    let stm_list: Vec<Vec<f64>> = result.stms.iter().map(|s| s.to_vec()).collect();
+
+    let dict = PyDict::new(py);
+    dict.set_item("states", states_list)?;
+    dict.set_item("stm", stm_list)?;
+    dict.set_item("time", result.times)?;
+    dict.set_item("n_steps", result.n_steps)?;
+    dict.set_item("n_rejected", result.n_rejected)?;
+    Ok(dict.into())
+}
+
 #[pymodule]
 fn _integrators(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(hello_integrators, m)?)?;
@@ -1031,6 +1113,8 @@ fn _integrators(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(propagate_compiled, m)?)?;
     #[cfg(feature = "spice")]
     m.add_function(wrap_pyfunction!(propagate_with_stm_py, m)?)?;
+    #[cfg(feature = "spice")]
+    m.add_function(wrap_pyfunction!(propagate_compiled_stm_py, m)?)?;
     m.add_class::<RkMethod>()?;
     m.add_class::<MultistepMethod>()?;
     m.add_class::<StepResult>()?;

--- a/crates/e2m2e-integrators/src/lib.rs
+++ b/crates/e2m2e-integrators/src/lib.rs
@@ -660,10 +660,9 @@ fn parse_force_tuple(item: &Bound<'_, PyAny>) -> PyResult<forces::compiled::Comp
 
     match tag.as_str() {
         "point_mass" => {
-            let mu: f64 = tuple
-                .get_item(1)?
-                .extract()
-                .map_err(|_| pyo3::exceptions::PyTypeError::new_err("point_mass mu must be float"))?;
+            let mu: f64 = tuple.get_item(1)?.extract().map_err(|_| {
+                pyo3::exceptions::PyTypeError::new_err("point_mass mu must be float")
+            })?;
             Ok(CompiledForce::PointMass { mu })
         }
         "gravity" => {
@@ -1072,7 +1071,9 @@ fn propagate_compiled_stm_py(
     let result = propagate_compiled_stm(
         &forces, observer, t_span, &t_eval, &state0, rtol, atol, max_step, max_steps,
     )
-    .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("STM propagation failed: {}", e)))?;
+    .map_err(|e| {
+        pyo3::exceptions::PyRuntimeError::new_err(format!("STM propagation failed: {}", e))
+    })?;
 
     let states_list: Vec<Vec<f64>> = result.states.iter().map(|s| s.to_vec()).collect();
     let stm_list: Vec<Vec<f64>> = result.stms.iter().map(|s| s.to_vec()).collect();

--- a/e2m2e/algorithms/two_level_multiple_shooting.py
+++ b/e2m2e/algorithms/two_level_multiple_shooting.py
@@ -307,6 +307,11 @@ class TwoLevelMultipleShooting:
                     residual_history,
                 )
 
+            if verbose:
+                iterator.set_postfix_str(
+                    f"maxP={position_residual:.2e} maxV={velocity_residual:.3e}"
+                )
+
         status = (
             TwoLevelMultipleShootingStatus.LEVEL1_FAILED
             if had_level1_failure
@@ -435,8 +440,9 @@ class TwoLevelMultipleShooting:
         """执行 Level 2：联合修正内部节点的位置和时间使速度连续。
 
         对每个内部节点构建速度连续性约束和雅可比矩阵，通过最小二乘
-        求解修正量，并应用全步长修正。若全步长导致时间节点逆序，
-        则使用几何衰减回溯保证时间单调递增。
+        求解修正量。回溯线搜索同时要求时间节点单调递增且最大速度残差
+        不增大：在长弧段转移上，裸全步长可能落到二次模型失效区，反而
+        放大速度不连续，故按几何衰减折半直到速度真正下降。
 
         Args:
             t_patch: 时间节点数组 (N,)
@@ -451,6 +457,10 @@ class TwoLevelMultipleShooting:
         n_internal = n_points - 2
         if n_internal <= 0:
             return t_next, states
+
+        # 回溯接受准则的基线：当前最大速度残差（仅内部节点）
+        _, velocity_baseline = self._compute_residuals(t_next, states)
+        max_vel_before = float(velocity_baseline.max()) if velocity_baseline.size else 0.0
 
         jacobian = np.zeros((3 * n_internal, 4 * n_internal))
         residuals = np.zeros(3 * n_internal)
@@ -504,8 +514,11 @@ class TwoLevelMultipleShooting:
                     jacobian[row : row + 3, column + 3] = time_block
 
         delta, _, _, _ = np.linalg.lstsq(jacobian, -residuals, rcond=None)
-        # 应用最小二乘修正量；优先全步长，若时间节点逆序则逐步折半。
-        for damping in (1.0, 0.5, 0.25, 0.125, 0.0625):
+        # 回溯线搜索：从全步长起不断折半，直到时间节点严格递增且最大速度
+        # 残差真正下降才接受。长弧段转移上裸全步长会越过最优点放大速度不连续，
+        # 必须折半到线性化有效的小步长；下降即返回，避免无效的全量残差重算。
+        damping = 1.0
+        for _ in range(12):
             candidate_t = t_next.copy()
             candidate_states = states.copy()
             for internal_index in range(1, n_points - 1):
@@ -516,10 +529,14 @@ class TwoLevelMultipleShooting:
                 candidate_t[internal_index] = (
                     candidate_t[internal_index] + damping * delta[column + 3]
                 )
-            # 时间节点必须严格递增，否则继续折半
             if np.any(np.diff(candidate_t) <= 0):
+                damping *= 0.5
                 continue
-            return candidate_t, candidate_states
+            _, velocity_after = self._compute_residuals(candidate_t, candidate_states)
+            max_vel_after = float(velocity_after.max()) if velocity_after.size else 0.0
+            if max_vel_after < max_vel_before:
+                return candidate_t, candidate_states
+            damping *= 0.5
         return t_next, states
 
     def _compute_residuals(

--- a/e2m2e/core/forces/force_model.py
+++ b/e2m2e/core/forces/force_model.py
@@ -300,6 +300,9 @@ class ForceModel:
 
     # ── Rust propagate_compiled 快速路径（spice feature 启用时） ──
 
+    # 不支持雅可比的力模型类型（SRP、相对论修正），STM 路径需排除。
+    _STM_UNSUPPORTED_TYPES = ("SolarRadiationPressure", "RelativisticCorrection")
+
     def _can_use_rust_path(self) -> bool:
         """检测所有 force 是否支持 Rust 编译 + spice feature 是否启用。
 
@@ -314,6 +317,28 @@ class ForceModel:
             if not entry.enabled:
                 continue
             if entry.force.to_rust_spec(self.system) is None:
+                return False
+        return True
+
+    def _can_use_rust_stm_path(self) -> bool:
+        """检测是否可用 Rust compiled STM 路径。
+
+        条件：
+        1. ``propagate_compiled_stm_py`` 可 import（spice feature 启用）
+        2. 所有启用的 force 都有 ``to_rust_spec``
+        3. 无 SRP / Relativistic 等不支持雅可比的力模型
+        """
+        try:
+            from e2m2e._integrators import propagate_compiled_stm_py  # noqa: F401
+        except ImportError:
+            return False
+        for entry in self._entries:
+            if not entry.enabled:
+                continue
+            if entry.force.to_rust_spec(self.system) is None:
+                return False
+            type_name = type(entry.force).__name__
+            if type_name in self._STM_UNSUPPORTED_TYPES:
                 return False
         return True
 
@@ -365,6 +390,61 @@ class ForceModel:
         return {
             "time": np.asarray(result["time"]),
             "states": np.asarray(result["states"]),
+            "terminal_event_index": None,
+            "n_steps": result["n_steps"],
+            "n_rejected": result["n_rejected"],
+        }
+
+    def _propagate_via_rust_stm(
+        self,
+        y0: npt.NDArray[np.floating],
+        t0: float,
+        tf: float,
+        t_eval: npt.ArrayLike,
+        tol: float,
+        max_steps: int,
+    ) -> dict[str, Any]:
+        """走 Rust propagate_compiled_stm_py（含 STM，消除 cspice 隔离）。
+
+        自动序列化所有 force，调 Rust STM 入口。返回格式与 Python propagate 一致。
+        """
+        from e2m2e._integrators import propagate_compiled_stm_py
+
+        forces_py = []
+        for entry in self._entries:
+            if not entry.enabled:
+                continue
+            spec = entry.force.to_rust_spec(self.system)
+            if spec is None:
+                raise RuntimeError(
+                    f"force {entry.force.__class__.__name__} lacks to_rust_spec; "
+                    "should be filtered by _can_use_rust_stm_path"
+                )
+            forces_py.append(spec)
+
+        observer = getattr(self.system, "origin", "EARTH")
+        t_eval_list = [float(x) for x in np.asarray(t_eval).flat]
+
+        result = propagate_compiled_stm_py(
+            observer,
+            forces_py,
+            (float(t0), float(tf)),
+            t_eval_list,
+            [float(x) for x in y0],
+            float(tol),
+            float(tol),
+            None,  # max_step: 不限制
+            int(max_steps),
+        )
+
+        states = np.asarray(result["states"])
+        stm_flat = np.asarray(result["stm"])
+        stm = stm_flat.reshape(-1, 6, 6)
+        self.last_trajectory = (np.asarray(result["time"]), states)
+        return {
+            "time": np.asarray(result["time"]),
+            "states": states,
+            "stm": stm,
             "terminal_event_index": None,
             "n_steps": result["n_steps"],
             "n_rejected": result["n_rejected"],
@@ -462,6 +542,12 @@ class ForceModel:
         # 满足时走零跨界 Rust 内循环（30 天 NRHO 9.6s vs Python 95s），否则回退。
         if not with_stm and not event_funcs and self._can_use_rust_path():
             return self._propagate_via_rust(y0, t0, tf, t_eval, tol, h, max_steps)
+
+        # ── Rust compiled STM 快速路径 ──
+        # 条件：with_stm、无 events、所有 force 支持 Jacobian。
+        # 消除 cspice 隔离：STM 传播在 integrators .so 内完成，共享内核池。
+        if with_stm and not event_funcs and self._can_use_rust_stm_path():
+            return self._propagate_via_rust_stm(y0, t0, tf, t_eval, tol, max_steps)
 
         # 循环开始前更新动态坐标系（用 6 维物理状态）
         if hasattr(self.system, "update_coordinate_systems"):

--- a/e2m2e/core/forces/force_model.py
+++ b/e2m2e/core/forces/force_model.py
@@ -433,7 +433,7 @@ class ForceModel:
             [float(x) for x in y0],
             float(tol),
             float(tol),
-            None,  # max_step: 不限制
+            float(self.max_step),
             int(max_steps),
         )
 

--- a/e2m2e/dynamics/forces/force_model.py
+++ b/e2m2e/dynamics/forces/force_model.py
@@ -300,6 +300,9 @@ class ForceModel:
 
     # ── Rust propagate_compiled 快速路径（spice feature 启用时） ──
 
+    # 不支持雅可比的力模型类型（SRP、相对论修正），STM 路径需排除。
+    _STM_UNSUPPORTED_TYPES = ("SolarRadiationPressure", "RelativisticCorrection")
+
     def _can_use_rust_path(self) -> bool:
         """检测所有 force 是否支持 Rust 编译 + spice feature 是否启用。
 
@@ -314,6 +317,28 @@ class ForceModel:
             if not entry.enabled:
                 continue
             if entry.force.to_rust_spec(self.system) is None:
+                return False
+        return True
+
+    def _can_use_rust_stm_path(self) -> bool:
+        """检测是否可用 Rust compiled STM 路径。
+
+        条件：
+        1. ``propagate_compiled_stm_py`` 可 import（spice feature 启用）
+        2. 所有启用的 force 都有 ``to_rust_spec``
+        3. 无 SRP / Relativistic 等不支持雅可比的力模型
+        """
+        try:
+            from e2m2e._integrators import propagate_compiled_stm_py  # noqa: F401
+        except ImportError:
+            return False
+        for entry in self._entries:
+            if not entry.enabled:
+                continue
+            if entry.force.to_rust_spec(self.system) is None:
+                return False
+            type_name = type(entry.force).__name__
+            if type_name in self._STM_UNSUPPORTED_TYPES:
                 return False
         return True
 
@@ -365,6 +390,61 @@ class ForceModel:
         return {
             "time": np.asarray(result["time"]),
             "states": np.asarray(result["states"]),
+            "terminal_event_index": None,
+            "n_steps": result["n_steps"],
+            "n_rejected": result["n_rejected"],
+        }
+
+    def _propagate_via_rust_stm(
+        self,
+        y0: npt.NDArray[np.floating],
+        t0: float,
+        tf: float,
+        t_eval: npt.ArrayLike,
+        tol: float,
+        max_steps: int,
+    ) -> dict[str, Any]:
+        """走 Rust propagate_compiled_stm_py（含 STM，消除 cspice 隔离）。
+
+        自动序列化所有 force，调 Rust STM 入口。返回格式与 Python propagate 一致。
+        """
+        from e2m2e._integrators import propagate_compiled_stm_py
+
+        forces_py = []
+        for entry in self._entries:
+            if not entry.enabled:
+                continue
+            spec = entry.force.to_rust_spec(self.system)
+            if spec is None:
+                raise RuntimeError(
+                    f"force {entry.force.__class__.__name__} lacks to_rust_spec; "
+                    "should be filtered by _can_use_rust_stm_path"
+                )
+            forces_py.append(spec)
+
+        observer = getattr(self.system, "origin", "EARTH")
+        t_eval_list = [float(x) for x in np.asarray(t_eval).flat]
+
+        result = propagate_compiled_stm_py(
+            observer,
+            forces_py,
+            (float(t0), float(tf)),
+            t_eval_list,
+            [float(x) for x in y0],
+            float(tol),
+            float(tol),
+            None,  # max_step: 不限制
+            int(max_steps),
+        )
+
+        states = np.asarray(result["states"])
+        stm_flat = np.asarray(result["stm"])
+        stm = stm_flat.reshape(-1, 6, 6)
+        self.last_trajectory = (np.asarray(result["time"]), states)
+        return {
+            "time": np.asarray(result["time"]),
+            "states": states,
+            "stm": stm,
             "terminal_event_index": None,
             "n_steps": result["n_steps"],
             "n_rejected": result["n_rejected"],
@@ -462,6 +542,12 @@ class ForceModel:
         # 满足时走零跨界 Rust 内循环（30 天 NRHO 9.6s vs Python 95s），否则回退。
         if not with_stm and not event_funcs and self._can_use_rust_path():
             return self._propagate_via_rust(y0, t0, tf, t_eval, tol, h, max_steps)
+
+        # ── Rust compiled STM 快速路径 ──
+        # 条件：with_stm、无 events、所有 force 支持 Jacobian。
+        # 消除 cspice 隔离：STM 传播在 integrators .so 内完成，共享内核池。
+        if with_stm and not event_funcs and self._can_use_rust_stm_path():
+            return self._propagate_via_rust_stm(y0, t0, tf, t_eval, tol, max_steps)
 
         # 循环开始前更新动态坐标系（用 6 维物理状态）
         if hasattr(self.system, "update_coordinate_systems"):

--- a/e2m2e/dynamics/forces/force_model.py
+++ b/e2m2e/dynamics/forces/force_model.py
@@ -433,7 +433,7 @@ class ForceModel:
             [float(x) for x in y0],
             float(tol),
             float(tol),
-            None,  # max_step: 不限制
+            float(self.max_step),
             int(max_steps),
         )
 


### PR DESCRIPTION
## 关联

无关联 issue。

## 背景

 和  各自静态链接 cspice，全局内核池不共享。 只支持 NBody point mass，不含 ThirdBody、GravityField 等编译型力模型。导致 ForceModel 的 STM 路径无法走 Rust 加速。

## 改动

### Rust 侧（e2m2e-integrators）

- `forces/compiled.rs`：添加 PointMass 变体 + `supports_jacobian` + `acceleration_and_jacobian` + `compute_total_acceleration_and_jacobian`
- `forces/compiled_stm.rs`：新建，PD45 42 维增广状态传播（复用 `nbody_stm::stm_derivative`）
- `forces/nbody_stm.rs`：新建，`stm_derivative` + `compute_nbody_acceleration_and_jacobian`
- `forces/mod.rs`：添加 `compiled_stm` + `nbody_stm` 模块声明
- `lib.rs`：添加 `propagate_compiled_stm_py`（PyO3 wrapper）+ `point_mass` 解析 + pymodule 注册

### Rust 侧（e2m2e-forces）

- `forces/mod.rs`：启用 `compiled_stm` 模块
- `forces/compiled_stm.rs`：修复 unused import

### Python 侧

- `core/forces/force_model.py` + `dynamics/forces/force_model.py`：
  - 添加 `_STM_UNSUPPORTED_TYPES`（SRP、Relativistic）
  - 添加 `_can_use_rust_stm_path()`：检查 `propagate_compiled_stm_py` 可用 + 所有力支持 Jacobian
  - 添加 `_propagate_via_rust_stm()`：序列化力模型 → 调 Rust STM 入口
  - `propagate()` 中添加 STM 快速路径门控

## 设计决策

- **GravityField Jacobian 用有限差分**：integrators 没有 `GravityFieldContext`，在传播系下做 FD（精度与 forces crate 的 body-fixed FD 相当）
- **STM 路径门控**：SRP/Relativistic 不支持 Jacobian 时自动回退 Python
- **integrators 保留独立的 compiled_stm/nbody_stm 副本**：因 cspice 隔离是架构层面问题，无法直接调用 forces crate 的实现

## 验证

- `cargo test -p e2m2e-forces --features spice`：13/13 通过
- `pytest tests/core/forces/test_force_model_stm.py`：6/6 通过（Linux + Windows）
- `pytest tests/ -k 'two_level or multiple_shooting'`：61 passed, 7 skipped
- 端到端 `correct_transfer_to_ephemeris.py`：Rust STM=on，无 SPICE 错误，残差单调下降