### PR TITLE
fix(stm): propagate_with_stm 内核缺失/截断时抛错而非静默返回（#246）

### DIFF
--- a/crates/e2m2e-forces/src/forces/nbody_stm.rs
+++ b/crates/e2m2e-forces/src/forces/nbody_stm.rs
@@ -220,6 +220,10 @@ pub struct PropagationResult {
 ///
 /// # 返回
 /// `PropagationResult`：每个 `t_eval` 对应的状态和 STM。
+///
+/// # 错误
+/// - 初值处右端项求值失败（如 SPICE 内核缺失导致第三体位置查询失败）；
+/// - 积分提前退出导致输出点数少于 `t_eval.len()`（如步长塌缩、中途力模型失败）。
 pub fn propagate_with_stm(
     config: &NBodyConfig,
     t_span: (f64, f64),
@@ -229,7 +233,7 @@ pub fn propagate_with_stm(
     atol: f64,
     max_step: Option<f64>,
     max_steps: Option<usize>,
-) -> PropagationResult {
+) -> Result<PropagationResult, String> {
     use e2m2e_propagation::solve_ivp::solve_ivp_capped;
 
     // 构造 42 维增广状态：[r(3), v(3), Φ(36)]
@@ -239,6 +243,11 @@ pub fn propagate_with_stm(
     for i in 0..6 {
         augmented0[6 + i * 6 + i] = 1.0;
     }
+
+    // 预检：初值处右端项必须可求值。SPICE 内核缺失时第三体位置查询
+    // 在此处确定性失败，避免积分静默返回截断结果（issue #246）。
+    augmented_eom(config, t_span.0, &augmented0)
+        .map_err(|e| format!("initial RHS evaluation failed at t={}: {}", t_span.0, e))?;
 
     let h_max = max_step.unwrap_or(f64::INFINITY);
     let s_max = max_steps.unwrap_or(500_000);
@@ -261,6 +270,19 @@ pub fn propagate_with_stm(
         Some(6), // 只统计前 6 维误差
     );
 
+    // 完整性校验：solve_ivp_capped 在力模型失败/步长塌缩时会提前退出，
+    // 输出点数不足即视为传播失败，不允许静默截断（issue #246）。
+    if sol.len() != t_eval.len() {
+        return Err(format!(
+            "propagation truncated: got {} of {} time points (t_span=({:.3}, {:.3})); \
+             likely cause: SPICE kernels not loaded or step size collapsed",
+            sol.len(),
+            t_eval.len(),
+            t_span.0,
+            t_span.1,
+        ));
+    }
+
     // 分离状态和 STM
     let mut states = Vec::with_capacity(sol.len());
     let mut stms = Vec::with_capacity(sol.len());
@@ -278,11 +300,11 @@ pub fn propagate_with_stm(
         times.push(t_eval[i]);
     }
 
-    PropagationResult {
+    Ok(PropagationResult {
         states,
         stms,
         times,
-    }
+    })
 }
 
 #[cfg(test)]
@@ -556,7 +578,8 @@ mod tests {
             1e-12,
             None,
             None,
-        );
+        )
+        .unwrap();
         assert_eq!(result.states.len(), 2, "应输出 2 个时间点");
         let r1 = result.states[1];
         let stm_flat = &result.stms[1];
@@ -579,7 +602,8 @@ mod tests {
                 1e-12,
                 None,
                 None,
-            );
+            )
+            .unwrap();
             let r1_pert = result_pert.states[1];
 
             for row in 0..2 {
@@ -613,7 +637,8 @@ mod tests {
                 1e-12,
                 None,
                 None,
-            );
+            )
+            .unwrap();
             let r1_pert = result_pert.states[1];
 
             for row in 0..2 {
@@ -662,7 +687,8 @@ mod tests {
             1e-12,
             None,
             None,
-        );
+        )
+        .unwrap();
 
         assert_eq!(result.states.len(), 2, "应输出 2 个时间点");
         assert_eq!(result.stms.len(), 2);
@@ -719,7 +745,8 @@ mod tests {
                 1e-12,
                 None,
                 None,
-            );
+            )
+            .unwrap();
 
             let r1_pert = result_pert.states[1];
 
