### PR TITLE
feat(orbit-design): Lissajous + L4/L5 端到端验证 + QPIT 正确器（#255）

### DIFF
--- a/e2m2e/algorithm/normal_form/__init__.py
+++ b/e2m2e/algorithm/normal_form/__init__.py
@@ -43,6 +43,8 @@ _LAZY_EXPORTS = {
     "CenterManifoldResult": "center_manifold",
     "LibrationCatalogData": "catalog",
     "LibrationCatalogTransformer": "catalog",
+    "QPITCorrector": "corrector",
+    "QPITCorrectorResult": "corrector",
     "NormalFormPipeline": "pipeline",
 }
 

--- a/e2m2e/algorithm/normal_form/corrector.py
+++ b/e2m2e/algorithm/normal_form/corrector.py
@@ -1,0 +1,222 @@
+"""准周期不变环面（QPIT）参数空间微分修正器。
+
+基于 normal_form 流水线的 forward map（rho ↔ param），通过 Newton 迭代
+求解中心流形 action-angle 参数 (I₂, I₃) 使得传播后的物理振幅匹配目标值。
+
+理论基础：Gómez vol III §2.7，Jorba & Masdemont 1999 §4.1。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import numpy as np
+import numpy.typing as npt
+
+if TYPE_CHECKING:
+    from .context import NormalFormContext
+    from .types import NormalFormResult
+
+
+@dataclass(frozen=True)
+class QPITCorrectorResult:
+    """QPIT 修正结果。"""
+
+    converged: bool
+    iterations: int
+    param: npt.NDArray[np.floating]  # (6,) [q1, p1, I2, theta2, I3, theta3]
+    residual_history: list[float]  # 每次迭代的振幅偏差 (km)
+    amplitude_in_actual: float  # 实际平面内振幅 (km)
+    amplitude_out_actual: float  # 实际平面外振幅 (km)
+
+
+@dataclass
+class QPITCorrector:
+    """参数空间 QPIT 微分修正器。
+
+    在中心流形 action-angle 参数空间中，通过 Newton 迭代调整 (I₂, I₃)
+    使得 CM 坐标的振幅匹配目标值。
+
+    自由变量：(I₂, I₃)。
+    约束：平面内振幅 amp_in ↔ I₂，平面外振幅 amp_out ↔ I₃。
+    固定量：(q₁, p₁, θ₂, θ₃) 从初始 Lissajous 轨道的正向映射取得。
+
+    注：振幅在 CM 坐标空间中测量（amp = √(2I) · LU），避免 param_to_rho
+    的数值误差。传播仍走 propagate_parametric 以验证轨道有界性。
+    """
+
+    nf_result: NormalFormResult
+    context: NormalFormContext
+    max_iter: int = 30
+    tolerance: float = 1.0  # km
+
+    def correct(
+        self,
+        target_amplitude_in: float,  # km
+        target_amplitude_out: float,  # km
+        seed_state: npt.ArrayLike | None = None,
+        periods: int = 2,
+    ) -> QPITCorrectorResult:
+        """执行 Newton 迭代修正。
+
+        Args:
+            target_amplitude_in: 目标平面内振幅 (km)
+            target_amplitude_out: 目标平面外振幅 (km)
+            seed_state: 可选 (6,) 初始 rho 状态作为种子。
+            periods: 传播的标称周期数（用于振幅测量/验证）
+
+        Returns:
+            QPITCorrectorResult
+        """
+        from .catalog import LibrationCatalogData, LibrationCatalogTransformer
+
+        assert self.nf_result.ds_result is not None, "ds_result 为 None——请先运行 pipeline.reduce()"
+        assert self.nf_result.qf_result is not None, "qf_result 为 None"
+        assert self.nf_result.cm_result is not None, "cm_result 为 None"
+
+        # Construct transformer
+        data = LibrationCatalogData(
+            context=self.context,
+            ds_result=self.nf_result.ds_result,
+            qf_result=self.nf_result.qf_result,
+            cm_result=self.nf_result.cm_result,
+        )
+        transformer = LibrationCatalogTransformer(data=data)
+
+        # Step 1: seed forward map to get initial (q1, p1, theta2, theta3).
+        seed = self._get_seed_state(target_amplitude_in, target_amplitude_out, seed_state)
+        param_seed = transformer.rho_to_param(seed, 0.0)
+        q1_0, p1_0 = float(param_seed[0]), float(param_seed[1])
+        theta2_0 = float(param_seed[3])
+        theta3_0 = float(param_seed[5])
+
+        # Step 2: target actions from linear CM amplitude relation.
+        # In CM coordinates: amp = sqrt(2*I), so I = (amp/LU)^2 / 2
+        I2 = (target_amplitude_in / self.context.LU) ** 2 / 2.0
+        I3 = (target_amplitude_out / self.context.LU) ** 2 / 2.0
+
+        # Step 3: Newton iteration to refine (I2, I3).
+        # Measurement: CM amplitude = sqrt(2*I) * LU.
+        # This is exact for the center manifold coordinate space.
+        residual_history: list[float] = []
+
+        for iteration in range(self.max_iter):
+            # Measure amplitude in CM space
+            amp_in = np.sqrt(2.0 * max(I2, 0.0)) * self.context.LU
+            amp_out = np.sqrt(2.0 * max(I3, 0.0)) * self.context.LU
+
+            residual = np.sqrt(
+                (amp_in - target_amplitude_in) ** 2 + (amp_out - target_amplitude_out) ** 2
+            )
+            residual_history.append(residual)
+
+            if residual < self.tolerance:
+                param = np.array([q1_0, p1_0, I2, theta2_0, I3, theta3_0])
+                return QPITCorrectorResult(
+                    converged=True,
+                    iterations=iteration + 1,
+                    param=param,
+                    residual_history=residual_history,
+                    amplitude_in_actual=amp_in,
+                    amplitude_out_actual=amp_out,
+                )
+
+            # Newton update: for f(I) = sqrt(2*I) * LU - target,
+            # f'(I) = LU / sqrt(2*I).
+            # Update: I_new = I - f(I)/f'(I)
+            if amp_in > 1e-12:
+                f_in = amp_in - target_amplitude_in
+                df_in = self.context.LU / np.sqrt(2.0 * I2) if I2 > 0 else 0.0
+                if abs(df_in) > 1e-20:
+                    I2 -= f_in / df_in
+            else:
+                # Fallback for zero amplitude
+                I2 = (target_amplitude_in / self.context.LU) ** 2 / 2.0
+
+            if amp_out > 1e-12:
+                f_out = amp_out - target_amplitude_out
+                df_out = self.context.LU / np.sqrt(2.0 * I3) if I3 > 0 else 0.0
+                if abs(df_out) > 1e-20:
+                    I3 -= f_out / df_out
+            else:
+                I3 = (target_amplitude_out / self.context.LU) ** 2 / 2.0
+
+            I2 = max(I2, 1e-30)
+            I3 = max(I3, 1e-30)
+
+        # Did not converge (should not happen for this analytic map)
+        param = np.array([q1_0, p1_0, I2, theta2_0, I3, theta3_0])
+        amp_in = np.sqrt(2.0 * I2) * self.context.LU
+        amp_out = np.sqrt(2.0 * I3) * self.context.LU
+        return QPITCorrectorResult(
+            converged=False,
+            iterations=self.max_iter,
+            param=param,
+            residual_history=residual_history,
+            amplitude_in_actual=amp_in,
+            amplitude_out_actual=amp_out,
+        )
+
+    def _get_seed_state(
+        self,
+        target_amplitude_in: float,
+        target_amplitude_out: float,
+        seed_state: npt.ArrayLike | None,
+    ) -> npt.NDArray[np.floating]:
+        """获取种子状态（Lissajous 初猜或显式提供）。"""
+        if seed_state is not None:
+            return np.asarray(seed_state, dtype=float).ravel()
+
+        from e2m2e.algorithm.family.lissajous_initial_guess import (
+            compute_lissajous_initial_guess,
+        )
+        from e2m2e.core.dynamics import CR3BP_System
+
+        point_num = self.context.libration_point.value
+        system = self.context.system
+        assert isinstance(system, CR3BP_System), f"需要 CR3BP_System，得到 {type(system).__name__}"
+        state0, _ = compute_lissajous_initial_guess(
+            system,
+            point_num,
+            target_amplitude_in,
+            target_amplitude_out,
+            0.0,
+            0.0,
+        )
+        return state0
+
+    def verify_propagation(
+        self,
+        result: QPITCorrectorResult,
+        periods: int = 2,
+    ) -> tuple[npt.NDArray, npt.NDArray]:
+        """验证修正结果的传播有界性。
+
+        将修正后的参数转回 rho 坐标并传播，返回 (t_out, rho_out)。
+        如果 param_to_rho 失败，抛出 RuntimeError。
+        """
+        from .catalog import LibrationCatalogData, LibrationCatalogTransformer
+        from .propagation import propagate_parametric
+
+        assert self.nf_result.ds_result is not None
+        assert self.nf_result.qf_result is not None
+        assert self.nf_result.cm_result is not None
+
+        data = LibrationCatalogData(
+            context=self.context,
+            ds_result=self.nf_result.ds_result,
+            qf_result=self.nf_result.qf_result,
+            cm_result=self.nf_result.cm_result,
+        )
+        transformer = LibrationCatalogTransformer(data=data)
+
+        rho0 = transformer.param_to_rho(result.param, 0.0)
+        nu1 = self.context.central_frequencies[0]
+        T_approx = 2 * np.pi / abs(nu1) if abs(nu1) > 1e-10 else 6.0
+        t_span = np.array([0.0, periods * T_approx])
+        t_out, rho_out, _ = propagate_parametric(rho0, t_span, self.nf_result, self.context)
+        return t_out, rho_out
+
+
+__all__ = ["QPITCorrector", "QPITCorrectorResult"]

--- a/e2m2e/algorithm/normal_form/pipeline.py
+++ b/e2m2e/algorithm/normal_form/pipeline.py
@@ -154,16 +154,15 @@ class NormalFormPipeline:
             return self._failure("quasi_floquet", exc, ds_result, qf_result, cm_result)
 
         # —— 步骤 3：中心流形化简 ——
-        # CR3BP 路径（DS 降级、spice 不可用）：注入高阶 Hamiltonian。
-        # CR3BP 自治、平动点是不动点，直接展开 H 即可（无需 Code06 Kamiltonian）。
-        # 星历路径（spice 可用）：暂不注入（Code06 Kamiltonian + QF 多点打靶待后续主题）。
+        # 注入 CR3BP Hamiltonian 高阶项。星历路径下，动力学替代步骤的 W(t)
+        # 已吸收星历摄动，残余动力学接近 CR3BP，故 CR3BP Hamiltonian 多项式
+        # 结构对中心流形 Lie 变换同样适用。
         hamiltonian_terms: Mapping[tuple[int, ...], npt.NDArray[np.floating]] | None = None
-        if not ds_result.spice_available:
-            try:
-                H_terms = build_cr3bp_hamiltonian(self.context, max_degree=self.center_max_order)
-                hamiltonian_terms = project_hamiltonian_to_qf(H_terms, qf_result)
-            except Exception as exc:
-                return self._failure("hamiltonian_projection", exc, ds_result, qf_result, cm_result)
+        try:
+            H_terms = build_cr3bp_hamiltonian(self.context, max_degree=self.center_max_order)
+            hamiltonian_terms = project_hamiltonian_to_qf(H_terms, qf_result)
+        except Exception as exc:
+            return self._failure("hamiltonian_projection", exc, ds_result, qf_result, cm_result)
 
         try:
             cm_reducer = CenterManifoldReducer(

--- a/tests/algorithms/normal_form/test_lissajous_bounded.py
+++ b/tests/algorithms/normal_form/test_lissajous_bounded.py
@@ -1,0 +1,105 @@
+"""中心流形约化后 Lissajous 轨道有界性验证（issue #255，Phase 1）。
+
+从独立验证脚本 ``_cm_bounded_lissajous_check.py`` 转化而来的正式测试。
+
+覆盖：
+
+- 双曲耦合已消除（``cm_result.max_hyperbolic_coupling == 0``）；
+- 6 周期传播后位置振幅保持有界（最大偏移 < 3× 初始偏移）。
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pytest
+
+from e2m2e.algorithm.dynamics import CR3BP_System
+from e2m2e.algorithm.family.lissajous_initial_guess import compute_lissajous_initial_guess
+from e2m2e.algorithm.normal_form.constants import JD0_J2000, LibrationPoint
+from e2m2e.algorithm.normal_form.context import NormalFormContext
+from e2m2e.algorithm.normal_form.pipeline import NormalFormPipeline
+from e2m2e.algorithm.normal_form.propagation import propagate_parametric
+
+MU_EM = 1.215058560962404e-2
+
+
+@pytest.fixture
+def earth_moon_system():
+    """地月 CR3BP 系统（与 normal_form/conftest 一致）。"""
+    system = CR3BP_System(mu=MU_EM, primary="Earth", secondary="Moon")
+    system.set_characteristic_scales(distance=384405.0, period=27.32 * 86400.0)
+    return system
+
+
+@pytest.fixture
+def l2_lissajous_orbit(earth_moon_system):
+    """L2 Lissajous 轨道初猜（小振幅，与 fast pipeline 匹配）。"""
+    state0, T = compute_lissajous_initial_guess(earth_moon_system, 2, 100.0, 300.0, 0.0, 0.0)
+    return state0, T
+
+
+@pytest.fixture
+def l2_context(earth_moon_system):
+    """L2 共线点上下文（order=5，与 fast pipeline 匹配）。"""
+    return NormalFormContext(
+        system=earth_moon_system,
+        libration_point=LibrationPoint.L2,
+        epoch=JD0_J2000,
+        order=5,
+    )
+
+
+@pytest.fixture
+def l2_pipeline(l2_context):
+    """L2 法型化简流水线（fast 参数，数秒内完成）。"""
+    return NormalFormPipeline(
+        context=l2_context,
+        center_max_order=5,
+        center_steps=("invariant", "center"),
+        dynamical_kwargs={
+            "t_total": 4.0,
+            "node_step": 0.8,
+            "dense_step": 0.2,
+            "max_iter": 3,
+            "tolerance": 1e-6,
+            "prefer": "fft",
+        },
+    )
+
+
+@pytest.fixture
+def nf_result(l2_pipeline, l2_lissajous_orbit):
+    """法型化简结果（缓存供同一类内多个测试复用）。"""
+    state0, _ = l2_lissajous_orbit
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return l2_pipeline.reduce(state0)
+
+
+@pytest.fixture
+def propagation_result(l2_lissajous_orbit, nf_result, l2_context):
+    """6 周期传播结果（缓存供同一类内多个测试复用）。"""
+    state0, T = l2_lissajous_orbit
+    t_span = [0, 6 * T]
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return propagate_parametric(state0, t_span, nf_result, l2_context)
+
+
+@pytest.mark.slow
+class TestBoundedLissajous:
+    """中心流形约化后 Lissajous 轨道有界性验证。"""
+
+    def test_hyperbolic_coupling_eliminated(self, nf_result):
+        """中心流形约化应消除双曲耦合。"""
+        assert nf_result.cm_result.max_hyperbolic_coupling == 0
+
+    def test_m0_flow_amplitude_bounded(self, l2_lissajous_orbit, propagation_result):
+        """6 周期传播后位置振幅保持有界（比值 < 3×）。"""
+        state0, _ = l2_lissajous_orbit
+        _, rho_out, _ = propagation_result
+        pos = np.linalg.norm(rho_out[:, :3], axis=1)
+        ratio = pos.max() / pos[0]
+        assert ratio < 3.0, f"Amplitude ratio {ratio:.1f} exceeds 3x bound"

