### PR TITLE
fix(design): design_orbit 分发测试因 Rust binding 导入失败（#301）

### DIFF
--- a/e2m2e/algorithm/design/design_orbit.py
+++ b/e2m2e/algorithm/design/design_orbit.py
@@ -38,13 +38,11 @@ from typing import Any
 
 import numpy as np
 
-from e2m2e.io import (
-    DEFAULT_PERTURBATION,
-    EphemerisTable,
-)
+from e2m2e.io import EphemerisTable
 
 from ...data.kernels._spice_loader import get_spiceypy
 from ...data.kernels.manager import SPICEManager
+from ...data.templates.perturbations import DEFAULT_PERTURBATION
 from ...data.types.orbit import Orbit
 from ..coordinate.coordinate_system import CoordinateSystem
 from ..coordinate.standard_axes import ICRSAxes
@@ -65,8 +63,6 @@ from ..family.cr3bp_orbits import (
     design_triangular,
     earth_moon_system,
 )
-from ..forces import ForceModel
-from ..forces.force_mapping import dfh_perturbation_to_force_config
 from ..solver.multiple_shooting import sample_patch_points_perilune_clustered
 
 __all__ = [
@@ -802,6 +798,9 @@ def design_orbit(
 
     # --- 3. 星历修正（N 体模型多重打靶） ---
     # 默认光压用炮弹模型、关耦合项（ECOM/耦合属 #253，显式开启会报错）
+    from ..forces import ForceModel
+    from ..forces.force_mapping import dfh_perturbation_to_force_config
+
     if perturbation is None:
         perturbation = DEFAULT_DESIGN_PERTURBATION
     sw = dict(perturbation)

--- a/e2m2e/algorithm/forces/force_model.py
+++ b/e2m2e/algorithm/forces/force_model.py
@@ -623,7 +623,7 @@ class ForceModel:
         initial_step: float | None = None,
         events: list[Callable[[float, npt.NDArray[np.floating]], float]] | None = None,
         max_steps: int = 100_000,
-        method: RkMethod = RkMethod.PD45,
+        method: RkMethod | None = None,
     ) -> dict[str, Any]:
         """使用 Rust rk_step 传播轨迹。
 
@@ -645,6 +645,8 @@ class ForceModel:
             包含 ``time``、``states`` 和 ``terminal_event_index`` 的字典；
             ``with_stm=True`` 时额外含 ``stm`` 键。
         """
+        if method is None:
+            method = RkMethod.PD45
         self._raise_for_unsupported(with_stm, with_jacobi)
 
         if len(t_span) != 2:
@@ -832,13 +834,15 @@ class ForceModel:
         *,
         initial_step: float | None = None,
         max_steps: int = 100_000,
-        method: RkMethod = RkMethod.PD45,
+        method: RkMethod | None = None,
     ) -> dict[str, Any]:
         """带脉冲机动的传播：coast 段之间在 burn epoch 处施加 Δv。
 
         按 epoch 排序 burns，依次 coast → 施加 Δv → 续传。burn epoch 处
         输出行携带 post-burn 速度（丢 pre-burn 行，无重复 epoch）。
         """
+        if method is None:
+            method = RkMethod.PD45
         t0, tf = float(t_span[0]), float(t_span[1])
         y = np.asarray(initial_state, dtype=float)
 


### PR DESCRIPTION
## 关联

Closes #301

## 改动

- `force_model.py`：`propagate()` 和 `propagate_maneuvers()` 的 `RkMethod.PD45` 默认值从函数签名移入函数体（延迟求值），解除模块加载时对 Rust 扩展的硬依赖
- `design_orbit.py`：`ForceModel`/`dfh_perturbation_to_force_config` 从模块顶层移入 `design_orbit()` 函数体内延迟导入；`DEFAULT_PERTURBATION` 改从 `data.templates.perturbations` 导入，符合 ADR 0012 依赖方向

## 测试

```
# 11 个受影响测试
uv run pytest tests/algorithms/test_axial_family.py::TestAxialDesignOrbit tests/algorithms/test_dpo_family.py::TestDpoDesignOrbit -v
# 结果：11/11 passed

# 两族全量
uv run pytest tests/algorithms/test_axial_family.py tests/algorithms/test_dpo_family.py -v
# 结果：39/39 passed

# 提交前检查
uv run ruff check e2m2e/algorithm/forces/force_model.py e2m2e/algorithm/design/design_orbit.py
uv run ruff format --check e2m2e/algorithm/forces/force_model.py e2m2e/algorithm/design/design_orbit.py
uv run mypy e2m2e/algorithm/forces/force_model.py e2m2e/algorithm/design/design_orbit.py --ignore-missing-imports
# 全部通过
```
