### PR TITLE
ci: 拆分 lint 与 test，lint 只做静态分析

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,33 +22,42 @@ jobs:
         with:
           components: rustfmt, clippy
       - uses: astral-sh/setup-uv@v7
-      # Rust 格式与风格
+      # Rust 格式与风格（无 spice）
       - run: cargo fmt --all -- --check
       - run: cargo clippy --workspace -- -D warnings
-      # spice-gated 代码（STM 传播、打靶等 Rust 大头）的编译与 lint 兜底。
-      # 编译包来自 cspice-v1 release（scripts/download_cspice.py），设好
-      # CSPICE_DIR 后 cspice-sys 跳过 NAIF 下载（国内网络常不可达）。
+      # spice-gated 代码的编译与 lint：编译包来自 cspice-v1 release，
+      # 设好 CSPICE_DIR 后 cspice-sys 跳过 NAIF 下载（国内网络常不可达）。
       - name: 下载 SPICE 编译包（cspice-v1 release）
         run: uv run python scripts/download_cspice.py >> "$GITHUB_ENV"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: cargo clippy --workspace --features spice -- -D warnings
-      - run: cargo test --workspace
-      # 下载 SPICE 内核到 kernels/，让 nbody_stm 里依赖 de430/de440s.bsp 的
-      # forces 测试在 CI 上真跑起来（此前因 .bsp 未入库被守卫跳过）。
-      # 内核来自 kernels-v1 release 资产，覆盖 nbody_stm.rs 列出的全部 8 个文件名。
-      - name: 下载 SPICE 内核（kernels-v1 release）
-        run: gh release download kernels-v1 --pattern '*.bsp' --pattern '*.tls' --pattern '*.tpc' --pattern '*.bpc' --pattern '*.tf' --dir kernels/ --clobber
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # spice 下的 forces 测试；--test-threads=1 因 cspice 有全局线程锁。
-      - run: cargo test -p e2m2e-forces --features spice -- --test-threads=1
       # Python 格式与风格
       - run: uv sync --group dev
       - run: uv run ruff check .
       - run: uv run ruff format --check .
       # 五层依赖方向检查（ADR 0012）：data/algorithm/api 无越层 import
       - run: uv run python scripts/check_layer_imports.py
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: astral-sh/setup-uv@v7
+      # 无 spice 的常规测试
+      - run: cargo test --workspace
+      # 下载 SPICE 编译包 + 内核，跑 spice-gated 测试（forces 等）
+      - name: 下载 SPICE 编译包（cspice-v1 release）
+        run: uv run python scripts/download_cspice.py >> "$GITHUB_ENV"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: 下载 SPICE 内核（kernels-v1 release）
+        run: gh release download kernels-v1 --pattern '*.bsp' --pattern '*.tls' --pattern '*.tpc' --pattern '*.bpc' --pattern '*.tf' --dir kernels/ --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # --test-threads=1 因 cspice 有全局线程锁
+      - run: cargo test -p e2m2e-forces --features spice -- --test-threads=1
 
   typecheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,25 +39,6 @@ jobs:
       # 五层依赖方向检查（ADR 0012）：data/algorithm/api 无越层 import
       - run: uv run python scripts/check_layer_imports.py
 
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: astral-sh/setup-uv@v7
-      # 无 spice 的常规测试
-      - run: cargo test --workspace
-      # 下载 SPICE 编译包 + 内核，跑 spice-gated 测试（forces 等）
-      - name: 下载 SPICE 编译包（cspice-v1 release）
-        run: uv run python scripts/download_cspice.py >> "$GITHUB_ENV"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: 下载 SPICE 内核（kernels-v1 release）
-        run: gh release download kernels-v1 --pattern '*.bsp' --pattern '*.tls' --pattern '*.tpc' --pattern '*.bpc' --pattern '*.tf' --dir kernels/ --clobber
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # --test-threads=1 因 cspice 有全局线程锁
-      - run: cargo test -p e2m2e-forces --features spice -- --test-threads=1
 
   typecheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,28 @@ jobs:
       - run: uv run ruff check .
       - run: uv run ruff format --check .
 
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: astral-sh/setup-uv@v7
+      # 无 spice 的常规测试
+      - run: cargo test --workspace
+      # 下载 SPICE 编译包 + 内核，跑 spice-gated 测试（forces 等）
+      - name: 下载 SPICE 编译包（cspice-v1 release）
+        run: uv run python scripts/download_cspice.py >> "$GITHUB_ENV"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: 下载 SPICE 内核（kernels-v1 release）
+        run: gh release download kernels-v1 --pattern '*.bsp' --pattern '*.tls' --pattern '*.tpc' --pattern '*.bpc' --pattern '*.tf' --dir kernels/ --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # --test-threads=1 因 cspice 有全局线程锁
+      - run: cargo test -p e2m2e-forces --features spice -- --test-threads=1
+
   build:
-    needs: lint
+    needs: [lint, test]
     strategy:
       matrix:
         include:


### PR DESCRIPTION
## 改动

将原 lint job 中的 Rust 测试和 SPICE 内核下载剥离至独立 test job，使 CI 结构更清晰：

- **lint job**：只做静态分析（cargo fmt、cargo clippy、cargo clippy --features spice、ruff check、ruff format、check_layer_imports）
- **test job**：承担所有 Rust 测试（cargo test --workspace、cargo test -p e2m2e-forces --features spice）
- 两个 job 并行运行，typecheck job 不变

## 关联

无关联 issue

## 测试

- CI 会在合并后自动运行，验证两个 job 各自正常工作