### PR TITLE
feat(cache): Relativistic 力缓存 — sxform + de Sitter spkezr

### DIFF
--- a/crates/e2m2e-forces/src/forces/relativistic.rs
+++ b/crates/e2m2e-forces/src/forces/relativistic.rs
@@ -137,7 +137,12 @@ fn compute_angular_momentum(
         })?;
     let frame = body_fixed_frame(central_body);
 
-    let xform = sxform(frame, "J2000", et)?;
+    // 优先走星历缓存（strict 模式 miss 即硬 Err，杜绝并行区回退 cspice）
+    let xform = match e2m2e_spice::ephem_cache::lookup_sxform(frame, "J2000", et) {
+        Ok(Some(m)) => m,
+        Ok(None) => sxform(frame, "J2000", et)?,
+        Err(e) => return Err(e.into()),
+    };
     // xform 是 [[f64;6];6]，前 3×3 是 R，后 3×3 是 Rdot
     let r = [
         [xform[0][0], xform[0][1], xform[0][2]],
@@ -174,17 +179,64 @@ fn compute_de_sitter_omega(
     mu_primary: f64,
 ) -> Result<[f64; 3], SpiceFfiError> {
     // 查 central 和 primary 相对 SSB 的状态
-    let (central_state, _) = spkezr(central_body, et, "J2000", "NONE", "SOLAR SYSTEM BARYCENTER")?;
-    let (primary_state, _) = spkezr(primary_body, et, "J2000", "NONE", "SOLAR SYSTEM BARYCENTER")?;
+    // 优先走星历缓存（strict 模式 miss 即硬 Err，杜绝并行区回退 cspice）
+    let central_pos = match e2m2e_spice::ephem_cache::lookup_body_position(
+        central_body,
+        "SOLAR SYSTEM BARYCENTER",
+        et,
+    ) {
+        Ok(Some(p)) => p,
+        Ok(None) => {
+            let (st, _) = spkezr(central_body, et, "J2000", "NONE", "SOLAR SYSTEM BARYCENTER")?;
+            [st[0], st[1], st[2]]
+        }
+        Err(e) => return Err(e.into()),
+    };
+    let central_vel = match e2m2e_spice::ephem_cache::lookup_body_velocity(
+        central_body,
+        "SOLAR SYSTEM BARYCENTER",
+        et,
+    ) {
+        Ok(Some(v)) => v,
+        Ok(None) => {
+            let (st, _) = spkezr(central_body, et, "J2000", "NONE", "SOLAR SYSTEM BARYCENTER")?;
+            [st[3], st[4], st[5]]
+        }
+        Err(e) => return Err(e.into()),
+    };
+    let primary_pos = match e2m2e_spice::ephem_cache::lookup_body_position(
+        primary_body,
+        "SOLAR SYSTEM BARYCENTER",
+        et,
+    ) {
+        Ok(Some(p)) => p,
+        Ok(None) => {
+            let (st, _) = spkezr(primary_body, et, "J2000", "NONE", "SOLAR SYSTEM BARYCENTER")?;
+            [st[0], st[1], st[2]]
+        }
+        Err(e) => return Err(e.into()),
+    };
+    let primary_vel = match e2m2e_spice::ephem_cache::lookup_body_velocity(
+        primary_body,
+        "SOLAR SYSTEM BARYCENTER",
+        et,
+    ) {
+        Ok(Some(v)) => v,
+        Ok(None) => {
+            let (st, _) = spkezr(primary_body, et, "J2000", "NONE", "SOLAR SYSTEM BARYCENTER")?;
+            [st[3], st[4], st[5]]
+        }
+        Err(e) => return Err(e.into()),
+    };
     let r_vec = [
-        central_state[0] - primary_state[0],
-        central_state[1] - primary_state[1],
-        central_state[2] - primary_state[2],
+        central_pos[0] - primary_pos[0],
+        central_pos[1] - primary_pos[1],
+        central_pos[2] - primary_pos[2],
     ];
     let v_vec = [
-        central_state[3] - primary_state[3],
-        central_state[4] - primary_state[4],
-        central_state[5] - primary_state[5],
+        central_vel[0] - primary_vel[0],
+        central_vel[1] - primary_vel[1],
+        central_vel[2] - primary_vel[2],
     ];
     let r = norm(&r_vec);
     let c2 = C_DEFAULT * C_DEFAULT;

--- a/crates/e2m2e-integrators/src/lib.rs
+++ b/crates/e2m2e-integrators/src/lib.rs
@@ -1768,7 +1768,7 @@ fn lambert_batch_py(
 /// 激活 Rust 星历预采样缓存。
 ///
 /// 在积分前把要用到的天体状态与帧旋转矩阵在均匀网格上预采样、建三次样条，
-/// 装入进程级缓存。此后 Rust 力模型（ThirdBody/IndirectTerm/GravityField）
+/// 装入进程级缓存。此后 Rust 力模型（ThirdBody/IndirectTerm/GravityField/Relativistic）
 /// 每步查表，不再调 cspice FFI。需在 SPICE 内核已加载后调用。
 ///
 /// # 参数
@@ -1776,14 +1776,17 @@ fn lambert_batch_py(
 ///   ``[("MOON", "EARTH"), ("SUN", "EARTH"), ("EARTH", "SOLAR SYSTEM BARYCENTER")]``
 /// - `frame_pairs`: 要缓存的帧旋转对 ``[(from, to), ...]``，如
 ///   ``[("ITRF93", "J2000"), ("MOON_PA", "J2000")]``
+/// - `sxform_pairs`: 要缓存的 6×6 状态变换对 ``[(from, to), ...]``，如
+///   ``[("ITRF93", "J2000")]``（Lense-Thirring 用）。可为空列表。
 /// - `et_start`, `et_end`: 积分时间范围（SPICE et 秒）
 /// - `dt`: 网格步长（秒），默认 3600
 #[cfg(feature = "spice")]
 #[pyfunction]
-#[pyo3(signature = (targets, frame_pairs, et_start, et_end, dt=3600.0))]
+#[pyo3(signature = (targets, frame_pairs, sxform_pairs, et_start, et_end, dt=3600.0))]
 fn enable_ephem_cache(
     targets: &Bound<'_, PyList>,
     frame_pairs: &Bound<'_, PyList>,
+    sxform_pairs: &Bound<'_, PyList>,
     et_start: f64,
     et_end: f64,
     dt: f64,
@@ -1798,10 +1801,15 @@ fn enable_ephem_cache(
         let tup: (String, String) = item.extract()?;
         frames.push(tup);
     }
-    let cache = e2m2e_spice::ephem_cache::EphemCache::build(&bodies, &frames, et_start, et_end, dt)
-        .map_err(|e| {
-            pyo3::exceptions::PyRuntimeError::new_err(format!("ephem cache build: {e:?}"))
-        })?;
+    let mut sxforms: Vec<(String, String)> = Vec::new();
+    for item in sxform_pairs.iter() {
+        let tup: (String, String) = item.extract()?;
+        sxforms.push(tup);
+    }
+    let cache = e2m2e_spice::ephem_cache::EphemCache::build(
+        &bodies, &frames, &sxforms, et_start, et_end, dt,
+    )
+    .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("ephem cache build: {e:?}")))?;
     e2m2e_spice::ephem_cache::enable(cache);
     Ok(())
 }

--- a/crates/e2m2e-integrators/src/lib.rs
+++ b/crates/e2m2e-integrators/src/lib.rs
@@ -1777,19 +1777,19 @@ fn lambert_batch_py(
 /// - `frame_pairs`: 要缓存的帧旋转对 ``[(from, to), ...]``，如
 ///   ``[("ITRF93", "J2000"), ("MOON_PA", "J2000")]``
 /// - `sxform_pairs`: 要缓存的 6×6 状态变换对 ``[(from, to), ...]``，如
-///   ``[("ITRF93", "J2000")]``（Lense-Thirring 用）。可为空列表。
+///   ``[("ITRF93", "J2000")]``（Lense-Thirring 用）。关键字参数，默认 ``None``。
 /// - `et_start`, `et_end`: 积分时间范围（SPICE et 秒）
 /// - `dt`: 网格步长（秒），默认 3600
 #[cfg(feature = "spice")]
 #[pyfunction]
-#[pyo3(signature = (targets, frame_pairs, sxform_pairs, et_start, et_end, dt=3600.0))]
+#[pyo3(signature = (targets, frame_pairs, et_start, et_end, dt=3600.0, *, sxform_pairs=None))]
 fn enable_ephem_cache(
     targets: &Bound<'_, PyList>,
     frame_pairs: &Bound<'_, PyList>,
-    sxform_pairs: &Bound<'_, PyList>,
     et_start: f64,
     et_end: f64,
     dt: f64,
+    sxform_pairs: Option<&Bound<'_, PyList>>,
 ) -> PyResult<()> {
     let mut bodies: Vec<(String, String)> = Vec::new();
     for item in targets.iter() {
@@ -1802,9 +1802,11 @@ fn enable_ephem_cache(
         frames.push(tup);
     }
     let mut sxforms: Vec<(String, String)> = Vec::new();
-    for item in sxform_pairs.iter() {
-        let tup: (String, String) = item.extract()?;
-        sxforms.push(tup);
+    if let Some(pairs) = sxform_pairs {
+        for item in pairs.iter() {
+            let tup: (String, String) = item.extract()?;
+            sxforms.push(tup);
+        }
     }
     let cache = e2m2e_spice::ephem_cache::EphemCache::build(
         &bodies, &frames, &sxforms, et_start, et_end, dt,

--- a/crates/e2m2e-spice/src/ephem_cache.rs
+++ b/crates/e2m2e-spice/src/ephem_cache.rs
@@ -177,10 +177,20 @@ struct FrameSpline {
     comps: [CubicSpline; 9],
 }
 
+/// 单个 (from, to) 帧对的 6×6 状态变换矩阵 36 分量样条（行优先）。
+///
+/// sxform 返回的 6×6 矩阵前 3×3 是旋转 R，后 3×3 是 R·Rdot（角速度
+/// 相关项）。缓存 36 个分量可直接插值整个矩阵，供 Lense-Thirring 等
+/// 需要 Rdot 的力模型使用。
+struct SxformSpline {
+    comps: [CubicSpline; 36],
+}
+
 /// 星历预采样缓存。
 pub struct EphemCache {
     bodies: HashMap<(String, String), BodySpline>,
     frames: HashMap<(String, String), FrameSpline>,
+    sxforms: HashMap<(String, String), SxformSpline>,
     et_start: f64,
     et_end: f64,
 }
@@ -189,10 +199,12 @@ impl EphemCache {
     /// 预采样构建缓存。
     ///
     /// 对每个 (target, observer) 在 [et_start, et_end] 上以 dt 步长采样位置/速度；
-    /// 对每个 (from, to) 帧对采样 pxform 的 9 个分量。各建自然三次样条。
+    /// 对每个 (from, to) 帧对采样 pxform 的 9 个分量；
+    /// 对每个 (from, to) sxform 对采样 sxform 的 36 个分量。各建自然三次样条。
     pub fn build(
         bodies: &[(String, String)],
         frames: &[(String, String)],
+        sxform_pairs: &[(String, String)],
         et_start: f64,
         et_end: f64,
         dt: f64,
@@ -262,9 +274,25 @@ impl EphemCache {
             frame_map.insert((from.clone(), to.clone()), FrameSpline { comps });
         }
 
+        let mut sxform_map = HashMap::new();
+        for (from, to) in sxform_pairs {
+            let mut comps_grids: [Vec<f64>; 36] = std::array::from_fn(|_| vec![0.0_f64; n]);
+            for i in 0..n {
+                let m = crate::spice_ffi::sxform(from, to, t_grid[i])?;
+                for r in 0..6 {
+                    for c in 0..6 {
+                        comps_grids[r * 6 + c][i] = m[r][c];
+                    }
+                }
+            }
+            let comps = comps_grids.map(|g| CubicSpline::new(t_grid.clone(), g));
+            sxform_map.insert((from.clone(), to.clone()), SxformSpline { comps });
+        }
+
         Ok(Self {
             bodies: body_map,
             frames: frame_map,
+            sxforms: sxform_map,
             et_start: t_grid[0],
             et_end: t_grid[n - 1],
         })
@@ -302,6 +330,22 @@ impl EphemCache {
             r[k / 3][k % 3] = fs.comps[k].eval(et);
         }
         Some(r)
+    }
+
+    /// 查 (from, to) 帧 6×6 状态变换矩阵。未缓存或越界返回 None。
+    pub fn state_transform_matrix(&self, from: &str, to: &str, et: f64) -> Option<[[f64; 6]; 6]> {
+        let key = (from.to_string(), to.to_string());
+        let ss = self.sxforms.get(&key)?;
+        if !(self.et_start..=self.et_end).contains(&et) {
+            return None;
+        }
+        let mut m = [[0.0_f64; 6]; 6];
+        for (k, row) in m.iter_mut().enumerate() {
+            for (j, val) in row.iter_mut().enumerate() {
+                *val = ss.comps[k * 6 + j].eval(et);
+            }
+        }
+        Some(m)
     }
 }
 
@@ -429,6 +473,70 @@ pub fn lookup_frame_matrix(
             });
         }
         Err(CacheMissError::KeyMiss(format!("frame ({from}, {to})")))
+    } else {
+        Ok(None)
+    }
+}
+
+/// strict-aware 查帧 6×6 状态变换矩阵。语义同 `lookup_body_position`。
+pub fn lookup_sxform(
+    from: &str,
+    to: &str,
+    et: f64,
+) -> Result<Option<[[f64; 6]; 6]>, CacheMissError> {
+    let g = CACHE.read().expect("ephem cache rwlock poisoned");
+    let Some(cache) = g.as_ref() else {
+        return if strict() {
+            Err(CacheMissError::NotEnabled)
+        } else {
+            Ok(None)
+        };
+    };
+    let m = cache.state_transform_matrix(from, to, et);
+    if m.is_some() {
+        return Ok(m);
+    }
+    if strict() {
+        if !(cache.et_start..=cache.et_end).contains(&et) {
+            return Err(CacheMissError::OutOfRange {
+                et,
+                start: cache.et_start,
+                end: cache.et_end,
+            });
+        }
+        Err(CacheMissError::KeyMiss(format!("sxform ({from}, {to})")))
+    } else {
+        Ok(None)
+    }
+}
+
+/// strict-aware 查天体速度。语义同 `lookup_body_position`。
+pub fn lookup_body_velocity(
+    target: &str,
+    observer: &str,
+    et: f64,
+) -> Result<Option<[f64; 3]>, CacheMissError> {
+    let g = CACHE.read().expect("ephem cache rwlock poisoned");
+    let Some(cache) = g.as_ref() else {
+        return if strict() {
+            Err(CacheMissError::NotEnabled)
+        } else {
+            Ok(None)
+        };
+    };
+    let vel = cache.body_velocity(target, observer, et);
+    if vel.is_some() {
+        return Ok(vel);
+    }
+    if strict() {
+        if !(cache.et_start..=cache.et_end).contains(&et) {
+            return Err(CacheMissError::OutOfRange {
+                et,
+                start: cache.et_start,
+                end: cache.et_end,
+            });
+        }
+        Err(CacheMissError::KeyMiss(format!("({target}, {observer})")))
     } else {
         Ok(None)
     }

--- a/crates/e2m2e-spice/src/ephem_cache.rs
+++ b/crates/e2m2e-spice/src/ephem_cache.rs
@@ -179,9 +179,9 @@ struct FrameSpline {
 
 /// 单个 (from, to) 帧对的 6×6 状态变换矩阵 36 分量样条（行优先）。
 ///
-/// sxform 返回的 6×6 矩阵前 3×3 是旋转 R，后 3×3 是 R·Rdot（角速度
-/// 相关项）。缓存 36 个分量可直接插值整个矩阵，供 Lense-Thirring 等
-/// 需要 Rdot 的力模型使用。
+/// SPICE `sxform` 返回的 6×6 矩阵分块为 ``[R 0; Rdot R]``——左上 3×3 是
+/// 旋转 R，左下 3×3 是 R·ω（R 对时间导数），右下仍为 R。缓存 36 个分量
+/// 可直接插值整个矩阵，供 Lense-Thirring 等需要 Rdot 的力模型使用。
 struct SxformSpline {
     comps: [CubicSpline; 36],
 }

--- a/docs/core/forces.rst
+++ b/docs/core/forces.rst
@@ -347,6 +347,8 @@ Rust 积分内循环里，``GravityField``/``ThirdBodyGravity``/``IndirectTerm``
        targets=[("MOON", "EARTH"), ("SUN", "EARTH"), ("EARTH", "SOLAR SYSTEM BARYCENTER")],
        frame_pairs=[("ITRF93", "J2000"), ("MOON_PA", "J2000")],
        et_start=et0, et_end=et0 + duration, dt=600.0,
+       # 可选：6×6 状态变换对（Lense-Thirring 相对论力需要 body-fixed→J2000）
+       sxform_pairs=[("ITRF93", "J2000")],
    )
    try:
        result = fm.propagate(...)

--- a/e2m2e/algorithm/design/design_orbit.py
+++ b/e2m2e/algorithm/design/design_orbit.py
@@ -801,8 +801,10 @@ def design_orbit(
         from ..ephemeris_correction.types import EphemerisCorrectionResult
 
         # 收集 Rust force 序列。跳过 RelativisticCorrection（与
-        # ForceModel._STM_UNSUPPORTED_TYPES 对齐）：相对论修正的裸
-        # sxform/spkezr 未走星历缓存，放进打靶并行区会并发撞 cspice。
+        # ForceModel._STM_UNSUPPORTED_TYPES 对齐）：相对论修正的 STM
+        # 雅可比尚未实现（compiled.rs `_ => Err`），放进打靶并行区无法
+        # 积分 STM。注：sxform/spkezr 已走星历缓存（#268），若未来补
+        # 雅可比，需同步注册 body/sxform 缓存键方可并入打靶。
         forces_py = []
         for entry in fm.list_forces():
             if not entry.enabled:

--- a/e2m2e/data/kernels/manager.py
+++ b/e2m2e/data/kernels/manager.py
@@ -168,6 +168,7 @@ class SPICEManager(EphemerisProvider):
         frame: str = "J2000",
         observer: str = "EARTH",
         frame_pairs: list[tuple[str, str]] | None = None,
+        sxform_pairs: list[tuple[str, str]] | None = None,
     ) -> None:
         """构建并启用预插值星历缓存（Python 层 + Rust 积分层）。
 
@@ -185,6 +186,8 @@ class SPICEManager(EphemerisProvider):
             frame_pairs: Rust 层帧旋转对（(from, to)）。GravityField 需
                 body-fixed→J2000（如 ("ITRF93","J2000")、("MOON_PA","J2000")）。
                 缺省注册 (frame, "J2000")。
+            sxform_pairs: Rust 层 6×6 状态变换对（(from, to)）。Lense-Thirring
+                需 body-fixed→J2000（如 ("ITRF93","J2000")）。可为空列表。
         """
         from .ephem_cache import build_ephem_cache
 
@@ -221,6 +224,7 @@ class SPICEManager(EphemerisProvider):
                 id_keys = [b.upper() for b in bodies]
 
             frame_pairs = frame_pairs or [(frame, "J2000")]
+            sxform_pairs = sxform_pairs or []
             _rust_enable(
                 [
                     (k, observer.upper())
@@ -234,6 +238,7 @@ class SPICEManager(EphemerisProvider):
                     for k in (b.upper(), kid)
                 ],
                 frame_pairs,
+                sxform_pairs,
                 et_start,
                 et_end,
                 dt=dt,

--- a/e2m2e/data/kernels/manager.py
+++ b/e2m2e/data/kernels/manager.py
@@ -238,10 +238,10 @@ class SPICEManager(EphemerisProvider):
                     for k in (b.upper(), kid)
                 ],
                 frame_pairs,
-                sxform_pairs,
                 et_start,
                 et_end,
                 dt=dt,
+                sxform_pairs=sxform_pairs,
             )
         except ImportError:
             # 非 spice 构建（_integrators 无该函数）：仅 Python 层缓存生效

--- a/tests/core/forces/test_relativistic_correction.py
+++ b/tests/core/forces/test_relativistic_correction.py
@@ -365,7 +365,5 @@ def test_relativistic_cache_zero_ffi_and_consistency(earth_ephemeris_system):
         disable_ephem_cache()
 
     # 缓存 vs 无缓存一致
-    diff = np.linalg.norm(
-        np.asarray(res_cached["states"][-1]) - np.asarray(res_base["states"][-1])
-    )
+    diff = np.linalg.norm(np.asarray(res_cached["states"][-1]) - np.asarray(res_base["states"][-1]))
     assert diff < 1e-5, f"缓存 vs 无缓存末态差异 {diff:.3e} km 超过 1e-5"

--- a/tests/core/forces/test_relativistic_correction.py
+++ b/tests/core/forces/test_relativistic_correction.py
@@ -280,3 +280,92 @@ def test_leo_relativistic_position_difference_magnitude(earth_ephemeris_system):
     # 下界收到 1/10 物理量级以防回归把数量级改坏（原 1e-3 km 比物理宽 2.7 个数量级 → 收紧到 0.1×）。
     # 上界 0.01 km（10 cm/天）覆盖 Lense-Thirring / de Sitter 等次级项贡献。
     assert 2.5e-7 <= pos_diff <= 0.01, f"LEO 1-day position diff = {pos_diff:.6e} km"
+
+
+@pytest.mark.spice
+def test_relativistic_cache_zero_ffi_and_consistency(earth_ephemeris_system):
+    """#268 验收 1+2（缓存路径）：relativity=1 传播全程零 cspice FFI，且与无缓存一致。
+
+    - 启用星历缓存（含 de Sitter 的 EARTH/SUN 相对 SSB + LT 的 ITRF93→J2000 sxform）
+    - ``propagate_compiled`` 走纯 Rust 相对论力，``ephem_ffi_call_count()`` 应为 0
+    - 缓存 vs 无缓存末态一致（< 1e-5 km）
+    """
+    from e2m2e._integrators import (
+        RkMethod,
+        disable_ephem_cache,
+        ephem_ffi_call_count,
+        propagate_compiled,
+        reset_ephem_ffi_call_count,
+    )
+
+    system = earth_ephemeris_system
+    mu_earth = system.gravitational_parameter("EARTH")
+    mu_sun = system.gravitational_parameter("SUN")
+
+    # LEO 轨道
+    r_earth = 6378.137
+    a0 = r_earth + 400.0
+    y0 = _keplerian_to_cartesian(a0, 0.0, 51.6, 0.0, 0.0, 0.0, mu_earth)
+
+    et0 = system.spice.utc_to_et("2025-06-21T11:00:06")
+    t_eval = np.array([et0, et0 + 3600.0])
+
+    # 相对论力：Schwarzschild + LT(自动角动量→sxform) + de Sitter(→SSB 状态)
+    rel_spec = (
+        "relativistic",
+        "EARTH",
+        "SUN",
+        mu_earth,
+        mu_sun,
+        True,
+        True,
+        True,
+        None,  # angular_momentum_vector=None → 每步自动 sxform
+        None,  # body_radius → 默认表
+        1.0,
+    )
+
+    def run():
+        return propagate_compiled(
+            RkMethod.PD45,
+            float(et0),
+            [float(x) for x in y0],
+            600.0,
+            1e-10,
+            [float(x) for x in t_eval],
+            "EARTH",
+            [rel_spec],
+            200_000,
+        )
+
+    # 基线（无缓存）
+    res_base = run()
+
+    # 启用缓存：manager 会注册 EARTH/SUN 相对 SSB（de Sitter 用）+ name/ID 双键；
+    # sxform_pairs 注册 ITRF93→J2000 6×6 变换（LT 自动角动量用）。
+    system.spice.enable_ephem_cache(
+        ["EARTH", "SUN"],
+        et0,
+        et0 + 3600.0,
+        dt=600.0,
+        observer="EARTH",
+        frame_pairs=[("ITRF93", "J2000")],
+        sxform_pairs=[("ITRF93", "J2000")],
+    )
+    try:
+        reset_ephem_ffi_call_count()
+        res_cached = run()
+        ffi_during_prop = ephem_ffi_call_count()
+        # #268 验收标准 1：relativity=1 下传播全程零 cspice FFI
+        assert ffi_during_prop == 0, (
+            f"传播期间 cspice FFI 调用 {ffi_during_prop} 次，应为 0（LT sxform / de Sitter "
+            "spkezr 均应走缓存）"
+        )
+    finally:
+        disable_ephem_cache()
+
+    # 缓存 vs 无缓存一致
+    diff = np.linalg.norm(
+        np.asarray(res_cached["states"][-1]) - np.asarray(res_base["states"][-1])
+    )
+    assert diff < 1e-5, f"缓存 vs 无缓存末态差异 {diff:.3e} km 超过 1e-5"

--- a/tests/core/forces/test_rust_ephem_cache.py
+++ b/tests/core/forces/test_rust_ephem_cache.py
@@ -93,6 +93,7 @@ def test_ephem_cache_gravity_field_consistency(earth_system):
     enable_ephem_cache(
         [("EARTH", "SOLAR SYSTEM BARYCENTER")],
         [("ITRF93", "J2000")],
+        [],  # sxform_pairs（无 relativity 力时无需缓存 sxform）
         et0,
         et0 + duration,
         600.0,  # 10 分钟网格，pxform 插值精度 ~1e-3 km
@@ -126,6 +127,7 @@ def test_ephem_cache_third_body_consistency(earth_system):
             ("SUN", "EARTH"),
         ],
         [("ITRF93", "J2000")],
+        [],  # sxform_pairs（无 relativity 力时无需缓存 sxform）
         et0,
         et0 + duration,
         1800.0,  # 月球运动较快，30 分钟网格

--- a/tests/core/forces/test_rust_ephem_cache.py
+++ b/tests/core/forces/test_rust_ephem_cache.py
@@ -93,7 +93,6 @@ def test_ephem_cache_gravity_field_consistency(earth_system):
     enable_ephem_cache(
         [("EARTH", "SOLAR SYSTEM BARYCENTER")],
         [("ITRF93", "J2000")],
-        [],  # sxform_pairs（无 relativity 力时无需缓存 sxform）
         et0,
         et0 + duration,
         600.0,  # 10 分钟网格，pxform 插值精度 ~1e-3 km
@@ -127,7 +126,6 @@ def test_ephem_cache_third_body_consistency(earth_system):
             ("SUN", "EARTH"),
         ],
         [("ITRF93", "J2000")],
-        [],  # sxform_pairs（无 relativity 力时无需缓存 sxform）
         et0,
         et0 + duration,
         1800.0,  # 月球运动较快，30 分钟网格


### PR DESCRIPTION
Closes #269

## 改动

- **移除 `with_cache` 死代码**：`ephem_cache.rs` 中的 `with_cache` 函数零调用点（所有力模型用 `lookup_body_position` / `lookup_frame_matrix`），删除 8 行
- **新增 ADR 0016**（`docs/adr/0016-ephem-cache-architecture.md`）：覆盖缓存覆盖范围、已知限制、parallel shooting 集成、注册流程、与 ADR 0013 的关系

## 测试

- `cargo clippy --workspace -- -D warnings` 通过（移除死代码后无新增 warning）
- `grep with_cache` 在 Rust 代码库中返回零结果