@@ -739,5 +766,45 @@ mod tests {
                 );
             }
         }
+    }
+
+    // =========================================================
+    // 测试 7：无星历天体必须返回 Err，不允许静默截断（issue #246）
+    // =========================================================
+
+    /// 第三体无星历数据时，propagate_with_stm 必须返回带上下文的 Err，
+    /// 而不是静默返回只有 t0 的截断结果。
+    #[test]
+    fn propagate_with_stm_unknown_body_returns_err() {
+        load_kernels();
+        let config = NBodyConfig {
+            bodies: vec!["EARTH".to_string(), "FAKEBODY".to_string()],
+            origin: "EARTH".to_string(),
+            gm_values: vec![398600.435436, 1.0],
+        };
+
+        let state0 = [7000.0, 0.0, 0.0, 0.0, 7.5, 0.0];
+        let t_eval = vec![0.0, 100.0];
+
+        let result = propagate_with_stm(
+            &config,
+            (0.0, 100.0),
+            &t_eval,
+            &state0,
+            1e-12,
+            1e-12,
+            None,
+            None,
+        );
+
+        let err = match result {
+            Ok(_) => panic!("无星历天体必须返回 Err"),
+            Err(e) => e,
+        };
+        assert!(
+            err.contains("FAKEBODY") || err.contains("SPICE"),
+            "错误信息应指名失败的天体或 SPICE 查询，实际: {}",
+            err
+        );
     }
 }

--- a/crates/e2m2e-integrators/src/lib.rs
+++ b/crates/e2m2e-integrators/src/lib.rs
@@ -1003,7 +1003,10 @@ fn propagate_with_stm_py(
 
     let result = propagate_with_stm(
         &config, t_span, &t_eval, &state0, rtol, atol, max_step, max_steps,
-    );
+    )
+    .map_err(|e| {
+        pyo3::exceptions::PyRuntimeError::new_err(format!("STM propagation failed: {}", e))
+    })?;
 
     // 转为 Python 对象
     let states_list: Vec<Vec<f64>> = result.states.iter().map(|s| s.to_vec()).collect();

--- a/crates/e2m2e-integrators/src/lib.rs
+++ b/crates/e2m2e-integrators/src/lib.rs
@@ -18,14 +18,14 @@ pub(crate) mod forces;
 #[cfg(feature = "spice")]
 pub mod multiple_shooting;
 pub(crate) mod multistep_methods;
-#[cfg(feature = "spice")]
-pub mod segmented_shooting;
-#[cfg(feature = "spice")]
-pub mod single_shooting;
 pub(crate) mod pd45;
 pub(crate) mod pd78;
 pub(crate) mod rk89;
 pub mod rk_methods;
+#[cfg(feature = "spice")]
+pub mod segmented_shooting;
+#[cfg(feature = "spice")]
+pub mod single_shooting;
 pub(crate) mod solid_tide;
 pub mod solve_ivp;
 pub(crate) mod spherical_harmonic;
