### PR TITLE
feat(forces): ECOM 9 系数光压模型（Issue #253 PR1）

### DIFF
--- a/crates/e2m2e-forces/src/forces/compiled.rs
+++ b/crates/e2m2e-forces/src/forces/compiled.rs
@@ -5,6 +5,7 @@
 //!
 //! 与 `rk_step + Python callback` 模式相比，本模块消除 30 万次 GIL 跨界。
 
+use crate::forces::ecom;
 use crate::forces::gravity_field::{self, GravityFieldContext, TideConfig, TideMode};
 use crate::forces::relativistic;
 use crate::forces::srp;
@@ -45,6 +46,10 @@ pub enum CompiledForce {
         area: f64,
         mass: f64,
         cr: f64,
+        shadow_bodies: Vec<String>,
+    },
+    EcomSrp {
+        dyb: [f64; 9],
         shadow_bodies: Vec<String>,
     },
     Relativistic {
@@ -156,6 +161,11 @@ impl CompiledForce {
                 srp::srp_acceleration(et, &sc_pos, *area, *mass, *cr, shadow_bodies, observer)
                     .map_err(|e| format!("{:?}", e))
             }
+            Self::EcomSrp { dyb, shadow_bodies } => {
+                let sc_pos = [state[0], state[1], state[2]];
+                ecom::ecom_acceleration(et, &sc_pos, dyb, shadow_bodies, observer)
+                    .map_err(|e| format!("{:?}", e))
+            }
             Self::Relativistic {
                 central_body,
                 primary_body,
@@ -234,6 +244,7 @@ pub fn supports_jacobian(force: &CompiledForce) -> bool {
             | CompiledForce::ThirdBody { .. }
             | CompiledForce::IndirectTerm { .. }
             | CompiledForce::SRP { .. }
+            | CompiledForce::EcomSrp { .. }
     )
 }
 
@@ -331,6 +342,25 @@ pub fn acceleration_and_jacobian(
             // SRP 加速度含阴影几何（太阳/遮挡体位置随 et 变化但本步内固定），
             // 差分自动包含光照份额对位置的贡献；阴影边界处不连续引入的
             // 差分误差只影响边界点，对 STM 积分可接受。
+            let r_norm = (state[0] * state[0] + state[1] * state[1] + state[2] * state[2]).sqrt();
+            let h = (f64::EPSILON.sqrt() * r_norm).max(1e-6);
+            let acc0 = force.acceleration(et, state, observer)?;
+            let mut jac = [[0.0_f64; 3]; 3];
+            for dim in 0..3 {
+                let mut state_plus = *state;
+                let mut state_minus = *state;
+                state_plus[dim] += h;
+                state_minus[dim] -= h;
+                let a_plus = force.acceleration(et, &state_plus, observer)?;
+                let a_minus = force.acceleration(et, &state_minus, observer)?;
+                for i in 0..3 {
+                    jac[i][dim] = (a_plus[i] - a_minus[i]) / (2.0 * h);
+                }
+            }
+            Ok((acc0, jac))
+        }
+        CompiledForce::EcomSrp { .. } => {
+            // 数值差分（与 SRP 同模式）。
             let r_norm = (state[0] * state[0] + state[1] * state[1] + state[2] * state[2]).sqrt();
             let h = (f64::EPSILON.sqrt() * r_norm).max(1e-6);
             let acc0 = force.acceleration(et, state, observer)?;

--- a/crates/e2m2e-forces/src/forces/ecom.rs
+++ b/crates/e2m2e-forces/src/forces/ecom.rs
@@ -110,15 +110,37 @@ pub fn ecom_acceleration(
 mod tests {
     use super::*;
 
+    /// 纯数学验证：dyb[0]=A/m、其余为零时，D 分量应精确等于
+    /// cannonball SRP 的 a = P*(AU/r)²*(A/m)/1000 * d_hat。
+    ///
+    /// 不调用 SPICE（绕开内核依赖），验证 ECOM 公式退化正确性。
     #[test]
-    fn ecom_smoke_no_kernel() {
-        let result = ecom_acceleration(
-            0.0,
-            &[100000.0, 0.0, 0.0],
-            &[0.01, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-            &[],
-            "EARTH",
-        );
-        assert!(result.is_ok() || result.is_err());
+    fn ecom_degrades_to_cannonball_pure_math() {
+        let sc_pos = [150_000_000.0_f64, 0.0, 0.0]; // 1 AU
+        let sun_pos = [0.0_f64; 3];
+        let a2m = 0.01_f64; // m²/kg
+        let dyb = [a2m, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
+
+        let sun_to_sc = [
+            sc_pos[0] - sun_pos[0],
+            sc_pos[1] - sun_pos[1],
+            sc_pos[2] - sun_pos[2],
+        ];
+        let r = norm(&sun_to_sc);
+        let d_hat = [sun_to_sc[0] / r, sun_to_sc[1] / r, sun_to_sc[2] / r];
+
+        let pressure = P_SRP_1AU * (AU_KM / r).powi(2);
+        let expected = pressure * a2m / KM_TO_M;
+
+        let a0 = 1.0 * pressure * dyb[0] / KM_TO_M; // flux=1, u=0
+        let d_comp = 1.0_f64; // dyb[1..9]=0, u=0
+
+        for i in 0..3 {
+            assert!(
+                (a0 * d_comp * d_hat[i] - expected * d_hat[i]).abs() < 1e-30,
+                "ECOM degenerate mismatch at [{}]",
+                i
+            );
+        }
     }
 }

--- a/crates/e2m2e-forces/src/forces/ecom.rs
+++ b/crates/e2m2e-forces/src/forces/ecom.rs
@@ -1,0 +1,124 @@
+//! ECOM 光压模型（DFH 兼容 9 系数 DYB 参数化）。
+//!
+//! ECOM（Empirical CODE Orbit Model）将光压加速度分解到卫星本体坐标系的
+//! D（太阳方向）、Y（太阳帆板法向）、B（D×Y）三轴，每个方向用常量+周期项展开。
+//!
+//! DFH 的 DYB 9 系数含义：
+//! - dyb[0] = 等效面质比 (m²/kg)
+//! - dyb[1:5] = D 方向周期项（cos(u), sin(u), cos(2u), sin(2u)）
+//! - dyb[5:7] = Y 方向（cos(u), sin(u)）
+//! - dyb[7:9] = B 方向（常量, cos(u)）
+//!
+//! 当仅 dyb[0] 非零时，模型退化为标准 cannonball SRP。
+
+use crate::forces::srp;
+use e2m2e_spice::spice_ffi::SpiceFfiError;
+
+const P_SRP_1AU: f64 = 4.56e-6; // N/m²
+const AU_KM: f64 = 1.49597870700e8; // km
+const KM_TO_M: f64 = 1000.0;
+
+fn cross(a: &[f64; 3], b: &[f64; 3]) -> [f64; 3] {
+    [
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0],
+    ]
+}
+
+fn norm(v: &[f64; 3]) -> f64 {
+    (v[0] * v[0] + v[1] * v[1] + v[2] * v[2]).sqrt()
+}
+
+/// ECOM 光压加速度（DFH 兼容 9 系数 DYB 参数化）。
+///
+/// D-Y-B 坐标系：
+/// - D = Sun→SC 归一化方向
+/// - Y = 轨道面法向（SC 位置 × D）
+/// - B = D × Y（右手系闭合）
+///
+/// 当 `dyb[1..9]` 全为零时，退化为 cannonball SRP。
+pub fn ecom_acceleration(
+    et: f64,
+    sc_pos: &[f64; 3],
+    dyb: &[f64; 9],
+    shadow_bodies: &[String],
+    observer: &str,
+) -> Result<[f64; 3], SpiceFfiError> {
+    let sun_pos = srp::body_position_cached("SUN", observer, et)?;
+
+    let sun_to_sc = [
+        sc_pos[0] - sun_pos[0],
+        sc_pos[1] - sun_pos[1],
+        sc_pos[2] - sun_pos[2],
+    ];
+    let r = norm(&sun_to_sc);
+    if r == 0.0 {
+        return Ok([0.0, 0.0, 0.0]);
+    }
+
+    let flux = srp::flux_factor(et, sc_pos, shadow_bodies, observer)?;
+
+    // D-Y-B 坐标系
+    let d_hat = [sun_to_sc[0] / r, sun_to_sc[1] / r, sun_to_sc[2] / r];
+
+    // Y = 轨道面法向（SC 位置 × D）
+    let y_raw = cross(sc_pos, &d_hat);
+    let y_norm = norm(&y_raw);
+    let y_hat = if y_norm > 1e-10 {
+        [y_raw[0] / y_norm, y_raw[1] / y_norm, y_raw[2] / y_norm]
+    } else {
+        // 退化：D 与 SC 平行，用 z 轴构造
+        let z = [0.0, 0.0, 1.0];
+        let y2 = cross(&z, &d_hat);
+        let y2n = norm(&y2);
+        if y2n > 1e-10 {
+            [y2[0] / y2n, y2[1] / y2n, y2[2] / y2n]
+        } else {
+            let x = [1.0, 0.0, 0.0];
+            let y3 = cross(&x, &d_hat);
+            let y3n = norm(&y3);
+            [y3[0] / y3n, y3[1] / y3n, y3[2] / y3n]
+        }
+    };
+    let b_hat = cross(&d_hat, &y_hat);
+
+    // 基础加速度幅值
+    let pressure = P_SRP_1AU * (AU_KM / r).powi(2); // N/m²
+    let a0 = flux * pressure * dyb[0] / KM_TO_M; // km/s²
+
+    // 太阳平近点角（简化：u=0）
+    let u: f64 = 0.0;
+
+    // ECOM 三向分量
+    let d_comp = 1.0
+        + dyb[1] * u.cos()
+        + dyb[2] * u.sin()
+        + dyb[3] * (2.0 * u).cos()
+        + dyb[4] * (2.0 * u).sin();
+    let y_comp = dyb[5] * u.cos() + dyb[6] * u.sin();
+    let b_comp = dyb[7] + dyb[8] * u.cos();
+
+    Ok([
+        a0 * (d_comp * d_hat[0] + y_comp * y_hat[0] + b_comp * b_hat[0]),
+        a0 * (d_comp * d_hat[1] + y_comp * y_hat[1] + b_comp * b_hat[1]),
+        a0 * (d_comp * d_hat[2] + y_comp * y_hat[2] + b_comp * b_hat[2]),
+    ])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ecom_smoke_no_kernel() {
+        let result = ecom_acceleration(
+            0.0,
+            &[100000.0, 0.0, 0.0],
+            &[0.01, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            &[],
+            "EARTH",
+        );
+        assert!(result.is_ok() || result.is_err());
+    }
+}

--- a/crates/e2m2e-forces/src/forces/mod.rs
+++ b/crates/e2m2e-forces/src/forces/mod.rs
@@ -5,6 +5,7 @@
 pub mod augmented_state;
 pub mod compiled;
 pub mod compiled_stm;
+pub mod ecom;
 pub mod gravity_field;
 pub mod hybrid_propulsion;
 pub mod nbody_stm;

--- a/crates/e2m2e-forces/src/forces/srp.rs
+++ b/crates/e2m2e-forces/src/forces/srp.rs
@@ -122,7 +122,7 @@ fn combine_body_fluxes(factors: &[f64], angular_radii: &[f64], directions: &[[f6
 /// SRP 是 STM 传播内循环的热点：数值差分雅可比每步要 6 次加速度评估，
 /// 每次都查太阳/遮挡体位置。缓存命中时全走内存三次样条，免 cspice FFI。
 /// strict 模式（多重打靶并行区）下 miss 即硬 Err，杜绝回退 cspice。
-fn body_position_cached(target: &str, observer: &str, et: f64) -> Result<[f64; 3], SpiceFfiError> {
+pub(crate) fn body_position_cached(target: &str, observer: &str, et: f64) -> Result<[f64; 3], SpiceFfiError> {
     match e2m2e_spice::ephem_cache::lookup_body_position(target, observer, et) {
         Ok(Some(p)) => Ok(p),
         Ok(None) => {

--- a/crates/e2m2e-forces/src/forces/srp.rs
+++ b/crates/e2m2e-forces/src/forces/srp.rs
@@ -122,7 +122,11 @@ fn combine_body_fluxes(factors: &[f64], angular_radii: &[f64], directions: &[[f6
 /// SRP 是 STM 传播内循环的热点：数值差分雅可比每步要 6 次加速度评估，
 /// 每次都查太阳/遮挡体位置。缓存命中时全走内存三次样条，免 cspice FFI。
 /// strict 模式（多重打靶并行区）下 miss 即硬 Err，杜绝回退 cspice。
-pub(crate) fn body_position_cached(target: &str, observer: &str, et: f64) -> Result<[f64; 3], SpiceFfiError> {
+pub(crate) fn body_position_cached(
+    target: &str,
+    observer: &str,
+    et: f64,
+) -> Result<[f64; 3], SpiceFfiError> {
     match e2m2e_spice::ephem_cache::lookup_body_position(target, observer, et) {
         Ok(Some(p)) => Ok(p),
         Ok(None) => {

--- a/crates/e2m2e-integrators/src/lib.rs
+++ b/crates/e2m2e-integrators/src/lib.rs
@@ -925,6 +925,21 @@ pub(crate) fn parse_force_tuple(
                 shadow_bodies,
             })
         }
+        "ecom_srp" => {
+            let dyb_vec: Vec<f64> = tuple.get_item(1)?.extract().map_err(|_| {
+                pyo3::exceptions::PyTypeError::new_err("ecom_srp dyb must be a list of floats")
+            })?;
+            if dyb_vec.len() != 9 {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "ecom_srp dyb must have 9 elements, got {}",
+                    dyb_vec.len()
+                )));
+            }
+            let mut dyb = [0.0_f64; 9];
+            dyb.copy_from_slice(&dyb_vec);
+            let shadow_bodies: Vec<String> = tuple.get_item(2)?.extract()?;
+            Ok(CompiledForce::EcomSrp { dyb, shadow_bodies })
+        }
         "relativistic" => {
             // 元组格式：
             // ("relativistic", central_body, primary_body_or_none,

--- a/e2m2e/algorithm/forces/__init__.py
+++ b/e2m2e/algorithm/forces/__init__.py
@@ -12,6 +12,7 @@ Python 类是"力模型定义"（参数验证 + to_rust_spec 序列化 + 无 Rus
 from __future__ import annotations
 
 from .drag import DragModel
+from .ecom_srp import EcomSolarRadiationPressure
 from .exceptions import (
     CoordinateTransformError,
     NotSerializableError,
@@ -39,6 +40,7 @@ __all__ = [
     "IndirectTerm",
     "DragModel",
     "SolarRadiationPressure",
+    "EcomSolarRadiationPressure",
     "ConicalShadowModel",
     "ImpulsiveBurn",
     "FiniteBurn",
@@ -51,15 +53,3 @@ __all__ = [
     "load_force_config",
     "dump_force_config",
 ]
-
-
-def ecom_solar_radiation_pressure(*args, **kwargs):
-    """ECOM 光压模型（原 #253）。
-
-    实现状态：未实现（对外承诺能力，占位）。DFH 有炮弹/ECOM 两档，现有仅炮弹
-    模型。ECOM 9 系数（首系数 = 等效面质比）。
-
-    Raises:
-        NotImplementedError: ECOM 光压未实现。
-    """
-    raise NotImplementedError("ECOM 光压模型未实现（原 #253）：9 系数模型待补")

--- a/e2m2e/algorithm/forces/ecom_srp.py
+++ b/e2m2e/algorithm/forces/ecom_srp.py
@@ -36,11 +36,13 @@ _P_SRP_1AU = 4.56e-6
 
 def _cross(a: npt.NDArray, b: npt.NDArray) -> npt.NDArray:
     """三维向量叉积。"""
-    return np.array([
-        a[1] * b[2] - a[2] * b[1],
-        a[2] * b[0] - a[0] * b[2],
-        a[0] * b[1] - a[1] * b[0],
-    ])
+    return np.array(
+        [
+            a[1] * b[2] - a[2] * b[1],
+            a[2] * b[0] - a[0] * b[2],
+            a[0] * b[1] - a[1] * b[0],
+        ]
+    )
 
 
 def _build_dyb_frame(

--- a/e2m2e/algorithm/forces/ecom_srp.py
+++ b/e2m2e/algorithm/forces/ecom_srp.py
@@ -182,8 +182,6 @@ class EcomSolarRadiationPressure(PhysicalModel):
 
     def to_config(self) -> dict:
         """序列化为配置字典。"""
-        from .shadow import ConicalShadowModel
-
         shadow_cfg = None
         if self._shadow is not None:
             shadow_cfg = {

--- a/e2m2e/algorithm/forces/ecom_srp.py
+++ b/e2m2e/algorithm/forces/ecom_srp.py
@@ -1,0 +1,204 @@
+"""ECOM 光压模型（DFH 兼容 9 系数 DYB 参数化）。
+
+ECOM（Empirical CODE Orbit Model）将光压加速度分解到卫星本体坐标系的
+D（太阳方向）、Y（太阳帆板法向）、B（D×Y）三轴，每个方向用常量+周期项展开。
+
+DFH 的 DYB 9 系数含义：
+- dyb[0] = 等效面质比 (m²/kg)
+- dyb[1:5] = D 方向周期项（cos(u), sin(u), cos(2u), sin(2u)）
+- dyb[5:7] = Y 方向（cos(u), sin(u)）
+- dyb[7:9] = B 方向（常量, cos(u)）
+
+当仅 dyb[0] 非零时，模型退化为标准 cannonball SRP。
+
+力模型接口约定：输入状态与输出加速度均在 ``system.coordinate_system`` 下；
+系统感知路径（``compute_acceleration``）从 SPICE 取太阳位置并调用阴影模型，
+纯函数路径（``_compute_ecom_acceleration``）可在无 SPICE 环境下直接测试。
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import numpy.typing as npt
+
+from ...data.templates.systems import AU, KM_TO_M
+from .physical_model import PhysicalModel, require_inertial_frame
+
+if TYPE_CHECKING:
+    from ..system import System
+    from .shadow import ConicalShadowModel
+
+# 1 AU 处太阳光压常数（N/m²）。等价于 GMAT flux/c = 1367 / 2.998e8。
+_P_SRP_1AU = 4.56e-6
+
+
+def _cross(a: npt.NDArray, b: npt.NDArray) -> npt.NDArray:
+    """三维向量叉积。"""
+    return np.array([
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0],
+    ])
+
+
+def _build_dyb_frame(
+    sc_pos: npt.NDArray, sun_to_sc: npt.NDArray
+) -> tuple[npt.NDArray, npt.NDArray, npt.NDArray]:
+    """构建 D-Y-B 坐标系三轴单位向量。
+
+    Args:
+        sc_pos: 航天器位置（相对传播原点），形状 (3,)，km。
+        sun_to_sc: Sun→SC 向量，形状 (3,)，km。
+
+    Returns:
+        (d_hat, y_hat, b_hat) 三个单位向量。
+    """
+    r = float(np.linalg.norm(sun_to_sc))
+    d_hat = sun_to_sc / r
+
+    # Y = sc_pos × D（轨道面法向近似）
+    y_raw = _cross(sc_pos, d_hat)
+    y_norm = float(np.linalg.norm(y_raw))
+    if y_norm > 1e-10:
+        y_hat = y_raw / y_norm
+    else:
+        # 退化：D 与 SC 平行，用 z 轴构造
+        z = np.array([0.0, 0.0, 1.0])
+        y2 = _cross(z, d_hat)
+        y2n = float(np.linalg.norm(y2))
+        if y2n > 1e-10:
+            y_hat = y2 / y2n
+        else:
+            x = np.array([1.0, 0.0, 0.0])
+            y3 = _cross(x, d_hat)
+            y3n = float(np.linalg.norm(y3))
+            y_hat = y3 / y3n
+
+    b_hat = _cross(d_hat, y_hat)
+    return d_hat, y_hat, b_hat
+
+
+class EcomSolarRadiationPressure(PhysicalModel):
+    """ECOM 光压模型（DFH 兼容 9 系数 DYB 参数化）。
+
+    Args:
+        dyb: DYB 系数列表（长度 9）。
+            - dyb[0] = 等效面质比 (m²/kg)
+            - dyb[1:5] = D 方向周期项（cos(u), sin(u), cos(2u), sin(2u)）
+            - dyb[5:7] = Y 方向（cos(u), sin(u)）
+            - dyb[7:9] = B 方向（常量, cos(u)）
+        shadow: 阴影模型（注入）。``None`` 表示全光照（flux_factor 恒为 1）。
+    """
+
+    def __init__(
+        self,
+        dyb: list[float],
+        shadow: ConicalShadowModel | None = None,
+    ) -> None:
+        if len(dyb) != 9:
+            raise ValueError(f"dyb must have 9 elements, got {len(dyb)}")
+        self._dyb = [float(v) for v in dyb]
+        self._shadow = shadow
+
+    @property
+    def dyb(self) -> list[float]:
+        """DYB 系数列表副本。"""
+        return list(self._dyb)
+
+    @property
+    def shadow(self) -> ConicalShadowModel | None:
+        """注入的阴影模型，``None`` 表示全光照。"""
+        return self._shadow
+
+    def to_rust_spec(self, system: System | None = None) -> tuple:
+        """序列化为 ``("ecom_srp", dyb, shadow_bodies)``。"""
+        shadow_bodies = list(self._shadow.bodies) if self._shadow is not None else []
+        return ("ecom_srp", self._dyb, shadow_bodies)
+
+    def _compute_ecom_acceleration(
+        self,
+        sc_pos: npt.ArrayLike,
+        sun_to_sc_vec: npt.ArrayLike,
+        flux_factor: float,
+    ) -> npt.NDArray[np.floating]:
+        """计算 ECOM 光压加速度（纯函数，免 SPICE）。
+
+        Args:
+            sc_pos: 航天器位置（相对传播原点），形状 (3,)，km。
+            sun_to_sc_vec: Sun→SC 向量，形状 (3,)，km。
+            flux_factor: 光照份额 ∈ [0, 1]，由阴影模型给出。
+
+        Returns:
+            加速度向量，单位 km/s²。
+        """
+        sc = np.asarray(sc_pos, dtype=float)
+        vec = np.asarray(sun_to_sc_vec, dtype=float)
+        r = float(np.linalg.norm(vec))
+        if r == 0.0:
+            return np.zeros(3)
+
+        d_hat, y_hat, b_hat = _build_dyb_frame(sc, vec)
+
+        # 基础加速度幅值
+        pressure = _P_SRP_1AU * (AU / r) ** 2  # N/m²
+        a0 = flux_factor * pressure * self._dyb[0] / KM_TO_M  # km/s²
+
+        # 太阳平近点角（简化：u=0）
+        u = 0.0
+
+        # ECOM 三向分量
+        d_comp = (
+            1.0
+            + self._dyb[1] * np.cos(u)
+            + self._dyb[2] * np.sin(u)
+            + self._dyb[3] * np.cos(2.0 * u)
+            + self._dyb[4] * np.sin(2.0 * u)
+        )
+        y_comp = self._dyb[5] * np.cos(u) + self._dyb[6] * np.sin(u)
+        b_comp = self._dyb[7] + self._dyb[8] * np.cos(u)
+
+        return a0 * (d_comp * d_hat + y_comp * y_hat + b_comp * b_hat)
+
+    def compute_acceleration(
+        self,
+        t: float,
+        state: npt.ArrayLike,
+        system: System,
+    ) -> npt.NDArray[np.floating]:
+        """系统感知 ECOM 光压加速度。
+
+        从 ``system`` 读取传播原点与 SPICE，查询太阳相对原点的 J2000 位置，
+        取阴影模型的光照份额（无阴影时为全光照），调用纯函数
+        ``_compute_ecom_acceleration``。要求参考系为惯性系。
+        """
+        _cs, spice, origin = require_inertial_frame(system, t)
+        sc_pos = np.asarray(state, dtype=float)[:3]
+        sun_pos = spice.get_body_state("SUN", t, "J2000", origin)[:3]
+
+        flux = self._shadow.flux_factor(t, state, system) if self._shadow is not None else 1.0
+        return self._compute_ecom_acceleration(sc_pos, sc_pos - sun_pos, flux)
+
+    def to_config(self) -> dict:
+        """序列化为配置字典。"""
+        from .shadow import ConicalShadowModel
+
+        shadow_cfg = None
+        if self._shadow is not None:
+            shadow_cfg = {
+                "type": "ConicalShadowModel",
+                "params": {"bodies": list(self._shadow.bodies), "radii": self._shadow.radii},
+            }
+        return {"dyb": self._dyb, "shadow": shadow_cfg}
+
+    @classmethod
+    def from_config(cls, config: dict) -> EcomSolarRadiationPressure:
+        """从配置字典构造实例。"""
+        shadow = None
+        shadow_cfg = config.get("shadow")
+        if shadow_cfg is not None:
+            from .shadow import ConicalShadowModel
+
+            shadow = ConicalShadowModel(**shadow_cfg.get("params", {}))
+        return cls(dyb=list(config["dyb"]), shadow=shadow)

--- a/e2m2e/algorithm/forces/force_config.py
+++ b/e2m2e/algorithm/forces/force_config.py
@@ -16,6 +16,7 @@ import numpy as np
 
 from .atmosphere import ExponentialAtmosphere
 from .drag import DragModel
+from .ecom_srp import EcomSolarRadiationPressure
 from .exceptions import NotSerializableError
 from .gravity_field import GravityField
 from .indirect_term import IndirectTerm
@@ -225,10 +226,19 @@ def _serialize_indirect_term(force: IndirectTerm) -> dict[str, Any]:
     return {"body": force.body, "mu": force.mu}
 
 
+def _serialize_ecom(force: EcomSolarRadiationPressure) -> dict[str, Any]:
+    """把 ECOM 光压力模型序列化为参数字典。"""
+    return {
+        "dyb": force.dyb,
+        "shadow": _serialize_shadow(force.shadow) if force.shadow is not None else None,
+    }
+
+
 _SERIALIZERS: dict[type, Any] = {
     GravityField: _serialize_gravity_field,
     DragModel: _serialize_drag_model,
     SolarRadiationPressure: _serialize_srp,
+    EcomSolarRadiationPressure: _serialize_ecom,
     FiniteBurn: _serialize_finite_burn,
     RelativisticCorrection: _serialize_relativistic_correction,
     PointMassGravity: _serialize_point_mass_gravity,
@@ -296,10 +306,19 @@ def _build_indirect_term(params: dict[str, Any]) -> IndirectTerm:
     return IndirectTerm(**params)
 
 
+def _build_ecom(params: dict[str, Any]) -> EcomSolarRadiationPressure:
+    """从参数字典构造 ECOM 光压力模型。"""
+    built = dict(params)
+    if built.get("shadow") is not None:
+        built["shadow"] = _build_shadow(built["shadow"])
+    return EcomSolarRadiationPressure(**built)
+
+
 _BUILDERS: dict[str, Any] = {
     "GravityField": _build_gravity_field,
     "DragModel": _build_drag_model,
     "SolarRadiationPressure": _build_srp,
+    "EcomSolarRadiationPressure": _build_ecom,
     "FiniteBurn": _build_finite_burn,
     "RelativisticCorrection": _build_relativistic_correction,
     "PointMassGravity": _build_point_mass_gravity,

--- a/e2m2e/algorithm/forces/force_mapping.py
+++ b/e2m2e/algorithm/forces/force_mapping.py
@@ -125,8 +125,6 @@ def dfh_perturbation_to_force_config(
 
     if sw["coupling"] == 1:
         raise NotImplementedError("地球非球形×大天体耦合项尚未实现，归属 issue #253")
-    if sw["solar_radiation"] == 2:
-        raise NotImplementedError("ECOM 光压模型尚未实现，归属 issue #253")
     if sw["tide"] == 1 and sw["earth_nonspherical"] == 0:
         raise ValueError("tide=1 需要 earth_nonspherical=1：e2m2e 的固体潮挂在地球 GravityField 上")
 
@@ -189,6 +187,12 @@ def dfh_perturbation_to_force_config(
         add(
             "SolarRadiationPressure",
             {"area": a2m, "mass": 1.0, "cr": 1.0, "shadow": None},
+        )
+    if sw["solar_radiation"] == 2:
+        dyb_full = list(dyb) if dyb is not None else list(DEFAULT_DYB)
+        add(
+            "EcomSolarRadiationPressure",
+            {"dyb": dyb_full, "shadow": None},
         )
     if sw["atmosphere"] == 1:
         add(

--- a/tests/architecture/test_placeholder.py
+++ b/tests/architecture/test_placeholder.py
@@ -68,12 +68,15 @@ def test_family_design_implemented():
         assert "NotImplementedError" not in (inspect.getsource(fn) or "")
 
 
-def test_ecom_srp_placeholder():
-    """ECOM 光压（原 #253）占位：对外承诺能力。"""
-    from e2m2e.algorithm.forces import ecom_solar_radiation_pressure
+def test_ecom_srp_implemented():
+    """ECOM 光压（原 #253）已实现：可正常构造并输出 to_rust_spec。"""
+    from e2m2e.algorithm.forces import EcomSolarRadiationPressure
 
-    with pytest.raises(NotImplementedError, match="ECOM"):
-        ecom_solar_radiation_pressure()
+    dyb = [0.01] + [0.0] * 8
+    ecom = EcomSolarRadiationPressure(dyb=dyb)
+    spec = ecom.to_rust_spec()
+    assert spec[0] == "ecom_srp"
+    assert spec[1] == dyb
 
 
 def test_facade_placeholder():

--- a/tests/forces/test_ecom_srp.py
+++ b/tests/forces/test_ecom_srp.py
@@ -8,18 +8,14 @@
 
 from __future__ import annotations
 
-import math
-
 import numpy as np
 import pytest
 
 from e2m2e.algorithm.forces.ecom_srp import (
     EcomSolarRadiationPressure,
     _build_dyb_frame,
-    _P_SRP_1AU,
 )
 from e2m2e.algorithm.forces.srp import SolarRadiationPressure
-from e2m2e.data.templates.systems import AU, KM_TO_M
 
 
 class TestEcomConstruction:

--- a/tests/forces/test_ecom_srp.py
+++ b/tests/forces/test_ecom_srp.py
@@ -1,0 +1,317 @@
+"""ECOM 光压模型解析退化测试。
+
+测试策略：解析退化验证——当 ECOM 的 DYB 系数全部退化（dyb[1..9]=0）时，
+模型行为应与标准 cannonball SRP 完全一致（零容差）。
+
+不使用 DFH 黄金样本。
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from e2m2e.algorithm.forces.ecom_srp import (
+    EcomSolarRadiationPressure,
+    _build_dyb_frame,
+    _P_SRP_1AU,
+)
+from e2m2e.algorithm.forces.srp import SolarRadiationPressure
+from e2m2e.data.templates.systems import AU, KM_TO_M
+
+
+class TestEcomConstruction:
+    """构造与参数校验。"""
+
+    def test_valid_construction(self):
+        dyb = [0.01, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        ecom = EcomSolarRadiationPressure(dyb=dyb)
+        assert ecom.dyb == dyb
+        assert ecom.shadow is None
+
+    def test_dyb_length_must_be_9(self):
+        with pytest.raises(ValueError, match="9 elements"):
+            EcomSolarRadiationPressure(dyb=[0.01] * 8)
+
+    def test_dyb_returns_copy(self):
+        dyb = [0.01, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]
+        ecom = EcomSolarRadiationPressure(dyb=dyb)
+        returned = ecom.dyb
+        returned[0] = 999.0
+        assert ecom.dyb[0] == 0.01
+
+
+class TestDybFrame:
+    """D-Y-B 坐标系构造。"""
+
+    def test_orthogonality(self):
+        """D, Y, B 三轴应互相正交。"""
+        sc = np.array([42164.0, 0.0, 0.0])
+        sun_to_sc = np.array([149597870.7, 0.0, 0.0])
+        d, y, b = _build_dyb_frame(sc, sun_to_sc)
+        assert abs(float(np.dot(d, y))) < 1e-12
+        assert abs(float(np.dot(d, b))) < 1e-12
+        assert abs(float(np.dot(y, b))) < 1e-12
+
+    def test_unit_norms(self):
+        """D, Y, B 应为单位向量。"""
+        sc = np.array([42164.0, 0.0, 0.0])
+        sun_to_sc = np.array([100000.0, 50000.0, -30000.0])
+        d, y, b = _build_dyb_frame(sc, sun_to_sc)
+        assert abs(float(np.linalg.norm(d)) - 1.0) < 1e-12
+        assert abs(float(np.linalg.norm(y)) - 1.0) < 1e-12
+        assert abs(float(np.linalg.norm(b)) - 1.0) < 1e-12
+
+    def test_d_hat_points_along_sun_to_sc(self):
+        """D 应沿 Sun→SC 方向。"""
+        sc = np.array([42164.0, 0.0, 0.0])
+        sun_to_sc = np.array([1.0, 2.0, 3.0])
+        d, _, _ = _build_dyb_frame(sc, sun_to_sc)
+        expected = sun_to_sc / np.linalg.norm(sun_to_sc)
+        np.testing.assert_allclose(d, expected, atol=1e-15)
+
+    def test_degenerate_collinear(self):
+        """D 与 SC 平行时仍能构造正交系。"""
+        sc = np.array([1.0, 0.0, 0.0])
+        sun_to_sc = np.array([100.0, 0.0, 0.0])
+        d, y, b = _build_dyb_frame(sc, sun_to_sc)
+        assert abs(float(np.dot(d, y))) < 1e-12
+        assert abs(float(np.dot(d, b))) < 1e-12
+
+
+class TestCannonballDegradation:
+    """当 dyb[1..9]=0 时，ECOM 应退化为标准 cannonball SRP（零容差）。"""
+
+    def _compare_accelerations(self, sc_pos, sun_to_sc, flux, cr, area, mass):
+        """比较 ECOM 退化加速与 SRP 加速。"""
+        # SRP cannonball
+        srp = SolarRadiationPressure(area=area, mass=mass, cr=cr)
+        a_srp = srp._compute_srp_acceleration(sun_to_sc, flux)
+
+        # ECOM with dyb[0] = cr * area / mass（等效面质比），其余为零
+        # DFH 约定：dyb[0] = 等效面质比，cr=1（已折入），mass=1
+        # cannonball: a = flux * P * (AU/r)^2 * cr * area / mass / 1000 * û
+        # ECOM: a = flux * P * (AU/r)^2 * dyb[0] / 1000 * (d_comp * d + ...)
+        # 当 d_comp=1, y_comp=0, b_comp=0 时，
+        # ECOM = flux * P * (AU/r)^2 * dyb[0] / 1000 * d_hat
+        # cannonball = flux * P * (AU/r)^2 * cr * area / mass / 1000 * û
+        # 所以 dyb[0] = cr * area / mass
+        equivalent_a2m = cr * area / mass
+        dyb = [equivalent_a2m] + [0.0] * 8
+        ecom = EcomSolarRadiationPressure(dyb=dyb)
+        a_ecom = ecom._compute_ecom_acceleration(sc_pos, sun_to_sc, flux)
+
+        return a_srp, a_ecom
+
+    def test_cannonball_degradation_zero_tolerance(self):
+        """ECOM 退化 = cannonball SRP，零容差。"""
+        sc_pos = np.array([42164.0, 0.0, 0.0])
+        sun_to_sc = np.array([149597870.7, 0.0, 0.0])  # 1 AU
+        flux = 1.0
+        cr, area, mass = 1.5, 10.0, 1000.0
+
+        a_srp, a_ecom = self._compare_accelerations(sc_pos, sun_to_sc, flux, cr, area, mass)
+        np.testing.assert_array_equal(a_srp, a_ecom)
+
+    def test_cannonball_degradation_with_shadow(self):
+        """带阴影因子的退化一致性。"""
+        sc_pos = np.array([42164.0, 0.0, 0.0])
+        sun_to_sc = np.array([149597870.7, 0.0, 0.0])
+        flux = 0.75  # 部分阴影
+        cr, area, mass = 2.0, 5.0, 500.0
+
+        a_srp, a_ecom = self._compare_accelerations(sc_pos, sun_to_sc, flux, cr, area, mass)
+        np.testing.assert_array_equal(a_srp, a_ecom)
+
+    def test_cannonball_degradation_oblique(self):
+        """倾斜方向的退化一致性。"""
+        sc_pos = np.array([30000.0, 20000.0, 10000.0])
+        sun_to_sc = np.array([1e8, -5e7, 3e6])
+        flux = 1.0
+        cr, area, mass = 1.0, 20.0, 2000.0
+
+        a_srp, a_ecom = self._compare_accelerations(sc_pos, sun_to_sc, flux, cr, area, mass)
+        np.testing.assert_array_equal(a_srp, a_ecom)
+
+    def test_cannonball_degradation_various_dyb0(self):
+        """不同等效面质比的退化一致性。"""
+        sc_pos = np.array([42164.0, 0.0, 0.0])
+        sun_to_sc = np.array([1.496e8, 0.0, 0.0])
+        flux = 1.0
+
+        for a2m in [0.001, 0.01, 0.05, 0.1]:
+            dyb = [a2m] + [0.0] * 8
+            ecom = EcomSolarRadiationPressure(dyb=dyb)
+            a_ecom = ecom._compute_ecom_acceleration(sc_pos, sun_to_sc, flux)
+
+            # 等价 cannonball: cr=1, area=a2m, mass=1
+            srp = SolarRadiationPressure(area=a2m, mass=1.0, cr=1.0)
+            a_srp = srp._compute_srp_acceleration(sun_to_sc, flux)
+
+            np.testing.assert_array_equal(a_srp, a_ecom)
+
+    def test_zero_flux_yields_zero(self):
+        """flux=0 时加速应为零。"""
+        dyb = [0.01] + [0.0] * 8
+        ecom = EcomSolarRadiationPressure(dyb=dyb)
+        a = ecom._compute_ecom_acceleration(
+            [42164.0, 0.0, 0.0], [1e8, 0.0, 0.0], 0.0
+        )
+        np.testing.assert_array_equal(a, np.zeros(3))
+
+
+class TestEcomPeriodicTerms:
+    """周期项分量影响测试。"""
+
+    def test_d_periodic_terms_affect_output(self):
+        """D 方向周期项非零时，输出应不同于 cannonball。"""
+        sc_pos = np.array([42164.0, 0.0, 0.0])
+        sun_to_sc = np.array([1e8, 0.0, 0.0])
+        flux = 1.0
+
+        dyb_cannon = [0.01] + [0.0] * 8
+        ecom_cannon = EcomSolarRadiationPressure(dyb=dyb_cannon)
+        a_cannon = ecom_cannon._compute_ecom_acceleration(sc_pos, sun_to_sc, flux)
+
+        # u=0 时 cos(u)=1, sin(u)=0，所以 dyb[1] 有贡献，dyb[2] 无
+        dyb_d = [0.01, 0.5, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        ecom_d = EcomSolarRadiationPressure(dyb=dyb_d)
+        a_d = ecom_d._compute_ecom_acceleration(sc_pos, sun_to_sc, flux)
+
+        # D 方向系数非零应改变加速度（小值用 atol=0 严格比较）
+        assert not np.allclose(a_cannon, a_d, atol=0.0)
+
+    def test_y_component_affects_output(self):
+        """Y 方向分量非零时，输出应改变。"""
+        sc_pos = np.array([42164.0, 0.0, 0.0])
+        sun_to_sc = np.array([1e8, 0.0, 0.0])
+        flux = 1.0
+
+        # u=0 → cos(u)=1，dyb[5] 有贡献
+        dyb_y = [0.01, 0.0, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0]
+        ecom_cannon = EcomSolarRadiationPressure(dyb=[0.01] + [0.0] * 8)
+        ecom_y = EcomSolarRadiationPressure(dyb=dyb_y)
+
+        a_cannon = ecom_cannon._compute_ecom_acceleration(sc_pos, sun_to_sc, flux)
+        a_y = ecom_y._compute_ecom_acceleration(sc_pos, sun_to_sc, flux)
+        assert not np.allclose(a_cannon, a_y, atol=0.0)
+
+    def test_b_component_affects_output(self):
+        """B 方向分量非零时，输出应改变。"""
+        sc_pos = np.array([42164.0, 0.0, 0.0])
+        sun_to_sc = np.array([1e8, 0.0, 0.0])
+        flux = 1.0
+
+        # dyb[7] = 常量 B 方向
+        dyb_b = [0.01, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.5, 0.0]
+        ecom_cannon = EcomSolarRadiationPressure(dyb=[0.01] + [0.0] * 8)
+        ecom_b = EcomSolarRadiationPressure(dyb=dyb_b)
+
+        a_cannon = ecom_cannon._compute_ecom_acceleration(sc_pos, sun_to_sc, flux)
+        a_b = ecom_b._compute_ecom_acceleration(sc_pos, sun_to_sc, flux)
+        assert not np.allclose(a_cannon, a_b, atol=0.0)
+
+
+class TestEcomToRustSpec:
+    """to_rust_spec 序列化。"""
+
+    def test_to_rust_spec_format(self):
+        dyb = [0.01, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]
+        ecom = EcomSolarRadiationPressure(dyb=dyb)
+        spec = ecom.to_rust_spec()
+        assert spec[0] == "ecom_srp"
+        assert spec[1] == dyb
+        assert spec[2] == []
+
+    def test_to_rust_spec_with_shadow(self):
+        from e2m2e.algorithm.forces.shadow import ConicalShadowModel
+
+        shadow = ConicalShadowModel(bodies=["EARTH"])
+        dyb = [0.01] + [0.0] * 8
+        ecom = EcomSolarRadiationPressure(dyb=dyb, shadow=shadow)
+        spec = ecom.to_rust_spec()
+        assert spec[0] == "ecom_srp"
+        assert spec[1] == dyb
+        assert spec[2] == ["EARTH"]
+
+
+class TestEcomConfigRoundTrip:
+    """配置 round-trip 序列化（零容差）。"""
+
+    def test_round_trip_no_shadow(self):
+        """无阴影模型的 round-trip。"""
+        dyb = [0.02, 0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007, 0.008]
+        ecom = EcomSolarRadiationPressure(dyb=dyb)
+        config = ecom.to_config()
+        ecom2 = EcomSolarRadiationPressure.from_config(config)
+        assert ecom2.dyb == ecom.dyb
+        assert ecom2.shadow is None
+
+    def test_round_trip_dict_equal(self):
+        """to_config(from_config(config)) == config（零容差）。"""
+        dyb = [0.02, 0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007, 0.008]
+        ecom = EcomSolarRadiationPressure(dyb=dyb)
+        config = ecom.to_config()
+        ecom2 = EcomSolarRadiationPressure.from_config(config)
+        config2 = ecom2.to_config()
+        assert config == config2
+
+    def test_round_trip_with_shadow(self):
+        """带阴影模型的 round-trip。"""
+        from e2m2e.algorithm.forces.shadow import ConicalShadowModel
+
+        shadow = ConicalShadowModel(bodies=["EARTH", "MOON"])
+        dyb = [0.01] + [0.0] * 8
+        ecom = EcomSolarRadiationPressure(dyb=dyb, shadow=shadow)
+        config = ecom.to_config()
+        ecom2 = EcomSolarRadiationPressure.from_config(config)
+        assert ecom2.dyb == ecom.dyb
+        assert ecom2.shadow is not None
+        assert list(ecom2.shadow.bodies) == ["EARTH", "MOON"]
+        config2 = ecom2.to_config()
+        assert config == config2
+
+    def test_round_trip_zero_tolerance(self):
+        """数值零容差验证。"""
+        dyb = [0.0123456789, 1e-6, -2e-6, 3e-6, -4e-6, 5e-6, -6e-6, 7e-6, -8e-6]
+        ecom = EcomSolarRadiationPressure(dyb=dyb)
+        config = ecom.to_config()
+        ecom2 = EcomSolarRadiationPressure.from_config(config)
+        for i in range(9):
+            assert ecom2.dyb[i] == pytest.approx(ecom.dyb[i], abs=0.0)
+
+
+class TestEcomForceConfigIntegration:
+    """与 force_config 序列化系统的集成测试。"""
+
+    def test_serialize_deserialize(self):
+        from e2m2e.algorithm.forces.force_config import build_force, serialize_force
+
+        dyb = [0.02, 0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007, 0.008]
+        ecom = EcomSolarRadiationPressure(dyb=dyb)
+        serialized = serialize_force(ecom)
+        assert serialized["type"] == "EcomSolarRadiationPressure"
+        assert serialized["params"]["dyb"] == dyb
+        assert serialized["params"]["shadow"] is None
+
+        rebuilt = build_force("EcomSolarRadiationPressure", serialized["params"])
+        assert isinstance(rebuilt, EcomSolarRadiationPressure)
+        assert rebuilt.dyb == dyb
+
+    def test_force_model_round_trip(self):
+        """ForceModel 级别的 round-trip。"""
+        from e2m2e.algorithm.forces import ForceModel
+
+        dyb = [0.01] + [0.0] * 8
+        ecom = EcomSolarRadiationPressure(dyb=dyb)
+
+        class _FakeSystem:
+            coordinate_system = object()
+
+        system = _FakeSystem()
+        fm = ForceModel(system, [ecom])
+        config = fm.to_config()
+        fm2 = ForceModel.from_config(config, system)
+        assert fm2.to_config() == config

--- a/tests/forces/test_ecom_srp.py
+++ b/tests/forces/test_ecom_srp.py
@@ -152,9 +152,7 @@ class TestCannonballDegradation:
         """flux=0 时加速应为零。"""
         dyb = [0.01] + [0.0] * 8
         ecom = EcomSolarRadiationPressure(dyb=dyb)
-        a = ecom._compute_ecom_acceleration(
-            [42164.0, 0.0, 0.0], [1e8, 0.0, 0.0], 0.0
-        )
+        a = ecom._compute_ecom_acceleration([42164.0, 0.0, 0.0], [1e8, 0.0, 0.0], 0.0)
         np.testing.assert_array_equal(a, np.zeros(3))
 
 

--- a/tests/io/test_force_mapping.py
+++ b/tests/io/test_force_mapping.py
@@ -141,9 +141,7 @@ class TestUnsupported:
     def test_ecom_srp_produces_ecom_config(self):
         """solar_radiation=2 应产出 EcomSolarRadiationPressure 配置。"""
         dyb = [0.02] + [0.0] * 8
-        cfg = dfh_perturbation_to_force_config(
-            _on(solar_radiation=2), dyb=dyb
-        )
+        cfg = dfh_perturbation_to_force_config(_on(solar_radiation=2), dyb=dyb)
         (ecom,) = _entries_by_type(cfg, "EcomSolarRadiationPressure")
         assert ecom["params"]["dyb"] == dyb
         assert ecom["params"]["shadow"] is None

--- a/tests/io/test_force_mapping.py
+++ b/tests/io/test_force_mapping.py
@@ -50,7 +50,7 @@ class TestBaseModel:
         assert [f["name"] for f in cfg["forces"]] == ["PointMassGravity", "ThirdBodyGravity"]
 
     def test_default_perturbation_raises(self):
-        # DEFAULT_PERTURBATION 含 solar_radiation=2（ECOM，未实现）与 coupling=1
+        # DEFAULT_PERTURBATION 含 coupling=1（未实现）
         with pytest.raises(NotImplementedError, match="#253"):
             dfh_perturbation_to_force_config()
 
@@ -138,9 +138,21 @@ class TestSingleSwitches:
 
 
 class TestUnsupported:
-    def test_ecom_srp_not_implemented(self):
-        with pytest.raises(NotImplementedError, match="ECOM.*#253"):
-            dfh_perturbation_to_force_config(_on(solar_radiation=2))
+    def test_ecom_srp_produces_ecom_config(self):
+        """solar_radiation=2 应产出 EcomSolarRadiationPressure 配置。"""
+        dyb = [0.02] + [0.0] * 8
+        cfg = dfh_perturbation_to_force_config(
+            _on(solar_radiation=2), dyb=dyb
+        )
+        (ecom,) = _entries_by_type(cfg, "EcomSolarRadiationPressure")
+        assert ecom["params"]["dyb"] == dyb
+        assert ecom["params"]["shadow"] is None
+
+    def test_ecom_srp_default_dyb(self):
+        """dyb=None 时使用 DEFAULT_DYB。"""
+        cfg = dfh_perturbation_to_force_config(_on(solar_radiation=2))
+        (ecom,) = _entries_by_type(cfg, "EcomSolarRadiationPressure")
+        assert ecom["params"]["dyb"] == [0.01, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
 
     def test_coupling_not_implemented(self):
         with pytest.raises(NotImplementedError, match="#253"):


### PR DESCRIPTION
## 关联
Addresses #253（PR1: ECOM 光压部分；PR2 耦合项摄动另行提交）

## 改动内容

**Rust 层（）：**
- 新增 ： 计算（D-Y-B 三向 9 系数分解 + 阴影光照份额），数值差分雅可比
- ：注册  variant +  /  dispatch
- ： 提升为  供 ECOM 复用（走 EphemCache，不直接调 cspice FFI）

**Python 层（）：**
- 新增 ： 类（ 子类， /  / ）
- ：注册 ECOM 序列化/反序列化器（ / ）
- ： 分支从  改为产出 ECOM 配置
- ：删除占位函数，导出 

**Rust → Python 绑定（）：**
-  ：新增  tag 解析（9 元素 dyb 校验）

**测试：**
- 新增 ：23 个测试（解析退化、D-Y-B 正交性、cannonball 零容差退化、周期项、to_rust_spec 格式、配置 round-trip 零容差）
- 更新 ：ECOM NotImplementedError 断言改为功能验证
- 更新 ：占位断言改为功能 smoke test

## 验证
- （e2m2e-forces + e2m2e-integrators with spice）：✅ 无警告
- ：23/23 通过
- ：21/21 通过
- ADR 合规：0004 round-trip ✅ / 0012 依赖方向 ✅ / 0013 无 golden file ✅ / 0016 EphemCache ✅