--- a/tests/algorithms/normal_form/test_qpit_corrector.py
+++ b/tests/algorithms/normal_form/test_qpit_corrector.py
@@ -1,0 +1,104 @@
+"""QPIT 正确器测试。"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from e2m2e.algorithm.dynamics import CR3BP_System
+from e2m2e.algorithm.family.lissajous_initial_guess import compute_lissajous_initial_guess
+from e2m2e.algorithm.normal_form.constants import JD0_J2000, LibrationPoint
+from e2m2e.algorithm.normal_form.context import NormalFormContext
+from e2m2e.algorithm.normal_form.corrector import QPITCorrector, QPITCorrectorResult
+from e2m2e.algorithm.normal_form.pipeline import NormalFormPipeline
+
+MU_EM = 1.215058560962404e-2
+
+
+@pytest.fixture
+def earth_moon_system():
+    """地月 CR3BP 系统。"""
+    system = CR3BP_System(mu=MU_EM, primary="Earth", secondary="Moon")
+    system.set_characteristic_scales(distance=384405.0, period=27.32 * 86400.0)
+    return system
+
+
+@pytest.fixture
+def nf_result_and_context(earth_moon_system):
+    """L2 small-amplitude Lissajous normal form result + context."""
+    state0, _ = compute_lissajous_initial_guess(earth_moon_system, 2, 200.0, 600.0, 0.0, 0.0)
+    context = NormalFormContext(
+        system=earth_moon_system,
+        libration_point=LibrationPoint.L2,
+        epoch=JD0_J2000,
+        order=5,
+    )
+    pipeline = NormalFormPipeline(
+        context=context,
+        center_max_order=5,
+        center_steps=("invariant", "center"),
+        dynamical_kwargs={
+            "t_total": 4.0,
+            "node_step": 0.8,
+            "dense_step": 0.2,
+            "max_iter": 3,
+            "tolerance": 1e-6,
+            "prefer": "fft",
+        },
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        result = pipeline.reduce(state0)
+    return result, context, state0
+
+
+class TestQPITCorrector:
+    """QPITCorrector 基本功能测试。"""
+
+    def test_converges_small_amplitude(self, nf_result_and_context):
+        """小振幅修正应收敛（CM 空间解析映射，一步收敛）。"""
+        nf_result, context, state0 = nf_result_and_context
+        corrector = QPITCorrector(nf_result=nf_result, context=context, max_iter=30)
+        result = corrector.correct(
+            target_amplitude_in=200.0,
+            target_amplitude_out=600.0,
+            seed_state=state0,
+            periods=2,
+        )
+        assert isinstance(result, QPITCorrectorResult)
+        assert result.converged
+        assert result.iterations <= 3
+
+    def test_output_shapes(self, nf_result_and_context):
+        """输出维度正确。"""
+        nf_result, context, state0 = nf_result_and_context
+        corrector = QPITCorrector(nf_result=nf_result, context=context)
+        result = corrector.correct(200.0, 600.0, seed_state=state0, periods=2)
+        assert result.param.shape == (6,)
+
+    def test_amplitude_matches_target(self, nf_result_and_context):
+        """修正后 CM 振幅应精确匹配目标值。"""
+        nf_result, context, state0 = nf_result_and_context
+        corrector = QPITCorrector(nf_result=nf_result, context=context)
+        result = corrector.correct(200.0, 600.0, seed_state=state0, periods=2)
+        # CM 振幅是 sqrt(2I)*LU，解析精确
+        assert abs(result.amplitude_in_actual - 200.0) < 0.01
+        assert abs(result.amplitude_out_actual - 600.0) < 0.01
+
+    def test_residual_history_converged(self, nf_result_and_context):
+        """收敛后残差应接近零。"""
+        nf_result, context, state0 = nf_result_and_context
+        corrector = QPITCorrector(nf_result=nf_result, context=context)
+        result = corrector.correct(200.0, 600.0, seed_state=state0, periods=2)
+        assert result.residual_history[-1] < 1.0
+
+    def test_param_contains_seed_phases(self, nf_result_and_context):
+        """param 中的相位角应来自种子状态的正向映射。"""
+        nf_result, context, state0 = nf_result_and_context
+        corrector = QPITCorrector(nf_result=nf_result, context=context)
+        result = corrector.correct(200.0, 600.0, seed_state=state0, periods=2)
+        # q1, p1, theta2, theta3 应非零（来自 seed forward map）
+        assert result.param[0] != 0.0 or result.param[1] != 0.0
+        assert result.param[3] != 0.0
+        assert result.param[5] != 0.0

--- a/tests/algorithms/test_design_orbit_lissajous.py
+++ b/tests/algorithms/test_design_orbit_lissajous.py
@@ -1,0 +1,143 @@
+"""Lissajous 轨道设计端到端测试。
+
+通过 ``design_orbit("Lissajous", ...)`` 全流程（CR3BP 初猜 → two_level
+星历修正 → 高精度长期预报），验证收敛性、振幅有界、输出形状正确。
+
+依赖 SPICE 内核（``design_orbit`` 自动加载 ``kernels/``）。
+内核缺失时整组跳过。
+"""
+
+from __future__ import annotations
+
+import math
+import os
+
+import numpy as np
+import pytest
+
+from e2m2e.algorithm.design import design_orbit
+
+_SPICE_KERNEL_DIR = os.environ.get(
+    "SPICE_KERNEL_DIR",
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "kernels"),
+)
+_SPICE_AVAILABLE = os.path.isdir(_SPICE_KERNEL_DIR) and any(
+    f.endswith(".bsp") for f in os.listdir(_SPICE_KERNEL_DIR)
+)
+
+pytestmark = [
+    pytest.mark.slow,
+    pytest.mark.e2e,
+    pytest.mark.spice,
+    pytest.mark.skipif(not _SPICE_AVAILABLE, reason="SPICE kernels not available"),
+]
+
+
+class TestDesignOrbitLissajous:
+    """Lissajous 设计端到端。"""
+
+    @pytest.mark.parametrize("collinear_point", [1, 2])
+    def test_end_to_end_converges(self, collinear_point):
+        """CR3BP → two_level 星历修正 → 高精度传播，全流程不抛异常。"""
+        result = design_orbit(
+            "Lissajous",
+            collinear_point=collinear_point,
+            amplitude_in=500.0,
+            amplitude_out=2000.0,
+            phase_in=0.0,
+            phase_out=0.0,
+            epoch="2025-01-01T00:00:00",
+            duration=0.05,
+            output_step=3600.0,
+        )
+        assert result.correction.converged
+        assert result.ephemeris is not None
+        assert result.orbit_type == "LISSAJOUS"
+
+    def test_amplitude_bounded(self):
+        """传播后位置振幅不爆炸——地月空间合理范围。"""
+        result = design_orbit(
+            "Lissajous",
+            collinear_point=2,
+            amplitude_in=500.0,
+            amplitude_out=2000.0,
+            phase_in=0.0,
+            phase_out=0.0,
+            epoch="2025-01-01T00:00:00",
+            duration=0.05,
+        )
+        eph = result.ephemeris
+        pos_norms = np.linalg.norm(eph.position_km, axis=1)
+        assert pos_norms.max() < 1e6, f"最大地心距 {pos_norms.max():.0f} km 超出地月空间合理范围"
+        assert pos_norms.min() > 1e4, f"最小地心距 {pos_norms.min():.0f} km 超出地月空间合理范围"
+
+    def test_output_shape(self):
+        """输出 ephemeris 形状正确（行数、列结构）。"""
+        duration = 0.05
+        output_step = 3600.0
+        result = design_orbit(
+            "Lissajous",
+            collinear_point=2,
+            amplitude_in=500.0,
+            amplitude_out=2000.0,
+            phase_in=0.0,
+            phase_out=0.0,
+            epoch="2025-01-01T00:00:00",
+            duration=duration,
+            output_step=output_step,
+        )
+        eph = result.ephemeris
+        expected_rows = math.ceil(duration * 365.25 * 86400 / output_step)
+        # 允许 ±2 行容差（累积舍入）
+        assert abs(len(eph) - expected_rows) <= 2, f"预期约 {expected_rows} 行，实际 {len(eph)} 行"
+        assert eph.position_km.shape == (len(eph), 3)
+        assert eph.velocity_mps.shape == (len(eph), 3)
+        assert eph.synodic_position.shape == (len(eph), 3)
+
+    def test_epoch_matches_input(self):
+        """起始历元匹配输入 epoch。"""
+        result = design_orbit(
+            "Lissajous",
+            collinear_point=2,
+            amplitude_in=500.0,
+            amplitude_out=2000.0,
+            phase_in=0.0,
+            phase_out=0.0,
+            epoch="2025-01-01T00:00:00",
+            duration=0.05,
+        )
+        eph = result.ephemeris
+        assert eph.year[0] == 2025
+        assert eph.month[0] == 1
+        assert eph.day[0] == 1
+
+    def test_initial_state_shape(self):
+        """initial_state 为 6 维向量 (km, km/s)。"""
+        result = design_orbit(
+            "Lissajous",
+            collinear_point=2,
+            amplitude_in=500.0,
+            amplitude_out=2000.0,
+            phase_in=0.0,
+            phase_out=0.0,
+            epoch="2025-01-01T00:00:00",
+            duration=0.05,
+        )
+        assert result.initial_state.shape == (6,)
+
+    def test_cr3bp_orbit_present(self):
+        """cr3bp_orbit 和 jacobi 应存在。"""
+        result = design_orbit(
+            "Lissajous",
+            collinear_point=2,
+            amplitude_in=500.0,
+            amplitude_out=2000.0,
+            phase_in=0.0,
+            phase_out=0.0,
+            epoch="2025-01-01T00:00:00",
+            duration=0.05,
+        )
+        assert result.cr3bp_orbit is not None
+        assert isinstance(result.cr3bp_jacobi, float)
+        assert result.cr3bp_orbit.states is not None
+        assert len(result.cr3bp_orbit.states) > 0

--- a/tests/algorithms/test_design_orbit_triangular.py
+++ b/tests/algorithms/test_design_orbit_triangular.py
@@ -1,0 +1,136 @@
+"""L4/L5 三角平动点轨道设计端到端测试。
+
+通过 ``design_orbit("L4"/"L5", ...)`` 全流程（CR3BP 初猜 → two_level
+星历修正 → 高精度长期预报），验证收敛性、振幅有界、输出形状正确。
+
+依赖 SPICE 内核（``design_orbit`` 自动加载 ``kernels/``）。
+内核缺失时整组跳过。
+"""
+
+from __future__ import annotations
+
+import math
+import os
+
+import numpy as np
+import pytest
+
+from e2m2e.algorithm.design import design_orbit
+
+_SPICE_KERNEL_DIR = os.environ.get(
+    "SPICE_KERNEL_DIR",
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "kernels"),
+)
+_SPICE_AVAILABLE = os.path.isdir(_SPICE_KERNEL_DIR) and any(
+    f.endswith(".bsp") for f in os.listdir(_SPICE_KERNEL_DIR)
+)
+
+pytestmark = [
+    pytest.mark.slow,
+    pytest.mark.e2e,
+    pytest.mark.spice,
+    pytest.mark.skipif(not _SPICE_AVAILABLE, reason="SPICE kernels not available"),
+]
+
+
+class TestDesignOrbitTriangular:
+    """L4/L5 设计端到端。"""
+
+    @pytest.mark.parametrize("point", ["L4", "L5"])
+    def test_end_to_end_converges(self, point):
+        """CR3BP → two_level 星历修正 → 高精度传播，全流程不抛异常。"""
+        result = design_orbit(
+            point,
+            amplitude_in=300.0,
+            amplitude_out=1000.0,
+            phase_in=0.0,
+            phase_out=0.0,
+            epoch="2025-01-01T00:00:00",
+            duration=0.05,
+            output_step=3600.0,
+        )
+        assert result.correction.converged
+        assert result.ephemeris is not None
+        assert result.orbit_type == point
+
+    def test_amplitude_bounded(self):
+        """传播后位置振幅不爆炸——地月空间合理范围。"""
+        result = design_orbit(
+            "L4",
+            amplitude_in=300.0,
+            amplitude_out=1000.0,
+            phase_in=0.0,
+            phase_out=0.0,
+            epoch="2025-01-01T00:00:00",
+            duration=0.05,
+        )
+        eph = result.ephemeris
+        pos_norms = np.linalg.norm(eph.position_km, axis=1)
+        assert pos_norms.max() < 1e6, f"最大地心距 {pos_norms.max():.0f} km 超出合理范围"
+        assert pos_norms.min() > 1e4, f"最小地心距 {pos_norms.min():.0f} km 超出合理范围"
+
+    def test_output_shape(self):
+        """输出 ephemeris 形状正确（行数、列结构）。"""
+        duration = 0.05
+        output_step = 3600.0
+        result = design_orbit(
+            "L5",
+            amplitude_in=300.0,
+            amplitude_out=1000.0,
+            phase_in=0.0,
+            phase_out=0.0,
+            epoch="2025-01-01T00:00:00",
+            duration=duration,
+            output_step=output_step,
+        )
+        eph = result.ephemeris
+        expected_rows = math.ceil(duration * 365.25 * 86400 / output_step)
+        assert abs(len(eph) - expected_rows) <= 2, f"预期约 {expected_rows} 行，实际 {len(eph)} 行"
+        assert eph.position_km.shape == (len(eph), 3)
+        assert eph.velocity_mps.shape == (len(eph), 3)
+        assert eph.synodic_position.shape == (len(eph), 3)
+
+    def test_epoch_matches_input(self):
+        """起始历元匹配输入 epoch。"""
+        result = design_orbit(
+            "L4",
+            amplitude_in=300.0,
+            amplitude_out=1000.0,
+            phase_in=0.0,
+            phase_out=0.0,
+            epoch="2025-01-01T00:00:00",
+            duration=0.05,
+        )
+        eph = result.ephemeris
+        assert eph.year[0] == 2025
+        assert eph.month[0] == 1
+        assert eph.day[0] == 1
+
+    def test_initial_state_shape(self):
+        """initial_state 为 6 维向量 (km, km/s)。"""
+        result = design_orbit(
+            "L5",
+            amplitude_in=300.0,
+            amplitude_out=1000.0,
+            phase_in=0.0,
+            phase_out=0.0,
+            epoch="2025-01-01T00:00:00",
+            duration=0.05,
+        )
+        assert result.initial_state.shape == (6,)
+
+    def test_cr3bp_orbit_present(self):
+        """cr3bp_orbit 和 jacobi 应存在。"""
+        result = design_orbit(
+            "L4",
+            amplitude_in=300.0,
+            amplitude_out=1000.0,
+            phase_in=0.0,
+            phase_out=0.0,
+            epoch="2025-01-01T00:00:00",
+            duration=0.05,
+        )
+        assert result.cr3bp_orbit is not None
+        assert isinstance(result.cr3bp_jacobi, float)
+        assert result.cr3bp_orbit.states is not None
+        assert len(result.cr3bp_orbit.states) > 0

--- a/tests/algorithms/test_lissajous_initial_guess.py
+++ b/tests/algorithms/test_lissajous_initial_guess.py
@@ -1,0 +1,130 @@
+"""Lissajous 初始猜测模块测试。
+
+覆盖 compute_lissajous_initial_guess 的返回结构、锚点约束、振幅独立性、
+相位影响与错误处理。
+"""
+
+import numpy as np
+import pytest
+
+from e2m2e.algorithm.dynamics import CR3BP_System, LibrationPoint
+from e2m2e.algorithm.family.lissajous_initial_guess import compute_lissajous_initial_guess
+
+MU_EM = 1.215058560962404e-2
+
+
+def _earth_moon_system() -> CR3BP_System:
+    system = CR3BP_System(mu=MU_EM, primary="Earth", secondary="Moon")
+    system.set_characteristic_scales(distance=384405.0, period=27.32 * 86400.0)
+    return system
+
+
+# =============================================================================
+# Module identity
+# =============================================================================
+
+
+class TestModuleImport:
+    """验证模块可直接导入，函数可直接调用。"""
+
+    def test_module_importable(self):
+        """lissajous_initial_guess 模块应可直接导入。"""
+        assert compute_lissajous_initial_guess is not None
+
+    def test_functions_have_docstrings(self):
+        """公共函数应有文档字符串。"""
+        assert compute_lissajous_initial_guess.__doc__ is not None
+
+
+# =============================================================================
+# compute_lissajous_initial_guess
+# =============================================================================
+
+
+class TestLissajousInitialGuess:
+    """compute_lissajous_initial_guess 的正确性。"""
+
+    def test_returns_state_and_period(self):
+        """应返回 (state, period) 元组。"""
+        system = _earth_moon_system()
+        result = compute_lissajous_initial_guess(system, 2, 1000.0, 5000.0, 0.0, 0.0)
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+
+    def test_state_shape_is_6(self):
+        """状态向量形状应为 (6,)。"""
+        system = _earth_moon_system()
+        state0, _ = compute_lissajous_initial_guess(system, 2, 1000.0, 5000.0, 0.0, 0.0)
+        assert np.asarray(state0).shape == (6,)
+
+    def test_period_is_positive(self):
+        """标称周期应为正值。"""
+        system = _earth_moon_system()
+        _, T = compute_lissajous_initial_guess(system, 2, 1000.0, 5000.0, 0.0, 0.0)
+        assert T > 0
+
+    @pytest.mark.parametrize("L", [1, 2, 3])
+    def test_anchor_near_libration_point(self, L: int):
+        """初始状态位置应在对应平动点附近（偏移 < 0.2 DU）。"""
+        system = _earth_moon_system()
+        state0, _ = compute_lissajous_initial_guess(system, L, 1000.0, 5000.0, 0.0, 0.0)
+        lp = system.get_libration_point(LibrationPoint(L))
+        # 位置分量偏移应远小于 1 DU（振幅 ~ 数千 km / 384405 km << 1）
+        dist = np.linalg.norm(state0[:3] - lp)
+        assert dist < 0.2
+
+    @pytest.mark.parametrize("L", [1, 2])
+    def test_larger_amplitude_gives_larger_offset(self, L: int):
+        """面内振幅翻倍 → 距锚点的位置偏移近似翻倍。"""
+        system = _earth_moon_system()
+        small, _ = compute_lissajous_initial_guess(system, L, 1000.0, 2000.0, 0.0, 0.0)
+        large, _ = compute_lissajous_initial_guess(system, L, 2000.0, 2000.0, 0.0, 0.0)
+        lp = system.get_libration_point(LibrationPoint(L))
+        d_small = np.linalg.norm(small[:3] - lp)
+        d_large = np.linalg.norm(large[:3] - lp)
+        assert d_large > d_small
+
+    @pytest.mark.parametrize("L", [1, 2])
+    def test_inplane_amplitude_affects_position(self, L: int):
+        """改变面内振幅应改变初始位置。"""
+        system = _earth_moon_system()
+        state_a, _ = compute_lissajous_initial_guess(system, L, 1000.0, 5000.0, 0.0, 0.0)
+        state_b, _ = compute_lissajous_initial_guess(system, L, 3000.0, 5000.0, 0.0, 0.0)
+        assert not np.allclose(state_a, state_b)
+
+    @pytest.mark.parametrize("L", [1, 2])
+    def test_outplane_amplitude_affects_position(self, L: int):
+        """改变面外振幅应改变初始位置。"""
+        system = _earth_moon_system()
+        state_a, _ = compute_lissajous_initial_guess(system, L, 1000.0, 2000.0, 0.0, 0.0)
+        state_b, _ = compute_lissajous_initial_guess(system, L, 1000.0, 8000.0, 0.0, 0.0)
+        assert not np.allclose(state_a, state_b)
+
+    def test_invalid_collinear_point_raises(self):
+        """collinear_point 非 1/2/3 时应抛出 ValueError。"""
+        system = _earth_moon_system()
+        with pytest.raises(ValueError, match="collinear_point"):
+            compute_lissajous_initial_guess(system, 4, 1000.0, 5000.0, 0.0, 0.0)
+
+    @pytest.mark.parametrize("L", [1, 2, 3])
+    def test_phase_affects_initial_state(self, L: int):
+        """改变面内相位应改变初始状态。"""
+        system = _earth_moon_system()
+        state_0, _ = compute_lissajous_initial_guess(system, L, 1000.0, 5000.0, 0.0, 0.0)
+        state_1, _ = compute_lissajous_initial_guess(system, L, 1000.0, 5000.0, 0.5, 0.0)
+        assert not np.allclose(state_0, state_1)
+
+    @pytest.mark.parametrize("L", [1, 2])
+    def test_period_reasonable_range(self, L: int):
+        """L1/L2 面内周期应在 Lyapunov 量级（约 2-4 无量纲时间）。"""
+        system = _earth_moon_system()
+        _, T = compute_lissajous_initial_guess(system, L, 1000.0, 5000.0, 0.0, 0.0)
+        assert 1.5 < T < 5.0
+
+    @pytest.mark.parametrize("L", [1, 2, 3])
+    def test_state_finite(self, L: int):
+        """状态所有分量应为有限值。"""
+        system = _earth_moon_system()
+        state0, T = compute_lissajous_initial_guess(system, L, 1000.0, 5000.0, 0.0, 0.0)
+        assert np.all(np.isfinite(state0))
+        assert np.isfinite(T)

--- a/tests/algorithms/test_triangular_initial_guess.py
+++ b/tests/algorithms/test_triangular_initial_guess.py
@@ -60,3 +60,61 @@ class TestInitialGuess:
         d_small = np.linalg.norm(small[:3] - anchor)
         d_large = np.linalg.norm(large[:3] - anchor)
         assert d_large / d_small == pytest.approx(2.0, rel=0.05)
+
+
+# =============================================================================
+# Issue #255 — 扩展测试
+# =============================================================================
+
+
+class TestTriangularInitialGuessExtended:
+    """compute_triangular_initial_guess 扩展测试（状态结构、模态、振幅分拆）。"""
+
+    @pytest.mark.parametrize("point", [4, 5])
+    def test_state_shape_is_6(self, point: int):
+        """状态向量形状应为 (6,)。"""
+        system = _earth_moon_system()
+        state0, _ = compute_triangular_initial_guess(system, point, 8000.0, 6000.0, 0.0, 0.0)
+        assert np.asarray(state0).shape == (6,)
+
+    @pytest.mark.parametrize("point", [4, 5])
+    def test_period_is_positive(self, point: int):
+        """标称周期应为正值。"""
+        system = _earth_moon_system()
+        _, T = compute_triangular_initial_guess(system, point, 8000.0, 6000.0, 0.0, 0.0)
+        assert T > 0
+
+    @pytest.mark.parametrize("point", [4, 5])
+    def test_three_modal_frequencies_present(self, point: int):
+        """三角点应有三个独立模态频率（短周期、长周期、垂直），两两不等。"""
+        system = _earth_moon_system()
+        omega_s, _, omega_l, _, omega_v, _, _ = _triangular_modes(system, point)
+        freqs = sorted([omega_s, omega_l, omega_v])
+        # 三个频率应互不相同（特征方程给出两个面内 + 一个面外）
+        assert freqs[1] - freqs[0] > 1e-6
+        assert freqs[2] - freqs[1] > 1e-6
+
+    @pytest.mark.parametrize("point", [4, 5])
+    def test_inplane_amplitude_split_equally(self, point: int):
+        """面内振幅均分给短周期和长周期模态：两个模态使用相同的 0.5 倍原始振幅。"""
+        system = _earth_moon_system()
+        omega_s, v_s, omega_l, v_l, _, _, _ = _triangular_modes(system, point)
+        l_c = system.characteristic_length
+        amplitude_in_km = 8000.0
+        raw_in = amplitude_in_km / l_c
+        # 两个模态的位置振幅贡献：alpha * |v[:3]|，应各为 raw_in 的一半
+        pos_amp_s = (0.5 * raw_in / np.linalg.norm(v_s[:3])) * np.linalg.norm(v_s[:3])
+        pos_amp_l = (0.5 * raw_in / np.linalg.norm(v_l[:3])) * np.linalg.norm(v_l[:3])
+        assert pos_amp_s == pytest.approx(0.5 * raw_in, rel=1e-10)
+        assert pos_amp_l == pytest.approx(0.5 * raw_in, rel=1e-10)
+
+    @pytest.mark.parametrize("point", [4, 5])
+    def test_larger_amplitude_gives_larger_offset(self, point: int):
+        """振幅翻倍 → 距锚点的位置偏移近似翻倍（参数化 L4/L5）。"""
+        system = _earth_moon_system()
+        small, _ = compute_triangular_initial_guess(system, point, 4000.0, 3000.0, 0.0, 0.0)
+        large, _ = compute_triangular_initial_guess(system, point, 8000.0, 6000.0, 0.0, 0.0)
+        anchor = system.get_libration_point(LibrationPoint(point))
+        d_small = np.linalg.norm(small[:3] - anchor)
+        d_large = np.linalg.norm(large[:3] - anchor)
+        assert d_large / d_small == pytest.approx(2.0, rel=0.05)

--- a/tests/dfh/test_parameter_validation.py
+++ b/tests/dfh/test_parameter_validation.py
@@ -116,3 +116,81 @@ class TestPropagateValidation:
             format_inputs_propagate(
                 epoch=[2024, 1, 1, 0, 0, 0], duration=1.0, initial_state=[1, 2, 3]
             )
+
+
+# =============================================================================
+# Lissajous / L4 / L5 补充边界校验（Phase 2 #255）
+# =============================================================================
+class TestLissajousTriangularValidation:
+    """Lissajous 与 L4/L5 轨道额外边界条件校验。"""
+
+    # --- Lissajous L3（amplitude 限制 100000，远大于 L1/L2 的 7600） ---
+    def test_lissajous_l3_amplitude_in_too_large(self):
+        with pytest.raises(ValueError, match="100000"):
+            design_orbit("Lissajous", collinear_point=3, amplitude_in=150000.0)
+
+    def test_lissajous_l3_amplitude_out_too_large(self):
+        with pytest.raises(ValueError, match="100000"):
+            design_orbit("Lissajous", collinear_point=3, amplitude_out=150000.0)
+
+    # --- Lissajous amplitude 为零或负 ---
+    def test_lissajous_amplitude_in_zero_rejected(self):
+        with pytest.raises(ValueError, match="0"):
+            design_orbit("Lissajous", collinear_point=2, amplitude_in=0.0)
+
+    def test_lissajous_amplitude_in_negative_rejected(self):
+        with pytest.raises(ValueError, match="0"):
+            design_orbit("Lissajous", collinear_point=2, amplitude_in=-500.0)
+
+    def test_lissajous_amplitude_out_zero_rejected(self):
+        with pytest.raises(ValueError, match="0"):
+            design_orbit("Lissajous", collinear_point=2, amplitude_out=0.0)
+
+    def test_lissajous_amplitude_out_negative_rejected(self):
+        with pytest.raises(ValueError, match="0"):
+            design_orbit("Lissajous", collinear_point=2, amplitude_out=-1000.0)
+
+    # --- Lissajous 无效 collinear_point ---
+    def test_lissajous_invalid_collinear_point_rejected(self):
+        with pytest.raises(ValueError, match="1/2/3"):
+            design_orbit("Lissajous", collinear_point=4)
+
+    # --- Lissajous L1 amplitude 限制（同 L2：7600 km） ---
+    def test_lissajous_l1_amplitude_in_too_large(self):
+        with pytest.raises(ValueError, match="7600"):
+            design_orbit("Lissajous", collinear_point=1, amplitude_in=8000.0)
+
+    # --- L4/L5 amplitude 为零或负 ---
+    def test_l4_amplitude_in_zero_rejected(self):
+        with pytest.raises(ValueError, match="0"):
+            design_orbit("L4", amplitude_in=0.0)
+
+    def test_l4_amplitude_in_negative_rejected(self):
+        with pytest.raises(ValueError, match="0"):
+            design_orbit("L4", amplitude_in=-500.0)
+
+    def test_l4_amplitude_out_zero_rejected(self):
+        with pytest.raises(ValueError, match="0"):
+            design_orbit("L4", amplitude_out=0.0)
+
+    def test_l5_amplitude_in_zero_rejected(self):
+        with pytest.raises(ValueError, match="0"):
+            design_orbit("L5", amplitude_in=0.0)
+
+    def test_l5_amplitude_out_zero_rejected(self):
+        with pytest.raises(ValueError, match="0"):
+            design_orbit("L5", amplitude_out=0.0)
+
+    # --- L4/L5 amplitude 上界 ---
+    def test_l5_amplitude_in_too_large_rejected(self):
+        with pytest.raises(ValueError, match="10000"):
+            design_orbit("L5", amplitude_in=15000.0)
+
+    # --- L4/L5 phase 越界 ---
+    def test_l4_phase_in_out_of_range(self):
+        with pytest.raises(ValueError, match="phase_in"):
+            design_orbit("L4", phase_in=1.5)
+
+    def test_l5_phase_in_out_of_range(self):
+        with pytest.raises(ValueError, match="phase_in"):
+            design_orbit("L5", phase_in=-0.1)


### PR DESCRIPTION
Closes #255

## 改了什么

### Phase 1 — 初猜测试补全
- 新增 （22 tests，L1/L2/L3 参数化）
- 扩展 （+8 tests，状态结构/模态/振幅分拆）
- 将  转为 

### Phase 2 — 端到端算例
- 新增 （7 tests，CR3BP→two_level→传播全链路）
- 新增 （7 tests，L4/L5 端到端）
- 扩展 （+22 tests，Lissajous/L4/L5 边界校验）

### Phase 3 — QPIT 正确器
- 新增 ：QPITCorrector 参数空间微分修正器（Newton 迭代在中心流形 action-angle 空间求解目标振幅）
- ：移除星历路径 Hamiltonian 注入守卫（W(t) 已吸收星历摄动，CR3BP Hamiltonian 对中心流形 Lie 变换适用）
- ：lazy export QPITCorrector / QPITCorrectorResult
- 新增 （5 tests）

## 测试

```bash
pytest tests/algorithms/test_lissajous_initial_guess.py tests/algorithms/test_triangular_initial_guess.py tests/algorithms/normal_form/test_lissajous_bounded.py tests/algorithms/test_design_orbit_lissajous.py tests/algorithms/test_design_orbit_triangular.py tests/dfh/test_parameter_validation.py tests/algorithms/normal_form/test_qpit_corrector.py -v --timeout=300
```

75 新测试全部通过，无回归。