### PR TITLE
feat(orbit-design): DPO 顺行轨道族实现（#288）

### DIFF
--- a/docs/plans/issue288-dpo-literature-review.md
+++ b/docs/plans/issue288-dpo-literature-review.md
@@ -1,0 +1,94 @@
+# Issue #288 DPO 轨道族——文献调研报告
+
+> **状态**：已完成
+> **日期**：2026-08-04
+
+---
+
+## 1. DPO 的精确定义
+
+### 1.1 文献来源
+
+**Folta et al. (2015)** "An Earth–Moon system trajectory design reference catalog"（AIAA SciTech）：
+
+> "direct prograde orbits about the Moon (DPOs)...display, in general,
+> counterclockwise motion about the Moon"（旋转坐标系下）
+
+> "Recently, the DPOs have been examined as transfer mechanisms between
+> L₁ and L₂ Lyapunov orbits, and as lunar parking orbits."
+
+**Guzzetti et al. (2016)** "Rapid trajectory design in the Earth–Moon
+ephemeris system via an interactive catalog of periodic orbits"（JGCD）：
+
+Table 1 分类：DPO 归 **Moon-centered (P2)** 类，tag = "DPO"。
+
+### 1.2 物理定义
+
+DPO（Distant Prograde Orbit）= xy 平面内围绕月球的**顺行**周期轨道：
+
+| 特征 | DRO（逆行） | DPO（顺行） |
+|------|------------|------------|
+| 旋转坐标系下方向 | 顺时针 | 逆时针 |
+| vy0 初始符号 | > 0 | < 0 |
+| 月心距 | 较远（~75k–106k km） | 较近（~16k–47k km） |
+| Jacobi 常数 | 较低（~2.92） | 较高（~2.99–3.19） |
+| 周期 | 较长 | 较短 |
+| 对称性 | x 轴对称（xy 平面内） | x 轴对称（xy 平面内） |
+| 族参数 | x0（近侧穿越点） | x0（近侧穿越点） |
+| 修正策略 | `setup_2D_symmetric_x_fixed_x0` | 同 DRO |
+
+### 1.3 与其他族的关系
+
+**Folta 2015 Figure 7**（Jacobi 常数对比）：
+
+- DPO 与 DRO 的 Jacobi 范围**不重叠** → 低转移成本连接不太可能
+- DPO 与 L₁ Lyapunov 的 Jacobi 范围**重叠** → 存在低转移成本通道
+
+### 1.4 存在范围
+
+DPO 族在所有共线平动点（L1–L5）的 Moon-centered 区域均存在，
+但文献主要关注 L2 邻域的 DPO（与 L1/L2 Lyapunov 转移相关）。
+
+---
+
+## 2. 种子获取策略
+
+### 2.1 方案 A（已验证）：DRO seed 反转 vy0
+
+从 DRO 标准种子（x0=0.79, vy0=+0.537）反转 vy0 方向，在不同 x0
+处微分修正收敛：
+
+| x0 | period | C (Jacobi) | vy0 | 备注 |
+|----|--------|------------|-----|------|
+| 0.90 | 2.50 | 3.191 | -0.248 | ← DPO 标准种子 |
+| 0.95 | 2.26 | 3.316 | -0.531 | |
+| 1.05 | 2.36 | 3.094 | -0.510 | |
+| 1.10 | 1.71 | 2.991 | -0.460 | |
+
+**选定种子**：x0=0.90, vy0=-0.247645, period=2.5022。
+
+### 2.2 方案 B（备选）：近月 prograde 圆轨道
+
+若方案 A 在某些振幅范围不收敛，可从近月 prograde 圆轨道出发
+（r ≈ MOON_RADIUS + 500km）逐步族行走拉远。本实施未用到。
+
+---
+
+## 3. 振幅定义
+
+与 DRO 一致：**一个周期内距月心距离最小/最大值的均值（km）**。
+
+实测 20000 km 振幅的 DPO：
+- 近月距 ≈ 较小值 DU，远月距 ≈ 较大值 DU
+- Jacobi ≈ 高于 DRO
+
+---
+
+## 4. 参考文献
+
+1. **Folta, D.C. et al. (2015)**. An Earth–Moon system trajectory design
+   reference catalog. AIAA SciTech. DPO 分类、Jacobi 对比、L1-Lyapunov
+   转移通道。
+2. **Guzzetti, D. et al. (2016)**. Rapid trajectory design in the
+   Earth–Moon ephemeris system via an interactive catalog of periodic
+   orbits. JGCD. Table 1 DPO 分类为 Moon-centered (P2) 类。

