### PR TITLE
feat(cache): tide 扰动体位置走 EphemCache，解锁 tide=1 并行打靶 (#267)

### DIFF
--- a/crates/e2m2e-forces/src/forces/gravity_field.rs
+++ b/crates/e2m2e-forces/src/forces/gravity_field.rs
@@ -230,17 +230,15 @@ fn effective_coefficients(
         };
     let mut perturbers_flat: Vec<f64> = Vec::with_capacity(perturbers_names.len() * 4);
     for &name in perturbers_names {
-        let pos_j2000: [f64; 3] = match e2m2e_spice::ephem_cache::lookup_body_position(
-            name, body, et,
-        ) {
-            Ok(Some(p)) => p,
-            Ok(None) => {
-                let (st, _) =
-                    e2m2e_spice::spice_ffi::spkezr(name, et, "J2000", "NONE", body)?;
-                [st[0], st[1], st[2]]
-            }
-            Err(e) => return Err(e.into()),
-        };
+        let pos_j2000: [f64; 3] =
+            match e2m2e_spice::ephem_cache::lookup_body_position(name, body, et) {
+                Ok(Some(p)) => p,
+                Ok(None) => {
+                    let (st, _) = e2m2e_spice::spice_ffi::spkezr(name, et, "J2000", "NONE", body)?;
+                    [st[0], st[1], st[2]]
+                }
+                Err(e) => return Err(e.into()),
+            };
         let pos_bf = mat3_t_mul_vec(&r_input_to_j2000, &pos_j2000);
         perturbers_flat.extend_from_slice(&pos_bf);
         // GM 用硬编码表（与 Python spice.get_gm 一致；DE430 bsp 不带 GM）

--- a/crates/e2m2e-forces/src/forces/gravity_field.rs
+++ b/crates/e2m2e-forces/src/forces/gravity_field.rs
@@ -216,14 +216,33 @@ fn effective_coefficients(
     let mut c = base_c.to_vec();
     let mut s = base_s.to_vec();
 
-    // 查扰动体位置（input_frame 系下，observer = 中心天体）
+    // 查扰动体位置（input_frame 系下，observer = 中心天体）。
+    // 走星历缓存：先查 (perturber, central_body) 在 J2000 的位置，再查
+    // (input_frame, "J2000") 帧旋转矩阵，合成 body-fixed 位置。
+    // strict 模式（并行打靶区）下 miss 硬 Err，杜绝并发 cspice。
     let perturbers_names = perturbers_for_body(body);
     let input_frame = input_frame_for_body(body);
+    let r_input_to_j2000: [[f64; 3]; 3] =
+        match e2m2e_spice::ephem_cache::lookup_frame_matrix(input_frame, "J2000", et) {
+            Ok(Some(m)) => m,
+            Ok(None) => pxform(input_frame, "J2000", et)?,
+            Err(e) => return Err(e.into()),
+        };
     let mut perturbers_flat: Vec<f64> = Vec::with_capacity(perturbers_names.len() * 4);
     for &name in perturbers_names {
-        // SPICE 查扰动体相对中心天体在 input_frame 系下的位置
-        let (state, _lt) = e2m2e_spice::spice_ffi::spkezr(name, et, input_frame, "NONE", body)?;
-        perturbers_flat.extend_from_slice(&[state[0], state[1], state[2]]);
+        let pos_j2000: [f64; 3] = match e2m2e_spice::ephem_cache::lookup_body_position(
+            name, body, et,
+        ) {
+            Ok(Some(p)) => p,
+            Ok(None) => {
+                let (st, _) =
+                    e2m2e_spice::spice_ffi::spkezr(name, et, "J2000", "NONE", body)?;
+                [st[0], st[1], st[2]]
+            }
+            Err(e) => return Err(e.into()),
+        };
+        let pos_bf = mat3_t_mul_vec(&r_input_to_j2000, &pos_j2000);
+        perturbers_flat.extend_from_slice(&pos_bf);
         // GM 用硬编码表（与 Python spice.get_gm 一致；DE430 bsp 不带 GM）
         let gm = gm_for_body(name)
             .ok_or_else(|| SpiceFfiError::Failed(format!("GM not known for body {:?}", name)))?;

--- a/e2m2e/algorithm/design/design_orbit.py
+++ b/e2m2e/algorithm/design/design_orbit.py
@@ -841,11 +841,7 @@ def design_orbit(
         # 扰动体→中心天体对（与 Rust perturbers_for_body 一致）：
         #   EARTH → [SUN, MOON]，MOON → [EARTH]。
         _perturber_map = {"EARTH": ["SUN", "MOON"], "MOON": ["EARTH"]}
-        _perturber_names = {
-            p
-            for b in bodies
-            for p in _perturber_map.get(b.upper(), [])
-        }
+        _perturber_names = {p for b in bodies for p in _perturber_map.get(b.upper(), [])}
         # 合并：原 bodies + 扰动体中未包含的天体（如 SUN），
         # enable_ephem_cache 自动注册 (name, observer) + (name, SSB) + NAIF-ID 变体。
         _cache_bodies = list(dict.fromkeys([*bodies, *_perturber_names]))

--- a/e2m2e/algorithm/design/design_orbit.py
+++ b/e2m2e/algorithm/design/design_orbit.py
@@ -830,19 +830,27 @@ def design_orbit(
             states_syn=state_patch_syn_n, t_syn_arr=t_patch_syn_n, et0=et0
         )
         per_rev = len(t_patch_syn_n) // n_rev  # 每圈节点数（NRHO 加密时非 8）
-        # 潮汐防御：effective_coefficients 的 body-fixed 位置裸调 cspice
-        # 未走星历缓存，tide=1 时放进并行打靶区会并发撞 cspice。本轮不支持
-        # 潮汐缓存 → 强制回退串行（E2M2E_MS_PARALLEL=0）。tide=0（main_design
-        # 默认）无此路径，可并行。
-        if sw["tide"] == 1 and verbose:
-            print("  提示: tide=1 未走星历缓存，打靶回退串行（潮汐缓存为后续扩展）")
         # 预采样星历缓存：打靶 + 逐段积分全程查三次样条表，不逐次调 cspice。
         # 这是 2 年 50 圈 × 每圈 8 节点 × 50 迭代打靶能跑完的关键（否则
         # 每步每力跨界查 SPICE，量级不可接受，且并发下触发 DAFFRNOTFOUND）。
         # 帧对覆盖 GravityField 的 body-fixed→J2000（地月非球形需要）。
+        # 潮汐扰动体对：effective_coefficients 查 (perturber, central_body)
+        # 在 J2000 的位置 + (input_frame, "J2000") 帧旋转，合成 body-fixed
+        # 位置。注册扰动体对确保 tide=1 下全程走缓存、零 cspice FFI。
         # try/finally：缓存是进程级单例，用完必须清除避免污染后续调用。
+        # 扰动体→中心天体对（与 Rust perturbers_for_body 一致）：
+        #   EARTH → [SUN, MOON]，MOON → [EARTH]。
+        _perturber_map = {"EARTH": ["SUN", "MOON"], "MOON": ["EARTH"]}
+        _perturber_names = {
+            p
+            for b in bodies
+            for p in _perturber_map.get(b.upper(), [])
+        }
+        # 合并：原 bodies + 扰动体中未包含的天体（如 SUN），
+        # enable_ephem_cache 自动注册 (name, observer) + (name, SSB) + NAIF-ID 变体。
+        _cache_bodies = list(dict.fromkeys([*bodies, *_perturber_names]))
         spice.enable_ephem_cache(
-            bodies,
+            _cache_bodies,
             et0,
             float(max(et_grid[-1], t_patch_j2000_n[-1])),
             dt=3600.0,
@@ -850,27 +858,21 @@ def design_orbit(
             frame_pairs=[("ITRF93", "J2000"), ("MOON_PA", "J2000")],
         )
         try:
-            if sw["tide"] == 1:
-                os.environ["E2M2E_MS_PARALLEL"] = "0"  # 潮汐未缓存 → 串行
-            try:
-                # 第 1 步段长（每组圈数）：段长与论文结构一致，段内圈数
-                # 控制在单圈量级（Halo 初猜在星历下第 1 圈就偏，段越短
-                # 初猜越贴真实动力学）。默认组内 3 圈，段多时自动增。
-                revs_per_group = max(1, min(3, n_rev))
-                t_patch_long, s_patch_long, max_residual = _design_apolune_segmented(
-                    forces_py,
-                    "EARTH",
-                    t_patch_j2000_n,
-                    state_patch_j2000_n,
-                    revs_per_group,
-                    per_rev,
-                    max_iter=50,
-                    tolerance=CORRECTION_TOL_KM,
-                    verbose=verbose,
-                )
-            finally:
-                if sw["tide"] == 1:
-                    os.environ.pop("E2M2E_MS_PARALLEL", None)
+            # 第 1 步段长（每组圈数）：段长与论文结构一致，段内圈数
+            # 控制在单圈量级（Halo 初猜在星历下第 1 圈就偏，段越短
+            # 初猜越贴真实动力学）。默认组内 3 圈，段多时自动增。
+            revs_per_group = max(1, min(3, n_rev))
+            t_patch_long, s_patch_long, max_residual = _design_apolune_segmented(
+                forces_py,
+                "EARTH",
+                t_patch_j2000_n,
+                state_patch_j2000_n,
+                revs_per_group,
+                per_rev,
+                max_iter=50,
+                tolerance=CORRECTION_TOL_KM,
+                verbose=verbose,
+            )
 
             # 逐段积分填满 et_grid：每段从修正后节点初值积分到下一节点
             states_list: list[np.ndarray] = []

--- a/tests/core/forces/test_rust_ephem_cache.py
+++ b/tests/core/forces/test_rust_ephem_cache.py
@@ -177,6 +177,4 @@ def test_ephem_cache_tide_solid_consistency(earth_system):
         disable_ephem_cache()
 
     diff = np.linalg.norm(state_cached - state_baseline)
-    assert diff < 1e-2, (
-        f"tide=1 缓存 vs 未缓存末态差异 {diff:.3e} km 超过 1e-2"
-    )
+    assert diff < 1e-2, f"tide=1 缓存 vs 未缓存末态差异 {diff:.3e} km 超过 1e-2"

--- a/tests/core/forces/test_rust_ephem_cache.py
+++ b/tests/core/forces/test_rust_ephem_cache.py
@@ -140,3 +140,43 @@ def test_ephem_cache_third_body_consistency(earth_system):
     # 1800s 网格下累积到 ~1 km 量级（月球 2 天走 ~7% 周期，插值误差较大）。
     # 这是三次样条插值的固有精度，非 bug；缩网格可降至任意精度。
     assert diff < 5.0, f"第三体缓存 vs 未缓存末态差异 {diff:.3e} km 超过 5.0"
+
+
+@pytest.mark.spice
+def test_ephem_cache_tide_solid_consistency(earth_system):
+    """tide=1(solid) 下缓存激活 vs 未激活，末态一致。
+
+    验证 effective_coefficients 的潮汐扰动体位置查询走 EphemCache 而非
+    裸调 cspice。注册扰动体对 (SUN, EARTH) + (MOON, EARTH) 后，
+    tide=1 的传播结果应与无缓存基线一致。
+    """
+    system = earth_system
+    gravity = GravityField("EARTH", degree=4, order=4, tide_mode="solid")
+    duration = 6 * 3600.0
+
+    # 未激活基线
+    state_baseline, et0 = _propagate_leo(system, [gravity], duration)
+
+    # 激活缓存：含扰动体 (SUN/MOON, EARTH) + 帧旋转 (ITRF93, J2000)
+    enable_ephem_cache(
+        [
+            ("EARTH", "SOLAR SYSTEM BARYCENTER"),
+            ("SUN", "EARTH"),
+            ("MOON", "EARTH"),
+            ("SUN", "SOLAR SYSTEM BARYCENTER"),
+            ("MOON", "SOLAR SYSTEM BARYCENTER"),
+        ],
+        [("ITRF93", "J2000")],
+        et0,
+        et0 + duration,
+        600.0,
+    )
+    try:
+        state_cached, _ = _propagate_leo(system, [gravity], duration)
+    finally:
+        disable_ephem_cache()
+
+    diff = np.linalg.norm(state_cached - state_baseline)
+    assert diff < 1e-2, (
+        f"tide=1 缓存 vs 未缓存末态差异 {diff:.3e} km 超过 1e-2"
+    )


### PR DESCRIPTION
Closes #267

## 改动

- **gravity_field.rs**:  潮汐扰动体位置查询从裸调  改为 EphemCache 样条查询（cache-first 模式），strict 模式下并行区零 cspice FFI
- **design_orbit.py**: 注册扰动体对  到星历缓存；移除  的 tide 串行回退 workaround
- **test_rust_ephem_cache.py**: 新增  测试

## 测试

-  ✅
-  ✅
- 27 gravity field tests ✅
- 25 earth tide tests ✅
- 5 Rust unit tests ✅
- SPICE integration tests 需 CI 环境（有 kernel 文件）