@@ -652,7 +652,9 @@ fn srp_acceleration(
 /// - `("indirect", body, mu)`
 /// - `("srp", area, mass, cr, shadow_bodies_list)`
 #[cfg(feature = "spice")]
-pub(crate) fn parse_force_tuple(item: &Bound<'_, PyAny>) -> PyResult<forces::compiled::CompiledForce> {
+pub(crate) fn parse_force_tuple(
+    item: &Bound<'_, PyAny>,
+) -> PyResult<forces::compiled::CompiledForce> {
     use forces::compiled::CompiledForce;
     use forces::gravity_field::TideMode;
 
@@ -1126,15 +1128,24 @@ fn _integrators(m: &Bound<PyModule>) -> PyResult<()> {
     #[cfg(feature = "spice")]
     m.add_function(wrap_pyfunction!(propagate_compiled_stm_py, m)?)?;
     #[cfg(feature = "spice")]
-    m.add_function(wrap_pyfunction!(multiple_shooting::multiple_shooting_correct_py, m)?)?;
+    m.add_function(wrap_pyfunction!(
+        multiple_shooting::multiple_shooting_correct_py,
+        m
+    )?)?;
     #[cfg(feature = "spice")]
     m.add_class::<multiple_shooting::MultipleShootingRustResult>()?;
     #[cfg(feature = "spice")]
-    m.add_function(wrap_pyfunction!(segmented_shooting::segmented_shooting_correct_py, m)?)?;
+    m.add_function(wrap_pyfunction!(
+        segmented_shooting::segmented_shooting_correct_py,
+        m
+    )?)?;
     #[cfg(feature = "spice")]
     m.add_class::<segmented_shooting::SegmentedShootingResult>()?;
     #[cfg(feature = "spice")]
-    m.add_function(wrap_pyfunction!(segmented_shooting::segmented_shooting_correct_py, m)?)?;
+    m.add_function(wrap_pyfunction!(
+        segmented_shooting::segmented_shooting_correct_py,
+        m
+    )?)?;
     #[cfg(feature = "spice")]
     m.add_class::<segmented_shooting::SegmentedShootingResult>()?;
     m.add_class::<RkMethod>()?;

--- a/crates/e2m2e-integrators/src/multiple_shooting.rs
+++ b/crates/e2m2e-integrators/src/multiple_shooting.rs
@@ -49,11 +49,7 @@ pub struct MultipleShootingRustResult {
 ///
 /// 残差定义：F_i = φ(t_{i+1}; t_i, x_i) - x_{i+1}
 /// 即第 i 段积分终端状态与第 i+1 个节点状态的差值。
-fn build_residual(
-    final_states: &[[f64; 6]],
-    state_work: &[[f64; 6]],
-    n_seg: usize,
-) -> Vec<f64> {
+fn build_residual(final_states: &[[f64; 6]], state_work: &[[f64; 6]], n_seg: usize) -> Vec<f64> {
     let mut f = vec![0.0_f64; n_seg * 6];
     for i in 0..n_seg {
         for j in 0..6 {
@@ -67,11 +63,7 @@ fn build_residual(
 ///
 /// DF[i*6:(i+1)*6, i*6:(i+1)*6] = Φ_i（状态转移矩阵）
 /// DF[i*6:(i+1)*6, (i+1)*6:(i+2)*6] = -I_6
-fn build_jacobian_fixed_time(
-    stms: &[[f64; 36]],
-    n_seg: usize,
-    n_vars: usize,
-) -> Vec<f64> {
+fn build_jacobian_fixed_time(stms: &[[f64; 36]], n_seg: usize, n_vars: usize) -> Vec<f64> {
     let n_constraints = n_seg * 6;
     let mut df = vec![0.0_f64; n_constraints * n_vars];
 
@@ -146,7 +138,7 @@ fn least_squares_solve(
     let mut dtf = vec![0.0_f64; n_vars];
     for i in 0..n_vars {
         for j in 0..n_constraints {
-            dtf[i] += df[j * n_vars + i] * (-f[j]);  // 注意负号
+            dtf[i] += df[j * n_vars + i] * (-f[j]); // 注意负号
         }
     }
 
@@ -167,7 +159,7 @@ fn least_squares_solve(
         for j in 0..n_vars {
             augmented[i * (n_vars + 1) + j] = dtd[i * n_vars + j];
         }
-        augmented[i * (n_vars + 1) + n_vars] = dtf[i];  // 注意：这里已经是 -DF^T F
+        augmented[i * (n_vars + 1) + n_vars] = dtf[i]; // 注意：这里已经是 -DF^T F
     }
 
     // 前向消元
@@ -313,7 +305,11 @@ pub fn multiple_shooting_correct(
         residual_history.push(max_res);
 
         if verbose {
-            eprintln!("Iteration {}: max_residual = {:.2e}", iteration + 1, max_res);
+            eprintln!(
+                "Iteration {}: max_residual = {:.2e}",
+                iteration + 1,
+                max_res
+            );
         }
 
         // 判断收敛

--- a/crates/e2m2e-integrators/src/segmented_shooting.rs
+++ b/crates/e2m2e-integrators/src/segmented_shooting.rs
@@ -193,7 +193,10 @@ pub fn segmented_shooting_correct(
     let mut converged = true;
 
     if verbose {
-        eprintln!("分段打靶拼接：{} 段，每段 {} 点", n_segments, config.points_per_segment);
+        eprintln!(
+            "分段打靶拼接：{} 段，每段 {} 点",
+            n_segments, config.points_per_segment
+        );
     }
 
     // 第1步：对每小段独立进行多重打靶修正
@@ -219,7 +222,11 @@ pub fn segmented_shooting_correct(
         if !result.converged {
             converged = false;
             if verbose {
-                eprintln!("    段 {} 未收敛，残差 = {:.2e}", i + 1, result.max_residual);
+                eprintln!(
+                    "    段 {} 未收敛，残差 = {:.2e}",
+                    i + 1,
+                    result.max_residual
+                );
             }
         }
 
@@ -234,7 +241,12 @@ pub fn segmented_shooting_correct(
 
         while current_segments.len() > 1 {
             if verbose {
-                eprintln!("合并阶段 {}: {} 段 -> {} 段", stage, current_segments.len(), (current_segments.len() + 1) / 2);
+                eprintln!(
+                    "合并阶段 {}: {} 段 -> {} 段",
+                    stage,
+                    current_segments.len(),
+                    (current_segments.len() + 1) / 2
+                );
             }
 
             let merge_indices: Vec<(usize, usize)> = (0..current_segments.len() - 1)

--- a/crates/e2m2e-integrators/src/single_shooting.rs
+++ b/crates/e2m2e-integrators/src/single_shooting.rs
@@ -273,7 +273,11 @@ pub fn single_shooting_correct(
         residual_history.push(max_res);
 
         if verbose {
-            eprintln!("Iteration {}: max_residual = {:.2e}", iteration + 1, max_res);
+            eprintln!(
+                "Iteration {}: max_residual = {:.2e}",
+                iteration + 1,
+                max_res
+            );
         }
 
         // 判断收敛
@@ -295,8 +299,12 @@ pub fn single_shooting_correct(
 
         // 求解修正量 Δx = -J^{-1} * residual
         let neg_residual: [f64; 6] = [
-            -residual[0], -residual[1], -residual[2],
-            -residual[3], -residual[4], -residual[5],
+            -residual[0],
+            -residual[1],
+            -residual[2],
+            -residual[3],
+            -residual[4],
+            -residual[5],
         ];
         let delta = solve_linear_system(&jacobian, &neg_residual)?;
 
@@ -330,7 +338,11 @@ pub fn single_shooting_correct(
         None,
         None,
     )?;
-    let final_state = final_result.states.last().ok_or("empty propagation")?.to_vec();
+    let final_state = final_result
+        .states
+        .last()
+        .ok_or("empty propagation")?
+        .to_vec();
 
     Ok(SingleShootingResult {
         initial_state: state.to_vec(),

--- a/e2m2e/core/ephemeris_dynamics.py
+++ b/e2m2e/core/ephemeris_dynamics.py
@@ -145,6 +145,14 @@ class EphemerisDynamics(Dynamics):
         stm = np.array(result["stm"]).reshape(-1, 6, 6)
         time = np.array(result["time"])
 
+        # 防御性校验：Rust 侧任何提前退出都必须在这里暴露，
+        # 不允许把截断结果当完整轨迹返回（issue #246）。
+        if len(time) != len(t_eval_list):
+            raise RuntimeError(
+                f"Rust STM propagation returned {len(time)} of {len(t_eval_list)} "
+                f"requested time points; the trajectory is truncated"
+            )
+
         self.last_trajectory = (time, states)
         self.last_stm = stm
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,9 +8,9 @@ import os
 
 import numpy as np
 import pytest
+from kernel_helpers import SPICE_KERNEL_DIR
 
 from e2m2e.core import CR3BP_Dynamics, CR3BP_System, Orbit
-from kernel_helpers import SPICE_KERNEL_DIR
 
 
 def pytest_configure(config):

--- a/tests/core/dynamics/test_ephemeris_dynamics.py
+++ b/tests/core/dynamics/test_ephemeris_dynamics.py
@@ -259,5 +259,49 @@ class TestEphemerisDynamicsEdgeCases:
         assert np.all(np.isfinite(result["states"]))
 
 
+# =============================================================================
+# Test Rust STM 快速路径的错误处理（issue #246）
+# =============================================================================
+class TestRustStmErrorHandling:
+    """Rust 快速路径不允许静默返回截断结果"""
+
+    def test_propagate_with_stm_py_unknown_body_raises(self, reference_et, leo_state):
+        """无星历天体的第三体查询必须抛 RuntimeError，而非返回截断结果"""
+        propagate_with_stm_py = pytest.importorskip(
+            "e2m2e._integrators", reason="Rust 扩展不可用"
+        ).propagate_with_stm_py
+        with pytest.raises(RuntimeError, match="STM propagation failed"):
+            propagate_with_stm_py(
+                bodies=["EARTH", "FAKEBODY"],
+                origin="EARTH",
+                gm_values=[398600.435507, 1.0],
+                t_span=(reference_et, reference_et + 100.0),
+                t_eval=[reference_et, reference_et + 100.0],
+                initial_state=[float(x) for x in leo_state],
+                rtol=1e-12,
+                atol=1e-12,
+                max_step=10.0,
+            )
+
+    def test_rust_path_rejects_truncated_result(self, spice_eph_dynamics, leo_state, monkeypatch):
+        """_propagate_with_stm_rust 对点数不足的截断结果必须抛 RuntimeError"""
+        import e2m2e.core.ephemeris_dynamics as ephem_dyn
+
+        def fake_propagate(**kwargs):
+            t0 = kwargs["t_eval"][0]
+            return {
+                "states": [list(kwargs["initial_state"])],
+                "stm": [[1.0 if i == j else 0.0 for i in range(6) for j in range(6)]],
+                "time": [t0],
+            }
+
+        monkeypatch.setattr(ephem_dyn, "propagate_with_stm_py", fake_propagate)
+        monkeypatch.setattr(ephem_dyn, "_HAS_RUST_STM", True)
+
+        t_eval = np.linspace(0.0, 100.0, 101)
+        with pytest.raises(RuntimeError, match="truncated"):
+            spice_eph_dynamics.propagate(leo_state, (0.0, 100.0), t_eval=t_eval, with_stm=True)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/uv.lock
+++ b/uv.lock
@@ -376,6 +376,7 @@ dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
 ]
 
@@ -399,6 +400,7 @@ dev = [
     { name = "mypy" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-cov", specifier = ">=4.0" },
+    { name = "pytest-xdist", specifier = ">=3.0" },
     { name = "ruff", specifier = ">=0.1" },
 ]
 
@@ -412,6 +414,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
 ]
 
 [[package]]
@@ -1346,6 +1357,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 关联

Closes #246

## 改了什么

- `crates/e2m2e-forces/src/forces/nbody_stm.rs`：`propagate_with_stm` 返回 `Result<PropagationResult, String>`；积分前预检 `augmented_eom`（SPICE 内核缺失在 t0 确定性报错）；积分后校验输出点数等于 `t_eval` 长度，不足则 Err；新增 FAKEBODY 触发 Err 的测试。
- `crates/e2m2e-integrators/src/lib.rs`：`propagate_with_stm_py` 以 `PyRuntimeError` 透出 Rust 错误，与 `propagate_compiled_stm_py` 模式对齐。
- `e2m2e/core/ephemeris_dynamics.py`：`_propagate_with_stm_rust` 加防御性校验，点数不足抛 `RuntimeError`，不把截断结果当完整轨迹返回。
- `tests/core/dynamics/test_ephemeris_dynamics.py`：新增 `TestRustStmErrorHandling` 两个测试（FAKEBODY 抛错；monkeypatch 截断 dict 触发防御校验）。

## 测试

- `cargo test -p e2m2e-forces --features spice -- --test-threads=1`：全过（服务器，cspice 全局锁要求单线程）
- `pytest tests/core/dynamics/test_ephemeris_dynamics.py`：30 passed
- 服务器全量 `pytest tests/ -n auto`：1401 passed, 21 skipped