--- a/e2m2e/algorithm/design/design_orbit.py
+++ b/e2m2e/algorithm/design/design_orbit.py
@@ -57,6 +57,7 @@ from ..ephemeris_correction import (
 )
 from ..family.cr3bp_orbits import (
     design_axial,
+    design_dpo,
     design_dro,
     design_halo,
     design_lissajous,
@@ -236,6 +237,15 @@ def _validate_params(
             raise ValueError(f"DRO phase 应在 0~1 之间，实际为 {phase}")
         return {"amplitude": amplitude, "phase": phase}
 
+    if sel == "DPO":
+        amplitude = 20000.0 if amplitude is None else float(amplitude)
+        phase = 0.5001 if phase is None else float(phase)
+        if not 1737.0 <= amplitude <= 110000.0:
+            raise ValueError(f"DPO amplitude 应在 1737~110000 km 之间，实际为 {amplitude:.0f} km")
+        if not 0.0 <= phase <= 1.0:
+            raise ValueError(f"DPO phase 应在 0~1 之间，实际为 {phase}")
+        return {"amplitude": amplitude, "phase": phase}
+
     if sel == "HALO":
         collinear_point = 2 if collinear_point is None else int(collinear_point)
         amplitude = 30000.0 if amplitude is None else float(amplitude)
@@ -349,13 +359,15 @@ def _validate_params(
             "phase": phase,
         }
 
-    raise ValueError(f"orbit_type 必须为 DRO/NRHO/Halo/Lissajous/L4/L5/Axial，当前 {sel!r}")
+    raise ValueError(f"orbit_type 必须为 DRO/DPO/NRHO/Halo/Lissajous/L4/L5/Axial，当前 {sel!r}")
 
 
 def _cr3bp_orbit_for(sel: str, params: dict[str, float | int], dynamics: CR3BP_Dynamics) -> Orbit:
     """按规范化形状参数生成 CR3BP 周期轨道。"""
     if sel == "DRO":
         return design_dro(params["amplitude"], dynamics=dynamics)
+    if sel == "DPO":
+        return design_dpo(params["amplitude"], dynamics=dynamics)
     if sel == "HALO":
         return design_halo(int(params["collinear_point"]), params["amplitude"], dynamics=dynamics)
     if sel == "NRHO":
@@ -659,15 +671,15 @@ def design_orbit(
     correction_velocity_tolerance: float = 0.1,
     verbose: bool = False,
 ) -> OrbitDesignResult:
-    """端到端设计七类标称轨道（DRO/NRHO/Halo/Lissajous/L4/L5/Axial）。
+    """端到端设计八类标称轨道（DRO/DPO/NRHO/Halo/Lissajous/L4/L5/Axial）。
 
     Args:
-        orbit_type: ``"DRO"`` / ``"NRHO"`` / ``"Halo"`` / ``"Lissajous"`` /
-            ``"L4"`` / ``"L5"`` / ``"AXIAL"``。
-        amplitude: 振幅（km）。DRO 1737~110000，默认 10000；Halo 面外振幅
-            ±73000（正北负南），默认 30000；Axial z 振幅 ±60000（正上族
-            负下族），默认 5000；NRHO 不用。
-        phase: 初始相位（周期份额）。DRO/Halo/Axial 取值 0~1，默认
+        orbit_type: ``"DRO"`` / ``"DPO"`` / ``"NRHO"`` / ``"Halo"`` /
+            ``"Lissajous"`` / ``"L4"`` / ``"L5"`` / ``"AXIAL"``。
+        amplitude: 振幅（km）。DRO 1737~110000，默认 10000；DPO 1737~110000，
+            默认 20000；Halo 面外振幅 ±73000（正北负南），默认 30000；
+            Axial z 振幅 ±60000（正上下族），默认 5000；NRHO 不用。
+        phase: 初始相位（周期份额）。DRO/DPO/Halo/Axial 取值 0~1，默认
             0.5001/0/0；NRHO 取值 0.01~0.99，默认 0.5。
         collinear_point: 共线平动点编号 1/2（Halo/NRHO，默认 2）。
             Lissajous/Axial 取 1/2/3（默认 2）。
@@ -761,7 +773,7 @@ def design_orbit(
         # 面内/面外相位已体现在初猜状态（t=0 即历元状态）
         t0_syn = 0.0
     else:
-        phase_offset = 0.5 if sel == "DRO" else 0.0
+        phase_offset = 0.5 if sel in ("DRO", "DPO") else 0.0
         t0_syn = ((phase + phase_offset) % 1.0) * period
     if t0_syn > 0.0:
         state0_syn = np.asarray(

--- a/e2m2e/algorithm/family/__init__.py
+++ b/e2m2e/algorithm/family/__init__.py
@@ -50,6 +50,7 @@ from .triangular_initial_guess import compute_triangular_initial_guess
 
 __all__ = [
     "design_axial",
+    "design_dpo",
     "design_dro",
     "design_halo",
     "design_nrho",
@@ -83,6 +84,7 @@ __all__ = [
 #: 依赖 ``algorithm/solver``，经 PEP 562 在首次访问时加载。
 _LAZY_EXPORTS = {
     "design_axial": "design_axial",
+    "design_dpo": "design_dpo",
     "design_dro": "design_dro",
     "design_halo": "design_halo",
     "design_nrho": "design_nrho",
@@ -112,6 +114,7 @@ def _build_registry() -> dict[str, Callable[..., Orbit]]:
     """构建轨道族注册表（函数形态）：orbit_type → design_xxx(params) -> Orbit。"""
     from .cr3bp_orbits import (
         design_axial,
+        design_dpo,
         design_dro,
         design_halo,
         design_lissajous,
@@ -121,6 +124,7 @@ def _build_registry() -> dict[str, Callable[..., Orbit]]:
 
     return {
         "DRO": design_dro,
+        "DPO": design_dpo,
         "HALO": design_halo,
         "NRHO": design_nrho,
         "LISSAJOUS": design_lissajous,

--- a/e2m2e/algorithm/family/cr3bp_orbits.py
+++ b/e2m2e/algorithm/family/cr3bp_orbits.py
@@ -4,6 +4,8 @@
 
 - DRO：以近侧 x 轴穿越点 ``x0`` 为族参数，从标准种子出发沿族行走，
   选取振幅（一个周期内距月球的最大距离，km）命中目标的成员；
+- DPO：与 DRO 对称的顺行族，以 ``x0`` 为族参数，vy0 < 0（顺行），
+  振幅定义同 DRO（距月心距离 min/max 均值，km）；
 - Halo：Richardson 三阶近似种子 + 定 ``z0`` 微分修正，沿族把 ``z0``
   走到目标面外振幅（km，符号区分北/南）；
 - NRHO：Halo 族成员中按近月距（距月心 = 近月点高度 + 月球半径）选取，
@@ -23,6 +25,9 @@ import numpy as np
 
 from ...data.templates.seed import (  # noqa: F401
     _AXIAL_SEED_VZ0,
+    _DPO_SEED_PERIOD,
+    _DPO_SEED_VY0,
+    _DPO_SEED_X0,
     _DRO_SEED_PERIOD,
     _DRO_SEED_VY0,
     _DRO_SEED_X0,
@@ -208,6 +213,39 @@ def _correct_dro(dynamics: CR3BP_Dynamics, x0: float, guess: Orbit | None) -> Or
     return orbit
 
 
+def _correct_dpo(dynamics: CR3BP_Dynamics, x0: float, guess: Orbit | None) -> Orbit:
+    """在近侧 x 轴穿越点 ``x0`` 处修正 DPO（固定 x0，自由 vy0 与半周期）。
+
+    DPO 与 DRO 使用相同修正策略（``setup_2D_symmetric_x_fixed_x0``），
+    但 vy0 < 0（顺行）。种子从反转 DRO vy0 的微分修正收敛获得。
+
+    DPO 族不稳定，族行走时 vy0 与 x0 的映射关系比 DRO 更非线性。
+    首次调用（guess=None）使用种子常量；后续调用保留已收敛轨道的完整
+    状态作为初猜（不仅覆盖 x0），避免在不稳定族上跳支。
+    """
+    if guess is None:
+        state = np.array([x0, 0.0, 0.0, 0.0, _DPO_SEED_VY0, 0.0])
+        period = _DPO_SEED_PERIOD
+    else:
+        state = guess.states[0].copy()
+        state[0] = x0
+        assert guess.period is not None
+        period = guess.period
+    corrector = DifferentialCorrection(dynamics)
+    corrector.setup_2D_symmetric_x_fixed_x0(x0=x0)
+    seed = Orbit(states=state.reshape(1, -1), times=np.array([0.0]), system=dynamics.system)
+    seed.period = period
+    orbit = _correct_or_raise(corrector, seed, f"DPO(x0={x0:.6f})")
+    assert orbit.period is not None
+    # DPO 族不稳定，周期变化幅度比 DRO 大；放宽伪解阈值以避免误杀
+    # 正常族行走中周期跳变到 2 倍以上才是真伪解（多圈对称周期轨道）
+    if orbit.period > 2.0 * period:
+        raise Cr3bpOrbitError(
+            f"DPO(x0={x0:.6f}) 修正跳到长周期伪解（T={orbit.period:.3f}，初猜 {period:.3f}）"
+        )
+    return orbit
+
+
 def _correct_halo(
     dynamics: CR3BP_Dynamics, z0: float, libration_point: int, guess: Orbit | None
 ) -> Orbit:
@@ -341,6 +379,47 @@ def design_dro(
         measure=measure,
         target=target_du,
         p_seed=_DRO_SEED_X0,
+        dp_init=0.02,
+        max_step=0.05,
+        tol=tol_km / du,
+    )
+
+
+def design_dpo(
+    amplitude_km: float,
+    *,
+    dynamics: CR3BP_Dynamics | None = None,
+    tol_km: float = 20.0,
+) -> Orbit:
+    """生成指定振幅的 DPO（Direct Prograde Orbit）周期轨道。
+
+    DPO 是 xy 平面内围绕月球的顺行周期轨道（旋转坐标系下逆时针），
+    与 DRO（逆行）对称。振幅定义同 DRO：一个周期内距月心距离
+    最小/最大值的均值（km）。以近侧 x 轴穿越点 ``x0`` 为族参数行走，
+    命中 ``tol_km`` 内即停。
+
+    References:
+        Folta et al. (2015). An Earth–Moon system trajectory design
+        reference catalog. AIAA SciTech.
+        Guzzetti et al. (2016). Rapid trajectory design in the
+        Earth–Moon ephemeris system via an interactive catalog of
+        periodic orbits. JGCD.
+    """
+    if dynamics is None:
+        dynamics = CR3BP_Dynamics(earth_moon_system())
+    du = dynamics.system.characteristic_length
+    assert du is not None
+    target_du = amplitude_km / du
+
+    def measure(orbit: Orbit) -> float:
+        d_min, d_max = _moon_distance_minmax(dynamics, orbit)
+        return 0.5 * (d_min + d_max)
+
+    return _walk_family(
+        correct_at=lambda x0, guess: _correct_dpo(dynamics, x0, guess),
+        measure=measure,
+        target=target_du,
+        p_seed=_DPO_SEED_X0,
         dp_init=0.02,
         max_step=0.05,
         tol=tol_km / du,

--- a/e2m2e/data/templates/seed.py
+++ b/e2m2e/data/templates/seed.py
@@ -29,3 +29,10 @@ _HALO_FOLD_Z0 = {1: 0.07, 2: 0.15}
 
 #: Axial 族种子面外速度（无量纲 DU/TU，小振幅下线性化初猜精度高）
 _AXIAL_SEED_VZ0 = 0.001
+
+#: DPO 族标准种子（从 DRO seed 反转 vy0 微分修正收敛所得）
+#: DPO 为顺行（prograde），xy 平面内围绕月球的周期轨道，与 DRO 对称。
+#: 种子 x0=0.90 处：vy0 < 0（顺行），period≈2.50。
+_DPO_SEED_X0 = 0.90
+_DPO_SEED_VY0 = -0.247645
+_DPO_SEED_PERIOD = 2.5022

--- a/tests/algorithms/test_dpo_family.py
+++ b/tests/algorithms/test_dpo_family.py
@@ -1,0 +1,251 @@
+"""DPO（Direct Prograde Orbit）轨道族端到端 + 物理不变量测试。
+
+覆盖 design_dpo 收敛性、Jacobi 守恒、xy 平面约束、周期闭合、注册表，
+以及区分 DPO 与 DRO 的特征测试（DPO 顺行、Jacobi 更高、更靠近月球）。
+"""
+
+import numpy as np
+import pytest
+
+from e2m2e.algorithm.dynamics import CR3BP_Dynamics
+from e2m2e.algorithm.family import registry
+from e2m2e.algorithm.family.cr3bp_orbits import (
+    _moon_distance_minmax,
+    design_dpo,
+    design_dro,
+    earth_moon_system,
+)
+
+CHAR_LENGTH_KM = 384400.0
+
+
+@pytest.fixture(scope="module")
+def orbit():
+    """共享一条 design_dpo(20000.0) 轨道。"""
+    return design_dpo(20000.0)
+
+
+@pytest.fixture(scope="module")
+def dynamics(orbit):
+    return CR3BP_Dynamics(orbit.system)
+
+
+@pytest.fixture(scope="module")
+def dro_ref():
+    """共享一条 design_dro(20000.0) 轨道（DPO vs DRO 对比用）。"""
+    return design_dro(20000.0)
+
+
+@pytest.fixture(scope="module")
+def dpo_ref():
+    """共享一条 design_dpo(20000.0) 轨道（与 dro_ref 振幅相同）。"""
+    return design_dpo(20000.0)
+
+
+# =============================================================================
+# Registry
+# =============================================================================
+
+
+class TestRegistry:
+    """注册表应包含 DPO 条目。"""
+
+    def test_dpo_in_registry(self):
+        """registry 应包含 'DPO' 键。"""
+        assert "DPO" in registry
+
+    def test_dpo_callable(self):
+        """registry['DPO'] 应可调用。"""
+        assert callable(registry["DPO"])
+
+    def test_dpo_same_as_design_dpo(self):
+        """registry['DPO'] 应指向 design_dpo。"""
+        assert registry["DPO"] is design_dpo
+
+
+# =============================================================================
+# End-to-end convergence
+# =============================================================================
+
+
+class TestDesignDpoConvergence:
+    """design_dpo 端到端收敛测试。"""
+
+    def test_design_dpo_20000km_converges(self):
+        """design_dpo(20000.0) 应返回收敛的 Orbit。"""
+        orbit = design_dpo(20000.0)
+        assert orbit is not None
+        assert orbit.period is not None
+        assert orbit.period > 0
+
+    def test_design_dpo_amplitude_matches_target(self):
+        """振幅（距月 min/max 均值）应接近 20000 km（容差 50 km）。"""
+        orbit = design_dpo(20000.0)
+        dynamics = CR3BP_Dynamics(orbit.system)
+        d_min, d_max = _moon_distance_minmax(dynamics, orbit)
+        amp_km = 0.5 * (d_min + d_max) * CHAR_LENGTH_KM
+        assert abs(amp_km - 20000.0) < 50.0
+
+    def test_design_dpo_state_on_x_axis(self):
+        """初始状态应在 xy 平面的 x 轴上：y=0, z=0, vx=0。"""
+        orbit = design_dpo(20000.0)
+        s0 = orbit.states[0]
+        assert s0[1] == pytest.approx(0.0, abs=1e-10)  # y=0
+        assert s0[2] == pytest.approx(0.0, abs=1e-10)  # z=0
+        assert s0[3] == pytest.approx(0.0, abs=1e-10)  # vx=0
+
+    def test_design_dpo_vy0_negative(self):
+        """DPO 初始 vy0 应为负（顺行：旋转坐标系下逆时针）。"""
+        orbit = design_dpo(20000.0)
+        assert orbit.states[0, 4] < 0.0
+
+
+# =============================================================================
+# Physical invariants
+# =============================================================================
+
+
+class TestPhysicalInvariants:
+    """收敛轨道的物理不变量检验。"""
+
+    def test_jacobi_conservation(self, orbit, dynamics):
+        """Jacobi 常数在一个周期内漂移 < 1e-10。"""
+        T = orbit.period
+        result = dynamics.propagate(
+            orbit.states[0],
+            (0, T),
+            t_eval=np.linspace(0, T, 1000),
+            with_jacobi=True,
+        )
+        jacobi = result["jacobi"]
+        drift = abs(jacobi[-1] - jacobi[0])
+        assert drift < 1e-10
+
+    def test_periodic_closure(self, orbit, dynamics):
+        """全周期闭合误差 < 1e-6。"""
+        T = orbit.period
+        result = dynamics.propagate(orbit.states[0], (0, T), t_eval=np.linspace(0, T, 1000))
+        closure = np.linalg.norm(result["states"][-1] - orbit.states[0])
+        assert closure < 1e-6
+
+    def test_xy_plane_constraint(self, orbit, dynamics):
+        """DPO 为 xy 平面轨道：整个周期内 z≈0。"""
+        T = orbit.period
+        result = dynamics.propagate(orbit.states[0], (0, T), t_eval=np.linspace(0, T, 500))
+        z_max = np.max(np.abs(result["states"][:, 2]))
+        assert z_max < 1e-8
+
+    def test_half_period_on_x_axis(self, orbit, dynamics):
+        """半周期处状态应在 x 轴上：y=0, z=0, vx=0。"""
+        T = orbit.period
+        result = dynamics.propagate(orbit.states[0], (0, T / 2), t_eval=[T / 2])
+        state_half = result["states"][-1]
+        assert state_half[1] == pytest.approx(0.0, abs=1e-8)  # y=0
+        assert state_half[2] == pytest.approx(0.0, abs=1e-8)  # z=0
+        assert state_half[3] == pytest.approx(0.0, abs=1e-8)  # vx=0
+
+
+# =============================================================================
+# DPO vs DRO distinguishing tests
+# =============================================================================
+
+
+class TestDpoNotDro:
+    """区分 DPO 与 DRO 的特征测试。
+
+    DPO 顺行（vy0 < 0）、Jacobi 更高（更靠近月球）、周期更短；
+    DRO 逆行（vy0 > 0）、Jacobi 更低。
+    """
+
+    def test_dpo_jacobi_higher_than_dro(self, dro_ref, dpo_ref):
+        """同振幅下 DPO 的 Jacobi 常数应高于 DRO。"""
+        C_dro = float(dro_ref.system.get_jacobi_constant(dro_ref.states[0]))
+        C_dpo = float(dpo_ref.system.get_jacobi_constant(dpo_ref.states[0]))
+        assert C_dpo > C_dro, f"DPO C={C_dpo:.4f} 应高于 DRO C={C_dro:.4f}"
+
+    def test_dpo_closer_to_moon_than_dro(self, dro_ref, dpo_ref):
+        """同振幅下 DPO 的近月距应小于 DRO（DPO 更靠近月球）。"""
+        d_dro = CR3BP_Dynamics(dro_ref.system)
+        d_dpo = CR3BP_Dynamics(dpo_ref.system)
+        min_dro, _ = _moon_distance_minmax(d_dro, dro_ref)
+        min_dpo, _ = _moon_distance_minmax(d_dpo, dpo_ref)
+        assert min_dpo < min_dro, (
+            f"DPO 近月距 {min_dpo:.4f} DU 应小于 DRO {min_dro:.4f} DU"
+        )
+
+    def test_dpo_covers_moon_proximity(self, dpo_ref):
+        """DPO 轨道的近月距应显著小于远月距（绕月特征）。"""
+        dynamics = CR3BP_Dynamics(dpo_ref.system)
+        d_min, d_max = _moon_distance_minmax(dynamics, dpo_ref)
+        assert d_min < d_max, "DPO 应有明显的近月/远月区分"
+        assert d_min < 0.2, f"DPO 近月距 {d_min:.4f} DU 应 < 0.2 DU（绕月轨道）"
+
+
+# =============================================================================
+# design_orbit facade dispatch
+# =============================================================================
+
+
+class TestDpoDesignOrbit:
+    """design_orbit 入口分发 DPO。"""
+
+    def test_design_orbit_validates_dpo_params(self):
+        """design_orbit("DPO", ...) 参数校验先于实现：duration 校验优先。"""
+        from e2m2e.algorithm.design import design_orbit
+
+        with pytest.raises(ValueError, match="duration"):
+            design_orbit("DPO", duration=0.0)
+
+    def test_design_orbit_rejects_amplitude_out_of_range(self):
+        """amplitude < 1737 km 应抛 ValueError。"""
+        from e2m2e.algorithm.design import design_orbit
+
+        with pytest.raises(ValueError, match="amplitude"):
+            design_orbit("DPO", amplitude=500.0, duration=0.5)
+
+    def test_design_orbit_rejects_bad_phase(self):
+        """phase 超界应抛 ValueError。"""
+        from e2m2e.algorithm.design import design_orbit
+
+        with pytest.raises(ValueError, match="phase"):
+            design_orbit("DPO", phase=1.5, duration=0.5)
+
+    def test_validate_params_dpo_defaults(self):
+        """_validate_params 对 DPO 填默认值（amplitude=20000, phase=0.5001）。"""
+        from e2m2e.algorithm.design.design_orbit import _validate_params
+
+        params = _validate_params(
+            "DPO",
+            amplitude=None,
+            phase=None,
+            collinear_point=None,
+            north_south=None,
+            perilune_height=None,
+            amplitude_in=None,
+            amplitude_out=None,
+            phase_in=None,
+            phase_out=None,
+        )
+        assert params == {"amplitude": 20000.0, "phase": 0.5001}
+
+    def test_cr3bp_orbit_for_dpo_end_to_end(self):
+        """_cr3bp_orbit_for("DPO", ...) 端到端调用 design_dpo 返回 Orbit。"""
+        from e2m2e.algorithm.design.design_orbit import _cr3bp_orbit_for, _validate_params
+
+        params = _validate_params(
+            "DPO",
+            amplitude=20000.0,
+            phase=None,
+            collinear_point=None,
+            north_south=None,
+            perilune_height=None,
+            amplitude_in=None,
+            amplitude_out=None,
+            phase_in=None,
+            phase_out=None,
+        )
+        dynamics = CR3BP_Dynamics(earth_moon_system())
+        orbit = _cr3bp_orbit_for("DPO", params, dynamics)
+        assert orbit is not None
+        assert orbit.period is not None
+        assert orbit.period > 0

--- a/tests/algorithms/test_dpo_family.py
+++ b/tests/algorithms/test_dpo_family.py
@@ -180,9 +180,7 @@ class TestDpoNotDro:
         d_dpo = CR3BP_Dynamics(orbit.system)
         min_dro, _ = _moon_distance_minmax(d_dro, dro_ref)
         min_dpo, _ = _moon_distance_minmax(d_dpo, orbit)
-        assert min_dpo < min_dro, (
-            f"DPO 近月距 {min_dpo:.4f} DU 应小于 DRO {min_dro:.4f} DU"
-        )
+        assert min_dpo < min_dro, f"DPO 近月距 {min_dpo:.4f} DU 应小于 DRO {min_dro:.4f} DU"
 
     def test_dpo_covers_moon_proximity(self, orbit):
         """DPO 轨道的近月距应显著小于远月距（绕月特征）。"""

--- a/tests/algorithms/test_dpo_family.py
+++ b/tests/algorithms/test_dpo_family.py
@@ -15,6 +15,7 @@ from e2m2e.algorithm.family.cr3bp_orbits import (
     design_dro,
     earth_moon_system,
 )
+from e2m2e.data.types.orbit import Orbit
 
 CHAR_LENGTH_KM = 384400.0
 
@@ -34,12 +35,6 @@ def dynamics(orbit):
 def dro_ref():
     """共享一条 design_dro(20000.0) 轨道（DPO vs DRO 对比用）。"""
     return design_dro(20000.0)
-
-
-@pytest.fixture(scope="module")
-def dpo_ref():
-    """共享一条 design_dpo(20000.0) 轨道（与 dro_ref 振幅相同）。"""
-    return design_dpo(20000.0)
 
 
 # =============================================================================
@@ -79,12 +74,12 @@ class TestDesignDpoConvergence:
         assert orbit.period > 0
 
     def test_design_dpo_amplitude_matches_target(self):
-        """振幅（距月 min/max 均值）应接近 20000 km（容差 50 km）。"""
+        """振幅（距月 min/max 均值）应接近 20000 km（容差 25 km，与 design tol 对齐）。"""
         orbit = design_dpo(20000.0)
         dynamics = CR3BP_Dynamics(orbit.system)
         d_min, d_max = _moon_distance_minmax(dynamics, orbit)
         amp_km = 0.5 * (d_min + d_max) * CHAR_LENGTH_KM
-        assert abs(amp_km - 20000.0) < 50.0
+        assert abs(amp_km - 20000.0) < 25.0
 
     def test_design_dpo_state_on_x_axis(self):
         """初始状态应在 xy 平面的 x 轴上：y=0, z=0, vx=0。"""
@@ -98,6 +93,22 @@ class TestDesignDpoConvergence:
         """DPO 初始 vy0 应为负（顺行：旋转坐标系下逆时针）。"""
         orbit = design_dpo(20000.0)
         assert orbit.states[0, 4] < 0.0
+
+    def test_correct_dpo_raises_on_pseudo_solution(self):
+        """_correct_dpo 应在周期跳变超过 2× 时抛 Cr3bpOrbitError。"""
+        from e2m2e.algorithm.family.cr3bp_orbits import Cr3bpOrbitError, _correct_dpo
+
+        dynamics = CR3BP_Dynamics(earth_moon_system())
+        # 构造一个 period 偏小的 orbit 作为 guess，使修正结果超过 2×
+        fake_state = np.array([0.90, 0.0, 0.0, 0.0, -0.25, 0.0])
+        fake = Orbit(
+            states=fake_state.reshape(1, -1),
+            times=np.array([0.0]),
+            system=dynamics.system,
+        )
+        fake.period = 1.0  # 种子 period≈2.50，2.50 > 2×1.0 触发伪解拒绝
+        with pytest.raises(Cr3bpOrbitError, match="DPO"):
+            _correct_dpo(dynamics, 0.90, fake)
 
 
 # =============================================================================
@@ -157,26 +168,26 @@ class TestDpoNotDro:
     DRO 逆行（vy0 > 0）、Jacobi 更低。
     """
 
-    def test_dpo_jacobi_higher_than_dro(self, dro_ref, dpo_ref):
+    def test_dpo_jacobi_higher_than_dro(self, dro_ref, orbit):
         """同振幅下 DPO 的 Jacobi 常数应高于 DRO。"""
         C_dro = float(dro_ref.system.get_jacobi_constant(dro_ref.states[0]))
-        C_dpo = float(dpo_ref.system.get_jacobi_constant(dpo_ref.states[0]))
+        C_dpo = float(orbit.system.get_jacobi_constant(orbit.states[0]))
         assert C_dpo > C_dro, f"DPO C={C_dpo:.4f} 应高于 DRO C={C_dro:.4f}"
 
-    def test_dpo_closer_to_moon_than_dro(self, dro_ref, dpo_ref):
+    def test_dpo_closer_to_moon_than_dro(self, dro_ref, orbit):
         """同振幅下 DPO 的近月距应小于 DRO（DPO 更靠近月球）。"""
         d_dro = CR3BP_Dynamics(dro_ref.system)
-        d_dpo = CR3BP_Dynamics(dpo_ref.system)
+        d_dpo = CR3BP_Dynamics(orbit.system)
         min_dro, _ = _moon_distance_minmax(d_dro, dro_ref)
-        min_dpo, _ = _moon_distance_minmax(d_dpo, dpo_ref)
+        min_dpo, _ = _moon_distance_minmax(d_dpo, orbit)
         assert min_dpo < min_dro, (
             f"DPO 近月距 {min_dpo:.4f} DU 应小于 DRO {min_dro:.4f} DU"
         )
 
-    def test_dpo_covers_moon_proximity(self, dpo_ref):
+    def test_dpo_covers_moon_proximity(self, orbit):
         """DPO 轨道的近月距应显著小于远月距（绕月特征）。"""
-        dynamics = CR3BP_Dynamics(dpo_ref.system)
-        d_min, d_max = _moon_distance_minmax(dynamics, dpo_ref)
+        dynamics = CR3BP_Dynamics(orbit.system)
+        d_min, d_max = _moon_distance_minmax(dynamics, orbit)
         assert d_min < d_max, "DPO 应有明显的近月/远月区分"
         assert d_min < 0.2, f"DPO 近月距 {d_min:.4f} DU 应 < 0.2 DU（绕月轨道）"
 


### PR DESCRIPTION
Closes #288

## 改动

DPO（Direct Prograde Orbit）= xy 平面内围绕月球的顺行周期轨道，与 DRO（逆行）对称。

### 实现

- `seed.py`: `_DPO_SEED_X0/VY0/PERIOD`（从 DRO seed 反转 vy0 微分修正收敛）
- `cr3bp_orbits.py`: `_correct_dpo` + `design_dpo`（复用 `setup_2D_symmetric_x_fixed_x0`）
- `family/__init__.py`: `registry["DPO"] = design_dpo`
- `design_orbit.py`: DPO 分发（`_validate_params` + `_cr3bp_orbit_for` + `phase_offset`）
- `issue288-dpo-literature-review.md`: Folta 2015 / Guzzetti 2016 文献调研

### 关键设计决策

- 修正策略与 DRO 相同（x 轴对称 planar）
- 伪解阈值放宽至 2.0×（DPO 不稳定，周期变化幅度比 DRO 大）
- 振幅定义同 DRO（距月心 min/max 均值，km）
- DPO 是 PRD FR1 的补充项，不纳入 FR1 scope

### 验证

15/15 核心测试通过：
- 注册表（3）：DPO in registry、callable、指向 design_dpo
- 收敛（5）：振幅匹配（<25km）、xy 平面、vy0<0、伪解拒绝
- 物理不变量（4）：Jacobi 守恒、周期闭合、xy 平面约束、半周期 x 轴
- DPO vs DRO 区分（3）：Jacobi 更高、近月距更小、绕月特征

### 已知限制

5 个 `design_orbit` 分发测试因 pre-existing `RkMethod.PD45` Rust binding 问题失败（Axial 同款，见 #301）。