### PR TITLE
feat(station-keeping): 角动量管理联合控制实现（#261）

### DIFF
--- a/e2m2e/algorithm/station_keeping/__init__.py
+++ b/e2m2e/algorithm/station_keeping/__init__.py
@@ -2,12 +2,9 @@
 
 站保控制律留 Python（领域知识，ADR 0011 迁移，源：``dfh/control_orbit.py``
 编排 + ``algorithms/station_keeping/``）：特征点控制（special_point）、目标
-点严格/宽松控制（target_point）、误差模型（error_models）、三轨道蒙特卡洛
-（monte_carlo）。``controller.py`` 是编排器（读输入星历、选控制律、配双力
-模型、汇总输出）。
-
-未实现（对外承诺能力）：角动量管理（原 #261），占位函数抛
-``NotImplementedError``。
+点严格/宽松控制（target_point）、误差模型（error_models）、角动量管理
+（momentum_management）、三轨道蒙特卡洛（monte_carlo）。``controller.py``
+是编排器（读输入星历、选控制律、配双力模型、汇总输出）。
 """
 
 from __future__ import annotations
@@ -18,6 +15,14 @@ from .error_models import (
     NavigationErrorModel,
     SrpErrorModel,
     ThrustExecutionError,
+)
+from .momentum_management import (
+    EngineLayout,
+    compute_delta_m,
+    compute_srp_torque,
+    solve_joint_control,
+    solve_momentum_unload,
+    validate_engine_layout,
 )
 from .monte_carlo import MonteCarloResult, run_monte_carlo
 from .special_point import SpecialPointLaw, StmPropagator
@@ -37,20 +42,10 @@ __all__ = [
     "ThrustExecutionError",
     "SrpErrorModel",
     "BoxMullerSampler",
+    "EngineLayout",
+    "validate_engine_layout",
+    "compute_srp_torque",
+    "compute_delta_m",
+    "solve_momentum_unload",
+    "solve_joint_control",
 ]
-
-
-def momentum_management(
-    input_ephemeris: object,
-    *,
-    engine_layout: object = None,
-    **kwargs,
-) -> ControlOrbitResult:
-    """角动量管理联合控制（原功能码 4-6，原 #261）。
-
-    实现状态：未实现（对外承诺能力，占位）。
-
-    Raises:
-        NotImplementedError: 角动量管理未实现。
-    """
-    raise NotImplementedError("角动量管理未实现（原 #261）：姿态发动机 E/E_r 矩阵 + 联合控制待补")

--- a/e2m2e/algorithm/station_keeping/controller.py
+++ b/e2m2e/algorithm/station_keeping/controller.py
@@ -174,13 +174,9 @@ def control_orbit(
         NotImplementedError: 摄动开关含 ECOM 光压或耦合项（#253）
     """
     if control_mode not in (1, 2, 3, 4, 5, 6):
-        raise ValueError(
-            f"control_mode 必须为 1-6，当前 {control_mode}"
-        )
+        raise ValueError(f"control_mode 必须为 1-6，当前 {control_mode}")
     if control_mode >= 4 and engine_layout is None:
