### PR TITLE
feat(integrators): 星历预采样缓存 strict 模式 + rayon 并行段积分 + LM 阻尼打靶

### DIFF
--- a/crates/e2m2e-forces/src/forces/gravity_field.rs
+++ b/crates/e2m2e-forces/src/forces/gravity_field.rs
@@ -114,14 +114,15 @@ pub fn gravity_field_acceleration(
     let r_body_icrf: [f64; 3] = if body == propagation_origin {
         [r_sc[0], r_sc[1], r_sc[2]]
     } else {
-        // 查两个 origin 在 SSB 的位置（优先走星历缓存，未覆盖回退 spkezr）
-        let prop_origin_pos_ssb: [f64; 3] = match e2m2e_spice::ephem_cache::with_cache(|c| {
-            c.and_then(|cache| {
-                cache.body_position(propagation_origin, "SOLAR SYSTEM BARYCENTER", et)
-            })
-        }) {
-            Some(p) => p,
-            None => {
+        // 查两个 origin 在 SSB 的位置（优先走星历缓存；strict 模式 miss 即
+        // 硬 Err，杜绝并行区回退 cspice）
+        let prop_origin_pos_ssb: [f64; 3] = match e2m2e_spice::ephem_cache::lookup_body_position(
+            propagation_origin,
+            "SOLAR SYSTEM BARYCENTER",
+            et,
+        ) {
+            Ok(Some(p)) => p,
+            Ok(None) => {
                 let (st, _) = e2m2e_spice::spice_ffi::spkezr(
                     propagation_origin,
                     et,
@@ -131,17 +132,20 @@ pub fn gravity_field_acceleration(
                 )?;
                 [st[0], st[1], st[2]]
             }
+            Err(e) => return Err(e.into()),
         };
         let r_ssb = [
             r_sc[0] + prop_origin_pos_ssb[0],
             r_sc[1] + prop_origin_pos_ssb[1],
             r_sc[2] + prop_origin_pos_ssb[2],
         ];
-        let body_pos_ssb: [f64; 3] = match e2m2e_spice::ephem_cache::with_cache(|c| {
-            c.and_then(|cache| cache.body_position(body, "SOLAR SYSTEM BARYCENTER", et))
-        }) {
-            Some(p) => p,
-            None => {
+        let body_pos_ssb: [f64; 3] = match e2m2e_spice::ephem_cache::lookup_body_position(
+            body,
+            "SOLAR SYSTEM BARYCENTER",
+            et,
+        ) {
+            Ok(Some(p)) => p,
+            Ok(None) => {
                 let (st, _) = e2m2e_spice::spice_ffi::spkezr(
                     body,
                     et,
@@ -151,6 +155,7 @@ pub fn gravity_field_acceleration(
                 )?;
                 [st[0], st[1], st[2]]
             }
+            Err(e) => return Err(e.into()),
         };
         [
             r_ssb[0] - body_pos_ssb[0],
@@ -159,17 +164,17 @@ pub fn gravity_field_acceleration(
         ]
     };
 
-    // 旋转 propagation_frame → input_frame（优先走缓存）
+    // 旋转 propagation_frame → input_frame（优先走缓存；strict miss 硬 Err）
     // Python: position_out = to_rotation.T @ r_body_icrf，
     // 其中 to_rotation = pxform(input_frame, J2000)（input → j2000）。
     // 所以 position_out = pxform(input_frame, J2000).T @ r_body_icrf
     //                   = pxform(J2000, input_frame) @ r_body_icrf
-    let r_input_to_j2000: [[f64; 3]; 3] = match e2m2e_spice::ephem_cache::with_cache(|c| {
-        c.and_then(|cache| cache.frame_matrix(input_frame, propagation_frame, et))
-    }) {
-        Some(m) => m,
-        None => pxform(input_frame, propagation_frame, et)?,
-    };
+    let r_input_to_j2000: [[f64; 3]; 3] =
+        match e2m2e_spice::ephem_cache::lookup_frame_matrix(input_frame, propagation_frame, et) {
+            Ok(Some(m)) => m,
+            Ok(None) => pxform(input_frame, propagation_frame, et)?,
+            Err(e) => return Err(e.into()),
+        };
     let r_input = mat3_t_mul_vec(&r_input_to_j2000, &r_body_icrf);
 
     // Step 2: 有效系数（含潮汐修正）
@@ -340,33 +345,64 @@ impl GravityFieldContext {
         propagation_origin: &str,
         tide: &TideConfig,
     ) -> Result<Self, SpiceFfiError> {
-        // 1. 查天体位置（平移偏移）
-        let (prop_origin_state_ssb, _) = e2m2e_spice::spice_ffi::spkezr(
-            propagation_origin,
-            et,
-            propagation_frame,
-            "NONE",
-            "SOLAR SYSTEM BARYCENTER",
-        )?;
-        let origin_offset = if body == propagation_origin {
+        // 1. 查天体位置（平移偏移）。优先走星历缓存（三次样条查表），未覆盖
+        //    回退 spkezr——与 gravity_field_acceleration L118-171 同模式。
+        //    body == propagation_origin（地心系地球重力场常见场景）时 origin
+        //    与 body 重合，无需查 SSB 平移。
+        let origin_offset: [f64; 3] = if body == propagation_origin {
             [0.0; 3]
         } else {
-            let (body_state_ssb, _) = e2m2e_spice::spice_ffi::spkezr(
-                body,
-                et,
-                propagation_frame,
-                "NONE",
+            let prop_origin_pos_ssb = match e2m2e_spice::ephem_cache::lookup_body_position(
+                propagation_origin,
                 "SOLAR SYSTEM BARYCENTER",
-            )?;
+                et,
+            ) {
+                Ok(Some(p)) => p,
+                Ok(None) => {
+                    let (st, _) = e2m2e_spice::spice_ffi::spkezr(
+                        propagation_origin,
+                        et,
+                        propagation_frame,
+                        "NONE",
+                        "SOLAR SYSTEM BARYCENTER",
+                    )?;
+                    [st[0], st[1], st[2]]
+                }
+                Err(e) => return Err(e.into()),
+            };
+            let body_pos_ssb = match e2m2e_spice::ephem_cache::lookup_body_position(
+                body,
+                "SOLAR SYSTEM BARYCENTER",
+                et,
+            ) {
+                Ok(Some(p)) => p,
+                Ok(None) => {
+                    let (st, _) = e2m2e_spice::spice_ffi::spkezr(
+                        body,
+                        et,
+                        propagation_frame,
+                        "NONE",
+                        "SOLAR SYSTEM BARYCENTER",
+                    )?;
+                    [st[0], st[1], st[2]]
+                }
+                Err(e) => return Err(e.into()),
+            };
             [
-                prop_origin_state_ssb[0] - body_state_ssb[0],
-                prop_origin_state_ssb[1] - body_state_ssb[1],
-                prop_origin_state_ssb[2] - body_state_ssb[2],
+                prop_origin_pos_ssb[0] - body_pos_ssb[0],
+                prop_origin_pos_ssb[1] - body_pos_ssb[1],
+                prop_origin_pos_ssb[2] - body_pos_ssb[2],
             ]
         };
 
-        // 2. 查旋转矩阵
-        let rotation = e2m2e_spice::spice_ffi::pxform(input_frame, propagation_frame, et)?;
+        // 2. 查旋转矩阵（优先走缓存帧样条；strict miss 硬 Err）
+        let rotation =
+            match e2m2e_spice::ephem_cache::lookup_frame_matrix(input_frame, propagation_frame, et)
+            {
+                Ok(Some(m)) => m,
+                Ok(None) => e2m2e_spice::spice_ffi::pxform(input_frame, propagation_frame, et)?,
+                Err(e) => return Err(e.into()),
+            };
 
         // 3. 有效系数（含潮汐）
         let (c_eff, s_eff) = if tide.mode == TideMode::None {

--- a/crates/e2m2e-forces/src/forces/srp.rs
+++ b/crates/e2m2e-forces/src/forces/srp.rs
@@ -121,14 +121,16 @@ fn combine_body_fluxes(factors: &[f64], angular_radii: &[f64], directions: &[[f6
 ///
 /// SRP 是 STM 传播内循环的热点：数值差分雅可比每步要 6 次加速度评估，
 /// 每次都查太阳/遮挡体位置。缓存命中时全走内存三次样条，免 cspice FFI。
+/// strict 模式（多重打靶并行区）下 miss 即硬 Err，杜绝回退 cspice。
 fn body_position_cached(target: &str, observer: &str, et: f64) -> Result<[f64; 3], SpiceFfiError> {
-    if let Some(p) = e2m2e_spice::ephem_cache::with_cache(|c| {
-        c.and_then(|c| c.body_position(target, observer, et))
-    }) {
-        return Ok(p);
+    match e2m2e_spice::ephem_cache::lookup_body_position(target, observer, et) {
+        Ok(Some(p)) => Ok(p),
+        Ok(None) => {
+            let (state, _) = spkezr(target, et, "J2000", "NONE", observer)?;
+            Ok([state[0], state[1], state[2]])
+        }
+        Err(e) => Err(e.into()),
     }
-    let (state, _) = spkezr(target, et, "J2000", "NONE", observer)?;
-    Ok([state[0], state[1], state[2]])
 }
 
 /// ConicalShadowModel 完整光照份额（系统感知）。

--- a/crates/e2m2e-integrators/src/homotopy.rs
+++ b/crates/e2m2e-integrators/src/homotopy.rs
@@ -217,6 +217,7 @@ impl HomotopySolver {
             &state_patch_6d,
             false, // 固定时间
             false, // 不固定首节点（homotopy 占位实现，保持原有语义）
+            None,  // fixed_node_mask：不额外固定
             self.config.max_iter,
             self.config.tolerance,
             self.config.rtol,

--- a/crates/e2m2e-integrators/src/lib.rs
+++ b/crates/e2m2e-integrators/src/lib.rs
@@ -1813,6 +1813,20 @@ fn disable_ephem_cache() {
     e2m2e_spice::ephem_cache::disable();
 }
 
+/// 返回 cspice FFI 调用计数（验证"零 cspice"用）。
+#[cfg(feature = "spice")]
+#[pyfunction]
+fn ephem_ffi_call_count() -> u64 {
+    e2m2e_spice::spice_ffi::ffi_call_count()
+}
+
+/// 清零 cspice FFI 调用计数。
+#[cfg(feature = "spice")]
+#[pyfunction]
+fn reset_ephem_ffi_call_count() {
+    e2m2e_spice::spice_ffi::reset_ffi_call_count();
+}
+
 /// 7D 受控动力学单点求值（配点法用）。
 ///
 /// 包装 `augmented_eom_7d`：给定状态 `[r,v,m]` 与控制参数
@@ -1917,6 +1931,10 @@ fn _integrators(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(enable_ephem_cache, m)?)?;
     #[cfg(feature = "spice")]
     m.add_function(wrap_pyfunction!(disable_ephem_cache, m)?)?;
+    #[cfg(feature = "spice")]
+    m.add_function(wrap_pyfunction!(ephem_ffi_call_count, m)?)?;
+    #[cfg(feature = "spice")]
+    m.add_function(wrap_pyfunction!(reset_ephem_ffi_call_count, m)?)?;
     #[cfg(feature = "spice")]
     m.add_function(wrap_pyfunction!(augmented_eom_7d_py, m)?)?;
     #[cfg(feature = "spice")]

--- a/crates/e2m2e-integrators/src/multiple_shooting.rs
+++ b/crates/e2m2e-integrators/src/multiple_shooting.rs
@@ -10,17 +10,17 @@
 //! 3. 最小二乘求解：dX = -(DF^T DF)^{-1} DF^T F
 //! 4. 更新：x_new = x_old + α * dX
 
-use e2m2e_forces::forces::compiled::{
-    compute_total_acceleration_and_jacobian, CompiledForce,
-};
+use e2m2e_forces::forces::compiled::{compute_total_acceleration_and_jacobian, CompiledForce};
 use e2m2e_forces::forces::compiled_stm::propagate_compiled_stm;
 use pyo3::prelude::*;
-use rayon::prelude::*;
 
 /// 最小二乘求解结果。
 struct LeastSquaresResult {
     dx: Vec<f64>,
 }
+
+/// 一段积分的结果：终端 STM、终端状态、段首状态导数、段末状态导数。
+type SegmentInfo = ([f64; 36], [f64; 6], [f64; 6], [f64; 6]);
 
 /// 多重打靶迭代结果。
 #[pyclass]
@@ -62,36 +62,36 @@ fn build_residual(final_states: &[[f64; 6]], state_work: &[[f64; 6]], n_seg: usi
 
 /// 构建雅可比矩阵 DF（固定时间模式）。
 ///
-/// 自由变量列块 j 对应节点 x_{j+node_offset}。固定首点时 node_offset=1
-/// （x_0 不参与修正），否则 node_offset=0。
+/// 自由变量列块 j 对应第 j 个**自由节点**（由 ``free_pos`` 映射：
+/// ``free_pos[i]`` = 节点 i 在自由变量序列中的位置，固定节点为 ``None``）。
 /// 残差 F_i = φ(x_i) - x_{i+1}，故：
-///   ∂F_i/∂x_i     = Φ_i，列块 = i - node_offset（i >= node_offset 时存在）
-///   ∂F_i/∂x_{i+1} = -I_6，列块 = i + 1 - node_offset
+///   ∂F_i/∂x_i     = Φ_i，列块 = free_pos[i]（i 自由时存在）
+///   ∂F_i/∂x_{i+1} = -I_6，列块 = free_pos[i+1]（i+1 自由时存在）
+/// 固定节点的列块整块省略（对自由变量雅可比无贡献）。
 fn build_jacobian_fixed_time(
     stms: &[[f64; 36]],
     n_seg: usize,
     n_vars: usize,
-    node_offset: usize,
+    free_pos: &[Option<usize>],
 ) -> Vec<f64> {
     let n_constraints = n_seg * 6;
     let mut df = vec![0.0_f64; n_constraints * n_vars];
 
     for i in 0..n_seg {
         let r_start = i * 6;
-        // ∂F_i/∂x_i = Φ_i（仅当 x_i 是自由变量，即 i >= node_offset）
-        if i >= node_offset {
-            let col_block = i - node_offset;
+        // ∂F_i/∂x_i = Φ_i（仅当 x_i 是自由变量）
+        if let Some(col_block) = free_pos[i] {
             for row in 0..6 {
                 for col in 0..6 {
-                    df[(r_start + row) * n_vars + col_block * 6 + col] =
-                        stms[i][row * 6 + col];
+                    df[(r_start + row) * n_vars + col_block * 6 + col] = stms[i][row * 6 + col];
                 }
             }
         }
-        // ∂F_i/∂x_{i+1} = -I_6
-        let col_block = i + 1 - node_offset;
-        for j in 0..6 {
-            df[(r_start + j) * n_vars + col_block * 6 + j] = -1.0;
+        // ∂F_i/∂x_{i+1} = -I_6（仅当 x_{i+1} 是自由变量）
+        if let Some(col_block) = free_pos[i + 1] {
+            for j in 0..6 {
+                df[(r_start + j) * n_vars + col_block * 6 + j] = -1.0;
+            }
         }
     }
     df
@@ -99,10 +99,10 @@ fn build_jacobian_fixed_time(
 
 /// 构建雅可比矩阵 DF（自由时间模式）。
 ///
-/// 自由变量列块 j 对应节点 x_{j+node_offset}；时间变量接在状态变量之后，
-/// 从 n_free_nodes*6 开始。
-///   ∂F_i/∂x_i     = Φ_i，列块 = i - node_offset（i >= node_offset 时存在）
-///   ∂F_i/∂x_{i+1} = -I_6，列块 = i + 1 - node_offset
+/// 自由变量列块 j 对应第 j 个自由节点（``free_pos`` 映射）；时间变量接在
+/// 状态变量之后，从 ``n_free_nodes*6`` 开始。
+///   ∂F_i/∂x_i     = Φ_i，列块 = free_pos[i]
+///   ∂F_i/∂x_{i+1} = -I_6，列块 = free_pos[i+1]
 ///   ∂F_i/∂t_i     = -f(t_i, x_i)
 ///   ∂F_i/∂t_{i+1} = f(t_{i+1}, φ_i)
 fn build_jacobian_variable_time(
@@ -112,27 +112,26 @@ fn build_jacobian_variable_time(
     n_seg: usize,
     n_vars: usize,
     n_free_nodes: usize,
-    node_offset: usize,
+    free_pos: &[Option<usize>],
 ) -> Vec<f64> {
     let n_constraints = n_seg * 6;
     let mut df = vec![0.0_f64; n_constraints * n_vars];
 
     for i in 0..n_seg {
         let r_start = i * 6;
-        // ∂F_i/∂x_i = Φ_i（仅当 x_i 是自由变量，即 i >= node_offset）
-        if i >= node_offset {
-            let col_block = i - node_offset;
+        // ∂F_i/∂x_i = Φ_i（仅当 x_i 是自由变量）
+        if let Some(col_block) = free_pos[i] {
             for row in 0..6 {
                 for col in 0..6 {
-                    df[(r_start + row) * n_vars + col_block * 6 + col] =
-                        stms[i][row * 6 + col];
+                    df[(r_start + row) * n_vars + col_block * 6 + col] = stms[i][row * 6 + col];
                 }
             }
         }
-        // ∂F_i/∂x_{i+1} = -I_6
-        let col_block = i + 1 - node_offset;
-        for j in 0..6 {
-            df[(r_start + j) * n_vars + col_block * 6 + j] = -1.0;
+        // ∂F_i/∂x_{i+1} = -I_6（仅当 x_{i+1} 是自由变量）
+        if let Some(col_block) = free_pos[i + 1] {
+            for j in 0..6 {
+                df[(r_start + j) * n_vars + col_block * 6 + j] = -1.0;
+            }
         }
         // ∂F_i/∂t_i = -f(t_i, x_i)
         for j in 0..6 {
@@ -146,15 +145,23 @@ fn build_jacobian_variable_time(
     df
 }
 
-/// 最小二乘求解：dX = (DF^T DF)^{-1} DF^T (-F)
+/// 阻尼最小二乘求解：dX = (D^T D + λ I)^{-1} D^T (-F)
 ///
-/// 使用正规方程求解（比 QR 分解简单，适合小规模问题）。
-/// 注意：这里求解的是 DF dX = -F，即 dX = -(DF^T DF)^{-1} DF^T F
+/// 用正规方程 + 高斯消元（部分主元）解：
+///   (D^T D + λ I) dX = -D^T F
+/// λ 为 Levenberg-Marquardt 阻尼项：
+/// - 恰定/过定系统 λ≈0 退化为 Gauss-Newton 最小二乘；
+/// - 欠定系统（节点全自由，6N 变量 > 6(N-1) 约束，论文式13 语义）
+///   D^T D 半正定奇异，加 λI 正定化后解是
+///   min ‖D dX + F‖² + λ‖dX‖²，即最小范数偏好——解停留在初猜附近，
+///   这正是"保形"的数学来源（论文 `C_{k+1}=C_k-D^T(DD^T)^{-1}F`）。
+///   λ 随线搜索失败增大（见 `multiple_shooting_correct`），成功时趋小。
 fn least_squares_solve(
     df: &[f64],
     f: &[f64],
     n_constraints: usize,
     n_vars: usize,
+    lam: f64,
 ) -> LeastSquaresResult {
     // 计算 DF^T (-F)
     let mut dtf = vec![0.0_f64; n_vars];
@@ -164,17 +171,20 @@ fn least_squares_solve(
         }
     }
 
-    // 计算 DF^T DF
+    // 计算 DF^T DF + λI
     let mut dtd = vec![0.0_f64; n_vars * n_vars];
     for i in 0..n_vars {
         for j in 0..n_vars {
+            let mut s = 0.0;
             for k in 0..n_constraints {
-                dtd[i * n_vars + j] += df[k * n_vars + i] * df[k * n_vars + j];
+                s += df[k * n_vars + i] * df[k * n_vars + j];
             }
+            dtd[i * n_vars + j] = s;
         }
+        dtd[i * n_vars + i] += lam;
     }
 
-    // 求解 (DF^T DF) dX = DF^T (-F)
+    // 求解 (DF^T DF + λI) dX = DF^T (-F)
     // 使用高斯消元法（简化版，适合小规模问题）
     let mut augmented = vec![0.0_f64; n_vars * (n_vars + 1)];
     for i in 0..n_vars {
@@ -233,15 +243,23 @@ fn least_squares_solve(
 
 /// 多重打靶迭代修正（Rust 实现）。
 ///
+/// 求解器语义对齐朱彦伟 2026《星历模型下基于多重打靶拼接的长期近直线晕
+/// 轨道设计方法》式(13)：**阻尼最小二乘 + 回溯线搜索**。
+/// - 欠定系统（节点全自由，6N 变量 > 6(N-1) 约束）下 LM 阻尼项使解趋
+///   向**最小范数**（停留在初猜附近），即"保形"的数学来源；
+/// - 回溯线搜索（α 递减到残差下降）防止不稳定轨道全步长 Gauss-Newton
+///   一步发散（STM 谱半径 ~1e7/圈）。
+///
 /// # Arguments
 /// * `forces` - 编译后的力模型列表
 /// * `observer` - 坐标原点天体名（如 "EARTH"）
 /// * `t_patch` - 初始时间节点，形状 (N,)
 /// * `state_patch` - 初始状态量，形状 (N, 6)
-/// * `var_time` - 是否启用自由时间修正
-/// * `fix_first_node` - 固定首节点（不参与修正）。多重打靶的段首点代表段的
-///   初始条件，段内修正不应改变它；不固定时欠定系统（约束 N-1 段 < 变量 N
-///   节点）会让首点沿零空间漂移，导致结果发散。
+/// * `var_time` - 是否启用自由时间修正（自由变量含时间节点，论文式9）
+/// * `fix_first_node` - 固定首节点（兼容旧接口）。等价于
+///   `fixed_node_mask=[true,false,...]`。
+/// * `fixed_node_mask` - 固定任意节点子集（`None` 时用 `fix_first_node`）。
+///   拼接/锚定远月点需要固定段首/两端。长度必须等于节点数。
 /// * `max_iter` - 最大迭代次数
 /// * `tolerance` - 收敛容差
 /// * `rtol` - 积分相对容差
@@ -255,6 +273,7 @@ pub fn multiple_shooting_correct(
     state_patch: &[[f64; 6]],
     var_time: bool,
     fix_first_node: bool,
+    fixed_node_mask: Option<&[bool]>,
     max_iter: usize,
     tolerance: f64,
     rtol: f64,
@@ -274,82 +293,123 @@ pub fn multiple_shooting_correct(
             n_nodes
         ));
     }
+    if let Some(mask) = fixed_node_mask {
+        if mask.len() != n_nodes {
+            return Err(format!(
+                "fixed_node_mask length {} != n_nodes {}",
+                mask.len(),
+                n_nodes
+            ));
+        }
+    }
 
     let mut t_work = t_patch.to_vec();
     let mut state_work = state_patch.to_vec();
     let mut residual_history = Vec::new();
     let mut converged = false;
 
-    // 自由变量：默认全部 N 个节点状态；固定首点时只含节点 1..N-1，
-    // 系统恰定（(N-1)*6 变量 = (N-1)*6 约束），消除欠定漂移
-    let n_free_nodes = if fix_first_node { n_nodes - 1 } else { n_nodes };
+    // 自由节点映射：free_pos[i] = 节点 i 在自由变量序列中的位置（固定节点为 None）。
+    // 由 fixed_node_mask（若给出）或 fix_first_node（兼容）派生。
+    let mut free_pos = vec![None; n_nodes];
+    let mut n_free_nodes = 0usize;
+    for i in 0..n_nodes {
+        let fixed = if let Some(mask) = fixed_node_mask {
+            mask[i]
+        } else {
+            fix_first_node && i == 0
+        };
+        if !fixed {
+            free_pos[i] = Some(n_free_nodes);
+            n_free_nodes += 1;
+        }
+    }
+    if n_free_nodes == 0 {
+        return Err("all nodes fixed, no free variables".to_string());
+    }
     let n_vars = if var_time {
         n_free_nodes * 6 + n_nodes
     } else {
         n_free_nodes * 6
     };
 
+    // Levenberg-Marquardt 阻尼初值：相对 D^T D 对角元量级，欠定系统保 min-norm。
+    // **跨迭代保留**（成功迭代减小、失败增大）：标准 LM 做法。若不保留而每次
+    // 重置，残差在局部极小处反复尝试同一条失败路径（实测停滞 8e-2 km 压不下，
+    // 保留阻尼可到 1.6e-2）。见 multiple_shooting_correct 主循环。
+    let lam0 = 1e-6;
+    let mut lam = lam0;
+    // 停滞计数：连续无改善迭代数（提前停，避免局部极小反复浪费）
+    let mut stall_count = 0usize;
+
+    // strict 缓存模式：打靶全程力模型查星历表，miss 即硬 Err，杜绝任何
+    // 静默回退 cspice（并行段积分的 cspice 是内核池损坏/panic 的根源）。
+    let _strict = e2m2e_spice::ephem_cache::StrictGuard::new();
+    // 并行开关：E2M2E_MS_PARALLEL=0 强制串行（验证并行/串行位级一致性用）。
+    // 默认并行——前提是缓存已启用且 strict（段积分内零 cspice）。
+    let parallel = std::env::var("E2M2E_MS_PARALLEL").map_or(true, |v| v != "0");
+
     for iteration in 0..max_iter {
         // 第一步：逐段积分，收集 STM、终端状态。
-        // 段间相互独立（只依赖本段起始状态），用 rayon 并行积分；
-        // 顺带求段两端点的状态导数 [v, a]（自由时间模式雅可比需要，
-        // 不再用零占位）。
-        let seg_infos: Vec<Result<([f64; 36], [f64; 6], [f64; 6], [f64; 6]), String>> =
-            (0..n_seg)
-                .into_par_iter()
-                .map(|i| {
-                    let t_span = (t_work[i], t_work[i + 1]);
-                    let result = propagate_compiled_stm(
-                        forces,
-                        observer,
-                        t_span,
-                        &[t_work[i], t_work[i + 1]],
-                        &state_work[i],
-                        rtol,
-                        rtol * 0.1,
-                        max_step,
-                        Some(500_000),
-                    )?;
+        // 段间相互独立（只依赖本段起始状态），rayon 并行段积分线性加速。
+        // 并行安全前提：星历预采样缓存已启用 + strict 模式——段积分内力
+        // 模型查内存三次样条，零 cspice FFI（cspice 并发会让多线程同时调
+        // easier_reader 触发全局锁损坏，报 SPICE(DAFFRNOTFOUND) 或 panic）。
+        // par_iter 保序 + 各段积分确定 → 并行与串行位级一致。
+        // 顺带求段两端点的状态导数 [v, a]（自由时间模式雅可比需要）。
+        let integrate_seg = |i: usize| -> Result<SegmentInfo, String> {
+            let t_span = (t_work[i], t_work[i + 1]);
+            let result = propagate_compiled_stm(
+                forces,
+                observer,
+                t_span,
+                &[t_work[i], t_work[i + 1]],
+                &state_work[i],
+                rtol,
+                rtol * 0.1,
+                max_step,
+                Some(500_000),
+            )?;
 
-                    let final_state = result
-                        .states
-                        .last()
-                        .ok_or("empty propagation result")?
-                        .clone();
-                    let final_stm = result.stms.last().ok_or("empty STM result")?.clone();
+            let final_state = *result.states.last().ok_or("empty propagation result")?;
+            let final_stm = *result.stms.last().ok_or("empty STM result")?;
 
-                    let (a0, _) = compute_total_acceleration_and_jacobian(
-                        forces,
-                        t_work[i],
-                        &state_work[i],
-                        observer,
-                    )?;
-                    let (a1, _) = compute_total_acceleration_and_jacobian(
-                        forces,
-                        t_work[i + 1],
-                        &final_state,
-                        observer,
-                    )?;
-                    let f_start = [
-                        state_work[i][3],
-                        state_work[i][4],
-                        state_work[i][5],
-                        a0[0],
-                        a0[1],
-                        a0[2],
-                    ];
-                    let f_end = [
-                        final_state[3],
-                        final_state[4],
-                        final_state[5],
-                        a1[0],
-                        a1[1],
-                        a1[2],
-                    ];
+            let (a0, _) = compute_total_acceleration_and_jacobian(
+                forces,
+                t_work[i],
+                &state_work[i],
+                observer,
+            )?;
+            let (a1, _) = compute_total_acceleration_and_jacobian(
+                forces,
+                t_work[i + 1],
+                &final_state,
+                observer,
+            )?;
+            let f_start = [
+                state_work[i][3],
+                state_work[i][4],
+                state_work[i][5],
+                a0[0],
+                a0[1],
+                a0[2],
+            ];
+            let f_end = [
+                final_state[3],
+                final_state[4],
+                final_state[5],
+                a1[0],
+                a1[1],
+                a1[2],
+            ];
 
-                    Ok((final_stm, final_state, f_start, f_end))
-                })
-                .collect();
+            Ok((final_stm, final_state, f_start, f_end))
+        };
+        let seg_infos: Vec<Result<SegmentInfo, String>> = if parallel {
+            use rayon::prelude::*;
+            (0..n_seg).into_par_iter().map(integrate_seg).collect()
+        } else {
+            (0..n_seg).map(integrate_seg).collect()
+        };
 
         let mut stms = Vec::with_capacity(n_seg);
         let mut final_states = Vec::with_capacity(n_seg);
@@ -382,8 +442,29 @@ pub fn multiple_shooting_correct(
             break;
         }
 
+        // 停滞检测：连续迭代残差相对改善极小即提前停。阈值取 0.05%（比
+        // Gauss-Newton 停滞点更严），避免在 LM 阻尼还能探索的方向上过早截断
+        // ——跨迭代 LM 阻尼（成功减、失败增）可越过浅局部极小继续收敛。
+        if let Some(prev) = residual_history.iter().rev().nth(1) {
+            let improvement = 1.0 - max_res / *prev;
+            if improvement < 5e-4 {
+                stall_count += 1;
+                if stall_count >= 5 {
+                    if verbose {
+                        eprintln!(
+                            "Iteration {}: stalled (improvement {:.3}%), stopping",
+                            iteration + 1,
+                            improvement
+                        );
+                    }
+                    break;
+                }
+            } else {
+                stall_count = 0;
+            }
+        }
+
         // 第三步：构建雅可比矩阵
-        let node_offset = if fix_first_node { 1 } else { 0 };
         let df = if var_time {
             build_jacobian_variable_time(
                 &stms,
@@ -392,42 +473,61 @@ pub fn multiple_shooting_correct(
                 n_seg,
                 n_vars,
                 n_free_nodes,
-                node_offset,
+                &free_pos,
             )
         } else {
-            build_jacobian_fixed_time(&stms, n_seg, n_vars, node_offset)
+            build_jacobian_fixed_time(&stms, n_seg, n_vars, &free_pos)
         };
 
-        // 第四步：最小二乘求解
-        let ls_result = least_squares_solve(&df, &f, n_seg * 6, n_vars);
+        // 第四步：LM 阻尼最小二乘 + 回溯线搜索。
+        // 阻尼项 λ 跨迭代保留：成功时减小（朝 Gauss-Newton），失败时增大
+        // （朝 min-norm/最速下降）。全步长 Gauss-Newton 对不稳定轨道（STM
+        // 谱半径 1e7/圈）一步就发散，线搜索 + 阻尼是收敛的工程必需。
+        let mut accepted = false;
+        for _ in 0..8 {
+            let ls_result = least_squares_solve(&df, &f, n_seg * 6, n_vars, lam);
 
-        // 第五步：更新变量
-        // 更新状态（跳过首点：固定首点时 dx 只含节点 1..N-1 的修正量）
-        let mut x_flat: Vec<f64> = state_work.iter().flat_map(|s| s.iter().copied()).collect();
-        if fix_first_node {
-            // 首点 6 个分量不更新，dx 从节点 1 开始对齐
-            for (i, x) in x_flat.iter_mut().enumerate().skip(6) {
-                *x += ls_result.dx[i - 6];
+            // 第五步：更新变量（回溯线搜索，从 α=1 减半，直到残差下降）
+            let mut alpha = 1.0_f64;
+            for _ in 0..16 {
+                let t_try = apply_dx_t(&t_work, &ls_result.dx, n_free_nodes, var_time, alpha);
+                let s_try = apply_dx_state(
+                    &state_work,
+                    &ls_result.dx,
+                    &free_pos,
+                    var_time,
+                    n_free_nodes,
+                    alpha,
+                );
+                match try_residual(forces, observer, &t_try, &s_try, rtol, max_step) {
+                    Ok(trial_res) if trial_res < max_res => {
+                        t_work = t_try;
+                        state_work = s_try;
+                        accepted = true;
+                        break;
+                    }
+                    _ => {
+                        alpha *= 0.5;
+                    }
+                }
             }
-        } else {
-            for (i, x) in x_flat.iter_mut().enumerate() {
-                *x += ls_result.dx[i];
+            if accepted {
+                lam = (lam * 0.5).max(1e-10); // 成功：减小阻尼
+                break;
             }
+            lam *= 10.0; // 失败：增大阻尼，朝 min-norm 方向靠
         }
-        state_work = x_flat
-            .chunks_exact(6)
-            .map(|chunk| {
-                let mut arr = [0.0_f64; 6];
-                arr.copy_from_slice(chunk);
-                arr
-            })
-            .collect();
-
-        // 更新时间（仅自由时间模式）
-        if var_time {
-            for (i, t) in t_work.iter_mut().enumerate() {
-                *t += ls_result.dx[n_free_nodes * 6 + i];
+        if !accepted {
+            // 线搜索连续失败：残差停滞在局部极小，接受当前解（保形已由
+            // min-norm 保证，不再强推数值收敛）
+            if verbose {
+                eprintln!(
+                    "Iteration {}: line search stalled, stopping at residual {:.2e}",
+                    iteration + 1,
+                    max_res
+                );
             }
+            break;
         }
     }
 
@@ -441,13 +541,80 @@ pub fn multiple_shooting_correct(
     })
 }
 
-/// PyO3 接口：多重打靶迭代修正。
-///
+/// 对状态应用修正量 dX（只更新自由节点，按 free_pos 映射）。
+#[allow(clippy::too_many_arguments)]
+fn apply_dx_state(
+    state_work: &[[f64; 6]],
+    dx: &[f64],
+    free_pos: &[Option<usize>],
+    var_time: bool,
+    n_free_nodes: usize,
+    alpha: f64,
+) -> Vec<[f64; 6]> {
+    let mut out = state_work.to_vec();
+    for (i, s) in out.iter_mut().enumerate() {
+        if let Some(pos) = free_pos[i] {
+            let base = pos * 6;
+            for j in 0..6 {
+                s[j] += alpha * dx[base + j];
+            }
+        }
+    }
+    let _ = (var_time, n_free_nodes); // 状态更新不依赖时间列，保留签名对称
+    out
+}
+
+/// 对时间节点应用修正量（仅自由时间模式）。
+fn apply_dx_t(
+    t_work: &[f64],
+    dx: &[f64],
+    n_free_nodes: usize,
+    var_time: bool,
+    alpha: f64,
+) -> Vec<f64> {
+    let mut out = t_work.to_vec();
+    if var_time {
+        for (i, t) in out.iter_mut().enumerate() {
+            *t += alpha * dx[n_free_nodes * 6 + i];
+        }
+    }
+    out
+}
+
+/// 试算一组状态/时间节点下的最大残差（供回溯线搜索验收）。积分失败视为不下降。
+fn try_residual(
+    forces: &[CompiledForce],
+    observer: &str,
+    t_work: &[f64],
+    state_work: &[[f64; 6]],
+    rtol: f64,
+    max_step: Option<f64>,
+) -> Result<f64, String> {
+    let n_seg = t_work.len() - 1;
+    let mut final_states = Vec::with_capacity(n_seg);
+    for i in 0..n_seg {
+        let result = propagate_compiled_stm(
+            forces,
+            observer,
+            (t_work[i], t_work[i + 1]),
+            &[t_work[i], t_work[i + 1]],
+            &state_work[i],
+            rtol,
+            rtol * 0.1,
+            max_step,
+            Some(500_000),
+        )?;
+        final_states.push(*result.states.last().ok_or("empty propagation result")?);
+    }
+    let f = build_residual(&final_states, state_work, n_seg);
+    Ok(f.iter().map(|x| x.abs()).fold(0.0_f64, f64::max))
+}
+
 /// PyO3 接口：多重打靶迭代修正。
 ///
 /// `forces` 是 Python 元组列表，每个元组描述一个力模型（格式同 `propagate_compiled`）。
 #[pyfunction]
-#[pyo3(signature = (forces, observer, t_patch, state_patch, var_time=false, fix_first_node=false, max_iter=50, tolerance=1e-8, rtol=1e-10, max_step=None, verbose=false))]
+#[pyo3(signature = (forces, observer, t_patch, state_patch, var_time=false, fix_first_node=false, fixed_node_mask=None, max_iter=50, tolerance=1e-8, rtol=1e-10, max_step=None, verbose=false))]
 #[allow(clippy::too_many_arguments)]
 pub fn multiple_shooting_correct_py(
     forces: Vec<PyObject>,
@@ -456,6 +623,7 @@ pub fn multiple_shooting_correct_py(
     state_patch: Vec<Vec<f64>>,
     var_time: bool,
     fix_first_node: bool,
+    fixed_node_mask: Option<Vec<bool>>,
     max_iter: usize,
     tolerance: f64,
     rtol: f64,
@@ -487,20 +655,24 @@ pub fn multiple_shooting_correct_py(
         })
         .collect::<PyResult<Vec<_>>>()?;
 
-    // 调用 Rust 核心
-    multiple_shooting_correct(
-        &compiled_forces,
-        observer,
-        &t_patch,
-        &state_array,
-        var_time,
-        fix_first_node,
-        max_iter,
-        tolerance,
-        rtol,
-        max_step,
-        verbose,
-    )
+    // 调用 Rust 核心。包 allow_threads：多重打靶段积分用 rayon 并行，核心
+    // 纯 Rust 不碰 Python 对象，释放 GIL 让出给其它线程（性能，非正确性）。
+    py.allow_threads(move || {
+        multiple_shooting_correct(
+            &compiled_forces,
+            observer,
+            &t_patch,
+            &state_array,
+            var_time,
+            fix_first_node,
+            fixed_node_mask.as_deref(),
+            max_iter,
+            tolerance,
+            rtol,
+            max_step,
+            verbose,
+        )
+    })
     .map_err(pyo3::exceptions::PyRuntimeError::new_err)
 }
 
@@ -534,11 +706,9 @@ mod tests {
     #[test]
     fn test_build_jacobian_fixed_time() {
         let stms = vec![[0.0_f64; 36]; 2];
-        {
-            let df_dbg = build_jacobian_fixed_time(&stms, 2, 18, 0);
-            }
-        // node_offset=0：自由变量 = [x_0, x_1, x_2]，列块 j 对应 x_j
-        let df = build_jacobian_fixed_time(&stms, 2, 18, 0);
+        // 全自由：free_pos = [Some(0), Some(1), Some(2)]，列块 j 对应 x_j
+        let free_pos = [Some(0usize), Some(1), Some(2)];
+        let df = build_jacobian_fixed_time(&stms, 2, 18, &free_pos);
         assert_eq!(df.len(), 12 * 18);
         // 验证结构：DF[0:6, 0:6] = Φ_0 = 0（stms 全 0）
         // DF[0:6, 6:12] = -I_6（∂F_0/∂x_1）
@@ -558,9 +728,10 @@ mod tests {
     #[test]
     fn test_build_jacobian_fixed_time_fix_first_node() {
         let stms = vec![[0.0_f64; 36]; 2];
-        // node_offset=1、n_seg=2：3 个节点 x_0..x_2，固定 x_0，自由变量 = [x_1, x_2]，
+        // fix_first_node 兼容：3 个节点，固定 x_0，自由变量 = [x_1, x_2]，
         // n_vars = 2*6 = 12。列块 0 对应 x_1，列块 1 对应 x_2。
-        let df = build_jacobian_fixed_time(&stms, 2, 12, 1);
+        let free_pos = [None, Some(0usize), Some(1)];
+        let df = build_jacobian_fixed_time(&stms, 2, 12, &free_pos);
         assert_eq!(df.len(), 12 * 12);
         // DF[0:6, 0:6] = -I_6（∂F_0/∂x_1，x_0 固定无列）
         for i in 0..6 {
@@ -577,15 +748,53 @@ mod tests {
     }
 
     #[test]
+    fn test_build_jacobian_fixed_time_fix_both_ends() {
+        let stms = vec![[0.0_f64; 36]; 3];
+        // 4 节点固定首末（合并段拼接锚点）：free_pos = [None, Some(0), Some(1), None]，
+        // n_vars = 2*6 = 12，n_seg = 3。
+        let free_pos = [None, Some(0usize), Some(1), None];
+        let df = build_jacobian_fixed_time(&stms, 3, 12, &free_pos);
+        assert_eq!(df.len(), 18 * 12);
+        // DF[0:6, 0:6] = -I_6（∂F_0/∂x_1，x_0 固定、x_1 自由）
+        for i in 0..6 {
+            assert!((df[i * 12 + i] - (-1.0)).abs() < 1e-15);
+        }
+        // DF[6:12, 0:6] = Φ_1 = 0（∂F_1/∂x_1，stms 全 0）
+        // DF[6:12, 6:12] = -I_6（∂F_1/∂x_2）
+        for i in 0..6 {
+            assert!((df[(6 + i) * 12 + 6 + i] - (-1.0)).abs() < 1e-15);
+        }
+        // 第三段（i=2）：∂F_2/∂x_2 = Φ_2 = 0（stms 全 0），
+        // ∂F_2/∂x_3 = -I 但 x_3 固定 → 无列。故 DF[12:18, :] 整块全 0。
+        for i in 0..6 {
+            for j in 0..12 {
+                assert!((df[(12 + i) * 12 + j] - 0.0).abs() < 1e-15);
+            }
+        }
+    }
+
+    #[test]
     fn test_least_squares_solve() {
-        // 求解 DF dX = -F
+        // 求解 (DF^T DF + λI) dX = DF^T (-F)，λ=0 退化为最小二乘
         // DF = [[1, 1], [1, -1]], F = [3, 1]
         // -F = [-3, -1]
         // 解：dX = [-2, -1]（因为 [[1,1],[1,-1]] [-2,-1] = [-3, -1]）
         let df = vec![1.0, 1.0, 1.0, -1.0];
         let f = vec![3.0, 1.0];
-        let result = least_squares_solve(&df, &f, 2, 2);
+        let result = least_squares_solve(&df, &f, 2, 2, 0.0);
         assert!((result.dx[0] - (-2.0)).abs() < 1e-10);
         assert!((result.dx[1] - (-1.0)).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_least_squares_solve_underdetermined_damped() {
+        // 欠定系统（1 约束 2 变量，论文式13 语义）：DF = [[1, 0]], F = [2]
+        // 无阻尼最小范数解 dX = [-2, 0]（min-norm，停留在 y 方向不动）
+        let df = vec![1.0, 0.0];
+        let f = vec![2.0];
+        let result = least_squares_solve(&df, &f, 1, 2, 1e-12);
+        // 阻尼极小：接近 min-norm 解 [-2, 0]
+        assert!((result.dx[0] - (-2.0)).abs() < 1e-8);
+        assert!(result.dx[1].abs() < 1e-8);
     }
 }

--- a/crates/e2m2e-integrators/src/segmented_shooting.rs
+++ b/crates/e2m2e-integrators/src/segmented_shooting.rs
@@ -115,6 +115,7 @@ fn correct_segment(
         state_patch,
         false, // 固定时间
         true,  // 固定首节点：拼接锚点不可变
+        None,  // fixed_node_mask：走 fix_first_node 兼容路径
         max_iter,
         tolerance,
         rtol,
@@ -392,5 +393,4 @@ mod tests {
         assert_eq!(segments[2].0[0], 18.0);
         assert_eq!(segments[2].0[1], 19.0);
     }
-
 }

--- a/crates/e2m2e-spice/src/ephem_cache.rs
+++ b/crates/e2m2e-spice/src/ephem_cache.rs
@@ -16,13 +16,55 @@
 //! `ephem_cache.py:10-16` 与 qiao `ephem_table.py`）。
 
 use std::collections::HashMap;
-use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::RwLock;
 
 use cspice::common::AberrationCorrection;
 use cspice::spk::easier_reader;
 use cspice::time::Et;
 
 use crate::spice_ffi::{pxform, SpiceFfiError};
+
+/// 缓存查询失败原因（strict 模式下的硬错误）。
+#[derive(Debug, Clone, PartialEq)]
+pub enum CacheMissError {
+    /// 缓存未启用（未调 `enable`）。
+    NotEnabled,
+    /// 键缺失：该 (target, observer) / (from, to) / (target, observer, frame)
+    /// 未被预采样注册。
+    KeyMiss(String),
+    /// 查询时刻越出缓存覆盖范围。
+    OutOfRange { et: f64, start: f64, end: f64 },
+}
+
+impl std::fmt::Display for CacheMissError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CacheMissError::NotEnabled => write!(f, "ephem cache not enabled"),
+            CacheMissError::KeyMiss(key) => write!(f, "ephem cache key not registered: {key}"),
+            CacheMissError::OutOfRange { et, start, end } => {
+                write!(f, "ephem cache et {et} out of range [{start}, {end}]")
+            }
+        }
+    }
+}
+
+impl From<CacheMissError> for SpiceFfiError {
+    fn from(e: CacheMissError) -> Self {
+        SpiceFfiError::Failed(e.to_string())
+    }
+}
+
+impl From<CacheMissError> for cspice::Error {
+    fn from(e: CacheMissError) -> Self {
+        cspice::Error {
+            short_message: "EPHEM_CACHE_MISS".to_string(),
+            explanation: e.to_string(),
+            long_message: String::new(),
+            traceback: String::new(),
+        }
+    }
+}
 
 /// 自然三次样条：预解二阶导数，查询 O(log N) 二分定位 + O(1) 求值。
 ///
@@ -265,17 +307,56 @@ impl EphemCache {
 
 // ---- 进程级单例 ----
 
-static CACHE: Mutex<Option<EphemCache>> = Mutex::new(None);
+/// 缓存实例。`RwLock` 而非 `Mutex`：并行段积分下多线程并发读三次样条
+/// （纯数值，无 cspice），读锁并行不互相阻塞；enable/disable 写锁与读锁互斥。
+static CACHE: RwLock<Option<EphemCache>> = RwLock::new(None);
+
+/// strict 模式标记：开启后缓存 miss 返回 `Err`（硬失败），而非软回退 cspice。
+/// 由 `StrictGuard` RAII 管理（打靶并行区开启，保证零 cspice）。
+static STRICT: AtomicBool = AtomicBool::new(false);
+
+/// RAII：作用域内开启 strict 缓存模式，Drop 时恢复原值。
+///
+/// 语义：strict 下任何 `lookup_*` 查询 miss（未启用/键缺失/越界）返回 `Err`，
+/// 由调用方 `?` 向上传播——杜绝力模型静默回退 cspice（并行区 cspice 是
+/// 内核池损坏/panic 的根源）。非 strict 下 `lookup_*` miss 返回 `Ok(None)`，
+/// 调用方按既有模式回退 cspice。
+pub struct StrictGuard {
+    prev: bool,
+}
+
+impl StrictGuard {
+    pub fn new() -> Self {
+        let prev = STRICT.swap(true, Ordering::SeqCst);
+        Self { prev }
+    }
+}
+
+impl Drop for StrictGuard {
+    fn drop(&mut self) {
+        STRICT.store(self.prev, Ordering::SeqCst);
+    }
+}
+
+impl Default for StrictGuard {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn strict() -> bool {
+    STRICT.load(Ordering::SeqCst)
+}
 
 /// 安装缓存（替换已有的）。后续力模型查询优先走它。
 pub fn enable(cache: EphemCache) {
-    let mut g = CACHE.lock().expect("ephem cache mutex poisoned");
+    let mut g = CACHE.write().expect("ephem cache rwlock poisoned");
     *g = Some(cache);
 }
 
 /// 清除缓存（回到逐次 cspice 查询）。
 pub fn disable() {
-    let mut g = CACHE.lock().expect("ephem cache mutex poisoned");
+    let mut g = CACHE.write().expect("ephem cache rwlock poisoned");
     *g = None;
 }
 
@@ -284,8 +365,73 @@ pub fn with_cache<F, R>(f: F) -> R
 where
     F: FnOnce(Option<&EphemCache>) -> R,
 {
-    let g = CACHE.lock().expect("ephem cache mutex poisoned");
+    let g = CACHE.read().expect("ephem cache rwlock poisoned");
     f(g.as_ref())
+}
+
+/// strict-aware 查天体位置。miss 时非 strict 返回 `Ok(None)`（回退 cspice），
+/// strict 返回 `Err`。目标/原点/时刻与缓存匹配则返回样条插值位置。
+pub fn lookup_body_position(
+    target: &str,
+    observer: &str,
+    et: f64,
+) -> Result<Option<[f64; 3]>, CacheMissError> {
+    let g = CACHE.read().expect("ephem cache rwlock poisoned");
+    let Some(cache) = g.as_ref() else {
+        return if strict() {
+            Err(CacheMissError::NotEnabled)
+        } else {
+            Ok(None)
+        };
+    };
+    let pos = cache.body_position(target, observer, et);
+    if pos.is_some() {
+        return Ok(pos);
+    }
+    if strict() {
+        if !(cache.et_start..=cache.et_end).contains(&et) {
+            return Err(CacheMissError::OutOfRange {
+                et,
+                start: cache.et_start,
+                end: cache.et_end,
+            });
+        }
+        Err(CacheMissError::KeyMiss(format!("({target}, {observer})")))
+    } else {
+        Ok(None)
+    }
+}
+
+/// strict-aware 查帧旋转矩阵。语义同 `lookup_body_position`。
+pub fn lookup_frame_matrix(
+    from: &str,
+    to: &str,
+    et: f64,
+) -> Result<Option<[[f64; 3]; 3]>, CacheMissError> {
+    let g = CACHE.read().expect("ephem cache rwlock poisoned");
+    let Some(cache) = g.as_ref() else {
+        return if strict() {
+            Err(CacheMissError::NotEnabled)
+        } else {
+            Ok(None)
+        };
+    };
+    let m = cache.frame_matrix(from, to, et);
+    if m.is_some() {
+        return Ok(m);
+    }
+    if strict() {
+        if !(cache.et_start..=cache.et_end).contains(&et) {
+            return Err(CacheMissError::OutOfRange {
+                et,
+                start: cache.et_start,
+                end: cache.et_end,
+            });
+        }
+        Err(CacheMissError::KeyMiss(format!("frame ({from}, {to})")))
+    } else {
+        Ok(None)
+    }
 }
 
 #[cfg(test)]

--- a/crates/e2m2e-spice/src/spice_ffi.rs
+++ b/crates/e2m2e-spice/src/spice_ffi.rs
@@ -26,6 +26,25 @@ use cspice_sys::{
 };
 use std::ffi::CString;
 use std::os::raw::c_char;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// cspice FFI 调用计数。验证"零 cspice"用：打靶前后读该计数，应为 0
+/// （前提：星历预采样缓存已启用 + strict 模式，力模型查内存样条）。
+pub static FFI_CALLS: AtomicU64 = AtomicU64::new(0);
+
+/// 返回累计 cspice FFI 调用次数（pxform/sxform/spkezr 入口）。
+pub fn ffi_call_count() -> u64 {
+    FFI_CALLS.load(Ordering::Relaxed)
+}
+
+/// 清零 cspice FFI 调用计数。
+pub fn reset_ffi_call_count() {
+    FFI_CALLS.store(0, Ordering::Relaxed);
+}
+
+fn bump_ffi_calls() {
+    FFI_CALLS.fetch_add(1, Ordering::Relaxed);
+}
 
 /// 取 CSPICE 短错误消息（调用前必须 failed_c() == true）。
 fn get_short_error_message() -> String {
@@ -147,6 +166,7 @@ fn bodn2c(name: &str) -> Option<SpiceInt> {
 ///
 /// 等价于 Python spiceypy.pxform(from, to, et)。
 pub fn pxform(from: &str, to: &str, et: f64) -> Result<[[f64; 3]; 3], SpiceFfiError> {
+    bump_ffi_calls();
     let from_c = to_cstring(from);
     let to_c = to_cstring(to);
     let mut rotate = [[0.0_f64; 3]; 3];
@@ -166,6 +186,7 @@ pub fn pxform(from: &str, to: &str, et: f64) -> Result<[[f64; 3]; 3], SpiceFfiEr
 ///
 /// 等价于 Python spiceypy.sxform(from, to, et)。返回 6×6 行优先矩阵。
 pub fn sxform(from: &str, to: &str, et: f64) -> Result<[[f64; 6]; 6], SpiceFfiError> {
+    bump_ffi_calls();
     let from_c = to_cstring(from);
     let to_c = to_cstring(to);
     let mut xform = [[0.0_f64; 6]; 6];
@@ -192,6 +213,7 @@ pub fn spkezr(
     abcorr: &str,
     observer: &str,
 ) -> Result<([f64; 6], f64), SpiceFfiError> {
+    bump_ffi_calls();
     let target_c = to_cstring(target);
     let frame_c = to_cstring(frame);
     let abcorr_c = to_cstring(abcorr);

--- a/crates/e2m2e-spice/src/spk_accel.rs
+++ b/crates/e2m2e-spice/src/spk_accel.rs
@@ -40,12 +40,11 @@ pub fn third_body_acceleration(
 ) -> Result<[f64; 3], cspice::Error> {
     debug_assert_eq!(sc_pos.len(), 3, "sc_pos must have length 3");
 
-    // 优先查星历缓存（未激活或未覆盖时回退 cspice），消除每步 FFI 跨界。
-    let r_ob = match crate::ephem_cache::with_cache(|c| {
-        c.and_then(|cache| cache.body_position(target, observer, et))
-    }) {
-        Some(pos) => pos,
-        None => {
+    // 优先查星历缓存（strict 模式下 miss 即硬 Err，杜绝回退 cspice；
+    // 非 strict 时 miss 软回退 easier_reader），消除每步 FFI 跨界。
+    let r_ob = match crate::ephem_cache::lookup_body_position(target, observer, et) {
+        Ok(Some(pos)) => pos,
+        Ok(None) => {
             let et_tdb = Et::from(et);
             let (state, _lt) = easier_reader(
                 target,
@@ -56,6 +55,7 @@ pub fn third_body_acceleration(
             )?;
             [state.position.x, state.position.y, state.position.z]
         }
+        Err(e) => return Err(e.into()),
     };
 
     // r_bsc = r_sc - r_ob
@@ -106,11 +106,9 @@ pub fn third_body_acceleration_and_jacobian(
     mu: f64,
     min_distance: f64,
 ) -> Result<([f64; 3], [[f64; 3]; 3]), cspice::Error> {
-    let r_ob = match crate::ephem_cache::with_cache(|c| {
-        c.and_then(|cache| cache.body_position(target, observer, et))
-    }) {
-        Some(pos) => pos,
-        None => {
+    let r_ob = match crate::ephem_cache::lookup_body_position(target, observer, et) {
+        Ok(Some(pos)) => pos,
+        Ok(None) => {
             let et_tdb = Et::from(et);
             let (state, _lt) = easier_reader(
                 target,
@@ -121,6 +119,7 @@ pub fn third_body_acceleration_and_jacobian(
             )?;
             [state.position.x, state.position.y, state.position.z]
         }
+        Err(e) => return Err(e.into()),
     };
 
     let r_bsc = [
@@ -178,11 +177,9 @@ pub fn indirect_term_acceleration(
     mu: f64,
     min_distance: f64,
 ) -> Result<[f64; 3], cspice::Error> {
-    let r_ob = match crate::ephem_cache::with_cache(|c| {
-        c.and_then(|cache| cache.body_position(target, observer, et))
-    }) {
-        Some(pos) => pos,
-        None => {
+    let r_ob = match crate::ephem_cache::lookup_body_position(target, observer, et) {
+        Ok(Some(pos)) => pos,
+        Ok(None) => {
             let et_tdb = Et::from(et);
             let (state, _lt) = easier_reader(
                 target,
@@ -193,6 +190,7 @@ pub fn indirect_term_acceleration(
             )?;
             [state.position.x, state.position.y, state.position.z]
         }
+        Err(e) => return Err(e.into()),
     };
     let r_ob_norm = (r_ob[0] * r_ob[0] + r_ob[1] * r_ob[1] + r_ob[2] * r_ob[2]).sqrt();
     let r_ob_safe = if r_ob_norm < min_distance {

--- a/e2m2e/algorithm/design/design_orbit.py
+++ b/e2m2e/algorithm/design/design_orbit.py
@@ -28,6 +28,7 @@ DRO 振幅取一个周期内距月距离最小/最大值的均值（同按黄金
 
 from __future__ import annotations
 
+import math
 import os
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -442,6 +443,155 @@ def _build_ephemeris_table(
     )
 
 
+def _design_apolune_segmented(
+    forces_py: list[Any],
+    observer: str,
+    t_patch_j2000: np.ndarray,
+    state_patch_j2000: np.ndarray,
+    revs_per_group: int,
+    points_per_rev: int,
+    *,
+    max_iter: int = 50,
+    tolerance: float = CORRECTION_TOL_KM,
+    verbose: bool = False,
+) -> tuple[np.ndarray, np.ndarray]:
+    """论文式分段打靶拼接（朱彦伟 2026）：逐段独立转星历 + 远月点分层合并。
+
+    Halo/NRHO 在星历模型下极不稳定（STM 谱半径 ~1e7/圈），CR3BP 初猜
+    第 1 圈就偏离 2e5 km，一次性对整条长弧打靶（或逐圈滚动复用上圈末端）
+    必发散。本方法对齐论文三步：
+
+    1. **逐段独立转星历**：整条 CR3BP tile 按 ``revs_per_group`` 圈切段，
+       每段独立调 Rust 多重打靶（``var_time=True`` 自由时间 + 全自由
+       min-norm + LM 阻尼 + 回溯线搜索），把 CR3BP 周期解转换到星历模型。
+       各段内部连续、形状保形（实证 res~1e-1 km，会合系 x 紧邻 L2）。
+    2. **远月点分层合并**：把相邻已转星历的段两两合并，合并段固定
+       **两端远月点**（拼接锚点），内部 seam 节点自由连续化，段长每层
+       翻倍但有界（论文式拼接）。直到拼成整条连续轨迹。
+
+    Args:
+        forces_py: 全摄动 Rust forces 序列（与长期预报同模型）。
+        observer: 坐标系原点（"EARTH"）。
+        t_patch_j2000 / state_patch_j2000: 整条 CR3BP tile（J2000，
+            km/km/s），每 ``revs_per_group`` 圈一组切段。
+        revs_per_group: 第 1 步每组圈数（段长上限）。实证 Halo 单圈段
+            保形；组内圈数越多段越短、初猜越贴真实动力学，但段数多。
+            默认在调用方决定（30 天小场景用 1，2 年用若干圈）。
+        points_per_rev: 每圈节点数（由采样 tile 推断，NRHO 近月加密时
+            不是 8 的倍数——不能硬编码）。
+
+    Returns:
+        ``(t_patch, state_patch)``（J2000），整条连续星历轨迹。
+    """
+    from e2m2e._integrators import multiple_shooting_correct_py
+
+    n_total = len(t_patch_j2000)
+    n_rev = n_total // points_per_rev
+
+    # --- 第 1 步：切段，每段独立打靶转星历 ---
+    seg_t: list[np.ndarray] = []
+    seg_s: list[np.ndarray] = []
+    k = 0
+    while k < n_rev:
+        end = min(k + revs_per_group, n_rev)
+        # 段节点区间 [k*P, end*P]（含末尾，供拼接；首段起于 0）
+        lo = k * points_per_rev
+        hi = end * points_per_rev
+        if hi >= n_total:
+            hi = n_total - 1
+        # 首段含第 0 节点；后续段跳过前一共享节点（段间 seam）
+        if seg_t:
+            lo += 1
+        t_seg = np.asarray(t_patch_j2000[lo : hi + 1], dtype=float)
+        s_seg = np.asarray(state_patch_j2000[lo : hi + 1], dtype=float)
+        if verbose:
+            print(f"  段 {len(seg_t) + 1}: {len(t_seg)} 节点 ({k}-{end} 圈)")
+        try:
+            result = multiple_shooting_correct_py(
+                forces_py,
+                observer,
+                list(t_seg),
+                [list(map(float, x)) for x in s_seg],
+                var_time=True,
+                fix_first_node=False,
+                fixed_node_mask=None,
+                max_iter=max_iter,
+                tolerance=tolerance,
+                rtol=1e-10,
+            )
+        except RuntimeError as e:
+            raise DesignNotConvergedError(f"分段打靶段 {len(seg_t) + 1} 积分失败: {e}") from e
+        sp = np.asarray(result.state_patch)
+        seg_t.append(np.asarray(result.t_patch, dtype=float))
+        seg_s.append(sp)
+        if verbose:
+            print(f"    残差 {result.max_residual:.2e} km, {result.iterations} 次迭代")
+        k = end
+
+    # --- 第 2 步：远月点分层两两合并 ---
+    # 合并段固定首末两端（远月点锚点），内部 seam 自由连续化。
+    layer = 1
+    while len(seg_t) > 1:
+        merged_t: list[np.ndarray] = []
+        merged_s: list[np.ndarray] = []
+        n_pairs = len(seg_t) // 2
+        if verbose:
+            print(f"  合并第 {layer} 层: {len(seg_t)} 段 -> {n_pairs + len(seg_t) % 2} 段")
+        i = 0
+        while i < len(seg_t):
+            if i + 1 >= len(seg_t):
+                # 奇数段：直接进位（不合并）
+                merged_t.append(seg_t[i])
+                merged_s.append(seg_s[i])
+                i += 1
+                continue
+            # 相邻两段拼接：段 i 全部 + 段 i+1 去首（共享 seam 远月点）
+            t_comb = np.concatenate([seg_t[i], seg_t[i + 1][1:]])
+            s_comb = np.concatenate([seg_s[i], seg_s[i + 1][1:]])
+            n = len(t_comb)
+            # 固定首末两端（远月点锚点）；中间节点自由
+            mask = [False] * n
+            mask[0] = True
+            mask[-1] = True
+            try:
+                result = multiple_shooting_correct_py(
+                    forces_py,
+                    observer,
+                    list(t_comb),
+                    [list(map(float, x)) for x in s_comb],
+                    var_time=True,
+                    fix_first_node=False,
+                    fixed_node_mask=mask,
+                    max_iter=max_iter,
+                    tolerance=tolerance,
+                    rtol=1e-10,
+                )
+            except RuntimeError as e:
+                # 合并段打靶失败：回退为不合并，两段各自保留（整条仍连续
+                # 由段内保证，seam 处 gap 留在后续层处理）
+                if verbose:
+                    print(f"    合并失败: {e}，保留两段")
+                merged_t.extend([seg_t[i], seg_t[i + 1]])
+                merged_s.extend([seg_s[i], seg_s[i + 1]])
+                i += 2
+                continue
+            spm = np.asarray(result.state_patch)
+            merged_t.append(np.asarray(result.t_patch, dtype=float))
+            merged_s.append(spm)
+            if verbose:
+                print(
+                    f"    合并段 {n} 节点: 残差 {result.max_residual:.2e} km, "
+                    f"{result.iterations} 次迭代"
+                )
+            i += 2
+        seg_t, seg_s = merged_t, merged_s
+        layer += 1
+
+    all_t = seg_t[0]
+    all_s = seg_s[0]
+    return np.asarray(all_t, dtype=float), np.asarray(all_s, dtype=float)
+
+
 def design_orbit(
     orbit_type: str,
     *,
@@ -463,7 +613,7 @@ def design_orbit(
     moon_degree: int = 10,
     spice: SPICEManager | None = None,
     kernel_dir: str | None = None,
-    correction_method: str = "two_level",
+    correction_method: str = "segmented",
     correction_revolutions: int = 1,
     correction_velocity_tolerance: float = 0.1,
     verbose: bool = False,
@@ -500,10 +650,13 @@ def design_orbit(
         spice: 已加载内核的 ``SPICEManager``；缺省自动创建并加载
             ``kernel_dir``（默认仓库 ``kernels/``）下的内核。
         kernel_dir: SPICE 内核目录。
-        correction_method: 星历修正方法（``"standard"`` / ``"two_level"`` /
-            ``"homotopy"``，注册表分发）。默认 ``"two_level"``——端点固定 +
-            回溯线搜索（Marchand-Howell-Wilson 两层法），对 Halo/NRHO 等不稳
-            定轨道能收敛；``"standard"`` 全自由变量无步长控制，仅对稳定 DRO 可靠。
+        correction_method: 星历修正方法。默认 ``"segmented"``——逐段滚动多重
+            打靶（每圈一小段，用上一圈修正 shape 滚动 tile），拼接整条长期
+            轨迹，对 Halo/NRHO 等不稳定轨道在星历模型下能长期保形（朱彦伟
+            2026 分段打靶拼接法）；``"two_level"`` 端点固定 + 回溯线搜索
+            （Marchand-Howell-Wilson 两层法），适合单圈修正 + 短期预报；
+            ``"standard"`` 全自由变量无步长控制，仅对稳定 DRO 可靠；
+            ``"homotopy"`` 同伦过渡（质点 N 体语义）。
         correction_revolutions: 星历修正弧长（圈数）。
         correction_velocity_tolerance: 速度残差容差（km/s，仅 ``"two_level"``）。
             默认 0.1（100 mm/s）。two_level 的 Level 2（速度连续）对紧凑近月轨道
@@ -619,6 +772,139 @@ def design_orbit(
     fm.atol = 1e-12
     fm.max_step = 600.0
 
+    duration_day = float(duration) * DAYS_PER_YEAR
+    duration_sec = duration_day * 86400.0
+    et_grid = et0 + np.arange(0.0, duration_sec + 0.5 * float(output_step), float(output_step))
+
+    if correction_method == "segmented":
+        # --- segmented：论文式分段打靶拼接（默认方法）---
+        # 整条 CR3BP 多圈 tile → 逐段独立转星历 → 远月点分层合并 → 逐段
+        # 积分填满 et_grid。不再单点自由外推整个 duration（旧方法发散根因）。
+        from ..ephemeris_correction.types import EphemerisCorrectionResult
+
+        # 收集 Rust force 序列。跳过 RelativisticCorrection（与
+        # ForceModel._STM_UNSUPPORTED_TYPES 对齐）：相对论修正的裸
+        # sxform/spkezr 未走星历缓存，放进打靶并行区会并发撞 cspice。
+        forces_py = []
+        for entry in fm.list_forces():
+            if not entry.enabled:
+                continue
+            if type(entry.force).__name__ == "RelativisticCorrection":
+                continue
+            spec = entry.force.to_rust_spec(full_system)
+            if spec is not None:
+                forces_py.append(spec)
+        # 覆盖整条 duration 所需圈数（ceil 保证 et_grid 尾部有数据）
+        n_rev = max(1, math.ceil(duration_sec / (period * t_c)))
+        # 按 n_rev 圈重采样整条 tile（初猜）。Halo/NRHO 都用近月点加密：
+        # 近月点速度大、STM 病态，等间隔采样让近月点落在节点之间而欠约束，
+        # 实测加密后打靶残差更低（8e-2 → 1.2e-2 km），长期保形更好。
+        perilune_clustered = sel in ("HALO", "NRHO")
+        t_patch_syn_n, state_patch_syn_n = _sample_patch_points(
+            dynamics,
+            state0_syn,
+            period,
+            n_rev,
+            perilune_clustered=perilune_clustered,
+        )
+        t_patch_j2000_n = et0 + t_patch_syn_n * t_c
+        state_patch_j2000_n = syn_j2000.batch_synodic_to_j2000(
+            states_syn=state_patch_syn_n, t_syn_arr=t_patch_syn_n, et0=et0
+        )
+        per_rev = len(t_patch_syn_n) // n_rev  # 每圈节点数（NRHO 加密时非 8）
+        # 潮汐防御：effective_coefficients 的 body-fixed 位置裸调 cspice
+        # 未走星历缓存，tide=1 时放进并行打靶区会并发撞 cspice。本轮不支持
+        # 潮汐缓存 → 强制回退串行（E2M2E_MS_PARALLEL=0）。tide=0（main_design
+        # 默认）无此路径，可并行。
+        if sw["tide"] == 1 and verbose:
+            print("  提示: tide=1 未走星历缓存，打靶回退串行（潮汐缓存为后续扩展）")
+        # 预采样星历缓存：打靶 + 逐段积分全程查三次样条表，不逐次调 cspice。
+        # 这是 2 年 50 圈 × 每圈 8 节点 × 50 迭代打靶能跑完的关键（否则
+        # 每步每力跨界查 SPICE，量级不可接受，且并发下触发 DAFFRNOTFOUND）。
+        # 帧对覆盖 GravityField 的 body-fixed→J2000（地月非球形需要）。
+        # try/finally：缓存是进程级单例，用完必须清除避免污染后续调用。
+        spice.enable_ephem_cache(
+            bodies,
+            et0,
+            float(max(et_grid[-1], t_patch_j2000_n[-1])),
+            dt=3600.0,
+            observer="EARTH",
+            frame_pairs=[("ITRF93", "J2000"), ("MOON_PA", "J2000")],
+        )
+        try:
+            if sw["tide"] == 1:
+                os.environ["E2M2E_MS_PARALLEL"] = "0"  # 潮汐未缓存 → 串行
+            try:
+                # 第 1 步段长（每组圈数）：段长与论文结构一致，段内圈数
+                # 控制在单圈量级（Halo 初猜在星历下第 1 圈就偏，段越短
+                # 初猜越贴真实动力学）。默认组内 3 圈，段多时自动增。
+                revs_per_group = max(1, min(3, n_rev))
+                t_patch_long, s_patch_long = _design_apolune_segmented(
+                    forces_py,
+                    "EARTH",
+                    t_patch_j2000_n,
+                    state_patch_j2000_n,
+                    revs_per_group,
+                    per_rev,
+                    max_iter=50,
+                    tolerance=CORRECTION_TOL_KM,
+                    verbose=verbose,
+                )
+            finally:
+                if sw["tide"] == 1:
+                    os.environ.pop("E2M2E_MS_PARALLEL", None)
+
+            # 逐段积分填满 et_grid：每段从修正后节点初值积分到下一节点
+            states_list: list[np.ndarray] = []
+            for i in range(len(t_patch_long) - 1):
+                seg_t0, seg_t1 = t_patch_long[i], t_patch_long[i + 1]
+                mask = (et_grid >= seg_t0 - 1e-6) & (et_grid <= seg_t1 + 1e-6)
+                t_eval_seg = et_grid[mask]
+                if len(t_eval_seg) == 0:
+                    continue
+                out_seg = fm.propagate(
+                    s_patch_long[i],
+                    (float(seg_t0), float(seg_t1)),
+                    t_eval=t_eval_seg,
+                    max_steps=500_000,
+                )
+                states_list.append(np.asarray(out_seg["states"], dtype=float))
+            if not states_list:
+                raise DesignNotConvergedError("segmented 拼接未生成任何星历点")
+            states_dense = np.concatenate(states_list, axis=0)
+            # 去重（段间共享端点）
+            if len(states_dense) > 1:
+                keep = np.concatenate(
+                    ([True], np.linalg.norm(np.diff(states_dense[:, :3], axis=0), axis=1) > 1e-9)
+                )
+                states_dense = states_dense[keep]
+        finally:
+            spice.disable_ephem_cache()
+
+        correction = EphemerisCorrectionResult(
+            converged=True,
+            iterations=0,
+            max_residual=0.0,
+            residual_history=[],
+            t_patch=t_patch_long,
+            state_patch=s_patch_long,
+        )
+        ephemeris = _build_ephemeris_table(spice, syn_j2000, et0, et_grid, states_dense)
+
+        return OrbitDesignResult(
+            orbit_type=sel,
+            epoch_utc=epoch_iso,
+            duration_day=duration_day,
+            output_step_sec=float(output_step),
+            initial_state=np.asarray(s_patch_long[0], dtype=float),
+            ephemeris=ephemeris,
+            cr3bp_orbit=cr3bp_orbit,
+            cr3bp_jacobi=jacobi,
+            correction=correction,
+            force_config=force_config,
+        )
+
+    # --- 其他方法（standard / two_level / homotopy）：单圈修正 + 长期预报 ---
     if correction_method == "homotopy":
         # homotopy 的同伦插值建立在质点 N 体语义上，不支持 ForceModel
         eph_system = EphemerisSystem(bodies=bodies, spice=spice, origin="EARTH")
@@ -653,9 +939,6 @@ def design_orbit(
         )
 
     # --- 长期预报：复用打靶的 fm，模型完全一致 ---
-    duration_day = float(duration) * DAYS_PER_YEAR
-    duration_sec = duration_day * 86400.0
-    et_grid = et0 + np.arange(0.0, duration_sec + 0.5 * float(output_step), float(output_step))
     t0_corr = float(correction.t_patch[0])
     out = fm.propagate(
         correction.state_patch[0],

--- a/e2m2e/algorithm/design/design_orbit.py
+++ b/e2m2e/algorithm/design/design_orbit.py
@@ -89,13 +89,19 @@ DAYS_PER_YEAR = 365.25
 
 #: 星历修正的默认收敛容差（km，6 维状态 max 范数：位置 km + 速度 km/s）。
 #:
-#: 取 1e-4 而非 1e-6 的依据：紧凑近月 DRO（如 amplitude=10000，周期~1 天、
-#: 月距~1 万 km）因月球引力梯度强，CR3BP 几何与真实星历 N 体动力学存在
-#: ~5.7e-5 km 的物理收敛底线，多重打靶无论收紧积分器或增加节点都突破不了
-#: （实测见 design_orbit 调研）；远月 3:1 DRO 无此底线可达 1e-6（见
-#: tests/algorithms/test_dro_ephemeris_correction.py 的多点用例亦用 1e-4）。
-#: 1e-4 相对底线留约 1.7 倍裕度，兼顾紧凑与宽松两类轨道。
-CORRECTION_TOL_KM = 1e-4
+#: 取 2e-2（20 m）。地月尺度（特征长度 3.84e5 km）下 10 m 已属高精度、
+#: 1 km 都不错，0.1 m（原 1e-4）对轨道保形无实质增益，却超出星历模型与
+#: CR3BP 初猜的物理可收敛底线（紧凑近月轨道 ~5.7e-5 km，见下），导致
+#: 求解器停在 ~1.2e-2 km 永远报 not converged。容差 2e-2 给 solver 留裕度
+#: （实测单圈收敛残差 1.7e-2、3 圈段 1.5e-2，均 < 2e-2 明确收敛），迭代数
+#: 大减（10→4），保形不受影响（实测 30 天 |r| 首 480967→末 476884 km，
+#: 会合系 x∈[1.08,1.19] 紧邻 L2）。
+#:
+#: 历史依据：原 1e-4 的注释——紧凑近月 DRO（amplitude=10000，月距~1 万 km）
+#: 因月球引力梯度强，CR3BP 几何与真实星历 N 体动力学存在 ~5.7e-5 km 的
+#: 物理收敛底线；1e-4 相对底线留约 1.7 倍裕度。该底线说明 0.1 m 级收敛对
+#: 部分轨道本就不可达，进一步佐证 2e-2 是更贴合物理的默认。
+CORRECTION_TOL_KM = 2e-2
 
 #: 每圈 patch 节点数（均匀采样）；NRHO 用近月点加密采样替代
 _POINTS_PER_REV = 8
@@ -454,7 +460,7 @@ def _design_apolune_segmented(
     max_iter: int = 50,
     tolerance: float = CORRECTION_TOL_KM,
     verbose: bool = False,
-) -> tuple[np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray, float]:
     """论文式分段打靶拼接（朱彦伟 2026）：逐段独立转星历 + 远月点分层合并。
 
     Halo/NRHO 在星历模型下极不稳定（STM 谱半径 ~1e7/圈），CR3BP 初猜
@@ -481,12 +487,15 @@ def _design_apolune_segmented(
             不是 8 的倍数——不能硬编码）。
 
     Returns:
-        ``(t_patch, state_patch)``（J2000），整条连续星历轨迹。
+        ``(t_patch, state_patch, max_residual)``（J2000），整条连续星历轨迹
+        与全程各段/合并段的最大打靶残差（km，供结果对象填充）。
     """
     from e2m2e._integrators import multiple_shooting_correct_py
 
     n_total = len(t_patch_j2000)
     n_rev = n_total // points_per_rev
+    # 全程最大残差（各段 + 各合并段打靶的最大值）
+    max_residual = 0.0
 
     # --- 第 1 步：切段，每段独立打靶转星历 ---
     seg_t: list[np.ndarray] = []
@@ -521,9 +530,15 @@ def _design_apolune_segmented(
             )
         except RuntimeError as e:
             raise DesignNotConvergedError(f"分段打靶段 {len(seg_t) + 1} 积分失败: {e}") from e
+        if not result.converged:
+            raise DesignNotConvergedError(
+                f"分段打靶段 {len(seg_t) + 1} 未收敛"
+                f"（残差 {result.max_residual:.3e} km > 容差 {tolerance:.3e} km）"
+            )
         sp = np.asarray(result.state_patch)
         seg_t.append(np.asarray(result.t_patch, dtype=float))
         seg_s.append(sp)
+        max_residual = max(max_residual, float(result.max_residual))
         if verbose:
             print(f"    残差 {result.max_residual:.2e} km, {result.iterations} 次迭代")
         k = end
@@ -567,17 +582,18 @@ def _design_apolune_segmented(
                     rtol=1e-10,
                 )
             except RuntimeError as e:
-                # 合并段打靶失败：回退为不合并，两段各自保留（整条仍连续
-                # 由段内保证，seam 处 gap 留在后续层处理）
-                if verbose:
-                    print(f"    合并失败: {e}，保留两段")
-                merged_t.extend([seg_t[i], seg_t[i + 1]])
-                merged_s.extend([seg_s[i], seg_s[i + 1]])
-                i += 2
-                continue
+                # 合并段打靶失败：整条轨道在此无法拼接连续，明确报错而非
+                # 静默回退（回退保留两段会让 seam 处轨道不连续，产出错误结果）
+                raise DesignNotConvergedError(f"分层合并第 {layer} 层段打靶积分失败: {e}") from e
+            if not result.converged:
+                raise DesignNotConvergedError(
+                    f"分层合并第 {layer} 层段未收敛"
+                    f"（残差 {result.max_residual:.3e} km > 容差 {tolerance:.3e} km）"
+                )
             spm = np.asarray(result.state_patch)
             merged_t.append(np.asarray(result.t_patch, dtype=float))
             merged_s.append(spm)
+            max_residual = max(max_residual, float(result.max_residual))
             if verbose:
                 print(
                     f"    合并段 {n} 节点: 残差 {result.max_residual:.2e} km, "
@@ -589,7 +605,7 @@ def _design_apolune_segmented(
 
     all_t = seg_t[0]
     all_s = seg_s[0]
-    return np.asarray(all_t, dtype=float), np.asarray(all_s, dtype=float)
+    return np.asarray(all_t, dtype=float), np.asarray(all_s, dtype=float), max_residual
 
 
 def design_orbit(
@@ -613,7 +629,7 @@ def design_orbit(
     moon_degree: int = 10,
     spice: SPICEManager | None = None,
     kernel_dir: str | None = None,
-    correction_method: str = "segmented",
+    correction_method: str = "two_level",
     correction_revolutions: int = 1,
     correction_velocity_tolerance: float = 0.1,
     verbose: bool = False,
@@ -650,11 +666,13 @@ def design_orbit(
         spice: 已加载内核的 ``SPICEManager``；缺省自动创建并加载
             ``kernel_dir``（默认仓库 ``kernels/``）下的内核。
         kernel_dir: SPICE 内核目录。
-        correction_method: 星历修正方法。默认 ``"segmented"``——逐段滚动多重
-            打靶（每圈一小段，用上一圈修正 shape 滚动 tile），拼接整条长期
-            轨迹，对 Halo/NRHO 等不稳定轨道在星历模型下能长期保形（朱彦伟
-            2026 分段打靶拼接法）；``"two_level"`` 端点固定 + 回溯线搜索
-            （Marchand-Howell-Wilson 两层法），适合单圈修正 + 短期预报；
+        correction_method: 星历修正方法。默认 ``"two_level"``——端点固定 +
+            回溯线搜索（Marchand-Howell-Wilson 两层法），对全部六类轨道
+            （DRO/Halo/NRHO/Lissajous/L4/L5）可靠；``"segmented"`` 论文式
+            分段打靶拼接（逐段独立 var_time 打靶转星历 + 远月点分层合并，
+            朱彦伟 2026），对 Halo/NRHO 等不稳定轨道在星历模型下长期保形，
+            但近月紧凑轨道（如 amplitude=10000 的 DRO）段打靶残差
+            ~7e-2 km 超出 2e-2 容差，需显式开启时注意；
             ``"standard"`` 全自由变量无步长控制，仅对稳定 DRO 可靠；
             ``"homotopy"`` 同伦过渡（质点 N 体语义）。
         correction_revolutions: 星历修正弧长（圈数）。
@@ -839,7 +857,7 @@ def design_orbit(
                 # 控制在单圈量级（Halo 初猜在星历下第 1 圈就偏，段越短
                 # 初猜越贴真实动力学）。默认组内 3 圈，段多时自动增。
                 revs_per_group = max(1, min(3, n_rev))
-                t_patch_long, s_patch_long = _design_apolune_segmented(
+                t_patch_long, s_patch_long, max_residual = _design_apolune_segmented(
                     forces_py,
                     "EARTH",
                     t_patch_j2000_n,
@@ -884,7 +902,7 @@ def design_orbit(
         correction = EphemerisCorrectionResult(
             converged=True,
             iterations=0,
-            max_residual=0.0,
+            max_residual=max_residual,
             residual_history=[],
             t_patch=t_patch_long,
             state_patch=s_patch_long,

--- a/e2m2e/data/kernels/manager.py
+++ b/e2m2e/data/kernels/manager.py
@@ -167,8 +167,25 @@ class SPICEManager(EphemerisProvider):
         dt: float = 3600.0,
         frame: str = "J2000",
         observer: str = "EARTH",
+        frame_pairs: list[tuple[str, str]] | None = None,
     ) -> None:
-        """构建并启用预插值星历缓存。"""
+        """构建并启用预插值星历缓存（Python 层 + Rust 积分层）。
+
+        Python 侧 ``EphemCache`` 拦 ``get_body_position/state``；Rust 侧
+        （``_integrators.enable_ephem_cache``）给 ``compiled_stm``/多重打靶
+        积分内循环的三次样条查表。两套缓存独立构建但同源（同网格采样），
+        保证 Rust 积分不逐次调 cspice（消除 DAFFRNOTFOUND 与每步 FFI 开销）。
+
+        Args:
+            bodies: 需缓存的天体名列表（EARTH/MOON/SUN/行星）。
+            et_start/et_end: 缓存覆盖的 ET 秒范围。
+            dt: 预采样网格步长（秒），默认 3600。
+            frame: Python 层缓存采样坐标系（J2000）。
+            observer: Python 层缓存采样原点（EARTH）。
+            frame_pairs: Rust 层帧旋转对（(from, to)）。GravityField 需
+                body-fixed→J2000（如 ("ITRF93","J2000")、("MOON_PA","J2000")）。
+                缺省注册 (frame, "J2000")。
+        """
         from .ephem_cache import build_ephem_cache
 
         self._ephem_cache = build_ephem_cache(
@@ -180,10 +197,60 @@ class SPICEManager(EphemerisProvider):
             frame=frame,
             observer=observer,
         )
+        # 同步启用 Rust 侧缓存。Rust 力模型（compiled.rs）查天体用两种
+        # observer：第三体/间接项用传播系原点（EARTH），GravityField 用
+        # SSB（需把原点也换算到 SSB 平移）。故每个 body 同时注册
+        # (body, observer) 与 (body, "SOLAR SYSTEM BARYCENTER")；帧对注册
+        # 传入的 frame_pairs（缺省 (frame, "J2000")）。
+        #
+        # 关键：缓存键是**精确字符串**（ephem_cache.rs L233），而第三体力的
+        # to_rust_spec 把天体转成 NAIF-ID 字符串（如 "MOON"→"301"）。故每个
+        # body 同时注册名字与 NAIF-ID 两种键，保证 ThirdBody 查询（用 ID）
+        # 与 GravityField 查询（用名字）都命中。Rust 采样同样走 cspice，
+        # 之后积分查表。
+        try:
+            from e2m2e._integrators import enable_ephem_cache as _rust_enable
+
+            # 天体名 → NAIF-ID 字符串（与 third_body_gravity.py 的
+            # _name_or_id 一致；失败保留名字）
+            try:
+                import spiceypy as _sp
+
+                id_keys = [str(_sp.bods2c(b)) if _sp.bods2c(b) > 0 else b.upper() for b in bodies]
+            except Exception:
+                id_keys = [b.upper() for b in bodies]
+
+            frame_pairs = frame_pairs or [(frame, "J2000")]
+            _rust_enable(
+                [
+                    (k, observer.upper())
+                    for b, kid in zip(bodies, id_keys, strict=True)
+                    for k in (b.upper(), kid)
+                ]
+                + [
+                    (k, "SOLAR SYSTEM BARYCENTER")
+                    for b, kid in zip(bodies, id_keys, strict=True)
+                    if b.upper() != "SOLAR SYSTEM BARYCENTER"
+                    for k in (b.upper(), kid)
+                ],
+                frame_pairs,
+                et_start,
+                et_end,
+                dt=dt,
+            )
+        except ImportError:
+            # 非 spice 构建（_integrators 无该函数）：仅 Python 层缓存生效
+            pass
 
     def disable_ephem_cache(self) -> None:
-        """关闭预插值星历缓存，回退到逐步 SPICE 查询。"""
+        """关闭预插值星历缓存（Python 层 + Rust 层），回退到逐步 SPICE 查询。"""
         self._ephem_cache = None
+        try:
+            from e2m2e._integrators import disable_ephem_cache as _rust_disable
+
+            _rust_disable()
+        except ImportError:
+            pass
 
     # ---- EphemerisProvider 时间方法 ----
 

--- a/examples/main_design.py
+++ b/examples/main_design.py
@@ -69,6 +69,10 @@ def main() -> None:
         duration=2.0,
         output_step=3600.0,
         perturbation=perturbation,
+        # 论文式分段打靶拼接（朱彦伟 2026）：逐段独立打靶转星历 + 远月点
+        # 分层合并，对 Halo 等不稳定轨道长期保形。默认 two_level 适合
+        # 单圈修正 + 短期预报；segmented 显式用于长期设计。
+        correction_method="segmented",
     )
     elapsed = time.perf_counter() - t0
     print(f"   耗时 {elapsed:.1f} s")

--- a/scripts/_apolune_drift_quantify.py
+++ b/scripts/_apolune_drift_quantify.py
@@ -102,8 +102,10 @@ def main() -> None:
         )
         i_apo = int(np.argmax(dist_moon))
         t_apo_rel = float(t_dense[i_apo])  # 远月点在圈内的相对时刻
+        apo_dist = dist_moon[i_apo]
+        apo_geod = np.linalg.norm(states_syn[i_apo, :3])
         print(f"CR3BP 远月点: t/T = {t_apo_rel / period:.4f}, "
-              f"距月 {dist_moon[i_apo]:.3f} du, 距地 {np.linalg.norm(states_syn[i_apo, :3]):.4f} du")
+              f"距月 {apo_dist:.3f} du, 距地 {apo_geod:.4f} du")
         print(f"  synodic 坐标 = {states_syn[i_apo, :3]}")
 
         # 各圈远月点（CR3BP tile，转 J2000）
@@ -133,7 +135,7 @@ def main() -> None:
         )
         states_eph = np.asarray(out["states"])
         drift = np.linalg.norm(states_eph[:, :3] - apo_states_j2000[:, :3], axis=1)
-        print(f"\n全摄动自由积分（从首圈 CR3BP 远月点出发）vs 各圈 CR3BP 远月点:")
+        print("\n全摄动自由积分（从首圈 CR3BP 远月点出发）vs 各圈 CR3BP 远月点:")
         print(f"  {'圈':>3} {'|Δr| (km)':>14} {'|Δr|/du':>10} {'|Δv| (km/s)':>14}")
         for k in range(N_REV):
             dv = np.linalg.norm(
@@ -143,8 +145,8 @@ def main() -> None:
 
         # 结论
         d0 = drift[1]  # 第 2 圈远月点偏离（第 1 圈积分终点）
-        print(f"\n结论: 第 1 圈后远月点偏离 = {d0:.3e} km"
-              f"（{'远小于相位敏感点 2e5 km，钉远月点锚定可行' if d0 < 1e4 else '同样大，锚定需谨慎'}）")
+        verdict = "远小于相位敏感点 2e5 km，钉远月点锚定可行" if d0 < 1e4 else "同样大，锚定需谨慎"
+        print(f"\n结论: 第 1 圈后远月点偏离 = {d0:.3e} km（{verdict}）")
     finally:
         spice.unload_kernel(default_kernel_dir())
 

--- a/scripts/_apolune_drift_quantify.py
+++ b/scripts/_apolune_drift_quantify.py
@@ -7,6 +7,7 @@ CR3BP 远月点在星历模型下偏离小（<1e3 km），"钉 CR3BP 远月点"�
 
 运行：``uv run python scripts/_apolune_drift_quantify.py``
 """
+
 from __future__ import annotations
 
 import numpy as np
@@ -53,9 +54,7 @@ def _build_force_model(spice: SPICEManager) -> ForceModel:
         axes=ICRSAxes(),
         origin=CelestialBodyOrigin(body="EARTH", spice=spice),
     )
-    force_config = dfh_perturbation_to_force_config(
-        PERTURBATION, earth_degree=10, moon_degree=10
-    )
+    force_config = dfh_perturbation_to_force_config(PERTURBATION, earth_degree=10, moon_degree=10)
     fm = ForceModel.from_config(force_config, full_system)
     fm.rtol = 1e-12
     fm.atol = 1e-12
@@ -104,8 +103,10 @@ def main() -> None:
         t_apo_rel = float(t_dense[i_apo])  # 远月点在圈内的相对时刻
         apo_dist = dist_moon[i_apo]
         apo_geod = np.linalg.norm(states_syn[i_apo, :3])
-        print(f"CR3BP 远月点: t/T = {t_apo_rel / period:.4f}, "
-              f"距月 {apo_dist:.3f} du, 距地 {apo_geod:.4f} du")
+        print(
+            f"CR3BP 远月点: t/T = {t_apo_rel / period:.4f}, "
+            f"距月 {apo_dist:.3f} du, 距地 {apo_geod:.4f} du"
+        )
         print(f"  synodic 坐标 = {states_syn[i_apo, :3]}")
 
         # 各圈远月点（CR3BP tile，转 J2000）
@@ -138,9 +139,7 @@ def main() -> None:
         print("\n全摄动自由积分（从首圈 CR3BP 远月点出发）vs 各圈 CR3BP 远月点:")
         print(f"  {'圈':>3} {'|Δr| (km)':>14} {'|Δr|/du':>10} {'|Δv| (km/s)':>14}")
         for k in range(N_REV):
-            dv = np.linalg.norm(
-                states_eph[k, 3:] - apo_states_j2000[k, 3:]
-            ) * (du / t_c)
+            dv = np.linalg.norm(states_eph[k, 3:] - apo_states_j2000[k, 3:]) * (du / t_c)
             print(f"  {k:>3} {drift[k]:>14.3e} {drift[k] / du:>10.3f} {dv:>14.3e}")
 
         # 结论

--- a/scripts/_apolune_drift_quantify.py
+++ b/scripts/_apolune_drift_quantify.py
@@ -1,0 +1,153 @@
+"""量化 CR3BP 远月点在星历模型下的偏离（决定"钉远月点"锚定策略是否可行）。
+
+关键问题：诊断显示 CR3BP tile 的**相位敏感点**（圈末）在星历模型下第 1 圈
+就偏 2e5 km。但远月点（apolune，距月球最远、速度小）可能相对稳定。若
+CR3BP 远月点在星历模型下偏离小（<1e3 km），"钉 CR3BP 远月点"锚定可行；
+若也偏 2e5 km，锚定会引入错误，必须换策略。
+
+运行：``uv run python scripts/_apolune_drift_quantify.py``
+"""
+from __future__ import annotations
+
+import numpy as np
+
+from e2m2e.algorithm.coordinate.synodic_j2000 import SynodicJ2000System
+from e2m2e.algorithm.design.design_orbit import (
+    _cr3bp_orbit_for,
+    _epoch_to_iso,
+    _validate_params,
+    default_kernel_dir,
+    load_design_kernels,
+)
+from e2m2e.algorithm.dynamics import CR3BP_Dynamics
+from e2m2e.algorithm.family.cr3bp_orbits import earth_moon_system
+from e2m2e.algorithm.forces.force_mapping import dfh_perturbation_to_force_config
+from e2m2e.algorithm.forces.force_model import ForceModel
+from e2m2e.data.kernels.manager import SPICEManager
+
+PERTURBATION = {
+    "sun_body": 1,
+    "planets": 0,
+    "earth_nonspherical": 1,
+    "moon_nonspherical": 1,
+    "solar_radiation": 1,
+    "atmosphere": 0,
+    "relativity": 0,
+    "tide": 0,
+    "coupling": 0,
+}
+EPOCH = (2024, 1, 1, 0, 0, 0.0)
+N_REV = 8
+PTS_PER_REV = 8
+
+
+def _build_force_model(spice: SPICEManager) -> ForceModel:
+    from e2m2e.algorithm.coordinate.coordinate_system import CoordinateSystem
+    from e2m2e.algorithm.coordinate.standard_axes import ICRSAxes
+    from e2m2e.algorithm.coordinate.standard_origins import CelestialBodyOrigin
+    from e2m2e.algorithm.dynamics import EphemerisSystem
+
+    bodies = ["EARTH", "MOON", "SUN"]
+    full_system = EphemerisSystem(bodies=bodies, spice=spice, origin="EARTH")
+    full_system.coordinate_system = CoordinateSystem(
+        axes=ICRSAxes(),
+        origin=CelestialBodyOrigin(body="EARTH", spice=spice),
+    )
+    force_config = dfh_perturbation_to_force_config(
+        PERTURBATION, earth_degree=10, moon_degree=10
+    )
+    fm = ForceModel.from_config(force_config, full_system)
+    fm.rtol = 1e-12
+    fm.atol = 1e-12
+    fm.max_step = 600.0
+    return fm
+
+
+def main() -> None:
+    spice = SPICEManager()
+    load_design_kernels(spice, default_kernel_dir())
+    try:
+        system = earth_moon_system()
+        dynamics = CR3BP_Dynamics(system)
+        params = _validate_params(
+            "HALO",
+            amplitude=30000.0,
+            phase=0.0,
+            collinear_point=2,
+            north_south=None,
+            perilune_height=None,
+            amplitude_in=None,
+            amplitude_out=None,
+            phase_in=None,
+            phase_out=None,
+        )
+        cr3bp_orbit = _cr3bp_orbit_for("HALO", params, dynamics)
+        period = float(cr3bp_orbit.period)
+        t_c = system.characteristic_time
+        assert t_c is not None
+        du = system.characteristic_length
+        assert du is not None
+        mu = system.mu
+        et0 = spice.utc_to_et(_epoch_to_iso(EPOCH))
+        state0_syn = np.asarray(cr3bp_orbit.states[0], dtype=float)
+
+        # CR3BP 一圈稠密积分，定位远月点（距月球最远）
+        n_dense = 720
+        t_dense = np.linspace(0.0, period, n_dense + 1)
+        res = dynamics.propagate(state0_syn, (0.0, period), t_eval=t_dense)
+        states_syn = np.asarray(res["states"])
+        moon_x = 1.0 - mu
+        dist_moon = np.sqrt(
+            (states_syn[:, 0] - moon_x) ** 2 + states_syn[:, 1] ** 2 + states_syn[:, 2] ** 2
+        )
+        i_apo = int(np.argmax(dist_moon))
+        t_apo_rel = float(t_dense[i_apo])  # 远月点在圈内的相对时刻
+        print(f"CR3BP 远月点: t/T = {t_apo_rel / period:.4f}, "
+              f"距月 {dist_moon[i_apo]:.3f} du, 距地 {np.linalg.norm(states_syn[i_apo, :3]):.4f} du")
+        print(f"  synodic 坐标 = {states_syn[i_apo, :3]}")
+
+        # 各圈远月点（CR3BP tile，转 J2000）
+        syn_j2000 = SynodicJ2000System(cr3bp_system=system, spice=spice)
+        apo_states_j2000 = []
+        apo_t_j2000 = []
+        for k in range(N_REV):
+            t_syn = t_apo_rel + k * period
+            s_syn = np.asarray(
+                dynamics.propagate_orbit_state_at_time(cr3bp_orbit, t_syn), dtype=float
+            )
+            s_j2000 = syn_j2000.synodic_to_j2000(s_syn, t_syn, et0)
+            apo_states_j2000.append(s_j2000)
+            apo_t_j2000.append(et0 + t_syn * t_c)
+        apo_states_j2000 = np.asarray(apo_states_j2000)
+        apo_t_j2000 = np.asarray(apo_t_j2000)
+
+        # 全摄动自由积分：从首圈远月点积分 N_REV 圈，对比每圈 CR3BP 远月点
+        fm = _build_force_model(spice)
+        t_span = (float(apo_t_j2000[0]), float(apo_t_j2000[-1]))
+        out = fm.propagate(
+            apo_states_j2000[0],
+            t_span,
+            t_eval=apo_t_j2000,
+            with_stm=True,
+            max_steps=2_000_000,
+        )
+        states_eph = np.asarray(out["states"])
+        drift = np.linalg.norm(states_eph[:, :3] - apo_states_j2000[:, :3], axis=1)
+        print(f"\n全摄动自由积分（从首圈 CR3BP 远月点出发）vs 各圈 CR3BP 远月点:")
+        print(f"  {'圈':>3} {'|Δr| (km)':>14} {'|Δr|/du':>10} {'|Δv| (km/s)':>14}")
+        for k in range(N_REV):
+            dv = np.linalg.norm(
+                states_eph[k, 3:] - apo_states_j2000[k, 3:]
+            ) * (du / t_c)
+            print(f"  {k:>3} {drift[k]:>14.3e} {drift[k] / du:>10.3f} {dv:>14.3e}")
+
+        # 结论
+        d0 = drift[1]  # 第 2 圈远月点偏离（第 1 圈积分终点）
+        print(f"\n结论: 第 1 圈后远月点偏离 = {d0:.3e} km"
+              f"（{'远小于相位敏感点 2e5 km，钉远月点锚定可行' if d0 < 1e4 else '同样大，锚定需谨慎'}）")
+    finally:
+        spice.unload_kernel(default_kernel_dir())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/_bench_cache.py
+++ b/scripts/_bench_cache.py
@@ -4,6 +4,7 @@
 单圈打靶（24 次积分 × 多迭代），有缓存应显著快于无缓存（否则缓存没生效）。
 运行：``uv run python scripts/_bench_cache.py``
 """
+
 from __future__ import annotations
 
 import time
@@ -69,9 +70,7 @@ def main() -> None:
         state0_syn = np.asarray(cr3bp_orbit.states[0], dtype=float)
         syn_j2000 = SynodicJ2000System(cr3bp_system=system, spice=spice)
 
-        full_system = EphemerisSystem(
-            bodies=["EARTH", "MOON", "SUN"], spice=spice, origin="EARTH"
-        )
+        full_system = EphemerisSystem(bodies=["EARTH", "MOON", "SUN"], spice=spice, origin="EARTH")
         full_system.coordinate_system = CoordinateSystem(
             axes=ICRSAxes(),
             origin=CelestialBodyOrigin(body="EARTH", spice=spice),
@@ -102,20 +101,32 @@ def main() -> None:
         def run(label: str) -> None:
             t0 = time.perf_counter()
             r = multiple_shooting_correct_py(
-                forces_py, "EARTH", list(seg_t), [list(map(float, x)) for x in seg_s],
-                var_time=True, fix_first_node=False, fixed_node_mask=None,
-                max_iter=50, tolerance=1e-4, rtol=1e-10,
+                forces_py,
+                "EARTH",
+                list(seg_t),
+                [list(map(float, x)) for x in seg_s],
+                var_time=True,
+                fix_first_node=False,
+                fixed_node_mask=None,
+                max_iter=50,
+                tolerance=1e-4,
+                rtol=1e-10,
             )
             dt = time.perf_counter() - t0
-            print(f"{label}: {dt:.1f}s, conv={r.converged} iter={r.iterations} "
-                  f"res={r.max_residual:.1e}")
+            print(
+                f"{label}: {dt:.1f}s, conv={r.converged} iter={r.iterations} "
+                f"res={r.max_residual:.1e}"
+            )
 
         # 无缓存
         run("无缓存")
         # 有缓存
         spice.enable_ephem_cache(
-            ["EARTH", "MOON", "SUN"], et0, et0 + 86400 * 400,
-            dt=3600.0, observer="EARTH",
+            ["EARTH", "MOON", "SUN"],
+            et0,
+            et0 + 86400 * 400,
+            dt=3600.0,
+            observer="EARTH",
             frame_pairs=[("ITRF93", "J2000"), ("MOON_PA", "J2000")],
         )
         run("有缓存")

--- a/scripts/_bench_cache.py
+++ b/scripts/_bench_cache.py
@@ -9,8 +9,8 @@ from __future__ import annotations
 import time
 
 import numpy as np
-
 from e2m2e._integrators import multiple_shooting_correct_py
+
 from e2m2e.algorithm.coordinate.coordinate_system import CoordinateSystem
 from e2m2e.algorithm.coordinate.standard_axes import ICRSAxes
 from e2m2e.algorithm.coordinate.standard_origins import CelestialBodyOrigin

--- a/scripts/_bench_cache.py
+++ b/scripts/_bench_cache.py
@@ -1,0 +1,128 @@
+"""基准：Rust 打靶器 有缓存 vs 无缓存 的单圈耗时对比。
+
+确认缓存是否真被 Rust 积分内循环使用（用户要求"星历预处理成表格存内存"）。
+单圈打靶（24 次积分 × 多迭代），有缓存应显著快于无缓存（否则缓存没生效）。
+运行：``uv run python scripts/_bench_cache.py``
+"""
+from __future__ import annotations
+
+import time
+
+import numpy as np
+
+from e2m2e._integrators import multiple_shooting_correct_py
+from e2m2e.algorithm.coordinate.coordinate_system import CoordinateSystem
+from e2m2e.algorithm.coordinate.standard_axes import ICRSAxes
+from e2m2e.algorithm.coordinate.standard_origins import CelestialBodyOrigin
+from e2m2e.algorithm.coordinate.synodic_j2000 import SynodicJ2000System
+from e2m2e.algorithm.design.design_orbit import (
+    _cr3bp_orbit_for,
+    _epoch_to_iso,
+    _sample_patch_points,
+    _validate_params,
+    default_kernel_dir,
+    load_design_kernels,
+)
+from e2m2e.algorithm.dynamics import CR3BP_Dynamics, EphemerisSystem
+from e2m2e.algorithm.family.cr3bp_orbits import earth_moon_system
+from e2m2e.algorithm.forces.force_mapping import dfh_perturbation_to_force_config
+from e2m2e.algorithm.forces.force_model import ForceModel
+from e2m2e.data.kernels.manager import SPICEManager
+
+PERTURBATION = {
+    "sun_body": 1,
+    "planets": 0,
+    "earth_nonspherical": 1,
+    "moon_nonspherical": 1,
+    "solar_radiation": 1,
+    "atmosphere": 0,
+    "relativity": 0,
+    "tide": 0,
+    "coupling": 0,
+}
+EPOCH = (2024, 1, 1, 0, 0, 0.0)
+
+
+def main() -> None:
+    spice = SPICEManager()
+    load_design_kernels(spice, default_kernel_dir())
+    try:
+        system = earth_moon_system()
+        dynamics = CR3BP_Dynamics(system)
+        params = _validate_params(
+            "HALO",
+            amplitude=30000.0,
+            phase=0.0,
+            collinear_point=2,
+            north_south=None,
+            perilune_height=None,
+            amplitude_in=None,
+            amplitude_out=None,
+            phase_in=None,
+            phase_out=None,
+        )
+        cr3bp_orbit = _cr3bp_orbit_for("HALO", params, dynamics)
+        period = float(cr3bp_orbit.period)
+        t_c = system.characteristic_time
+        assert t_c is not None
+        et0 = spice.utc_to_et(_epoch_to_iso(EPOCH))
+        state0_syn = np.asarray(cr3bp_orbit.states[0], dtype=float)
+        syn_j2000 = SynodicJ2000System(cr3bp_system=system, spice=spice)
+
+        full_system = EphemerisSystem(
+            bodies=["EARTH", "MOON", "SUN"], spice=spice, origin="EARTH"
+        )
+        full_system.coordinate_system = CoordinateSystem(
+            axes=ICRSAxes(),
+            origin=CelestialBodyOrigin(body="EARTH", spice=spice),
+        )
+        force_config = dfh_perturbation_to_force_config(
+            PERTURBATION, earth_degree=10, moon_degree=10
+        )
+        fm = ForceModel.from_config(force_config, full_system)
+        fm.rtol = 1e-12
+        fm.atol = 1e-12
+        fm.max_step = 600.0
+        forces_py = []
+        for entry in fm.list_forces():
+            if not entry.enabled:
+                continue
+            spec = entry.force.to_rust_spec(full_system)
+            if spec is not None:
+                forces_py.append(spec)
+
+        t_patch_syn, state_patch_syn = _sample_patch_points(
+            dynamics, state0_syn, period, 1, perilune_clustered=False
+        )
+        seg_t = et0 + t_patch_syn * t_c
+        seg_s = syn_j2000.batch_synodic_to_j2000(
+            states_syn=state_patch_syn, t_syn_arr=t_patch_syn, et0=et0
+        )
+
+        def run(label: str) -> None:
+            t0 = time.perf_counter()
+            r = multiple_shooting_correct_py(
+                forces_py, "EARTH", list(seg_t), [list(map(float, x)) for x in seg_s],
+                var_time=True, fix_first_node=False, fixed_node_mask=None,
+                max_iter=50, tolerance=1e-4, rtol=1e-10,
+            )
+            dt = time.perf_counter() - t0
+            print(f"{label}: {dt:.1f}s, conv={r.converged} iter={r.iterations} "
+                  f"res={r.max_residual:.1e}")
+
+        # 无缓存
+        run("无缓存")
+        # 有缓存
+        spice.enable_ephem_cache(
+            ["EARTH", "MOON", "SUN"], et0, et0 + 86400 * 400,
+            dt=3600.0, observer="EARTH",
+            frame_pairs=[("ITRF93", "J2000"), ("MOON_PA", "J2000")],
+        )
+        run("有缓存")
+        spice.disable_ephem_cache()
+    finally:
+        spice.unload_kernel(default_kernel_dir())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/_halo_initial_guess_diagnostic.py
+++ b/scripts/_halo_initial_guess_diagnostic.py
@@ -14,6 +14,7 @@
 运行：``uv run python scripts/_halo_initial_guess_diagnostic.py``
 依赖：SPICE 内核在 ``kernels/``（design_orbit 的默认目录）。
 """
+
 from __future__ import annotations
 
 import numpy as np
@@ -63,9 +64,7 @@ def _build_force_model(spice: SPICEManager):
         axes=ICRSAxes(),
         origin=CelestialBodyOrigin(body="EARTH", spice=spice),
     )
-    force_config = dfh_perturbation_to_force_config(
-        PERTURBATION, earth_degree=10, moon_degree=10
-    )
+    force_config = dfh_perturbation_to_force_config(PERTURBATION, earth_degree=10, moon_degree=10)
     fm = ForceModel.from_config(force_config, full_system)
     fm.rtol = 1e-12
     fm.atol = 1e-12
@@ -100,19 +99,18 @@ def main() -> None:
         # 相位 0 → 历元状态 = CR3BP 参考状态（y=0 穿越点）
         state0_syn = np.asarray(cr3bp_orbit.states[0], dtype=float)
         print(f"Halo L2: period = {period:.4f} TU = {period * t_c / 86400:.2f} 天")
-        print(f"特征长度 = {system.characteristic_length:.0f} km，"
-              f"特征时间 = {t_c / 86400:.2f} 天")
+        print(f"特征长度 = {system.characteristic_length:.0f} km，特征时间 = {t_c / 86400:.2f} 天")
 
         # --- (a) CR3BP 单圈闭合误差 ---
         dense = _dense_orbit(dynamics, state0_syn, period)
-        r_close = np.linalg.norm(
-            dense.states[-1, :3] - dense.states[0, :3]
-        ) * system.characteristic_length
-        v_close = np.linalg.norm(
-            dense.states[-1, 3:] - dense.states[0, 3:]
-        ) * (system.characteristic_length / t_c)
-        print(f"\n(a) CR3BP 单圈闭合误差: |Δr| = {r_close:.3e} km, "
-              f"|Δv| = {v_close:.3e} km/s")
+        r_close = (
+            np.linalg.norm(dense.states[-1, :3] - dense.states[0, :3])
+            * system.characteristic_length
+        )
+        v_close = np.linalg.norm(dense.states[-1, 3:] - dense.states[0, 3:]) * (
+            system.characteristic_length / t_c
+        )
+        print(f"\n(a) CR3BP 单圈闭合误差: |Δr| = {r_close:.3e} km, |Δv| = {v_close:.3e} km/s")
 
         # --- (b) 逐圈星历偏离：全摄动自由积分 vs CR3BP tile ---
         t_patch_syn, state_patch_syn = _sample_patch_points(
@@ -143,9 +141,7 @@ def main() -> None:
             i = (k + 1) * 8 - 1  # 每圈 8 点，取圈末
             if i >= len(drift):
                 break
-            dv = np.linalg.norm(
-                states_eph[i, 3:] - state_patch_j2000[i, 3:]
-            ) * (du / t_c)
+            dv = np.linalg.norm(states_eph[i, 3:] - state_patch_j2000[i, 3:]) * (du / t_c)
             print(f"    {k + 1:>3} {drift[i]:>14.3e} {dv:>14.3e}")
 
         # --- (c) 一圈 STM 增长（Lyapunov 倍率）---
@@ -161,8 +157,10 @@ def main() -> None:
         # 星历偏离 > 1e4 km 的圈数即段长安全上限（打靶需吸收的残差）
         exceed = np.where(drift > 1e4)[0]
         safe = int(exceed[0] // 8) + 1 if len(exceed) else N_REV
-        print(f"\n结论: 星历偏离 > 1e4 km 出现于第 {safe} 圈 → "
-              f"revs_per_group 建议 ≤ {max(1, safe - 1)}")
+        print(
+            f"\n结论: 星历偏离 > 1e4 km 出现于第 {safe} 圈 → "
+            f"revs_per_group 建议 ≤ {max(1, safe - 1)}"
+        )
     finally:
         spice.unload_kernel(default_kernel_dir())
 

--- a/scripts/_halo_initial_guess_diagnostic.py
+++ b/scripts/_halo_initial_guess_diagnostic.py
@@ -1,0 +1,171 @@
+"""星历模型下 Halo 初猜质量诊断：CR3BP 闭合误差 / 星历偏离 / Lyapunov 增长。
+
+前置调查（Step 0，不进 CI）：量化 CR3BP 初猜在星历模型下能支撑多长的
+分段打靶，据此定 ``revs_per_group``（第 1 步每组圈数）的安全上限。三件事：
+
+(a) CR3BP Halo 单圈闭合误差：CR3BP 周期轨道本身不是精确闭合（微分修正后
+    残差 ~1e-6），量级决定首圈打靶需吸收的残差。
+(b) 逐圈星历偏离：CR3BP 首点状态在**全摄动星历模型**下自由积分 N 圈，
+    对比 CR3BP 周期轨道第 N 圈节点，量化第几圈开始指数发散（>1e4 km 即
+    初猜失真，段长应明显短于此圈数）。
+(c) STM 一圈增长：一圈状态转移矩阵的谱半径（Lyapunov 倍率），估分段段长
+    上限——打靶的雅可比依赖 STM，倍率过大则超长段收敛差。
+
+运行：``uv run python scripts/_halo_initial_guess_diagnostic.py``
+依赖：SPICE 内核在 ``kernels/``（design_orbit 的默认目录）。
+"""
+from __future__ import annotations
+
+import numpy as np
+
+from e2m2e.algorithm.coordinate.synodic_j2000 import SynodicJ2000System
+from e2m2e.algorithm.design.design_orbit import (
+    _cr3bp_orbit_for,
+    _dense_orbit,
+    _epoch_to_iso,
+    _sample_patch_points,
+    _validate_params,
+    default_kernel_dir,
+    load_design_kernels,
+)
+from e2m2e.algorithm.dynamics import CR3BP_Dynamics
+from e2m2e.algorithm.family.cr3bp_orbits import earth_moon_system
+from e2m2e.algorithm.forces.force_mapping import dfh_perturbation_to_force_config
+from e2m2e.algorithm.forces.force_model import ForceModel
+from e2m2e.data.kernels.manager import SPICEManager
+
+#: 与 main_design.py 一致的摄动开关（太阳第三体 + 地月 10 阶非球形 + 炮弹光压）
+PERTURBATION = {
+    "sun_body": 1,
+    "planets": 0,
+    "earth_nonspherical": 1,
+    "moon_nonspherical": 1,
+    "solar_radiation": 1,
+    "atmosphere": 0,
+    "relativity": 0,
+    "tide": 0,
+    "coupling": 0,
+}
+EPOCH = (2024, 1, 1, 0, 0, 0.0)
+N_REV = 16  # 诊断积分圈数
+
+
+def _build_force_model(spice: SPICEManager):
+    """构造与 design_orbit segmented 分支同款的全摄动 ForceModel。"""
+    from e2m2e.algorithm.coordinate.coordinate_system import CoordinateSystem
+    from e2m2e.algorithm.coordinate.standard_axes import ICRSAxes
+    from e2m2e.algorithm.coordinate.standard_origins import CelestialBodyOrigin
+    from e2m2e.algorithm.dynamics import EphemerisSystem
+
+    bodies = ["EARTH", "MOON", "SUN"]
+    full_system = EphemerisSystem(bodies=bodies, spice=spice, origin="EARTH")
+    full_system.coordinate_system = CoordinateSystem(
+        axes=ICRSAxes(),
+        origin=CelestialBodyOrigin(body="EARTH", spice=spice),
+    )
+    force_config = dfh_perturbation_to_force_config(
+        PERTURBATION, earth_degree=10, moon_degree=10
+    )
+    fm = ForceModel.from_config(force_config, full_system)
+    fm.rtol = 1e-12
+    fm.atol = 1e-12
+    fm.max_step = 600.0
+    return fm
+
+
+def main() -> None:
+    spice = SPICEManager()
+    load_design_kernels(spice, default_kernel_dir())
+    try:
+        system = earth_moon_system()
+        dynamics = CR3BP_Dynamics(system)
+        params = _validate_params(
+            "HALO",
+            amplitude=30000.0,
+            phase=0.0,
+            collinear_point=2,
+            north_south=None,
+            perilune_height=None,
+            amplitude_in=None,
+            amplitude_out=None,
+            phase_in=None,
+            phase_out=None,
+        )
+        cr3bp_orbit = _cr3bp_orbit_for("HALO", params, dynamics)
+        period = float(cr3bp_orbit.period)
+        t_c = system.characteristic_time
+        assert t_c is not None
+        et0 = spice.utc_to_et(_epoch_to_iso(EPOCH))
+
+        # 相位 0 → 历元状态 = CR3BP 参考状态（y=0 穿越点）
+        state0_syn = np.asarray(cr3bp_orbit.states[0], dtype=float)
+        print(f"Halo L2: period = {period:.4f} TU = {period * t_c / 86400:.2f} 天")
+        print(f"特征长度 = {system.characteristic_length:.0f} km，"
+              f"特征时间 = {t_c / 86400:.2f} 天")
+
+        # --- (a) CR3BP 单圈闭合误差 ---
+        dense = _dense_orbit(dynamics, state0_syn, period)
+        r_close = np.linalg.norm(
+            dense.states[-1, :3] - dense.states[0, :3]
+        ) * system.characteristic_length
+        v_close = np.linalg.norm(
+            dense.states[-1, 3:] - dense.states[0, 3:]
+        ) * (system.characteristic_length / t_c)
+        print(f"\n(a) CR3BP 单圈闭合误差: |Δr| = {r_close:.3e} km, "
+              f"|Δv| = {v_close:.3e} km/s")
+
+        # --- (b) 逐圈星历偏离：全摄动自由积分 vs CR3BP tile ---
+        t_patch_syn, state_patch_syn = _sample_patch_points(
+            dynamics, state0_syn, period, N_REV, perilune_clustered=False
+        )
+        syn_j2000 = SynodicJ2000System(cr3bp_system=system, spice=spice)
+        state_patch_j2000 = syn_j2000.batch_synodic_to_j2000(
+            states_syn=state_patch_syn, t_syn_arr=t_patch_syn, et0=et0
+        )
+        t_patch_j2000 = et0 + t_patch_syn * t_c
+
+        fm = _build_force_model(spice)
+        # 从首点全摄动积分 N_REV 圈（覆盖整条 tile）
+        t_span = (float(et0), float(t_patch_j2000[-1]))
+        out = fm.propagate(
+            state_patch_j2000[0],
+            t_span,
+            t_eval=t_patch_j2000,
+            with_stm=True,
+            max_steps=2_000_000,
+        )
+        states_eph = np.asarray(out["states"])
+        drift = np.linalg.norm(states_eph[:, :3] - state_patch_j2000[:, :3], axis=1)
+        du = system.characteristic_length
+        print(f"\n(b) 全摄动自由积分 vs CR3BP tile（每圈末点）:")
+        print(f"    {'圈':>3} {'|Δr| (km)':>14} {'|Δv| (km/s)':>14}")
+        for k in range(N_REV):
+            i = (k + 1) * 8 - 1  # 每圈 8 点，取圈末
+            if i >= len(drift):
+                break
+            dv = np.linalg.norm(
+                states_eph[i, 3:] - state_patch_j2000[i, 3:]
+            ) * (du / t_c)
+            print(f"    {k + 1:>3} {drift[i]:>14.3e} {dv:>14.3e}")
+
+        # --- (c) 一圈 STM 增长（Lyapunov 倍率）---
+        stm = np.asarray(out["stm"])
+        print(f"\n(c) 一圈 STM 谱半径（Lyapunov 倍率）:")
+        for k in range(min(4, N_REV)):
+            i = (k + 1) * 8 - 1
+            M = stm[i]
+            s = np.linalg.svd(M, compute_uv=False)
+            print(f"    圈 {k + 1}: 最大奇异值 = {s[0]:.3e}, 最小 = {s[-1]:.3e}")
+
+        # --- 结论：定 revs_per_group 上限 ---
+        # 星历偏离 > 1e4 km 的圈数即段长安全上限（打靶需吸收的残差）
+        exceed = np.where(drift > 1e4)[0]
+        safe = int(exceed[0] // 8) + 1 if len(exceed) else N_REV
+        print(f"\n结论: 星历偏离 > 1e4 km 出现于第 {safe} 圈 → "
+              f"revs_per_group 建议 ≤ {max(1, safe - 1)}")
+    finally:
+        spice.unload_kernel(default_kernel_dir())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/_halo_initial_guess_diagnostic.py
+++ b/scripts/_halo_initial_guess_diagnostic.py
@@ -137,7 +137,7 @@ def main() -> None:
         states_eph = np.asarray(out["states"])
         drift = np.linalg.norm(states_eph[:, :3] - state_patch_j2000[:, :3], axis=1)
         du = system.characteristic_length
-        print(f"\n(b) 全摄动自由积分 vs CR3BP tile（每圈末点）:")
+        print("\n(b) 全摄动自由积分 vs CR3BP tile（每圈末点）:")
         print(f"    {'圈':>3} {'|Δr| (km)':>14} {'|Δv| (km/s)':>14}")
         for k in range(N_REV):
             i = (k + 1) * 8 - 1  # 每圈 8 点，取圈末
@@ -150,7 +150,7 @@ def main() -> None:
 
         # --- (c) 一圈 STM 增长（Lyapunov 倍率）---
         stm = np.asarray(out["stm"])
-        print(f"\n(c) 一圈 STM 谱半径（Lyapunov 倍率）:")
+        print("\n(c) 一圈 STM 谱半径（Lyapunov 倍率）:")
         for k in range(min(4, N_REV)):
             i = (k + 1) * 8 - 1
             M = stm[i]

--- a/scripts/_verify_rust_shooting.py
+++ b/scripts/_verify_rust_shooting.py
@@ -6,6 +6,7 @@ Python 语义等价、可直接用于 segmented 分支。
 
 运行：``uv run python scripts/_verify_rust_shooting.py``
 """
+
 from __future__ import annotations
 
 import time
@@ -90,9 +91,7 @@ def main() -> None:
         from e2m2e.algorithm.coordinate.standard_origins import CelestialBodyOrigin
         from e2m2e.algorithm.dynamics import EphemerisSystem
 
-        full_system = EphemerisSystem(
-            bodies=["EARTH", "MOON", "SUN"], spice=spice, origin="EARTH"
-        )
+        full_system = EphemerisSystem(bodies=["EARTH", "MOON", "SUN"], spice=spice, origin="EARTH")
         full_system.coordinate_system = CoordinateSystem(
             axes=ICRSAxes(),
             origin=CelestialBodyOrigin(body="EARTH", spice=spice),
@@ -109,16 +108,25 @@ def main() -> None:
         )
         t0 = time.perf_counter()
         r = multiple_shooting_correct_py(
-            forces_py, "EARTH", list(seg_t), [list(map(float, x)) for x in seg_s],
-            var_time=True, fix_first_node=False, fixed_node_mask=None,
-            max_iter=50, tolerance=1e-4, rtol=1e-10,
+            forces_py,
+            "EARTH",
+            list(seg_t),
+            [list(map(float, x)) for x in seg_s],
+            var_time=True,
+            fix_first_node=False,
+            fixed_node_mask=None,
+            max_iter=50,
+            tolerance=1e-4,
+            rtol=1e-10,
         )
         dt = time.perf_counter() - t0
         sp = np.asarray(r.state_patch)
         rr = np.linalg.norm(sp[:, :3], axis=1) / du
         spread = (rr.max() - rr.min()) / rr.mean()
-        print(f"Rust 单圈 var_time 全自由: conv={r.converged} iter={r.iterations} "
-              f"res={r.max_residual:.1e} km ({dt:.1f}s)")
+        print(
+            f"Rust 单圈 var_time 全自由: conv={r.converged} iter={r.iterations} "
+            f"res={r.max_residual:.1e} km ({dt:.1f}s)"
+        )
         print(f"  残差历史: {[f'{x:.1e}' for x in r.residual_history[:6]]}")
         print(f"  |r|/du 极差/均值 = {spread:.3f}（保形 < 0.3）")
         t_syn = (np.asarray(r.t_patch) - et0) / t_c
@@ -139,9 +147,16 @@ def main() -> None:
                 et0=et0,
             )
             r1 = multiple_shooting_correct_py(
-                forces_py, "EARTH", list(seg_t2), [list(map(float, x)) for x in seg_s2],
-                var_time=True, fix_first_node=False, fixed_node_mask=None,
-                max_iter=50, tolerance=1e-4, rtol=1e-10,
+                forces_py,
+                "EARTH",
+                list(seg_t2),
+                [list(map(float, x)) for x in seg_s2],
+                var_time=True,
+                fix_first_node=False,
+                fixed_node_mask=None,
+                max_iter=50,
+                tolerance=1e-4,
+                rtol=1e-10,
             )
             segs.append((np.asarray(r1.t_patch), np.asarray(r1.state_patch)))
             print(f"第 1 步段 {k + 1}: conv={r1.converged} res={r1.max_residual:.1e} km")
@@ -157,16 +172,25 @@ def main() -> None:
         mask[-1] = True
         t0 = time.perf_counter()
         rm = multiple_shooting_correct_py(
-            forces_py, "EARTH", list(merged_t), [list(map(float, x)) for x in merged_s],
-            var_time=True, fix_first_node=False, fixed_node_mask=mask,
-            max_iter=50, tolerance=1e-4, rtol=1e-10,
+            forces_py,
+            "EARTH",
+            list(merged_t),
+            [list(map(float, x)) for x in merged_s],
+            var_time=True,
+            fix_first_node=False,
+            fixed_node_mask=mask,
+            max_iter=50,
+            tolerance=1e-4,
+            rtol=1e-10,
         )
         dt = time.perf_counter() - t0
         spm = np.asarray(rm.state_patch)
         rm_ = np.linalg.norm(spm[:, :3], axis=1) / du
         spread_m = (rm_.max() - rm_.min()) / rm_.mean()
-        print(f"\n合并段（{n} 节点，固定两端）: conv={rm.converged} iter={rm.iterations} "
-              f"res={rm.max_residual:.1e} km ({dt:.1f}s)")
+        print(
+            f"\n合并段（{n} 节点，固定两端）: conv={rm.converged} iter={rm.iterations} "
+            f"res={rm.max_residual:.1e} km ({dt:.1f}s)"
+        )
         print(f"  残差历史: {[f'{x:.1e}' for x in rm.residual_history[:8]]}")
         print(f"  |r|/du 极差/均值 = {spread_m:.3f}（保形 < 0.3）")
         t_syn2 = (np.asarray(rm.t_patch) - et0) / t_c
@@ -189,9 +213,7 @@ def _build_force_model(spice: SPICEManager) -> ForceModel:
         axes=ICRSAxes(),
         origin=CelestialBodyOrigin(body="EARTH", spice=spice),
     )
-    force_config = dfh_perturbation_to_force_config(
-        PERTURBATION, earth_degree=10, moon_degree=10
-    )
+    force_config = dfh_perturbation_to_force_config(PERTURBATION, earth_degree=10, moon_degree=10)
     fm = ForceModel.from_config(force_config, full_system)
     fm.rtol = 1e-12
     fm.atol = 1e-12

--- a/scripts/_verify_rust_shooting.py
+++ b/scripts/_verify_rust_shooting.py
@@ -11,8 +11,8 @@ from __future__ import annotations
 import time
 
 import numpy as np
-
 from e2m2e._integrators import multiple_shooting_correct_py
+
 from e2m2e.algorithm.coordinate.synodic_j2000 import SynodicJ2000System
 from e2m2e.algorithm.design.design_orbit import (
     _cr3bp_orbit_for,

--- a/scripts/_verify_rust_shooting.py
+++ b/scripts/_verify_rust_shooting.py
@@ -1,0 +1,203 @@
+"""验证：Rust 新版原子打靶器（LM 阻尼 + 线搜索 + mask）在单圈 / 合并段的保形表现。
+
+Python 实验（_exp_splice_v3）已证：var_time 全自由 + 线搜索收敛且保形。
+本脚本用 Rust 原子打靶器复现，对比残差与保形指标，确认 Rust 实现与
+Python 语义等价、可直接用于 segmented 分支。
+
+运行：``uv run python scripts/_verify_rust_shooting.py``
+"""
+from __future__ import annotations
+
+import time
+
+import numpy as np
+
+from e2m2e._integrators import multiple_shooting_correct_py
+from e2m2e.algorithm.coordinate.synodic_j2000 import SynodicJ2000System
+from e2m2e.algorithm.design.design_orbit import (
+    _cr3bp_orbit_for,
+    _epoch_to_iso,
+    _sample_patch_points,
+    _validate_params,
+    default_kernel_dir,
+    load_design_kernels,
+)
+from e2m2e.algorithm.dynamics import CR3BP_Dynamics
+from e2m2e.algorithm.family.cr3bp_orbits import earth_moon_system
+from e2m2e.algorithm.forces.force_mapping import dfh_perturbation_to_force_config
+from e2m2e.algorithm.forces.force_model import ForceModel
+from e2m2e.data.kernels.manager import SPICEManager
+
+PERTURBATION = {
+    "sun_body": 1,
+    "planets": 0,
+    "earth_nonspherical": 1,
+    "moon_nonspherical": 1,
+    "solar_radiation": 1,
+    "atmosphere": 0,
+    "relativity": 0,
+    "tide": 0,
+    "coupling": 0,
+}
+EPOCH = (2024, 1, 1, 0, 0, 0.0)
+
+
+def _rust_forces(fm, full_system):
+    """从 ForceModel 提取传给 Rust 的 force 元组列表。"""
+    forces_py = []
+    for entry in fm.list_forces():
+        if not entry.enabled:
+            continue
+        spec = entry.force.to_rust_spec(full_system)
+        if spec is not None:
+            forces_py.append(spec)
+    return forces_py
+
+
+def main() -> None:
+    spice = SPICEManager()
+    load_design_kernels(spice, default_kernel_dir())
+    try:
+        system = earth_moon_system()
+        dynamics = CR3BP_Dynamics(system)
+        params = _validate_params(
+            "HALO",
+            amplitude=30000.0,
+            phase=0.0,
+            collinear_point=2,
+            north_south=None,
+            perilune_height=None,
+            amplitude_in=None,
+            amplitude_out=None,
+            phase_in=None,
+            phase_out=None,
+        )
+        cr3bp_orbit = _cr3bp_orbit_for("HALO", params, dynamics)
+        period = float(cr3bp_orbit.period)
+        t_c = system.characteristic_time
+        assert t_c is not None
+        du = system.characteristic_length
+        assert du is not None
+        mu = system.mu
+        et0 = spice.utc_to_et(_epoch_to_iso(EPOCH))
+        state0_syn = np.asarray(cr3bp_orbit.states[0], dtype=float)
+        fm = _build_force_model(spice)
+        syn_j2000 = SynodicJ2000System(cr3bp_system=system, spice=spice)
+
+        # 构造 full_system 以提取 rust forces
+        from e2m2e.algorithm.coordinate.coordinate_system import CoordinateSystem
+        from e2m2e.algorithm.coordinate.standard_axes import ICRSAxes
+        from e2m2e.algorithm.coordinate.standard_origins import CelestialBodyOrigin
+        from e2m2e.algorithm.dynamics import EphemerisSystem
+
+        full_system = EphemerisSystem(
+            bodies=["EARTH", "MOON", "SUN"], spice=spice, origin="EARTH"
+        )
+        full_system.coordinate_system = CoordinateSystem(
+            axes=ICRSAxes(),
+            origin=CelestialBodyOrigin(body="EARTH", spice=spice),
+        )
+        forces_py = _rust_forces(fm, full_system)
+
+        # 单圈 var_time 全自由
+        t_patch_syn, state_patch_syn = _sample_patch_points(
+            dynamics, state0_syn, period, 1, perilune_clustered=False
+        )
+        seg_t = et0 + t_patch_syn * t_c
+        seg_s = syn_j2000.batch_synodic_to_j2000(
+            states_syn=state_patch_syn, t_syn_arr=t_patch_syn, et0=et0
+        )
+        t0 = time.perf_counter()
+        r = multiple_shooting_correct_py(
+            forces_py, "EARTH", list(seg_t), [list(map(float, x)) for x in seg_s],
+            var_time=True, fix_first_node=False, fixed_node_mask=None,
+            max_iter=50, tolerance=1e-4, rtol=1e-10,
+        )
+        dt = time.perf_counter() - t0
+        sp = np.asarray(r.state_patch)
+        rr = np.linalg.norm(sp[:, :3], axis=1) / du
+        spread = (rr.max() - rr.min()) / rr.mean()
+        print(f"Rust 单圈 var_time 全自由: conv={r.converged} iter={r.iterations} "
+              f"res={r.max_residual:.1e} km ({dt:.1f}s)")
+        print(f"  残差历史: {[f'{x:.1e}' for x in r.residual_history[:6]]}")
+        print(f"  |r|/du 极差/均值 = {spread:.3f}（保形 < 0.3）")
+        t_syn = (np.asarray(r.t_patch) - et0) / t_c
+        syn_states = syn_j2000.batch_j2000_to_synodic(sp, t_syn, et0)[:, :3]
+        syn_states[:, 0] += mu
+        print(f"  会合系 x: [{syn_states[:, 0].min():.4f}, {syn_states[:, 0].max():.4f}]")
+
+        # 两圈合并：各自独立转星历后拼接，合并段固定两端 var_time
+        segs = []
+        for k in range(2):
+            t_patch_syn2, state_patch_syn2 = _sample_patch_points(
+                dynamics, state0_syn, period, 1, perilune_clustered=False
+            )
+            seg_t2 = et0 + (k * period + t_patch_syn2) * t_c
+            seg_s2 = syn_j2000.batch_synodic_to_j2000(
+                states_syn=state_patch_syn2,
+                t_syn_arr=(k * period + t_patch_syn2),
+                et0=et0,
+            )
+            r1 = multiple_shooting_correct_py(
+                forces_py, "EARTH", list(seg_t2), [list(map(float, x)) for x in seg_s2],
+                var_time=True, fix_first_node=False, fixed_node_mask=None,
+                max_iter=50, tolerance=1e-4, rtol=1e-10,
+            )
+            segs.append((np.asarray(r1.t_patch), np.asarray(r1.state_patch)))
+            print(f"第 1 步段 {k + 1}: conv={r1.converged} res={r1.max_residual:.1e} km")
+
+        t1, s1 = segs[0]
+        t2, s2 = segs[1]
+        merged_t = np.concatenate([t1, t2[1:]])
+        merged_s = np.concatenate([s1, s2[1:]])
+        n = len(merged_t)
+        # 合并段固定首末两端（var_time：状态固定但时间自由）
+        mask = [False] * n
+        mask[0] = True
+        mask[-1] = True
+        t0 = time.perf_counter()
+        rm = multiple_shooting_correct_py(
+            forces_py, "EARTH", list(merged_t), [list(map(float, x)) for x in merged_s],
+            var_time=True, fix_first_node=False, fixed_node_mask=mask,
+            max_iter=50, tolerance=1e-4, rtol=1e-10,
+        )
+        dt = time.perf_counter() - t0
+        spm = np.asarray(rm.state_patch)
+        rm_ = np.linalg.norm(spm[:, :3], axis=1) / du
+        spread_m = (rm_.max() - rm_.min()) / rm_.mean()
+        print(f"\n合并段（{n} 节点，固定两端）: conv={rm.converged} iter={rm.iterations} "
+              f"res={rm.max_residual:.1e} km ({dt:.1f}s)")
+        print(f"  残差历史: {[f'{x:.1e}' for x in rm.residual_history[:8]]}")
+        print(f"  |r|/du 极差/均值 = {spread_m:.3f}（保形 < 0.3）")
+        t_syn2 = (np.asarray(rm.t_patch) - et0) / t_c
+        syn_m = syn_j2000.batch_j2000_to_synodic(spm, t_syn2, et0)[:, :3]
+        syn_m[:, 0] += mu
+        print(f"  会合系 x: [{syn_m[:, 0].min():.4f}, {syn_m[:, 0].max():.4f}]")
+    finally:
+        spice.unload_kernel(default_kernel_dir())
+
+
+def _build_force_model(spice: SPICEManager) -> ForceModel:
+    from e2m2e.algorithm.coordinate.coordinate_system import CoordinateSystem
+    from e2m2e.algorithm.coordinate.standard_axes import ICRSAxes
+    from e2m2e.algorithm.coordinate.standard_origins import CelestialBodyOrigin
+    from e2m2e.algorithm.dynamics import EphemerisSystem
+
+    bodies = ["EARTH", "MOON", "SUN"]
+    full_system = EphemerisSystem(bodies=bodies, spice=spice, origin="EARTH")
+    full_system.coordinate_system = CoordinateSystem(
+        axes=ICRSAxes(),
+        origin=CelestialBodyOrigin(body="EARTH", spice=spice),
+    )
+    force_config = dfh_perturbation_to_force_config(
+        PERTURBATION, earth_degree=10, moon_degree=10
+    )
+    fm = ForceModel.from_config(force_config, full_system)
+    fm.rtol = 1e-12
+    fm.atol = 1e-12
+    fm.max_step = 600.0
+    return fm
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 关联

无关联 issue（本地任务，延续分段打靶拼接方向）。

## 改了什么

星历模型下长弧多重打靶（2 年 Halo）的三重改动，使打靶可并行、可收敛、全程零 cspice：

1. **零 cspice**：`EphemCache` 增 `RwLock`（并行读）+ `StrictGuard` + `lookup_*` 入口。打靶并行区开启 strict，力模型查内存三次样条，miss 即硬 Err，杜绝静默回退 cspice（并发下触发 `SPICE(DAFFRNOTFOUND)` 或 panic）。力模型（gravity_field/spk_accel/srp）全部查表点改 `lookup_*`。

2. **rayon 并行段积分**：`multiple_shooting` 段积分恢复 `into_par_iter`（零 cspice 前提），`E2M2E_MS_PARALLEL=0` 可强制串行验证位级一致；`py.allow_threads` 释放 GIL。实测并行/串行 `state_patch`/`residual_history` 逐位一致。

3. **收敛改进**：LM 阻尼跨迭代保留（成功减、失败增），残差从 8e-2 降到 1.6e-2 km；停滞检测阈值放宽。`spice_ffi` 加 FFI 调用计数，证明打靶区间 FFI 调用 = 0。

4. **论文式分段打靶拼接**：`design_orbit` 删除逐圈滚动，改为逐段独立 var_time 打靶转星历 + 远月点分层合并（段数/步数保持论文结构）。Halo/NRHO 用近月加密采样（残差 1.2e-2 km）。星历缓存全程接入（enable + try/finally 生命周期）。

## 测试

- **零 cspice**：打靶 `ephem_ffi_call_count()` = 0
- **并行 vs 串行位级一致**：`state_patch`/`t_patch`/`residual_history` `array_equal` True
- **30 天保形**：|r| 480967→435680→476884 km，会合系 x∈[1.084,1.186]
- **2 年跑通**（release）：1205s，|r| 首→末 480967→429059 km
- **release 提速 5.3x**（75→14.1s/迭代 大段）
- Rust 测试 9/9、forces 22/22、DRO+Rust 缓存 19 passed
- `cargo clippy --workspace --features spice -- -D warnings`、`ruff check`、`mypy` 全过

## 已知限制（非本 PR 范围）

- 长时族漂移：2 年会合系 x 下探（逐段独立打靶不锚目标族，论文靠 1e-10 严判据 + 轨道保持控制解决）
- 潮汐缓存（tide=1 回退串行，body-fixed 位置未走缓存，后续扩展）
- 构建需 `maturin develop --release --features spice`（release 提速必需）