### PR TITLE
fix(transfer): LGA 精化到达段 TOF 计算修正（#258）

### DIFF
--- a/e2m2e/algorithm/transfer/lga.py
+++ b/e2m2e/algorithm/transfer/lga.py
@@ -65,6 +65,7 @@ class LgaCandidate:
     departure_state: np.ndarray
     perilune_state: np.ndarray
     perilune_alt_km: float
+    perilune_time_dim: float
     arrival_state: np.ndarray
     dv_departure: float
     dv_arrival: float
@@ -241,6 +242,7 @@ def search_lga_trajectories(
                     departure_state=x0.copy(),
                     perilune_state=state_peri.copy(),
                     perilune_alt_km=alt_km,
+                    perilune_time_dim=float(t_peri),
                     arrival_state=arrival_state.copy(),
                     dv_departure=dv_dep,
                     dv_arrival=dv_arr,
@@ -281,8 +283,13 @@ def _refine_lga_candidate(
         shooter = ThreeBodyLambert(dynamics)
 
         peri_phys = system.dimensionless_to_physical(candidate.perilune_state)
-        # 到达段的 tof：从传播结果计算实际到达时间
-        tof_arrival = candidate.arrival_time_dim * char_time
+        # 到达段的 tof：近月点 → 目标的剩余时间（非出发→到达的总时间）
+        tof_arrival = (candidate.arrival_time_dim - candidate.perilune_time_dim) * char_time
+        if tof_arrival <= 0.0:
+            raise ValueError(
+                f"到达段剩余时间非正：arrival_time_dim={candidate.arrival_time_dim}, "
+                f"perilune_time_dim={candidate.perilune_time_dim}, tof_arrival={tof_arrival}"
+            )
 
         target_phys = system.dimensionless_to_physical(target_state)
 
@@ -305,6 +312,7 @@ def _refine_lga_candidate(
                 departure_state=candidate.departure_state,
                 perilune_state=candidate.perilune_state,
                 perilune_alt_km=candidate.perilune_alt_km,
+                perilune_time_dim=candidate.perilune_time_dim,
                 arrival_state=candidate.arrival_state,
                 dv_departure=candidate.dv_departure,
                 dv_arrival=dv_arr,
@@ -324,6 +332,7 @@ def _refine_lga_candidate(
         departure_state=candidate.departure_state,
         perilune_state=candidate.perilune_state,
         perilune_alt_km=candidate.perilune_alt_km,
+        perilune_time_dim=candidate.perilune_time_dim,
         arrival_state=candidate.arrival_state,
         dv_departure=candidate.dv_departure,
         dv_arrival=candidate.dv_arrival,

--- a/tests/transfer/test_lga.py
+++ b/tests/transfer/test_lga.py
@@ -21,6 +21,7 @@ from e2m2e.algorithm.transfer import (
 from e2m2e.algorithm.transfer.hohmann import TliParams
 from e2m2e.algorithm.transfer.lga import (
     _compute_jacobi,
+    _refine_lga_candidate,
     search_lga_trajectories,
 )
 
@@ -146,6 +147,68 @@ class TestLgaSearch:
         for c in candidates:
             assert c.perilune_alt_km >= _SEARCH_PARAMS.perilune_alt_min
             assert c.perilune_alt_km <= _SEARCH_PARAMS.perilune_alt_max
+
+    def test_perilune_time_dim_populated(self, cr3bp_setup):
+        """候选的 perilune_time_dim 为正且在到达时刻之前（近月点 → 到达段剩余时间 > 0）。"""
+        system, dynamics, dep_state, tgt_state = cr3bp_setup
+        candidates = search_lga_trajectories(dep_state, tgt_state, system, dynamics, _SEARCH_PARAMS)
+        if not candidates:
+            pytest.skip("无可行候选，跳过 perilune_time_dim 验证")
+        for c in candidates:
+            assert c.perilune_time_dim > 0.0, (
+                f"perilune_time_dim 应为正，实际 {c.perilune_time_dim}"
+            )
+            assert c.arrival_time_dim > c.perilune_time_dim, (
+                f"到达时刻 {c.arrival_time_dim} 应晚于近月点时刻 {c.perilune_time_dim}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# TestLgaRefine：_refine_lga_candidate 精化测试
+# ---------------------------------------------------------------------------
+
+
+class TestLgaRefine:
+    """_refine_lga_candidate ThreeBodyLambert 打靶精化测试。"""
+
+    @pytest.fixture
+    def cr3bp_setup(self):
+        system, dynamics = _make_cr3bp_system()
+        dep_state = _make_departure_state(system)
+        tgt_state = _make_target_state(system)
+        return system, dynamics, dep_state, tgt_state
+
+    def test_refine_candidate_converges(self, cr3bp_setup):
+        """最优候选经 _refine_lga_candidate 精化后 converged=True。"""
+        system, dynamics, dep_state, tgt_state = cr3bp_setup
+        candidates = search_lga_trajectories(dep_state, tgt_state, system, dynamics, _SEARCH_PARAMS)
+        if not candidates:
+            pytest.skip("无可行候选，跳过精化测试")
+
+        best = candidates[0]
+        refined = _refine_lga_candidate(best, system, dynamics, tgt_state)
+        tof_arr = (best.arrival_time_dim - best.perilune_time_dim) * system.characteristic_time
+        assert refined.converged, (
+            f"精化应收敛：best.total_dv={best.total_dv:.4f}, tof_arrival={tof_arr:.2f}s"
+        )
+
+    def test_refine_tof_arrival_correct(self, cr3bp_setup):
+        """精化使用的 tof_arrival = (arrival - perilune) * char_time，而非总 TOF。"""
+        system, dynamics, dep_state, tgt_state = cr3bp_setup
+        candidates = search_lga_trajectories(dep_state, tgt_state, system, dynamics, _SEARCH_PARAMS)
+        if not candidates:
+            pytest.skip("无可行候选，跳过 tof_arrival 验证")
+
+        best = candidates[0]
+        char_time = system.characteristic_time
+        tof_arrival_expected = (best.arrival_time_dim - best.perilune_time_dim) * char_time
+        tof_total = best.arrival_time_dim * char_time
+
+        # 到达段 TOF 必须严格小于总 TOF（否则说明 perilune 时刻未被减去）
+        assert tof_arrival_expected < tof_total, (
+            f"到达段 TOF ({tof_arrival_expected:.2f}s) 应小于总 TOF ({tof_total:.2f}s)"
+        )
+        assert tof_arrival_expected > 0.0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 关联

PR #297 合并后的 follow-up，修复 code review S2 建议项。

## 改了什么

修复 `_refine_lga_candidate` 到达段 TOF 计算错误：ThreeBodyLambert 以近月点为起点，但传入的 TOF 是出发到到达的总时间，应为近月点到目标的剩余时间。原 bug 导致精化大概率不收敛、静默回退到原始候选（精化功能形同虚设）。

- `LgaCandidate` 新增 `perilune_time_dim` 字段（无量纲近月点时刻）
- `search_lga_trajectories` 填充 `t_peri` 到候选
- `tof_arrival = (arrival_time_dim - perilune_time_dim) * char_time`
- 防御性检查 `tof_arrival <= 0` 抛 ValueError

### 文件变更

| 文件 | 说明 |
|------|------|
| `e2m2e/algorithm/transfer/lga.py` | LgaCandidate 字段 + 搜索填充 + 精化 TOF 修正 |
| `tests/transfer/test_lga.py` | 新增 3 个测试 |

## 测试

```bash
uv run pytest tests/transfer/test_lga.py -v  # 18/18 passed
uv run ruff check e2m2e/algorithm/transfer/lga.py tests/transfer/test_lga.py
uv run ruff format --check e2m2e/algorithm/transfer/lga.py tests/transfer/test_lga.py
uv run mypy e2m2e/algorithm/transfer/lga.py --ignore-missing-imports
```

新增测试：
- `test_perilune_time_dim_populated` — 字段正确填充
- `test_refine_candidate_converges` — 精化收敛（`converged=True`）
- `test_refine_tof_arrival_correct` — 到达段 TOF < 总 TOF