### PR TITLE
fix(forces): COF/GFC 文件读取增加 UTF-8 容错解码

### DIFF
--- a/e2m2e/algorithm/forces/gravity_file.py
+++ b/e2m2e/algorithm/forces/gravity_file.py
@@ -68,7 +68,7 @@ def load_gfc_file(
         解析后的重力场数据。
     """
     path = Path(path)
-    text = path.read_text(encoding="utf-8")
+    text = path.read_text(encoding="utf-8", errors="replace")
 
     model_name = "unknown"
     mu = float(default_mu)
@@ -229,7 +229,7 @@ def load_cof_file(
         解析后的重力场数据。
     """
     path = Path(path)
-    text = path.read_text(encoding="utf-8")
+    text = path.read_text(encoding="utf-8", errors="replace")
 
     model_name = path.stem
     mu = float(default_mu)


### PR DESCRIPTION
## 关联

Closes #263

## 改动

-  和  的  增加 
- 非 UTF-8 字节（如 GBK 中文注释）被替换为 U+FFFD，不再抛 
- 注释行被解析器跳过，替换字符不影响系数解析

## 测试

- 原 6 个 Windows 失败用例全部通过
- 全量回归：1376 passed, 0 failed