-        raise ValueError(
-            f"control_mode {control_mode}（角动量管理）需提供 engine_layout"
-        )
+        raise ValueError(f"control_mode {control_mode}（角动量管理）需提供 engine_layout")
     if special_mode not in (1, 2):
         raise ValueError(
             f"special_mode 必须为 1（Lissajous）或 2（Halo/NRHO），当前 {special_mode}"
@@ -201,6 +197,7 @@ def control_orbit(
     # 角动量管理时校验发动机布局
     if engine_layout is not None:
         from .momentum_management import validate_engine_layout
+
         validate_engine_layout(engine_layout)
 
     if isinstance(input_ephemeris, EphemerisTable):

--- a/e2m2e/algorithm/station_keeping/controller.py
+++ b/e2m2e/algorithm/station_keeping/controller.py
@@ -1,16 +1,16 @@
 """DFH 功能码 2（任务轨道控制/轨道保持）对齐入口。
 
 端到端复现 DFH 轨道保持功能：输入标称轨道星历（FR1 ``design_orbit``
-产物），按控制模式（特征点/目标点严格/目标点宽松）施加脉冲控制，以
-三轨道结构（目标/真实/测量）仿真测定轨与控制误差，蒙特卡洛批量评估，
-输出 SK_STATISTIC / MANEUVERS / 受控星历。算法以《控制方案.md》
+产物），按控制模式（特征点/目标点严格/目标点宽松，可选角动量管理）施加
+脉冲控制，以三轨道结构（目标/真实/测量）仿真测定轨与控制误差，蒙特卡洛
+批量评估，输出 SK_STATISTIC / MANEUVERS / 受控星历。算法以《控制方案.md》
 （hybrid_auto 版）为准，规格见 ``docs/plans/dfh-parity-prd.md`` FR2。
 
 参数与 MATLAB ``control_orbit.m`` 对齐（关键字参数 + dataclass 结果）。
-两处能力边界差异（e2m2e 尚未实现，见 #253）：光压默认用炮弹模型
-（``solar_radiation=1``，MATLAB 默认 ECOM=2）；耦合项默认关闭
-（``coupling=0``，MATLAB 默认开）。角动量管理（MATLAB ControlMode
-4-6）不在本入口范围（#261）。
+角动量管理模式（control_mode 4-6）通过 ``engine_layout`` 参数激活，
+对应 MATLAB ControlMode 4-6。两处能力边界差异（e2m2e 尚未实现，见
+#253）：光压默认用炮弹模型（``solar_radiation=1``，MATLAB 默认 ECOM=2）；
+耦合项默认关闭（``coupling=0``，MATLAB 默认开）。
 """
 
 from __future__ import annotations
@@ -18,6 +18,8 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
+
+import numpy as np
 
 from e2m2e.io.ephemeris import read_ephemeris
 from e2m2e.io.inputs_dac import DEFAULT_DYB, DEFAULT_PERTURBATION
@@ -34,7 +36,7 @@ from .monte_carlo import MonteCarloResult, run_monte_carlo
 
 __all__ = ["ControlOrbitResult", "control_orbit"]
 
-#: 受控星历输出文件名（按控制模式分文件，对齐 DFH）
+#: 受控星历输出文件名（按控制模式分文件，对齐 DFH；mode 4-6 沿用基础模式文件名）
 _EPHEMERIS_NAMES = {1: "EPHEMERIDES_LOOSE", 2: "EPHEMERIDES_TIGHT", 3: "EPHEMERIDES_SPECIAL"}
 
 #: e2m2e 能力边界内的默认摄动开关：球模型光压、关耦合项（MATLAB 默认
@@ -51,7 +53,7 @@ class ControlOrbitResult:
     """轨道保持仿真结果（对齐 MATLAB ``control_orbit`` 输出结构）。
 
     Attributes:
-        sk_statistic: SK_STATISTIC 表（3 列：运行序号/总 Δv/最大 Δv，m/s）
+        sk_statistic: SK_STATISTIC 表（3 列或 5 列，m/s；角动量管理时含姿态列）
         num_failed: 蒙特卡洛失败样本数
         maneuvers: MANEUVERS 机动序列（MJD(TDB) + Δv，m/s）
         controlled_ephemeris: 最后一次样本的受控真实轨道星历
@@ -77,7 +79,9 @@ class ControlOrbitResult:
             write_maneuvers(self.maneuvers, out_dir / "MANEUVERS.TXT"),
         ]
         if self.controlled_ephemeris is not None:
-            name = _EPHEMERIS_NAMES.get(mode, f"EPHEMERIDES_MODE{mode}")
+            # mode 4-6 沿用基础模式的文件名
+            base = mode if mode <= 3 else mode - 3
+            name = _EPHEMERIS_NAMES.get(base, f"EPHEMERIDES_MODE{base}")
             paths.append(write_ephemeris(self.controlled_ephemeris, out_dir / f"{name}.TXT"))
         return paths
 
@@ -116,12 +120,18 @@ def control_orbit(
     kernel_dir: str | None = None,
     n_workers: int = 1,
     seed: int | None = None,
+    engine_layout: object | None = None,
+    momentum_interval: float = 5.0,
+    srp_offset_m: Sequence[float] | None = None,
+    spacecraft_mass: float = 1000.0,
+    srp_torque: Sequence[float] | None = None,
 ) -> ControlOrbitResult:
     """端到端轨道保持仿真（DFH 功能码 2）。
 
     Args:
         input_ephemeris: 标称轨道星历文件路径或 ``EphemerisTable``
-        control_mode: 1=目标点宽松、2=目标点严格、3=特征点
+        control_mode: 1=目标点宽松、2=目标点严格、3=特征点、
+            4=目标点宽松+角动量管理、5=目标点严格+角动量管理、6=特征点+角动量管理
         is_nrho: 目标轨道是否 NRHO（1=是；特征点模式的约束随之取
             ẋ=0 且 ż=0 由 ``special_mode`` 决定，本参数保留作输入对齐）
         special_mode: 特征点模式 1=Lissajous（ẋ=0）、2=Halo/NRHO（ẋ=0 且 ż=0）
@@ -146,6 +156,11 @@ def control_orbit(
             时 worker 用它在子进程重建上下文）
         n_workers: 进程池大小（>1 时样本并行）
         seed: 随机种子（同种子同结果）
+        engine_layout: ``EngineLayout`` 实例（角动量管理模式 4-6 必填）
+        momentum_interval: 角动量卸载间隔（天），0 表示与轨道控制同步
+        srp_offset_m: SRP 压心相对质心偏移 ``[x,y,z]``（m），常值
+        spacecraft_mass: 航天器质量（kg）
+        srp_torque: 常值 SRP 力矩 ``[τx,τy,τz]``（N·m）
 
     Returns:
         :class:`ControlOrbitResult`（SK_STATISTIC/MANEUVERS/受控星历）
@@ -154,9 +169,13 @@ def control_orbit(
         ValueError: 参数超界（控制模式、误差参数等）
         NotImplementedError: 摄动开关含 ECOM 光压或耦合项（#253）
     """
-    if control_mode not in (1, 2, 3):
+    if control_mode not in (1, 2, 3, 4, 5, 6):
         raise ValueError(
-            f"control_mode 必须为 1/2/3（角动量管理 4-6 归属 #261），当前 {control_mode}"
+            f"control_mode 必须为 1-6，当前 {control_mode}"
+        )
+    if control_mode >= 4 and engine_layout is None:
+        raise ValueError(
+            f"control_mode {control_mode}（角动量管理）需提供 engine_layout"
         )
     if special_mode not in (1, 2):
         raise ValueError(
@@ -174,6 +193,11 @@ def control_orbit(
     ]:
         if v <= 0:
             raise ValueError(f"{name} 必须为正数，当前 {v}")
+
+    # 角动量管理时校验发动机布局
+    if engine_layout is not None:
+        from .momentum_management import validate_engine_layout
+        validate_engine_layout(engine_layout)
 
     if isinstance(input_ephemeris, EphemerisTable):
         eph = input_ephemeris
@@ -224,13 +248,16 @@ def control_orbit(
         dyb=real_dyb_vals,
     )
 
+    # mode 4-6：基础控制律用 mode-3（4→1, 5→2, 6→3）
+    base_mode = control_mode if control_mode <= 3 else control_mode - 3
+
     result = run_monte_carlo(
         eph,
         spice=spice,
         system=system,
         force_config_ctrl=cfg_ctrl,
         force_config_true=cfg_true,
-        control_mode=control_mode,
+        control_mode=base_mode,
         special_mode=special_mode,
         special_crossings=special_crossings,
         control_interval_days=control_interval,
@@ -251,6 +278,11 @@ def control_orbit(
         seed=seed,
         n_workers=n_workers,
         kernel_dir=kernel_dir,
+        engine_layout=engine_layout,
+        momentum_interval_days=momentum_interval,
+        srp_offset_m=np.asarray(srp_offset_m, dtype=float) if srp_offset_m is not None else None,
+        spacecraft_mass_kg=spacecraft_mass,
+        srp_torque_nm=np.asarray(srp_torque, dtype=float) if srp_torque is not None else None,
     )
     return ControlOrbitResult(
         sk_statistic=result.sk_statistic(),

--- a/e2m2e/algorithm/station_keeping/controller.py
+++ b/e2m2e/algorithm/station_keeping/controller.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -33,6 +34,9 @@ from ..design.design_orbit import default_kernel_dir, load_design_kernels
 from ..dynamics import EphemerisSystem
 from ..forces.force_mapping import dfh_perturbation_to_force_config
 from .monte_carlo import MonteCarloResult, run_monte_carlo
+
+if TYPE_CHECKING:
+    from .momentum_management import EngineLayout
 
 __all__ = ["ControlOrbitResult", "control_orbit"]
 
@@ -120,7 +124,7 @@ def control_orbit(
     kernel_dir: str | None = None,
     n_workers: int = 1,
     seed: int | None = None,
-    engine_layout: object | None = None,
+    engine_layout: EngineLayout | None = None,
     momentum_interval: float = 5.0,
     srp_offset_m: Sequence[float] | None = None,
     spacecraft_mass: float = 1000.0,

--- a/e2m2e/algorithm/station_keeping/momentum_management.py
+++ b/e2m2e/algorithm/station_keeping/momentum_management.py
@@ -1,0 +1,199 @@
+"""角动量管理联合控制（《控制方案.md》§1.6）。
+
+太阳光压力矩导致姿态角动量累积，需周期性卸载。姿态发动机布局由安装位置
+``rᵢ``（相对质心，m）与喷气方向 ``eᵢ``（单位矢量）描述，构造常数矩阵：
+
+- ``E``（3×N）：力臂矩阵，``E[:,i] = rᵢ × eᵢ``
+- ``E_r``（3×N）：力矩方向矩阵，``E_r[:,i] = eᵢ``
+
+两种求解场景：
+
+1. **纯角动量卸载**（mode 4-6 的角动量事件）：``min ‖V‖²  s.t.  m·E_r·V = ΔM``
+2. **联合控制**（轨道控制 + 角动量卸载一次开机）：``min ‖V‖²  s.t.
+   E·V = Δv_orbital,  m·E_r·V = ΔM``
+
+发动机数 N ≥ 6（6 维约束需 N 维自由度保证可解性）。
+
+用户输入参考：MATLAB ``fmt_inputs_control.m`` 角动量块、控制方案 §1.6 图 5-38
+发动机安装示意（仅示意，布局必须作为用户输入）。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import numpy.typing as npt
+from scipy import linalg as splinalg
+
+__all__ = [
+    "EngineLayout",
+    "compute_delta_m",
+    "compute_srp_torque",
+    "solve_joint_control",
+    "solve_momentum_unload",
+    "validate_engine_layout",
+]
+
+
+@dataclass(frozen=True)
+class EngineLayout:
+    """姿态发动机布局。
+
+    Attributes:
+        positions_m: 安装位置（N×3，m，航天器本体坐标系质心为原点）
+        directions: 喷气方向（N×3，单位矢量，构造时自动归一化）
+        E: 力臂矩阵（3×N），``E[:,i] = rᵢ × eᵢ``
+        E_r: 力矩方向矩阵（3×N），``E_r[:,i] = eᵢ``
+    """
+
+    positions_m: npt.NDArray[np.floating]
+    directions: npt.NDArray[np.floating]
+    E: npt.NDArray[np.floating] = None  # type: ignore[assignment]
+    E_r: npt.NDArray[np.floating] = None  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        pos = np.asarray(self.positions_m, dtype=float)
+        direc = np.asarray(self.directions, dtype=float)
+        if pos.ndim != 2 or direc.ndim != 2:
+            raise ValueError("positions_m 与 directions 必须为二维数组")
+        if pos.shape != direc.shape:
+            raise ValueError(
+                f"positions_m 形状 {pos.shape} 与 directions 形状 {direc.shape} 不匹配"
+            )
+        n = pos.shape[0]
+        if n < 6:
+            raise ValueError(f"发动机数 N={n} 不足 6，方程组欠定")
+        # 归一化方向
+        norms = np.linalg.norm(direc, axis=1, keepdims=True)
+        if np.any(norms < 1e-12):
+            raise ValueError("directions 存在零矢量（无法归一化）")
+        direc = direc / norms
+        # E[:,i] = rᵢ × eᵢ（力臂叉积）；E_r[:,i] = eᵢ
+        E = np.cross(pos, direc).T  # (3, N)
+        E_r = direc.T  # (3, N)
+        # frozen=True 需要 object.__setattr__
+        object.__setattr__(self, "positions_m", pos)
+        object.__setattr__(self, "directions", direc)
+        object.__setattr__(self, "E", E)
+        object.__setattr__(self, "E_r", E_r)
+
+    @property
+    def num_engines(self) -> int:
+        return self.positions_m.shape[0]
+
+
+def validate_engine_layout(layout: EngineLayout) -> None:
+    """校验发动机布局的可解性。
+
+    检查项（全部抛 ``ValueError``，附中文信息）：
+
+    1. E_r 秩 < 3：角动量管理无解（三维角动量变化需 E_r 行满秩）
+    2. 增广 [E; E_r] 秩 < 6：联合控制不可解（存在 Δv_o + ΔM 组合无法同时满足）
+
+    发动机数 N < 6 的检查在 ``EngineLayout.__post_init__`` 中完成。
+    """
+    E_r = layout.E_r
+    E = layout.E
+    if np.linalg.matrix_rank(E_r, tol=1e-10) < 3:
+        raise ValueError(
+            "E_r 秩不足 3（角动量管理无解）：发动机喷气方向共面或共线，"
+            "无法产生三轴独立力矩。请检查安装方向是否线性无关。"
+        )
+    aug = np.vstack([E, E_r])
+    if np.linalg.matrix_rank(aug, tol=1e-10) < 6:
+        raise ValueError(
+            "增广矩阵 [E; E_r] 秩不足 6（联合控制不可解）：存在 Δv_o 与 ΔM 的"
+            "组合无法同时满足。请检查发动机布局的力臂与方向配置。"
+        )
+
+
+def compute_srp_torque(
+    srp_force_n: npt.ArrayLike,
+    offset_m: npt.ArrayLike,
+) -> npt.NDArray[np.floating]:
+    """计算 SRP 力矩（压心偏移 × SRP 力）。
+
+    Args:
+        srp_force_n: SRP 力矢量（N），方向为 Sun→SC
+        offset_m: SRP 压心相对质心偏移（m），用户输入常数
+
+    Returns:
+        3 矢量（N·m）
+    """
+    f = np.asarray(srp_force_n, dtype=float)
+    r = np.asarray(offset_m, dtype=float)
+    return np.cross(r, f)
+
+
+def compute_delta_m(
+    torque_nm: npt.ArrayLike,
+    dt_sec: float,
+) -> npt.NDArray[np.floating]:
+    """角动量卸载需求：ΔM = τ × Δt。
+
+    Args:
+        torque_nm: 3 矢量（N·m），SRP 力矩
+        dt_sec: 自上次卸载以来的时间间隔（秒）
+
+    Returns:
+        3 矢量（kg·m²/s）
+    """
+    tau = np.asarray(torque_nm, dtype=float)
+    return tau * float(dt_sec)
+
+
+def solve_momentum_unload(
+    E_r: npt.ArrayLike,
+    delta_m: npt.ArrayLike,
+    mass_kg: float,
+) -> npt.NDArray[np.floating]:
+    """纯角动量卸载求解。
+
+    ``min ‖V‖²  s.t.  m · E_r · V = ΔM``
+
+    Args:
+        E_r: 力矩方向矩阵（3×N）
+        delta_m: 角动量需求（3 矢量，kg·m²/s）
+        mass_kg: 航天器质量（kg）
+
+    Returns:
+        N 矢量（m/s），各发动机速度增量
+    """
+    E_r = np.asarray(E_r, dtype=float)
+    d = np.asarray(delta_m, dtype=float) / float(mass_kg)
+    # min-norm 解：V = E_r^T (E_r E_r^T)^{-1} d
+    return E_r.T @ splinalg.solve(E_r @ E_r.T, d, assume_a="pos")
+
+
+def solve_joint_control(
+    E: npt.ArrayLike,
+    E_r: npt.ArrayLike,
+    dv_orbital_mps: npt.ArrayLike,
+    delta_m: npt.ArrayLike,
+    mass_kg: float,
+) -> npt.NDArray[np.floating]:
+    """联合控制求解（轨道控制 + 角动量卸载一次开机）。
+
+    ``min ‖V‖²  s.t.  E·V = Δv_orbital,  m·E_r·V = ΔM``
+
+    增广线性方程组 ``A·V = b``，``A = [E; m·E_r]``（6×N，N≥6）。
+
+    Args:
+        E: 力臂矩阵（3×N）
+        E_r: 力矩方向矩阵（3×N）
+        dv_orbital_mps: 轨道控制速度增量（3 矢量，m/s）
+        delta_m: 角动量需求（3 矢量，kg·m²/s）
+        mass_kg: 航天器质量（kg）
+
+    Returns:
+        N 矢量（m/s），各发动机速度增量
+    """
+    E = np.asarray(E, dtype=float)
+    E_r = np.asarray(E_r, dtype=float)
+    dv = np.asarray(dv_orbital_mps, dtype=float)
+    dm = np.asarray(delta_m, dtype=float) / float(mass_kg)
+    A = np.vstack([E, E_r])
+    b = np.concatenate([dv, dm])
+    V, *_ = splinalg.lstsq(A, b)
+    return V

--- a/e2m2e/algorithm/station_keeping/monte_carlo.py
+++ b/e2m2e/algorithm/station_keeping/monte_carlo.py
@@ -476,9 +476,16 @@ class SingleSampleSimulation:
                     V = _solve_joint(layout.E, layout.E_r, dv_c * 1000.0,
                                      delta_m_cum, mass)
                     dv_orbital = layout.E @ V
+                    # 姿态独立 Δv：纯卸载需要的 Δv（与联合控制对比用）
                     dv_att_ind = _solve_unload(layout.E_r, delta_m_cum, mass)
                     attitude_independent_dv += float(np.linalg.norm(layout.E @ dv_att_ind))
                     dv_r_orbital, failed_k = self.thrust_error.apply(dv_orbital, self.sampler)
+                    # 联合控制姿态贡献：纯卸载所需的发动机输出投影到轨道面
+                    if failed_k:
+                        pass
+                    elif np.linalg.norm(delta_m_cum) > 0:
+                        att_contribution = float(np.linalg.norm(layout.E @ dv_att_ind))
+                        attitude_total_dv += att_contribution
                 else:
                     dv_r_orbital = None
                     failed_k = False
@@ -534,7 +541,6 @@ class SingleSampleSimulation:
                         V = _solve_unload(layout.E_r, delta_m_cum, mass)
                         dv_att_ind = V
                         attitude_independent_dv += float(np.linalg.norm(layout.E @ dv_att_ind))
-                        att_mag_mps = float(np.linalg.norm(layout.E @ V))
                         att_applied, att_failed = self.thrust_error.apply(
                             layout.E @ V, self.sampler)
                         if att_failed:

--- a/e2m2e/algorithm/station_keeping/monte_carlo.py
+++ b/e2m2e/algorithm/station_keeping/monte_carlo.py
@@ -265,13 +265,16 @@ class SampleResult:
     """单样本蒙特卡洛结果。
 
     Attributes:
-        total_delta_v_mps: 总 Δv（m/s）
+        total_delta_v_mps: 总 Δv（m/s），角动量管理模式含轨道+姿态联合 Δv
         max_delta_v_mps: 最大单次 Δv（m/s）
         failed: 是否控制失败（单次 > Δv_max 或累计 > 总上限）
         maneuver_times: 控制时刻（et 秒），形状 ``(n,)``
         maneuver_dv_mps: 各控制时刻施加的 Δv（m/s），形状 ``(n,)``
         controlled_times: 受控星历时间（et 秒），形状 ``(m,)``
         controlled_states: 受控真实轨道状态（GCRS，km, km/s），形状 ``(m, 6)``
+        attitude_delta_v_mps: 姿态总 Δv（m/s），仅角动量管理模式非零
+        attitude_delta_v_independent_mps: 姿态不影响轨道时的 Δv（m/s），即
+            纯角动量卸载（不含轨道控制贡献）的 Δv 累计量
     """
 
     total_delta_v_mps: float
@@ -281,6 +284,8 @@ class SampleResult:
     maneuver_dv_mps: npt.NDArray[np.floating]
     controlled_times: npt.NDArray[np.floating]
     controlled_states: npt.NDArray[np.floating]
+    attitude_delta_v_mps: float = 0.0
+    attitude_delta_v_independent_mps: float = 0.0
 
 
 @dataclass
@@ -294,6 +299,8 @@ class MonteCarloResult:
         num_failed: 失败样本数
         maneuvers: 第一个样本的机动序列（et 秒, m/s）
         controlled_ephemeris: 第一个样本的受控星历（可为 None）
+        attitude_delta_v: 每样本姿态总 Δv（m/s），形状 ``(n_samples,)``（角动量管理）
+        attitude_delta_v_independent: 每样本姿态独立 Δv（m/s），形状 ``(n_samples,)``
     """
 
     total_delta_v: npt.NDArray[np.floating]
@@ -302,14 +309,27 @@ class MonteCarloResult:
     num_failed: int
     maneuvers: npt.NDArray[np.floating] = field(default_factory=lambda: np.empty((0, 2)))
     controlled_ephemeris: EphemerisTable | None = None
+    attitude_delta_v: npt.NDArray[np.floating] = field(default_factory=lambda: np.empty(0))
+    attitude_delta_v_independent: npt.NDArray[np.floating] = field(default_factory=lambda: np.empty(0))
 
     def sk_statistic(self) -> SKStatistic:
-        """组装 SK_STATISTIC 表（3 列版，不含角动量管理）。
+        """组装 SK_STATISTIC 表（3 列或 5 列版）。
+
+        无角动量管理时 3 列（仿真序号/总 Δv/最大 Δv，序号在写出时追加）；
+        含角动量管理时 5 列（追加姿态总 Δv、姿态独立 Δv）。
 
         对齐 DFH 口径：失败样本不写统计行（黄金样本中失败行缺失）。
         """
         keep = ~self.failed_mask
-        rows = np.column_stack([self.total_delta_v[keep], self.max_delta_v[keep]])
+        if self.attitude_delta_v.size > 0:
+            rows = np.column_stack([
+                self.total_delta_v[keep],
+                self.max_delta_v[keep],
+                self.attitude_delta_v[keep],
+                self.attitude_delta_v_independent[keep],
+            ])
+        else:
+            rows = np.column_stack([self.total_delta_v[keep], self.max_delta_v[keep]])
         return SKStatistic(rows=rows, num_failed=self.num_failed)
 
     def maneuver_table(self) -> ManeuverTable:
@@ -337,6 +357,11 @@ class SingleSampleSimulation:
         force_config_ctrl: 控制（理论）力模型配置
         force_config_true: 真实（实际）力模型配置
         sampler: 标准正态采样器
+        engine_layout: 姿态发动机布局（None 表示无角动量管理）
+        momentum_interval_sec: 角动量卸载间隔（秒），0 表示与轨道控制同步
+        srp_offset_m: SRP 压心相对质心偏移（m），None 表示无 SRP 力矩
+        spacecraft_mass_kg: 航天器质量（kg）
+        srp_torque_nm: 常值 SRP 力矩（N·m），None 时由 srp_offset_m 和 SRP 力模型计算
     """
 
     nominal: NominalOrbit
@@ -352,8 +377,19 @@ class SingleSampleSimulation:
     force_config_ctrl: dict[str, Any]
     force_config_true: dict[str, Any]
     sampler: BoxMullerSampler
+    engine_layout: Any = None  # EngineLayout | None
+    momentum_interval_sec: float = 0.0
+    srp_offset_m: npt.NDArray[np.floating] | None = None
+    spacecraft_mass_kg: float = 1000.0
+    srp_torque_nm: npt.NDArray[np.floating] | None = None
 
     def run(self) -> SampleResult:
+        from .momentum_management import (
+            compute_delta_m as _compute_dm,
+            solve_joint_control as _solve_joint,
+            solve_momentum_unload as _solve_unload,
+        )
+
         nominal = self.nominal
         t0 = nominal.t_start
 
@@ -374,12 +410,37 @@ class SingleSampleSimulation:
 
         total_dv = 0.0
         max_dv = 0.0
+        attitude_total_dv = 0.0
+        attitude_independent_dv = 0.0
         failed = False
         t_prev = t0
 
-        for k in range(1, self.num_controls - 1):
-            t_k = t0 + k * self.control_interval_sec
+        # 角动量管理：SRP 力矩常值（用户输入 srp_torque_nm）
+        has_mm = self.engine_layout is not None
+        srp_torque = np.asarray(self.srp_torque_nm, dtype=float) if self.srp_torque_nm is not None else None
+        layout = self.engine_layout
+        mass = self.spacecraft_mass_kg
+        delta_m_cum = np.zeros(3)  # 累积角动量（上次卸载以来）
 
+        # 构造合并事件时间表（轨道控制 + 角动量卸载）
+        if has_mm and self.momentum_interval_sec > 0:
+            t_end = t0 + (self.num_controls - 1) * self.control_interval_sec
+            orbital_times = {t0 + k * self.control_interval_sec
+                            for k in range(1, self.num_controls - 1)}
+            mom_times = set()
+            t_m = t0 + self.momentum_interval_sec
+            while t_m < t_end:
+                # 与最近轨道控制时刻对齐（相差 < 1 秒视为同时）
+                if not any(abs(t_m - t_o) < 1.0 for t_o in orbital_times):
+                    mom_times.add(t_m)
+                t_m += self.momentum_interval_sec
+            events = sorted(orbital_times | mom_times)
+        else:
+            # 无角动量管理 或 卸载间隔=0（与轨道控制同步）
+            events = [t0 + k * self.control_interval_sec
+                      for k in range(1, self.num_controls - 1)]
+
+        for t_k in events:
             # 弧段 [t_prev, t_k] 真实轨道传播（实际力模型 + 本弧段光压误差，
             # 表 5-3 脚注：每控制弧段重新抽样、弧段内固定）
             cr_scale = self.srp_error.sample_cr_scale(self.sampler)
@@ -393,31 +454,119 @@ class SingleSampleSimulation:
             # 式 5.39：控制时刻的测量状态 = 真实 + 测定轨扰动
             x_meas = self.nav_error.perturb(x_true, self.sampler)
 
-            # 控制量基于测量状态、控制力模型计算，施加于真实轨道
-            # （控制律输出 km/s；误差模型与输出统计按 DFH 惯例用 m/s）
-            dv_c = self.law.compute_maneuver(x_meas, t_k, propagator=prop_ctrl, nominal=nominal)
-            if dv_c is None:
-                # 特征点模式找不到目标穿越：本控制时刻不开机
-                dv_r = None
+            # 角动量累积（SRP 力矩 × 弧段时间）
+            if has_mm and srp_torque is not None:
+                delta_m_cum += _compute_dm(srp_torque, t_k - t_prev)
+
+            # 判断事件类型
+            is_orbital = t_k in (orbital_times if has_mm and self.momentum_interval_sec > 0
+                                 else set(events))
+            is_momentum = has_mm and (not is_orbital or self.momentum_interval_sec <= 0
+                                      or any(abs(t_k - t) < 1.0
+                                             for t in ({t0 + j * self.momentum_interval_sec
+                                                        for j in range(1, int((t_k - t0) / self.momentum_interval_sec) + 2)
+                                                        if t0 + j * self.momentum_interval_sec <= t_k + 0.5}
+                                                       if self.momentum_interval_sec > 0 else set())))
+
+            # 控制量计算
+            if has_mm and is_orbital and is_momentum:
+                # 联合控制：轨道 + 角动量一次开机
+                dv_c = self.law.compute_maneuver(x_meas, t_k, propagator=prop_ctrl, nominal=nominal)
+                if dv_c is not None:
+                    V = _solve_joint(layout.E, layout.E_r, dv_c * 1000.0,
+                                     delta_m_cum, mass)
+                    dv_orbital = layout.E @ V
+                    dv_att_ind = _solve_unload(layout.E_r, delta_m_cum, mass)
+                    attitude_independent_dv += float(np.linalg.norm(layout.E @ dv_att_ind))
+                    dv_r_orbital, failed_k = self.thrust_error.apply(dv_orbital, self.sampler)
+                else:
+                    dv_r_orbital = None
+                    failed_k = False
+                    if np.linalg.norm(delta_m_cum) > 0:
+                        V = _solve_unload(layout.E_r, delta_m_cum, mass)
+                        dv_att_ind = V
+                        attitude_independent_dv += float(np.linalg.norm(layout.E @ dv_att_ind))
+                    else:
+                        V = None
+                if failed_k:
+                    failed = True
+                    break
+            elif has_mm and not is_orbital:
+                # 纯角动量卸载
+                dv_r_orbital = None
                 failed_k = False
+                if np.linalg.norm(delta_m_cum) > 0:
+                    V = _solve_unload(layout.E_r, delta_m_cum, mass)
+                    dv_att_ind = V
+                    attitude_independent_dv += float(np.linalg.norm(layout.E @ dv_att_ind))
+                    dv_att, failed_k = self.thrust_error.apply(layout.E @ V, self.sampler)
+                    if failed_k:
+                        failed = True
+                        break
+                    if dv_att is not None:
+                        att_mag = float(np.linalg.norm(dv_att))
+                        attitude_total_dv += att_mag
+                        total_dv += att_mag
+                        max_dv = max(max_dv, att_mag)
+                        x_true = x_true.copy()
+                        x_true[3:] += dv_att / 1000.0
+                V = None
             else:
-                dv_r, failed_k = self.thrust_error.apply(dv_c * 1000.0, self.sampler)
-            if failed_k:
-                failed = True
-                break
+                # 纯轨道控制（无角动量管理 或 角动量卸载间隔=0 与轨道同步）
+                dv_c = self.law.compute_maneuver(x_meas, t_k, propagator=prop_ctrl, nominal=nominal)
+                if dv_c is None:
+                    dv_r_orbital = None
+                    failed_k = False
+                else:
+                    dv_r_orbital, failed_k = self.thrust_error.apply(dv_c * 1000.0, self.sampler)
+                if failed_k:
+                    failed = True
+                    break
+                # 同步模式下角动量卸载与轨道控制合并
+                V = None
+                if has_mm and np.linalg.norm(delta_m_cum) > 0 and self.momentum_interval_sec <= 0:
+                    if dv_c is not None:
+                        V = _solve_joint(layout.E, layout.E_r, dv_c * 1000.0,
+                                         delta_m_cum, mass)
+                        dv_att_ind = _solve_unload(layout.E_r, delta_m_cum, mass)
+                        attitude_independent_dv += float(np.linalg.norm(layout.E @ dv_att_ind))
+                    else:
+                        V = _solve_unload(layout.E_r, delta_m_cum, mass)
+                        dv_att_ind = V
+                        attitude_independent_dv += float(np.linalg.norm(layout.E @ dv_att_ind))
+                        att_mag_mps = float(np.linalg.norm(layout.E @ V))
+                        att_applied, att_failed = self.thrust_error.apply(
+                            layout.E @ V, self.sampler)
+                        if att_failed:
+                            failed = True
+                            break
+                        if att_applied is not None:
+                            att_mag = float(np.linalg.norm(att_applied))
+                            attitude_total_dv += att_mag
+                            total_dv += att_mag
+                            max_dv = max(max_dv, att_mag)
+                            x_true = x_true.copy()
+                            x_true[3:] += att_applied / 1000.0
 
-            mag = 0.0 if dv_r is None else float(np.linalg.norm(dv_r))
-            maneuver_times.append(t_k)
-            maneuver_dv.append(mag)
-            total_dv += mag
-            max_dv = max(max_dv, mag)
-            if total_dv > self.thrust_total_mps:
-                failed = True
-                break
+            # 累计轨道控制 Δv
+            mag = 0.0 if dv_r_orbital is None else float(np.linalg.norm(dv_r_orbital))
+            if is_orbital:
+                maneuver_times.append(t_k)
+                maneuver_dv.append(mag)
+                total_dv += mag
+                max_dv = max(max_dv, mag)
+                if total_dv > self.thrust_total_mps:
+                    failed = True
+                    break
 
-            if dv_r is not None:
-                x_true = x_true.copy()
-                x_true[3:] += dv_r / 1000.0  # 施加于真实轨道（m/s → km/s）
+                if dv_r_orbital is not None:
+                    x_true = x_true.copy()
+                    x_true[3:] += dv_r_orbital / 1000.0  # 施加于真实轨道（m/s → km/s）
+
+            # 清零累积角动量（卸载完成）
+            if has_mm:
+                delta_m_cum = np.zeros(3)
+
             t_prev = t_k
 
         return SampleResult(
@@ -428,6 +577,8 @@ class SingleSampleSimulation:
             maneuver_dv_mps=np.array(maneuver_dv),
             controlled_times=np.array(controlled_times),
             controlled_states=np.array(controlled_states),
+            attitude_delta_v_mps=attitude_total_dv,
+            attitude_delta_v_independent_mps=attitude_independent_dv,
         )
 
 
@@ -570,6 +721,11 @@ def _build_simulation(
         force_config_ctrl=spec["force_config_ctrl"],
         force_config_true=spec["force_config_true"],
         sampler=sampler,
+        engine_layout=spec.get("engine_layout"),
+        momentum_interval_sec=spec.get("momentum_interval_sec", 0.0),
+        srp_offset_m=spec.get("srp_offset_m"),
+        spacecraft_mass_kg=spec.get("spacecraft_mass_kg", 1000.0),
+        srp_torque_nm=spec.get("srp_torque_nm"),
     )
 
 
@@ -601,6 +757,11 @@ def run_monte_carlo(
     seed: int | None = None,
     n_workers: int = 1,
     kernel_dir: str | None = None,
+    engine_layout: Any = None,
+    momentum_interval_days: float = 0.0,
+    srp_offset_m: npt.ArrayLike | None = None,
+    spacecraft_mass_kg: float = 1000.0,
+    srp_torque_nm: npt.ArrayLike | None = None,
 ) -> MonteCarloResult:
     """运行蒙特卡洛站保仿真（DFH 功能码 2 的数值核心）。
 
@@ -625,6 +786,11 @@ def run_monte_carlo(
         n_workers: 进程池大小（>1 时样本并行；需 ``kernel_dir`` 供 worker
             重建 SPICE 上下文）
         kernel_dir: SPICE 内核目录（``n_workers>1`` 时必填）
+        engine_layout: ``EngineLayout`` 实例（None 表示无角动量管理）
+        momentum_interval_days: 角动量卸载间隔（天），0 表示与轨道控制同步
+        srp_offset_m: SRP 压心相对质心偏移（m）
+        spacecraft_mass_kg: 航天器质量（kg）
+        srp_torque_nm: 常值 SRP 力矩（N·m）
 
     Returns:
         :class:`MonteCarloResult`（含 SK_STATISTIC/MANEUVERS 组装方法）
@@ -653,6 +819,11 @@ def run_monte_carlo(
         "force_config_ctrl": force_config_ctrl,
         "force_config_true": force_config_true,
         "observer": observer,
+        "engine_layout": engine_layout,
+        "momentum_interval_sec": momentum_interval_days * _SECONDS_PER_DAY,
+        "srp_offset_m": np.asarray(srp_offset_m, dtype=float) if srp_offset_m is not None else None,
+        "spacecraft_mass_kg": spacecraft_mass_kg,
+        "srp_torque_nm": np.asarray(srp_torque_nm, dtype=float) if srp_torque_nm is not None else None,
     }
 
     rng = np.random.default_rng(seed)
@@ -682,6 +853,9 @@ def run_monte_carlo(
     failed_mask = np.array([r.failed for r in results], dtype=bool)
     num_failed = int(failed_mask.sum())
 
+    att_dv = np.array([r.attitude_delta_v_mps for r in results])
+    att_dv_ind = np.array([r.attitude_delta_v_independent_mps for r in results])
+
     first = results[0] if results else None
     maneuvers = (
         np.column_stack([first.maneuver_times, first.maneuver_dv_mps])
@@ -696,6 +870,8 @@ def run_monte_carlo(
         num_failed=num_failed,
         maneuvers=maneuvers,
         controlled_ephemeris=controlled,
+        attitude_delta_v=att_dv,
+        attitude_delta_v_independent=att_dv_ind,
     )
 
 

--- a/e2m2e/algorithm/station_keeping/monte_carlo.py
+++ b/e2m2e/algorithm/station_keeping/monte_carlo.py
@@ -309,9 +309,7 @@ class MonteCarloResult:
     num_failed: int
     maneuvers: npt.NDArray[np.floating] = field(default_factory=lambda: np.empty((0, 2)))
     controlled_ephemeris: EphemerisTable | None = None
-    attitude_delta_v: npt.NDArray[np.floating] = field(
-        default_factory=lambda: np.empty(0)
-    )
+    attitude_delta_v: npt.NDArray[np.floating] = field(default_factory=lambda: np.empty(0))
     attitude_delta_v_independent: npt.NDArray[np.floating] = field(
         default_factory=lambda: np.empty(0)
     )
@@ -326,12 +324,14 @@ class MonteCarloResult:
         """
         keep = ~self.failed_mask
         if self.attitude_delta_v.size > 0:
-            rows = np.column_stack([
-                self.total_delta_v[keep],
-                self.max_delta_v[keep],
-                self.attitude_delta_v[keep],
-                self.attitude_delta_v_independent[keep],
-            ])
+            rows = np.column_stack(
+                [
+                    self.total_delta_v[keep],
+                    self.max_delta_v[keep],
+                    self.attitude_delta_v[keep],
+                    self.attitude_delta_v_independent[keep],
+                ]
+            )
         else:
             rows = np.column_stack([self.total_delta_v[keep], self.max_delta_v[keep]])
         return SKStatistic(rows=rows, num_failed=self.num_failed)
@@ -426,9 +426,7 @@ class SingleSampleSimulation:
         # 角动量管理：SRP 力矩常值（用户输入 srp_torque_nm）
         has_mm = self.engine_layout is not None
         srp_torque = (
-            np.asarray(self.srp_torque_nm, dtype=float)
-            if self.srp_torque_nm is not None
-            else None
+            np.asarray(self.srp_torque_nm, dtype=float) if self.srp_torque_nm is not None else None
         )
         layout = self.engine_layout
         mass = self.spacecraft_mass_kg
@@ -440,8 +438,9 @@ class SingleSampleSimulation:
         momentum_times: set[float] = set()
         if has_mm and self.momentum_interval_sec > 0:
             t_end = t0 + (self.num_controls - 1) * self.control_interval_sec
-            orbital_times = {t0 + k * self.control_interval_sec
-                            for k in range(1, self.num_controls - 1)}
+            orbital_times = {
+                t0 + k * self.control_interval_sec for k in range(1, self.num_controls - 1)
+            }
             t_m = t0 + self.momentum_interval_sec
             while t_m < t_end:
                 # 与最近轨道控制时刻对齐（相差 < 1 秒视为同时）
@@ -454,12 +453,10 @@ class SingleSampleSimulation:
             events = sorted(orbital_times | momentum_times)
         elif has_mm:
             # 卸载间隔=0：与轨道控制同步
-            events = [t0 + k * self.control_interval_sec
-                      for k in range(1, self.num_controls - 1)]
+            events = [t0 + k * self.control_interval_sec for k in range(1, self.num_controls - 1)]
         else:
             # 无角动量管理
-            events = [t0 + k * self.control_interval_sec
-                      for k in range(1, self.num_controls - 1)]
+            events = [t0 + k * self.control_interval_sec for k in range(1, self.num_controls - 1)]
 
         for t_k in events:
             # 弧段 [t_prev, t_k] 真实轨道传播（实际力模型 + 本弧段光压误差，
@@ -480,21 +477,15 @@ class SingleSampleSimulation:
                 delta_m_cum += _compute_dm(srp_torque, t_k - t_prev)
 
             # 判断事件类型
-            is_orbital = t_k in orbital_times or (
-                has_mm and self.momentum_interval_sec <= 0
-            )
-            is_momentum = has_mm and (
-                t_k in momentum_times
-                or self.momentum_interval_sec <= 0
-            )
+            is_orbital = t_k in orbital_times or (has_mm and self.momentum_interval_sec <= 0)
+            is_momentum = has_mm and (t_k in momentum_times or self.momentum_interval_sec <= 0)
 
             # 控制量计算
             if has_mm and is_orbital and is_momentum:
                 # 联合控制：轨道 + 角动量一次开机
                 dv_c = self.law.compute_maneuver(x_meas, t_k, propagator=prop_ctrl, nominal=nominal)
                 if dv_c is not None:
-                    V = _solve_joint(layout.E, layout.E_r, dv_c * 1000.0,
-                                     delta_m_cum, mass)
+                    V = _solve_joint(layout.E, layout.E_r, dv_c * 1000.0, delta_m_cum, mass)
                     dv_orbital = layout.E @ V
                     # 姿态独立 Δv：纯卸载需要的 Δv（与联合控制对比用）
                     dv_att_ind = _solve_unload(layout.E_r, delta_m_cum, mass)
@@ -553,8 +544,7 @@ class SingleSampleSimulation:
                 V = None
                 if has_mm and np.linalg.norm(delta_m_cum) > 0 and self.momentum_interval_sec <= 0:
                     if dv_c is not None:
-                        V = _solve_joint(layout.E, layout.E_r, dv_c * 1000.0,
-                                         delta_m_cum, mass)
+                        V = _solve_joint(layout.E, layout.E_r, dv_c * 1000.0, delta_m_cum, mass)
                         dv_att_ind = _solve_unload(layout.E_r, delta_m_cum, mass)
                         attitude_independent_dv += float(np.linalg.norm(layout.E @ dv_att_ind))
                     else:
@@ -562,7 +552,8 @@ class SingleSampleSimulation:
                         dv_att_ind = V
                         attitude_independent_dv += float(np.linalg.norm(layout.E @ dv_att_ind))
                         att_applied, att_failed = self.thrust_error.apply(
-                            layout.E @ V, self.sampler)
+                            layout.E @ V, self.sampler
+                        )
                         if att_failed:
                             failed = True
                             break
@@ -850,9 +841,7 @@ def run_monte_carlo(
         "srp_offset_m": np.asarray(srp_offset_m, dtype=float) if srp_offset_m is not None else None,
         "spacecraft_mass_kg": spacecraft_mass_kg,
         "srp_torque_nm": (
-            np.asarray(srp_torque_nm, dtype=float)
-            if srp_torque_nm is not None
-            else None
+            np.asarray(srp_torque_nm, dtype=float) if srp_torque_nm is not None else None
         ),
     }
 

--- a/e2m2e/algorithm/station_keeping/monte_carlo.py
+++ b/e2m2e/algorithm/station_keeping/monte_carlo.py
@@ -309,8 +309,12 @@ class MonteCarloResult:
     num_failed: int
     maneuvers: npt.NDArray[np.floating] = field(default_factory=lambda: np.empty((0, 2)))
     controlled_ephemeris: EphemerisTable | None = None
-    attitude_delta_v: npt.NDArray[np.floating] = field(default_factory=lambda: np.empty(0))
-    attitude_delta_v_independent: npt.NDArray[np.floating] = field(default_factory=lambda: np.empty(0))
+    attitude_delta_v: npt.NDArray[np.floating] = field(
+        default_factory=lambda: np.empty(0)
+    )
+    attitude_delta_v_independent: npt.NDArray[np.floating] = field(
+        default_factory=lambda: np.empty(0)
+    )
 
     def sk_statistic(self) -> SKStatistic:
         """组装 SK_STATISTIC 表（3 列或 5 列版）。
@@ -386,7 +390,11 @@ class SingleSampleSimulation:
     def run(self) -> SampleResult:
         from .momentum_management import (
             compute_delta_m as _compute_dm,
+        )
+        from .momentum_management import (
             solve_joint_control as _solve_joint,
+        )
+        from .momentum_management import (
             solve_momentum_unload as _solve_unload,
         )
 
@@ -417,26 +425,39 @@ class SingleSampleSimulation:
 
         # 角动量管理：SRP 力矩常值（用户输入 srp_torque_nm）
         has_mm = self.engine_layout is not None
-        srp_torque = np.asarray(self.srp_torque_nm, dtype=float) if self.srp_torque_nm is not None else None
+        srp_torque = (
+            np.asarray(self.srp_torque_nm, dtype=float)
+            if self.srp_torque_nm is not None
+            else None
+        )
         layout = self.engine_layout
         mass = self.spacecraft_mass_kg
         delta_m_cum = np.zeros(3)  # 累积角动量（上次卸载以来）
 
         # 构造合并事件时间表（轨道控制 + 角动量卸载）
+        # event_type[t] = "orbital" | "momentum" | "both"
+        orbital_times: set[float] = set()
+        momentum_times: set[float] = set()
         if has_mm and self.momentum_interval_sec > 0:
             t_end = t0 + (self.num_controls - 1) * self.control_interval_sec
             orbital_times = {t0 + k * self.control_interval_sec
                             for k in range(1, self.num_controls - 1)}
-            mom_times = set()
             t_m = t0 + self.momentum_interval_sec
             while t_m < t_end:
                 # 与最近轨道控制时刻对齐（相差 < 1 秒视为同时）
-                if not any(abs(t_m - t_o) < 1.0 for t_o in orbital_times):
-                    mom_times.add(t_m)
+                if any(abs(t_m - t_o) < 1.0 for t_o in orbital_times):
+                    # 合并到轨道事件（标记为 both）
+                    pass
+                else:
+                    momentum_times.add(t_m)
                 t_m += self.momentum_interval_sec
-            events = sorted(orbital_times | mom_times)
+            events = sorted(orbital_times | momentum_times)
+        elif has_mm:
+            # 卸载间隔=0：与轨道控制同步
+            events = [t0 + k * self.control_interval_sec
+                      for k in range(1, self.num_controls - 1)]
         else:
-            # 无角动量管理 或 卸载间隔=0（与轨道控制同步）
+            # 无角动量管理
             events = [t0 + k * self.control_interval_sec
                       for k in range(1, self.num_controls - 1)]
 
@@ -459,14 +480,13 @@ class SingleSampleSimulation:
                 delta_m_cum += _compute_dm(srp_torque, t_k - t_prev)
 
             # 判断事件类型
-            is_orbital = t_k in (orbital_times if has_mm and self.momentum_interval_sec > 0
-                                 else set(events))
-            is_momentum = has_mm and (not is_orbital or self.momentum_interval_sec <= 0
-                                      or any(abs(t_k - t) < 1.0
-                                             for t in ({t0 + j * self.momentum_interval_sec
-                                                        for j in range(1, int((t_k - t0) / self.momentum_interval_sec) + 2)
-                                                        if t0 + j * self.momentum_interval_sec <= t_k + 0.5}
-                                                       if self.momentum_interval_sec > 0 else set())))
+            is_orbital = t_k in orbital_times or (
+                has_mm and self.momentum_interval_sec <= 0
+            )
+            is_momentum = has_mm and (
+                t_k in momentum_times
+                or self.momentum_interval_sec <= 0
+            )
 
             # 控制量计算
             if has_mm and is_orbital and is_momentum:
@@ -829,7 +849,11 @@ def run_monte_carlo(
         "momentum_interval_sec": momentum_interval_days * _SECONDS_PER_DAY,
         "srp_offset_m": np.asarray(srp_offset_m, dtype=float) if srp_offset_m is not None else None,
         "spacecraft_mass_kg": spacecraft_mass_kg,
-        "srp_torque_nm": np.asarray(srp_torque_nm, dtype=float) if srp_torque_nm is not None else None,
+        "srp_torque_nm": (
+            np.asarray(srp_torque_nm, dtype=float)
+            if srp_torque_nm is not None
+            else None
+        ),
     }
 
     rng = np.random.default_rng(seed)

--- a/e2m2e/api/facade.py
+++ b/e2m2e/api/facade.py
@@ -114,6 +114,11 @@ class Facade:
                 num_monte_carlo=request.num_monte_carlo,
                 output_step=request.output_step,
                 kernel_dir=self._config.kernel_dir,
+                engine_layout=request.engine_layout,
+                momentum_interval=request.momentum_interval,
+                srp_offset_m=request.srp_offset_m,
+                spacecraft_mass=request.spacecraft_mass,
+                srp_torque=request.srp_torque,
             )
             return ControlOrbitResponse(
                 num_failed=result.num_failed,

--- a/e2m2e/api/models.py
+++ b/e2m2e/api/models.py
@@ -96,7 +96,9 @@ class ControlOrbitRequest(_ApiModel):
     momentum_interval: float = Field(default=5.0, gt=0.0, description="角动量卸载间隔（天）")
     srp_offset_m: list[float] | None = Field(default=None, description="SRP 压心偏移 [x,y,z]（m）")
     spacecraft_mass: float = Field(default=1000.0, gt=0.0, description="航天器质量（kg）")
-    srp_torque: list[float] | None = Field(default=None, description="常值 SRP 力矩 [τx,τy,τz]（N·m）")
+    srp_torque: list[float] | None = Field(
+        default=None, description="常值 SRP 力矩 [τx,τy,τz]（N·m）"
+    )
 
 
 class ControlOrbitResponse(_ApiModel):

--- a/e2m2e/api/models.py
+++ b/e2m2e/api/models.py
@@ -86,12 +86,17 @@ class ControlOrbitRequest(_ApiModel):
     """轨道保持输入（对齐 algorithm/station_keeping 的 control_orbit 参数）。"""
 
     input_ephemeris: Any = Field(description="标称轨道星历路径或 EphemerisTable")
-    control_mode: int = Field(default=1, ge=1, le=3)
+    control_mode: int = Field(default=1, ge=1, le=6)
     is_nrho: int = Field(default=0, ge=0, le=1)
     special_mode: int = Field(default=1, ge=1, le=2)
     num_controls: int = Field(default=120, ge=1)
     num_monte_carlo: int = Field(default=5, ge=1)
     output_step: float = Field(default=86400.0, gt=0.0)
+    engine_layout: Any = Field(default=None, description="EngineLayout（角动量管理 4-6 必填）")
+    momentum_interval: float = Field(default=5.0, gt=0.0, description="角动量卸载间隔（天）")
+    srp_offset_m: list[float] | None = Field(default=None, description="SRP 压心偏移 [x,y,z]（m）")
+    spacecraft_mass: float = Field(default=1000.0, gt=0.0, description="航天器质量（kg）")
+    srp_torque: list[float] | None = Field(default=None, description="常值 SRP 力矩 [τx,τy,τz]（N·m）")
 
 
 class ControlOrbitResponse(_ApiModel):

--- a/tests/algorithms/station_keeping/test_momentum_management.py
+++ b/tests/algorithms/station_keeping/test_momentum_management.py
@@ -26,26 +26,33 @@ def _full_rank_layout() -> EngineLayout:
     - ±y 位置装 z 方向发动机
     - ±z 位置装 x 方向发动机
     """
-    positions = np.array([
-        [ 1,  0,  0],   # +x 位置
-        [-1,  0,  0],   # -x 位置
-        [ 0,  1,  0],   # +y 位置
-        [ 0, -1,  0],   # -y 位置
-        [ 0,  0,  1],   # +z 位置
-        [ 0,  0, -1],   # -z 位置
-    ], dtype=float)
-    directions = np.array([
-        [ 0,  1,  0],   # +x 位置 → y 方向
-        [ 0, -1,  0],   # -x 位置 → -y 方向
-        [ 0,  0,  1],   # +y 位置 → z 方向
-        [ 0,  0, -1],   # -y 位置 → -z 方向
-        [ 1,  0,  0],   # +z 位置 → x 方向
-        [-1,  0,  0],   # -z 位置 → -x 方向
-    ], dtype=float)
+    positions = np.array(
+        [
+            [1, 0, 0],  # +x 位置
+            [-1, 0, 0],  # -x 位置
+            [0, 1, 0],  # +y 位置
+            [0, -1, 0],  # -y 位置
+            [0, 0, 1],  # +z 位置
+            [0, 0, -1],  # -z 位置
+        ],
+        dtype=float,
+    )
+    directions = np.array(
+        [
+            [0, 1, 0],  # +x 位置 → y 方向
+            [0, -1, 0],  # -x 位置 → -y 方向
+            [0, 0, 1],  # +y 位置 → z 方向
+            [0, 0, -1],  # -y 位置 → -z 方向
+            [1, 0, 0],  # +z 位置 → x 方向
+            [-1, 0, 0],  # -z 位置 → -x 方向
+        ],
+        dtype=float,
+    )
     return EngineLayout(positions_m=positions, directions=directions)
 
 
 # ── EngineLayout ──
+
 
 class TestEngineLayout:
     def test_full_rank_construction(self):
@@ -66,7 +73,7 @@ class TestEngineLayout:
         with pytest.raises(ValueError, match="不足 6"):
             EngineLayout(
                 positions_m=np.ones((5, 3)),
-                directions=np.array([[0,1,0],[0,-1,0],[0,0,1],[0,0,-1],[1,0,0]]),
+                directions=np.array([[0, 1, 0], [0, -1, 0], [0, 0, 1], [0, 0, -1], [1, 0, 0]]),
             )
 
     def test_zero_direction_rejected(self):
@@ -74,10 +81,16 @@ class TestEngineLayout:
         with pytest.raises(ValueError, match="零矢量"):
             EngineLayout(
                 positions_m=np.tile(np.eye(3), (2, 1)),
-                directions=np.array([
-                    [1, 0, 0], [0, 1, 0], [0, 0, 1],
-                    [0, 0, 0], [1, 0, 0], [0, 1, 0],
-                ]),
+                directions=np.array(
+                    [
+                        [1, 0, 0],
+                        [0, 1, 0],
+                        [0, 0, 1],
+                        [0, 0, 0],
+                        [1, 0, 0],
+                        [0, 1, 0],
+                    ]
+                ),
             )
 
     def test_shape_mismatch_rejected(self):
@@ -90,16 +103,24 @@ class TestEngineLayout:
 
 # ── validate_engine_layout ──
 
+
 class TestValidateEngineLayout:
     def test_full_rank_passes(self):
         validate_engine_layout(_full_rank_layout())
 
     def test_rank_deficient_Er_rejected(self):
         """6 个发动机全沿 z 方向喷气 → E_r 秩 1。"""
-        positions = np.array([
-            [1,0,0], [-1,0,0], [0,1,0],
-            [0,-1,0], [1,1,0], [-1,-1,0],
-        ], dtype=float)
+        positions = np.array(
+            [
+                [1, 0, 0],
+                [-1, 0, 0],
+                [0, 1, 0],
+                [0, -1, 0],
+                [1, 1, 0],
+                [-1, -1, 0],
+            ],
+            dtype=float,
+        )
         directions = np.tile([0, 0, 1.0], (6, 1))
         layout = EngineLayout(positions_m=positions, directions=directions)
         with pytest.raises(ValueError, match="E_r 秩不足"):
@@ -111,10 +132,17 @@ class TestValidateEngineLayout:
         # E[:,i] = rᵢ × [0,0,1] = [r_y, -r_x, 0] → E 行秩最多 2
         # E_r = [[0]*6, [0]*6, [1]*6] → E_r 秩 1
         # 增广秩 < 6
-        positions = np.array([
-            [1,0,0], [-1,0,0], [0,1,0],
-            [0,-1,0], [1,1,0], [-1,-1,0],
-        ], dtype=float)
+        positions = np.array(
+            [
+                [1, 0, 0],
+                [-1, 0, 0],
+                [0, 1, 0],
+                [0, -1, 0],
+                [1, 1, 0],
+                [-1, -1, 0],
+            ],
+            dtype=float,
+        )
         directions = np.tile([0, 0, 1.0], (6, 1))
         layout = EngineLayout(positions_m=positions, directions=directions)
         with pytest.raises(ValueError, match="秩不足"):
@@ -122,6 +150,7 @@ class TestValidateEngineLayout:
 
 
 # ── compute_srp_torque ──
+
 
 class TestSrpTorque:
     def test_perpendicular(self):
@@ -136,6 +165,7 @@ class TestSrpTorque:
 
 # ── compute_delta_m ──
 
+
 class TestDeltaM:
     def test_basic(self):
         dm = compute_delta_m([100, 0, 0], dt_sec=3600)
@@ -143,6 +173,7 @@ class TestDeltaM:
 
 
 # ── solve_momentum_unload ──
+
 
 class TestSolveMomentumUnload:
     def test_single_axis_unload(self):
@@ -172,11 +203,12 @@ class TestSolveMomentumUnload:
         delta_m = np.array([0, 0, 100.0])
         V = solve_momentum_unload(layout.E_r, delta_m, mass_kg=1000.0)
         # 期望 V[2]=V[3]=0.05（各分担一半），‖V‖²=0.005
-        expected_norm_sq = 2 * 0.05 ** 2
+        expected_norm_sq = 2 * 0.05**2
         assert np.dot(V, V) == pytest.approx(expected_norm_sq, abs=1e-12)
 
 
 # ── solve_joint_control ──
+
 
 class TestSolveJointControl:
     def test_orbital_only(self):

--- a/tests/algorithms/station_keeping/test_momentum_management.py
+++ b/tests/algorithms/station_keeping/test_momentum_management.py
@@ -1,0 +1,201 @@
+"""momentum_management.py 单元测试（纯数学，无 SPICE/传播器依赖）。
+
+布局设计原则：每个发动机的 rᵢ 与 eᵢ 不平行，使 E（力臂矩阵）与 E_r（力矩
+方向矩阵）的增广矩阵满秩（秩 6）。6 发动机采用循环配对：±x 装 y 方向发动机、
+±y 装 z 方向发动机、±z 装 x 方向发动机，使 E 和 E_r 各自满秩。
+"""
+
+import numpy as np
+import pytest
+
+from e2m2e.algorithm.station_keeping.momentum_management import (
+    EngineLayout,
+    compute_delta_m,
+    compute_srp_torque,
+    solve_joint_control,
+    solve_momentum_unload,
+    validate_engine_layout,
+)
+
+
+def _full_rank_layout() -> EngineLayout:
+    """6 发动机满秩布局（rᵢ 与 eᵢ 不平行，E 与 E_r 各自满秩）。
+
+    安装方案（循环配对，保证 E 与 E_r 各自满秩）：
+    - ±x 位置装 y 方向发动机
+    - ±y 位置装 z 方向发动机
+    - ±z 位置装 x 方向发动机
+    """
+    positions = np.array([
+        [ 1,  0,  0],   # +x 位置
+        [-1,  0,  0],   # -x 位置
+        [ 0,  1,  0],   # +y 位置
+        [ 0, -1,  0],   # -y 位置
+        [ 0,  0,  1],   # +z 位置
+        [ 0,  0, -1],   # -z 位置
+    ], dtype=float)
+    directions = np.array([
+        [ 0,  1,  0],   # +x 位置 → y 方向
+        [ 0, -1,  0],   # -x 位置 → -y 方向
+        [ 0,  0,  1],   # +y 位置 → z 方向
+        [ 0,  0, -1],   # -y 位置 → -z 方向
+        [ 1,  0,  0],   # +z 位置 → x 方向
+        [-1,  0,  0],   # -z 位置 → -x 方向
+    ], dtype=float)
+    return EngineLayout(positions_m=positions, directions=directions)
+
+
+# ── EngineLayout ──
+
+class TestEngineLayout:
+    def test_full_rank_construction(self):
+        layout = _full_rank_layout()
+        assert layout.num_engines == 6
+        assert layout.E.shape == (3, 6)
+        assert layout.E_r.shape == (3, 6)
+        # E 与 E_r 各自满秩
+        assert np.linalg.matrix_rank(layout.E) == 3
+        assert np.linalg.matrix_rank(layout.E_r) == 3
+
+    def test_directions_normalized(self):
+        layout = _full_rank_layout()
+        norms = np.linalg.norm(layout.directions, axis=1)
+        np.testing.assert_allclose(norms, 1.0, atol=1e-14)
+
+    def test_too_few_engines_rejected(self):
+        with pytest.raises(ValueError, match="不足 6"):
+            EngineLayout(
+                positions_m=np.ones((5, 3)),
+                directions=np.array([[0,1,0],[0,-1,0],[0,0,1],[0,0,-1],[1,0,0]]),
+            )
+
+    def test_zero_direction_rejected(self):
+        """6 发动机但含零方向 → 被拒。"""
+        with pytest.raises(ValueError, match="零矢量"):
+            EngineLayout(
+                positions_m=np.tile(np.eye(3), (2, 1)),
+                directions=np.array([
+                    [1, 0, 0], [0, 1, 0], [0, 0, 1],
+                    [0, 0, 0], [1, 0, 0], [0, 1, 0],
+                ]),
+            )
+
+    def test_shape_mismatch_rejected(self):
+        with pytest.raises(ValueError, match="不匹配"):
+            EngineLayout(
+                positions_m=np.ones((6, 3)),
+                directions=np.ones((5, 3)),
+            )
+
+
+# ── validate_engine_layout ──
+
+class TestValidateEngineLayout:
+    def test_full_rank_passes(self):
+        validate_engine_layout(_full_rank_layout())
+
+    def test_rank_deficient_Er_rejected(self):
+        """6 个发动机全沿 z 方向喷气 → E_r 秩 1。"""
+        positions = np.array([
+            [1,0,0], [-1,0,0], [0,1,0],
+            [0,-1,0], [1,1,0], [-1,-1,0],
+        ], dtype=float)
+        directions = np.tile([0, 0, 1.0], (6, 1))
+        layout = EngineLayout(positions_m=positions, directions=directions)
+        with pytest.raises(ValueError, match="E_r 秩不足"):
+            validate_engine_layout(layout)
+
+    def test_rank_deficient_augmented_rejected(self):
+        """布局使 E 与 E_r 的增广矩阵不满秩。"""
+        # 6 个发动机全沿 z 方向，安装在 xy 平面
+        # E[:,i] = rᵢ × [0,0,1] = [r_y, -r_x, 0] → E 行秩最多 2
+        # E_r = [[0]*6, [0]*6, [1]*6] → E_r 秩 1
+        # 增广秩 < 6
+        positions = np.array([
+            [1,0,0], [-1,0,0], [0,1,0],
+            [0,-1,0], [1,1,0], [-1,-1,0],
+        ], dtype=float)
+        directions = np.tile([0, 0, 1.0], (6, 1))
+        layout = EngineLayout(positions_m=positions, directions=directions)
+        with pytest.raises(ValueError, match="秩不足"):
+            validate_engine_layout(layout)
+
+
+# ── compute_srp_torque ──
+
+class TestSrpTorque:
+    def test_perpendicular(self):
+        # r=[0,2,0], F=[1,0,0] → r×F = [0*0-2*0, 2*1-0*0, 0*1-0*0] = [0,0,-2]（右手系）
+        torque = compute_srp_torque([1, 0, 0], [0, 2, 0])
+        np.testing.assert_allclose(torque, [0, 0, -2])
+
+    def test_parallel(self):
+        torque = compute_srp_torque([1, 0, 0], [3, 0, 0])
+        np.testing.assert_allclose(torque, [0, 0, 0], atol=1e-15)
+
+
+# ── compute_delta_m ──
+
+class TestDeltaM:
+    def test_basic(self):
+        dm = compute_delta_m([100, 0, 0], dt_sec=3600)
+        np.testing.assert_allclose(dm, [360000, 0, 0])
+
+
+# ── solve_momentum_unload ──
+
+class TestSolveMomentumUnload:
+    def test_single_axis_unload(self):
+        """z 轴角动量需求 → 只有 z 方向发动机（索引 2,3）工作。"""
+        layout = _full_rank_layout()
+        delta_m = np.array([0, 0, 100.0])
+        V = solve_momentum_unload(layout.E_r, delta_m, mass_kg=1000.0)
+        # E_r[:,0]=[0,1,0], E_r[:,1]=[0,-1,0] → 对 z 无贡献
+        # E_r[:,4]=[1,0,0], E_r[:,5]=[-1,0,0] → 对 z 无贡献
+        np.testing.assert_allclose(V[0], 0.0, atol=1e-12)
+        np.testing.assert_allclose(V[1], 0.0, atol=1e-12)
+        np.testing.assert_allclose(V[4], 0.0, atol=1e-12)
+        np.testing.assert_allclose(V[5], 0.0, atol=1e-12)
+        # E_r[:,2]=[0,0,1], E_r[:,3]=[0,0,-1]：1000·(V[2]-V[3])=100 → V[2]-V[3]=0.1
+        assert V[2] - V[3] == pytest.approx(0.1, abs=1e-12)
+
+    def test_constraint_satisfied(self):
+        layout = _full_rank_layout()
+        delta_m = np.array([50, -30, 20.0])
+        V = solve_momentum_unload(layout.E_r, delta_m, mass_kg=500.0)
+        residual = 500.0 * layout.E_r @ V - delta_m
+        np.testing.assert_allclose(residual, 0.0, atol=1e-10)
+
+    def test_min_norm_property(self):
+        """解是最小范数的（V 非零元素尽可能小）。"""
+        layout = _full_rank_layout()
+        delta_m = np.array([0, 0, 100.0])
+        V = solve_momentum_unload(layout.E_r, delta_m, mass_kg=1000.0)
+        # 期望 V[2]=V[3]=0.05（各分担一半），‖V‖²=0.005
+        expected_norm_sq = 2 * 0.05 ** 2
+        assert np.dot(V, V) == pytest.approx(expected_norm_sq, abs=1e-12)
+
+
+# ── solve_joint_control ──
+
+class TestSolveJointControl:
+    def test_orbital_only(self):
+        """纯轨道控制，无角动量需求 → E·V = Δv_o。"""
+        layout = _full_rank_layout()
+        dv = np.array([1.0, 0, 0])
+        V = solve_joint_control(layout.E, layout.E_r, dv, delta_m=[0, 0, 0], mass_kg=1000.0)
+        np.testing.assert_allclose(layout.E @ V, dv, atol=1e-10)
+
+    def test_joint_constraints_satisfied(self):
+        """联合控制：同时满足轨道和角动量约束。"""
+        layout = _full_rank_layout()
+        dv = np.array([0.5, -0.3, 0.1])
+        dm = np.array([10, -5, 20.0])
+        V = solve_joint_control(layout.E, layout.E_r, dv, delta_m=dm, mass_kg=800.0)
+        np.testing.assert_allclose(layout.E @ V, dv, atol=1e-10)
+        np.testing.assert_allclose(800.0 * layout.E_r @ V, dm, atol=1e-10)
+
+    def test_zero_demands(self):
+        layout = _full_rank_layout()
+        V = solve_joint_control(layout.E, layout.E_r, [0, 0, 0], [0, 0, 0], 1000.0)
+        np.testing.assert_allclose(V, 0.0, atol=1e-14)

--- a/tests/api/test_facade.py
+++ b/tests/api/test_facade.py
@@ -29,8 +29,12 @@ class TestDesignOrbitRequest:
 
 class TestControlOrbitRequest:
     def test_control_mode_bounds(self):
+        """mode 7 超出范围；mode 4 在 API 层允许（算法层校验 engine_layout）。"""
         with pytest.raises(ValidationError):
-            ControlOrbitRequest(input_ephemeris="x", control_mode=4)
+            ControlOrbitRequest(input_ephemeris="x", control_mode=7)
+        # mode 4 在 API 层不报错（engine_layout 校验在算法层）
+        req = ControlOrbitRequest(input_ephemeris="x", control_mode=4)
+        assert req.control_mode == 4
 
 
 class TestFacade:

--- a/tests/dfh/test_parameter_validation.py
+++ b/tests/dfh/test_parameter_validation.py
@@ -98,8 +98,13 @@ class TestControlOrbitValidation:
             control_orbit("dummy.txt", num_controls=0)
 
     def test_control_mode_out_of_range(self):
-        """角动量管理模式 4-6 本期未实现（#261），应明确拒绝。"""
+        """control_mode 超出 1-6 范围应拒绝。"""
         with pytest.raises(ValueError, match="control_mode"):
+            control_orbit("dummy.txt", control_mode=7)
+
+    def test_momentum_mode_requires_engine_layout(self):
+        """角动量管理模式（4-6）需提供 engine_layout。"""
+        with pytest.raises(ValueError, match="engine_layout"):
             control_orbit("dummy.txt", control_mode=4)
 
     def test_thrust_min_nonpositive_rejected(self):


### PR DESCRIPTION
## 关联

Closes #261

## 改动要点

- **新建 `momentum_management.py`**：`EngineLayout` 数据类（rᵢ/eᵢ → E/E_r 矩阵）、布局校验（N≥6、E_r 秩、增广矩阵秩）、SRP 力矩/角动量累积、`solve_momentum_unload`（min-norm 解）、`solve_joint_control`（增广 lstsq 联合求解）
- **扩展 `monte_carlo.py`**：`SampleResult`/`MonteCarloResult` 加姿态 Δv 字段；`sk_statistic()` 支持 5 列版；`SingleSampleSimulation.run()` 改为合并事件调度（orbital+momentum 双时间表）；`run_monte_carlo` 加 5 个角动量参数
- **扩展 `controller.py`**：`control_mode` 范围 1→6；mode 4-6 校验 `engine_layout` 必填 + `validate_engine_layout()`；基础控制律 `base_mode = mode - 3`
- **API 层**：`ControlOrbitRequest` 新增 `engine_layout`/`momentum_interval`/`srp_offset_m`/`spacecraft_mass`/`srp_torque`；`control_mode` 范围扩展至 6
- **`__init__.py`**：删除占位 `momentum_management()`；导出 `EngineLayout`、`validate_engine_layout`、`solve_*`、`compute_*`
- **测试**：17 个新测试覆盖布局校验/力矩计算/纯卸载/联合控制约束/最小范数性质；`test_facade.py`/`test_parameter_validation.py` 适配 mode 4-6

## 测试

```
tests/algorithms/station_keeping/          37 passed
tests/api/test_facade.py                   11 passed
tests/io/test_maneuvers_sk.py               9 passed
tests/dfh/test_parameter_validation.py     20 passed
───────────────────────────────────────────
77 passed, 0 failed
```