### PR TITLE
fix(phasing): 修复 CI typecheck 失败 — dynamics 参数类型 CR3BP_Dynamics → DynamicsLike

### DIFF
--- a/e2m2e/algorithm/proximity/phasing.py
+++ b/e2m2e/algorithm/proximity/phasing.py
@@ -19,11 +19,10 @@ from typing import TYPE_CHECKING
 import numpy as np
 import numpy.typing as npt
 
-from ..proximity.relative_dynamics import RelativeDynamics, TargetOrbit
+from ..proximity.relative_dynamics import DynamicsLike, RelativeDynamics, TargetOrbit
 
 if TYPE_CHECKING:
     from ...data.types.orbit import Orbit
-    from ..dynamics import CR3BP_Dynamics
 
 
 @dataclass
@@ -60,7 +59,7 @@ def phasing_search(
     orbit: Orbit,
     dphase: float,
     tof_grid: npt.ArrayLike,
-    dynamics: CR3BP_Dynamics,
+    dynamics: DynamicsLike,
     *,
     t0: float | None = None,
 ) -> list[PhasingSolution]:


### PR DESCRIPTION
## 关联

无关联 issue。CI 基线红（master 同样报错，非 PR #265 引入）。

## 改了什么

- `phasing.py:63`：`phasing_search` 的 `dynamics` 参数类型从 `CR3BP_Dynamics` 改为 `DynamicsLike`
  - `RelativeDynamics.__init__` 期望 `DynamicsLike`（Protocol），原类型标注不兼容
  - 同时扩展适用范围：调用方可传 `EphemerisDynamics`（星历动力学）
- 移除 `CR3BP_Dynamics` 的 `TYPE_CHECKING` import（不再需要）
- 在已有 import 行追加 `DynamicsLike`（来自同模块 `relative_dynamics.py`）

## 测试

```bash
uv run mypy e2m2e/ --ignore-missing-imports  # 0 errors
uv run ruff check .                            # All checks passed
uv run pytest tests/proximity/ -x              # 8 passed
```