### PR TITLE
feat(facade): 一档 transfer_design/orbit_propagation/spacetime_transform 三方法落地（#291）

### DIFF
--- a/e2m2e/algorithm/coordinate/__init__.py
+++ b/e2m2e/algorithm/coordinate/__init__.py
@@ -9,6 +9,10 @@ Axes/Origin/CoordinateSystem 抽象（不新增 Frame 抽象）：所有坐标�
 
 from __future__ import annotations
 
+from typing import Any
+
+import numpy as np
+
 from .axes import Axes
 from .coordinate_system import CoordinateSystem
 from .dynamic_axes import DynamicAxes
@@ -62,4 +66,87 @@ __all__ = [
     "precession_angles",
     "rho_to_eci",
     "eci_to_rho",
+    "spacetime_convert",
 ]
+
+#: SPICE ET 秒 → JD_TDB 转换基准
+_JD_TDB_AT_ET0 = 2451545.0
+_SECONDS_PER_DAY = 86400.0
+
+
+def spacetime_convert(
+    transform_type: str,
+    state: Any,
+    epoch: float,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """时空坐标转换统一入口。
+
+    按 transform_type 分发到 SynodicJ2000System 或 GCRSEBCRSSystem。
+    不缓存转换器实例（每次调用新建）。
+
+    Args:
+        transform_type: ``synodic_to_j2000`` / ``j2000_to_synodic`` /
+            ``gcrs_to_ebcrs`` / ``ebcrs_to_gcrs``。
+        state: 单条状态向量。
+        epoch: 时间值（JD_TDB，synodic 转换时为无量纲时间 t_syn）。
+        kwargs: 额外参数（``et0_jd`` 参考历元 JD_TDB；``ephemeris_path``
+            GCRS↔EBCRS 必需）。
+
+    Returns:
+        ``{"state": ndarray, "time": float, "transform_type": str, "details": dict}``
+    """
+    state_arr = np.asarray(state, dtype=float)
+    if state_arr.ndim != 1:
+        raise ValueError(f"state 应为一维数组，实际形状 {state_arr.shape}")
+
+    et0_jd = float(kwargs.get("et0_jd", _JD_TDB_AT_ET0))
+    et0 = (et0_jd - _JD_TDB_AT_ET0) * _SECONDS_PER_DAY
+
+    if transform_type in ("synodic_to_j2000", "j2000_to_synodic"):
+        from ...data.kernels.manager import SPICEManager
+        from ..design.design_orbit import load_design_kernels
+        from ..dynamics.cr3bp_system import CR3BP_System
+
+        conv: Any
+        spice = SPICEManager()
+        load_design_kernels(spice, kwargs.get("kernel_dir"))
+
+        MU_EM = 1.21506683e-2
+        cr3bp_system = CR3BP_System(
+            mu=MU_EM, primary="Earth", secondary="Moon"
+        )._with_default_scales()
+        conv = SynodicJ2000System(cr3bp_system=cr3bp_system, spice=spice)
+    elif transform_type in ("gcrs_to_ebcrs", "ebcrs_to_gcrs"):
+        ephemeris_path = kwargs.get("ephemeris_path")
+        if not ephemeris_path:
+            raise ValueError("GCRS↔EBCRS 转换需要 ephemeris_path（含时间星历的历表路径）")
+        conv = GCRSEBCRSSystem(ephemeris_path)
+    else:
+        raise ValueError(f"未知 transform_type: {transform_type!r}")
+
+    if transform_type == "synodic_to_j2000":
+        t_syn = float(epoch)
+        result = conv.synodic_to_j2000(state_arr, t_syn, et0)
+        out_time = et0_jd + t_syn * conv._get_time_unit() / _SECONDS_PER_DAY
+    elif transform_type == "j2000_to_synodic":
+        t_syn = float(epoch)
+        result = conv.j2000_to_synodic(state_arr, t_syn, et0)
+        out_time = et0_jd + t_syn * conv._get_time_unit() / _SECONDS_PER_DAY
+    elif transform_type == "gcrs_to_ebcrs":
+        if state_arr.shape[0] != 3:
+            raise ValueError(f"GCRS→EBCRS 输入应为 3 维位置，实际 {state_arr.shape[0]} 维")
+        out_time, result = conv.gcrs_to_ebcrs(float(epoch), state_arr[:3])
+    elif transform_type == "ebcrs_to_gcrs":
+        if state_arr.shape[0] != 3:
+            raise ValueError(f"EBCRS→GCRS 输入应为 3 维位置，实际 {state_arr.shape[0]} 维")
+        out_time, result = conv.ebcrs_to_gcrs(float(epoch), state_arr[:3])
+    else:
+        raise ValueError(f"未知 transform_type: {transform_type!r}")
+
+    return {
+        "state": np.asarray(result, dtype=float),
+        "time": float(out_time),
+        "transform_type": transform_type,
+        "details": {"epoch_in": float(epoch), "et0_jd": et0_jd},
+    }

--- a/e2m2e/algorithm/propagation.py
+++ b/e2m2e/algorithm/propagation.py
@@ -6,6 +6,7 @@ EphemerisTable。单文件模块（不是目录）。
 
 from __future__ import annotations
 
+import os
 from typing import Any
 
 import numpy as np
@@ -13,6 +14,31 @@ import numpy as np
 from ..data.types import EphemerisTable
 
 __all__ = ["propagate_orbit"]
+
+#: 默认三体力模型（地月日点质量引力）
+_DEFAULT_FORCE_CONFIG: dict[str, Any] = {
+    "version": 1,
+    "forces": [
+        {
+            "name": "gravity_earth",
+            "type": "PointMassGravity",
+            "enabled": True,
+            "params": {"body": "EARTH", "mu": 398600.435507},
+        },
+        {
+            "name": "gravity_moon",
+            "type": "PointMassGravity",
+            "enabled": True,
+            "params": {"body": "MOON", "mu": 4902.800118},
+        },
+        {
+            "name": "gravity_sun",
+            "type": "PointMassGravity",
+            "enabled": True,
+            "params": {"body": "SUN", "mu": 1.32712440018e11},
+        },
+    ],
+}
 
 
 def propagate_orbit(
@@ -31,7 +57,7 @@ def propagate_orbit(
         initial_state: 初值（GCRS，km, km/s，形状 (6,)）。
         epoch: 起始历元 UTC（ISO 字符串或 ``[年,月,日,时,分,秒]``）。
         duration: 预报时长（秒）。
-        force_config: 力模型配置（缺省用空力模型）。
+        force_config: 力模型配置（缺省用默认三体力模型）。
         output_step: 输出间隔（秒）。
         kwargs: 传给 ForceModel 的额外配置（如 system/spice 等）。
 
@@ -40,7 +66,6 @@ def propagate_orbit(
 
     Raises:
         ValueError: 初值形状或时长非法。
-        NotImplementedError: force_config 缺失且无默认力模型可用（当前占位）。
     """
     state = np.asarray(initial_state, dtype=float)
     if state.shape != (6,):
@@ -48,8 +73,144 @@ def propagate_orbit(
     if float(duration) <= 0:
         raise ValueError(f"duration 必须为正数，当前 {duration}")
 
-    # 薄封装：力模型配置 → 传播 → EphemerisTable。当前为骨架，能力在规划中
-    # （FR4 全链路接入 dfh 编排后落地）。
-    raise NotImplementedError(
-        "propagate_orbit 实现未完成（能力在规划中）：待接入 ForceModel + EphemerisSystem"
+    from ..data.kernels.manager import SPICEManager
+    from .coordinate.coordinate_system import CoordinateSystem
+    from .coordinate.standard_axes import ICRSAxes
+    from .coordinate.standard_origins import CelestialBodyOrigin
+    from .dynamics.ephemeris_system import EphemerisSystem
+    from .forces import ForceModel
+
+    spice = SPICEManager()
+    _load_propagation_kernels(spice, kwargs.get("kernel_dir"))
+
+    if force_config is None:
+        force_config = _DEFAULT_FORCE_CONFIG
+    bodies = _extract_bodies(force_config)
+    if not bodies:
+        bodies = ["EARTH", "MOON", "SUN"]
+
+    system = EphemerisSystem(bodies=bodies, spice=spice, origin="EARTH")
+    system.coordinate_system = CoordinateSystem(
+        axes=ICRSAxes(),
+        origin=CelestialBodyOrigin(body="EARTH", spice=spice),
     )
+    fm = ForceModel.from_config(force_config, system)
+
+    if isinstance(epoch, str):
+        et0 = spice.utc_to_et(epoch)
+    else:
+        epoch_parts = list(epoch)
+        if len(epoch_parts) == 6:
+            y, mo, d, h, mi, s = epoch_parts
+            epoch_iso = (
+                f"{int(y):04d}-{int(mo):02d}-{int(d):02d}T{int(h):02d}:{int(mi):02d}:{s:06.3f}"
+            )
+            et0 = spice.utc_to_et(epoch_iso)
+        else:
+            raise ValueError(f"不支持的 epoch 格式: {epoch}")
+
+    etf = et0 + float(duration)
+    t_eval = np.arange(et0, etf + 0.5 * float(output_step), float(output_step))
+
+    result = fm.propagate(state, t_span=(et0, etf), t_eval=t_eval)
+
+    times = result["time"]
+    states = result["states"]
+    n = len(times)
+
+    years = np.empty(n, dtype=int)
+    months = np.empty(n, dtype=int)
+    days = np.empty(n, dtype=int)
+    hours = np.empty(n, dtype=int)
+    minutes = np.empty(n, dtype=int)
+    seconds = np.empty(n, dtype=float)
+    for i, et in enumerate(times):
+        utc_str = spice.et_to_utc(float(et))
+        y, mo, d, h, mi, s = _parse_utc_calendar(utc_str)
+        years[i] = y
+        months[i] = mo
+        days[i] = d
+        hours[i] = h
+        minutes[i] = mi
+        seconds[i] = s
+
+    return EphemerisTable(
+        year=years,
+        month=months,
+        day=days,
+        hour=hours,
+        minute=minutes,
+        second=seconds,
+        position_km=states[:, :3].copy(),
+        velocity_mps=states[:, 3:6].copy() * 1000.0,
+        synodic_position=np.zeros((n, 3)),
+    )
+
+
+def _extract_bodies(force_config: dict[str, Any]) -> list[str]:
+    """从 force_config 提取唯一天体列表。"""
+    bodies: list[str] = []
+    seen: set[str] = set()
+    for entry in force_config.get("forces", []):
+        body = entry.get("params", {}).get("body")
+        if body:
+            name = str(body).upper()
+            if name not in seen:
+                seen.add(name)
+                bodies.append(name)
+    return bodies
+
+
+def _load_propagation_kernels(spice: Any, kernel_dir: str | None = None) -> list[str]:
+    """加载传播所需内核：行星历 + body-fixed 帧内核，注册行星名。"""
+    from ..data.kernels._spice_loader import get_spiceypy
+
+    _BODY_ID_ALIASES = [
+        ("MERCURY", 1),
+        ("VENUS", 2),
+        ("EARTH", 399),
+        ("MARS", 4),
+        ("JUPITER", 5),
+        ("SATURN", 6),
+        ("URANUS", 7),
+        ("NEPTUNE", 8),
+        ("MOON", 301),
+        ("SUN", 10),
+    ]
+    _BODY_FIXED_KERNELS = [
+        "earth_latest_high_prec.bpc",
+        "pck00010.tpc",
+        "SPICELunaCurrentKernel.bpc",
+        "SPICELunaFrameKernel.tf",
+    ]
+
+    if kernel_dir is None:
+        from .design.design_orbit import default_kernel_dir
+
+        kernel_dir = default_kernel_dir()
+
+    for name, naif_id in _BODY_ID_ALIASES:
+        get_spiceypy().boddef(name, naif_id)
+    loaded: list[str] = []
+    for name in ["de440s.bsp", "de430.bsp"]:
+        path = os.path.join(kernel_dir, name)
+        if os.path.exists(path):
+            spice.load_kernel(path)
+            loaded.append(path)
+            break
+    else:
+        raise FileNotFoundError(f"行星历内核不存在（de440s/de430）: {kernel_dir}")
+    for name in _BODY_FIXED_KERNELS:
+        path = os.path.join(kernel_dir, name)
+        if os.path.exists(path):
+            spice.load_kernel(path)
+            loaded.append(path)
+    return loaded
+
+
+def _parse_utc_calendar(utc_str: str) -> tuple[int, int, int, int, int, float]:
+    """把 SPICE et2utc ISO-C 输出拆为 (y, mo, d, h, mi, s)。"""
+    date_part, time_part = utc_str.split("T")
+    y, mo, d = date_part.split("-")
+    h, mi, s = time_part.split(":")
+    return int(y), int(mo), int(d), int(h), int(mi), float(s)

--- a/e2m2e/algorithm/propagation.py
+++ b/e2m2e/algorithm/propagation.py
@@ -6,7 +6,6 @@ EphemerisTable。单文件模块（不是目录）。
 
 from __future__ import annotations
 
-import os
 from typing import Any
 
 import numpy as np
@@ -14,6 +13,10 @@ import numpy as np
 from ..data.types import EphemerisTable
 
 __all__ = ["propagate_orbit"]
+
+#: J2000 历元的 TDB 儒略日（SPICE ET 定义为相对此历元的 TDB 秒）
+_J2000_JD_TDB = 2451545.0
+_SECONDS_PER_DAY = 86400.0
 
 #: 默认三体力模型（地月日点质量引力）
 _DEFAULT_FORCE_CONFIG: dict[str, Any] = {
@@ -81,7 +84,9 @@ def propagate_orbit(
     from .forces import ForceModel
 
     spice = SPICEManager()
-    _load_propagation_kernels(spice, kwargs.get("kernel_dir"))
+    from .design.design_orbit import load_design_kernels
+
+    load_design_kernels(spice, kwargs.get("kernel_dir"))
 
     if force_config is None:
         force_config = _DEFAULT_FORCE_CONFIG
@@ -144,6 +149,7 @@ def propagate_orbit(
         position_km=states[:, :3].copy(),
         velocity_mps=states[:, 3:6].copy() * 1000.0,
         synodic_position=np.zeros((n, 3)),
+        times_jd_tdb=(_J2000_JD_TDB + times / _SECONDS_PER_DAY).copy(),
     )
 
 
@@ -159,53 +165,6 @@ def _extract_bodies(force_config: dict[str, Any]) -> list[str]:
                 seen.add(name)
                 bodies.append(name)
     return bodies
-
-
-def _load_propagation_kernels(spice: Any, kernel_dir: str | None = None) -> list[str]:
-    """加载传播所需内核：行星历 + body-fixed 帧内核，注册行星名。"""
-    from ..data.kernels._spice_loader import get_spiceypy
-
-    _BODY_ID_ALIASES = [
-        ("MERCURY", 1),
-        ("VENUS", 2),
-        ("EARTH", 399),
-        ("MARS", 4),
-        ("JUPITER", 5),
-        ("SATURN", 6),
-        ("URANUS", 7),
-        ("NEPTUNE", 8),
-        ("MOON", 301),
-        ("SUN", 10),
-    ]
-    _BODY_FIXED_KERNELS = [
-        "earth_latest_high_prec.bpc",
-        "pck00010.tpc",
-        "SPICELunaCurrentKernel.bpc",
-        "SPICELunaFrameKernel.tf",
-    ]
-
-    if kernel_dir is None:
-        from .design.design_orbit import default_kernel_dir
-
-        kernel_dir = default_kernel_dir()
-
-    for name, naif_id in _BODY_ID_ALIASES:
-        get_spiceypy().boddef(name, naif_id)
-    loaded: list[str] = []
-    for name in ["de440s.bsp", "de430.bsp"]:
-        path = os.path.join(kernel_dir, name)
-        if os.path.exists(path):
-            spice.load_kernel(path)
-            loaded.append(path)
-            break
-    else:
-        raise FileNotFoundError(f"行星历内核不存在（de440s/de430）: {kernel_dir}")
-    for name in _BODY_FIXED_KERNELS:
-        path = os.path.join(kernel_dir, name)
-        if os.path.exists(path):
-            spice.load_kernel(path)
-            loaded.append(path)
-    return loaded
 
 
 def _parse_utc_calendar(utc_str: str) -> tuple[int, int, int, int, int, float]:

--- a/e2m2e/api/facade.py
+++ b/e2m2e/api/facade.py
@@ -4,14 +4,17 @@
 保留细粒度 API（专家用）。MCP 工具 = Facade 方法全集（纯派生），方法带
 ``mcp_exposed`` 元数据控制是否对 MCP 暴露。
 
-实现状态：一档任务已接入 algorithm/ 编排器（design_orbit/control_orbit），
-二档子任务已接入已有算法（family/stability/proximity）；未实现能力
-（transfer_design/orbit_propagation/spacetime_transform 等）保持占位。
+实现状态：一档任务已接入 algorithm/ 编排器（design_orbit/control_orbit/
+transfer_design/orbit_propagation/spacetime_transform），二档子任务已接入
+已有算法（family/stability/proximity）。
 """
 
 from __future__ import annotations
 
+import dataclasses
 from typing import Any
+
+import numpy as np
 
 from .config import Config
 from .models import (
@@ -20,6 +23,12 @@ from .models import (
     DesignOrbitRequest,
     DesignOrbitResponse,
     OrbitError,
+    PropagationRequest,
+    PropagationResponse,
+    SpacetimeTransformRequest,
+    SpacetimeTransformResponse,
+    TransferDesignRequest,
+    TransferDesignResponse,
 )
 
 __all__ = ["Facade", "mcp_tools"]
@@ -29,6 +38,30 @@ def mcp_exposed(func):
     """标记 Facade 方法对 MCP 暴露（纯派生 + 元数据标记，ADR 0014）。"""
     func.mcp_exposed = True  # type: ignore[attr-defined]
     return func
+
+
+def _details_to_dict(details: Any) -> dict[str, Any]:
+    """把 details dataclass 转为 JSON 兼容 dict（ndarray → list）。"""
+    if details is None:
+        return {}
+    if isinstance(details, dict):
+        return {k: _serialize_value(v) for k, v in details.items()}
+    if dataclasses.is_dataclass(details) and not isinstance(details, type):
+        return {
+            f.name: _serialize_value(getattr(details, f.name)) for f in dataclasses.fields(details)
+        }
+    return {"value": _serialize_value(details)}
+
+
+def _serialize_value(value: Any) -> Any:
+    """递归序列化 numpy 值为 JSON 兼容类型。"""
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, (list, tuple)):
+        return [_serialize_value(v) for v in value]
+    if isinstance(value, dict):
+        return {k: _serialize_value(v) for k, v in value.items()}
+    return value
 
 
 class Facade:
@@ -139,28 +172,130 @@ class Facade:
             raise OrbitError("CONTROL_FAILED", str(exc)) from exc
 
     @mcp_exposed
-    def transfer_design(self, **params) -> Any:
+    def transfer_design(self, **params) -> TransferDesignResponse:
         """转移轨道设计（一档）。
 
-        实现状态：占位（编排器 transfer_orbit 能力在规划中）。
+        薄封装 ``algorithm/transfer/transfer_orbit``：Pydantic 校验 → 编排 →
+        结果翻译为 Response。
         """
-        raise NotImplementedError("Facade.transfer_design 待接入 algorithm/transfer/")
+        try:
+            request = TransferDesignRequest(**params)
+            from e2m2e.algorithm.transfer import TliParams, transfer_orbit
+
+            tli_params = TliParams(
+                epoch=request.tli_epoch,
+                parking_alt_km=request.parking_alt_km,
+                inclination_deg=request.incl_deg,
+                flight_path_angle_deg=request.flight_path_deg,
+            )
+            tof_range = (
+                (float(request.tof_range[0]), float(request.tof_range[1]))
+                if request.tof_range
+                else None
+            )
+            result = transfer_orbit(
+                request.transfer_type,
+                target_ephemeris=request.target_ephemeris,
+                tli_params=tli_params,
+                tof_range=tof_range,
+                target_orbit_radius_km=request.target_orbit_radius_km,
+                lga_search_params=request.lga_search_params,
+                wsb_search_params=request.wsb_search_params,
+            )
+            trajectory = (
+                result.trajectory.tolist()
+                if result.trajectory is not None and isinstance(result.trajectory, np.ndarray)
+                else result.trajectory
+            )
+            return TransferDesignResponse(
+                transfer_type=result.transfer_type,
+                delta_v=result.delta_v,
+                trajectory=trajectory,
+                details=_details_to_dict(result.details),
+            )
+        except OrbitError:
+            raise
+        except (ValueError, TypeError) as exc:
+            raise OrbitError("INVALID_PARAMS", str(exc)) from exc
+        except Exception as exc:
+            raise OrbitError("TRANSFER_FAILED", str(exc)) from exc
 
     @mcp_exposed
-    def orbit_propagation(self, **params) -> Any:
+    def orbit_propagation(self, **params) -> PropagationResponse:
         """轨道预报（一档）。
 
-        实现状态：占位（propagate_orbit 能力在规划中）。
+        薄封装 ``algorithm/propagation/propagate_orbit``：Pydantic 校验 →
+        传播 → EphemerisTable 翻译为 Response。
         """
-        raise NotImplementedError("Facade.orbit_propagation 待接入 algorithm/propagation.py")
+        try:
+            request = PropagationRequest(**params)
+            from e2m2e.algorithm.propagation import propagate_orbit
+
+            result = propagate_orbit(
+                initial_state=request.initial_state,
+                epoch=request.epoch,
+                duration=request.duration,
+                force_config=request.force_config,
+                output_step=request.output_step,
+                kernel_dir=self._config.kernel_dir,
+            )
+            return PropagationResponse(
+                epoch_utc=str(request.epoch) if isinstance(request.epoch, str) else "",
+                duration_sec=float(request.duration),
+                output_step=float(request.output_step),
+                time_sec=[float(t) for t in range(len(result.year))],
+                position_km=result.position_km.tolist(),
+                velocity_mps=result.velocity_mps.tolist(),
+            )
+        except OrbitError:
+            raise
+        except (ValueError, TypeError) as exc:
+            raise OrbitError("INVALID_PARAMS", str(exc)) from exc
+        except Exception as exc:
+            raise OrbitError("PROPAGATION_FAILED", str(exc)) from exc
 
     @mcp_exposed
-    def spacetime_transform(self, **params) -> Any:
+    def spacetime_transform(self, **params) -> SpacetimeTransformResponse:
         """时空坐标转换（一档）。
 
-        实现状态：占位（统一转换入口待接入 algorithm/coordinate/）。
+        薄封装 ``algorithm/coordinate/spacetime_convert``：Pydantic 校验 →
+        逐条转换 → 结果翻译为 Response。
         """
-        raise NotImplementedError("Facade.spacetime_transform 待接入 algorithm/coordinate/")
+        try:
+            request = SpacetimeTransformRequest(**params)
+            from e2m2e.algorithm.coordinate import spacetime_convert
+
+            if len(request.states) != len(request.times):
+                raise ValueError("states 与 times 长度必须一致")
+
+            converted_states: list[list[float]] = []
+            converted_times: list[float] = []
+            for state, t in zip(request.states, request.times, strict=True):
+                result = spacetime_convert(
+                    request.transform_type,
+                    state,
+                    float(t),
+                    et0_jd=request.et0_jd,
+                    ephemeris_path=request.ephemeris_path,
+                )
+                converted_states.append(result["state"].tolist())
+                converted_times.append(float(result["time"]))
+
+            return SpacetimeTransformResponse(
+                states=converted_states,
+                times=converted_times,
+                transform_type=request.transform_type,
+                details={
+                    "n_states": len(converted_states),
+                    "et0_jd": request.et0_jd,
+                },
+            )
+        except OrbitError:
+            raise
+        except (ValueError, TypeError) as exc:
+            raise OrbitError("INVALID_PARAMS", str(exc)) from exc
+        except Exception as exc:
+            raise OrbitError("TRANSFORM_FAILED", str(exc)) from exc
 
     # ---- 二档子任务（mcp_exposed=True）----
 

--- a/e2m2e/api/facade.py
+++ b/e2m2e/api/facade.py
@@ -217,6 +217,8 @@ class Facade:
             raise
         except (ValueError, TypeError) as exc:
             raise OrbitError("INVALID_PARAMS", str(exc)) from exc
+        except NotImplementedError as exc:
+            raise OrbitError("NOT_IMPLEMENTED", str(exc)) from exc
         except Exception as exc:
             raise OrbitError("TRANSFER_FAILED", str(exc)) from exc
 
@@ -239,18 +241,26 @@ class Facade:
                 output_step=request.output_step,
                 kernel_dir=self._config.kernel_dir,
             )
+            times_jd = result.times_jd_tdb
+            assert times_jd is not None  # propagate_orbit 始终填充
+            vel_km_s = result.velocity_mps / 1000.0
             return PropagationResponse(
                 epoch_utc=str(request.epoch) if isinstance(request.epoch, str) else "",
                 duration_sec=float(request.duration),
                 output_step=float(request.output_step),
-                time_sec=[float(t) for t in range(len(result.year))],
+                n_points=len(result.year),
+                time_sec=((times_jd - times_jd[0]) * 86400.0).tolist(),
+                times_jd_tdb=times_jd.tolist(),
                 position_km=result.position_km.tolist(),
-                velocity_mps=result.velocity_mps.tolist(),
+                velocity_km_s=vel_km_s.tolist(),
+                final_state=result.position_km[-1].tolist() + vel_km_s[-1].tolist(),
             )
         except OrbitError:
             raise
         except (ValueError, TypeError) as exc:
             raise OrbitError("INVALID_PARAMS", str(exc)) from exc
+        except NotImplementedError as exc:
+            raise OrbitError("NOT_IMPLEMENTED", str(exc)) from exc
         except Exception as exc:
             raise OrbitError("PROPAGATION_FAILED", str(exc)) from exc
 
@@ -277,6 +287,7 @@ class Facade:
                     float(t),
                     et0_jd=request.et0_jd,
                     ephemeris_path=request.ephemeris_path,
+                    kernel_dir=self._config.kernel_dir,
                 )
                 converted_states.append(result["state"].tolist())
                 converted_times.append(float(result["time"]))
@@ -294,6 +305,8 @@ class Facade:
             raise
         except (ValueError, TypeError) as exc:
             raise OrbitError("INVALID_PARAMS", str(exc)) from exc
+        except NotImplementedError as exc:
+            raise OrbitError("NOT_IMPLEMENTED", str(exc)) from exc
         except Exception as exc:
             raise OrbitError("TRANSFORM_FAILED", str(exc)) from exc
 

--- a/e2m2e/api/models.py
+++ b/e2m2e/api/models.py
@@ -122,7 +122,7 @@ class TransferDesignRequest(_ApiModel):
     tli_epoch: Any = Field(description="TLI 历元（UTC ISO 字符串或 JD_TDB 浮点数）")
     parking_alt_km: float = Field(default=200.0, gt=0.0, description="地球停泊轨道高度 (km)")
     incl_deg: float = Field(default=28.5, ge=0.0, le=180.0, description="轨道倾角 (度)")
-    flight_path_deg: float = Field(default=0.0, ge=0.0, le=360.0, description="航迹角 (度)")
+    flight_path_deg: float = Field(default=0.0, ge=0.0, le=0.0, description="航迹角 (度，仅支持 0)")
     target_ephemeris: Any = Field(
         default=None, description="目标星历（EphemerisTable/NominalOrbit/ndarray）"
     )
@@ -146,7 +146,9 @@ class TransferDesignResponse(_ApiModel):
 class PropagationRequest(_ApiModel):
     """轨道预报输入（对齐 algorithm/propagation 的 propagate_orbit 参数）。"""
 
-    initial_state: list[float] = Field(description="初值（GCRS，km, km/s，长度 6）")
+    initial_state: list[float] = Field(
+        min_length=6, max_length=6, description="初值（GCRS，km, km/s，长度 6）"
+    )
     epoch: Any = Field(description="起始历元 UTC（ISO 字符串或 [年,月,日,时,分,秒]）")
     duration: float = Field(gt=0.0, description="预报时长（秒）")
     force_config: dict[str, Any] | None = Field(
@@ -161,9 +163,12 @@ class PropagationResponse(_ApiModel):
     epoch_utc: str
     duration_sec: float
     output_step: float
+    n_points: int
     time_sec: list[float]
+    times_jd_tdb: list[float]
     position_km: list[list[float]]
-    velocity_mps: list[list[float]]
+    velocity_km_s: list[list[float]]
+    final_state: list[float]
 
 
 class SpacetimeTransformRequest(_ApiModel):

--- a/e2m2e/api/models.py
+++ b/e2m2e/api/models.py
@@ -17,6 +17,12 @@ __all__ = [
     "DesignOrbitResponse",
     "ControlOrbitRequest",
     "ControlOrbitResponse",
+    "TransferDesignRequest",
+    "TransferDesignResponse",
+    "PropagationRequest",
+    "PropagationResponse",
+    "SpacetimeTransformRequest",
+    "SpacetimeTransformResponse",
 ]
 
 
@@ -107,3 +113,75 @@ class ControlOrbitResponse(_ApiModel):
     num_failed: int
     sk_statistic: dict[str, Any]
     maneuvers: dict[str, Any]
+
+
+class TransferDesignRequest(_ApiModel):
+    """转移轨道设计输入（对齐 algorithm/transfer 的 transfer_orbit 参数）。"""
+
+    transfer_type: str = Field(description="HMN/LGA/WSB/low_thrust")
+    tli_epoch: Any = Field(description="TLI 历元（UTC ISO 字符串或 JD_TDB 浮点数）")
+    parking_alt_km: float = Field(default=200.0, gt=0.0, description="地球停泊轨道高度 (km)")
+    incl_deg: float = Field(default=28.5, ge=0.0, le=180.0, description="轨道倾角 (度)")
+    flight_path_deg: float = Field(default=0.0, ge=0.0, le=360.0, description="航迹角 (度)")
+    target_ephemeris: Any = Field(
+        default=None, description="目标星历（EphemerisTable/NominalOrbit/ndarray）"
+    )
+    target_orbit_radius_km: float | None = Field(
+        default=None, gt=0.0, description="目标轨道半径 (km)，HMN 必需"
+    )
+    tof_range: list[float] | None = Field(default=None, description="飞行时间范围 [min, max]（天）")
+    lga_search_params: Any = Field(default=None, description="LGA 搜索参数（LgaSearchParams 实例）")
+    wsb_search_params: Any = Field(default=None, description="WSB 搜索参数（WsbSearchParams 实例）")
+
+
+class TransferDesignResponse(_ApiModel):
+    """转移轨道设计输出。"""
+
+    transfer_type: str
+    delta_v: float
+    trajectory: list[list[float]] | None
+    details: dict[str, Any]
+
+
+class PropagationRequest(_ApiModel):
+    """轨道预报输入（对齐 algorithm/propagation 的 propagate_orbit 参数）。"""
+
+    initial_state: list[float] = Field(description="初值（GCRS，km, km/s，长度 6）")
+    epoch: Any = Field(description="起始历元 UTC（ISO 字符串或 [年,月,日,时,分,秒]）")
+    duration: float = Field(gt=0.0, description="预报时长（秒）")
+    force_config: dict[str, Any] | None = Field(
+        default=None, description="力模型配置（缺省用默认三体力模型）"
+    )
+    output_step: float = Field(default=3600.0, gt=0.0, description="输出间隔（秒）")
+
+
+class PropagationResponse(_ApiModel):
+    """轨道预报输出。"""
+
+    epoch_utc: str
+    duration_sec: float
+    output_step: float
+    time_sec: list[float]
+    position_km: list[list[float]]
+    velocity_mps: list[list[float]]
+
+
+class SpacetimeTransformRequest(_ApiModel):
+    """时空坐标转换输入。"""
+
+    states: list[list[float]] = Field(description="状态列表，每项 [x,y,z,vx,vy,vz]")
+    times: list[float] = Field(description="每个状态的 JD_TDB 时间值")
+    transform_type: str = Field(
+        description="synodic_to_j2000/j2000_to_synodic/gcrs_to_ebcrs/ebcrs_to_gcrs"
+    )
+    et0_jd: float = Field(description="参考历元 JD_TDB")
+    ephemeris_path: str | None = Field(default=None, description="历表路径（GCRS↔EBCRS 必需）")
+
+
+class SpacetimeTransformResponse(_ApiModel):
+    """时空坐标转换输出。"""
+
+    states: list[list[float]]
+    times: list[float]
+    transform_type: str
+    details: dict[str, Any]

--- a/e2m2e/data/types/trajectory.py
+++ b/e2m2e/data/types/trajectory.py
@@ -29,6 +29,8 @@ class EphemerisTable:
         velocity_mps: GCRS 速度（m/s），形状 ``(n, 3)``
         synodic_position: 地月会合系位置（无量纲），形状 ``(n, 3)``
         raw_text: 原始文件文本；程序生成（非读入）时为空串。
+        times_jd_tdb: 历元 TDB 儒略日序列（形状 ``(n,)``），由预报/设计链路
+            填充；读入的 DFH 星历可能为 ``None``。JD_TDB = 2451545.0 + ET/86400。
     """
 
     year: np.ndarray
@@ -41,6 +43,7 @@ class EphemerisTable:
     velocity_mps: np.ndarray
     synodic_position: np.ndarray
     raw_text: str = field(default="", repr=False)
+    times_jd_tdb: np.ndarray | None = field(default=None, repr=False)
 
     def __len__(self) -> int:
         return len(self.year)

--- a/tests/algorithm/test_propagation.py
+++ b/tests/algorithm/test_propagation.py
@@ -1,0 +1,179 @@
+"""algorithm/propagation 模块测试。"""
+
+from __future__ import annotations
+
+import os
+
+import numpy as np
+import pytest
+
+from e2m2e.algorithm.propagation import _extract_bodies, propagate_orbit
+
+# ---------------------------------------------------------------------------
+# SPICE 与 kernel 可用性检测（与 tests/algorithms/normal_form/test_hamiltonian.py 一致）
+# ---------------------------------------------------------------------------
+
+_SPICE_KERNEL_DIR = os.environ.get(
+    "SPICE_KERNEL_DIR",
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "..", "kernels"),
+)
+
+
+def _has_spice_kernels() -> bool:
+    """检查 SPICE .tls + .bsp 都可用。"""
+    if not os.path.isdir(_SPICE_KERNEL_DIR):
+        return False
+    has_tls = any(f.endswith(".tls") for f in os.listdir(_SPICE_KERNEL_DIR))
+    has_bsp = any(f.endswith(".bsp") for f in os.listdir(_SPICE_KERNEL_DIR))
+    return has_tls and has_bsp
+
+
+_requires_spice = pytest.mark.skipif(
+    not _has_spice_kernels(),
+    reason="SPICE kernels (.tls + .bsp) not available",
+)
+
+
+@pytest.fixture
+def _spice_loaded():
+    """加载 leapseconds + 任一可用 SPK；不可用时跳过。"""
+    if not _has_spice_kernels():
+        pytest.skip("SPICE kernels not available")
+    import spiceypy as spice
+
+    for fname in ("naif0012.tls", "naif0011.tls"):
+        path = os.path.join(_SPICE_KERNEL_DIR, fname)
+        if os.path.exists(path):
+            spice.furnsh(path)
+    for fname in ("de440.bsp", "de440s.bsp", "de438.bsp", "de435.bsp", "de430.bsp"):
+        path = os.path.join(_SPICE_KERNEL_DIR, fname)
+        if os.path.exists(path):
+            spice.furnsh(path)
+            return path
+    pytest.skip("No SPICE ephemeris kernel (.bsp) found")
+
+
+class TestExtractBodies:
+    def test_single_body(self):
+        cfg = {
+            "version": 1,
+            "forces": [
+                {
+                    "name": "g",
+                    "type": "PointMassGravity",
+                    "enabled": True,
+                    "params": {"body": "EARTH"},
+                }
+            ],
+        }
+        assert _extract_bodies(cfg) == ["EARTH"]
+
+    def test_unique_and_uppercase(self):
+        cfg = {
+            "version": 1,
+            "forces": [
+                {
+                    "name": "g1",
+                    "type": "PointMassGravity",
+                    "enabled": True,
+                    "params": {"body": "earth"},
+                },
+                {
+                    "name": "g2",
+                    "type": "PointMassGravity",
+                    "enabled": True,
+                    "params": {"body": "EARTH"},
+                },
+                {
+                    "name": "g3",
+                    "type": "PointMassGravity",
+                    "enabled": True,
+                    "params": {"body": "MOON"},
+                },
+            ],
+        }
+        assert _extract_bodies(cfg) == ["EARTH", "MOON"]
+
+    def test_empty_forces(self):
+        assert _extract_bodies({"version": 1, "forces": []}) == []
+
+    def test_missing_body(self):
+        assert _extract_bodies({"version": 1, "forces": [{"params": {"mu": 1.0}}]}) == []
+
+
+@_requires_spice
+class TestPropagateOrbit:
+    def test_default_three_body(self, _spice_loaded, reference_epoch):
+        initial_state = np.array(
+            [
+                -6000.0,  # km
+                -2500.0,
+                0.0,
+                5.0,  # km/s
+                -4.5,
+                0.0,
+            ]
+        )
+        result = propagate_orbit(
+            initial_state=initial_state,
+            epoch=reference_epoch,
+            duration=86400.0,
+            output_step=3600.0,
+        )
+        assert len(result) == 25  # 0..24h inclusive
+        assert result.position_km.shape == (25, 3)
+        assert result.velocity_mps.shape == (25, 3)
+        assert not np.allclose(result.position_km[0], result.position_km[-1])
+
+    def test_epoch_tuple(self, _spice_loaded):
+        initial_state = np.zeros(6)
+        result = propagate_orbit(
+            initial_state=initial_state,
+            epoch=[2025, 6, 21, 11, 0, 6.0],
+            duration=3600.0,
+            output_step=3600.0,
+        )
+        assert len(result) == 2
+
+    def test_invalid_initial_state_shape(self):
+        with pytest.raises(ValueError, match="initial_state"):
+            propagate_orbit(
+                initial_state=np.zeros(5),
+                epoch="2025-06-21T11:00:00",
+                duration=3600.0,
+            )
+
+    def test_invalid_duration(self):
+        with pytest.raises(ValueError, match="duration"):
+            propagate_orbit(
+                initial_state=np.zeros(6),
+                epoch="2025-06-21T11:00:00",
+                duration=0.0,
+            )
+
+    def test_custom_force_config(self, _spice_loaded, reference_epoch):
+        force_config = {
+            "version": 1,
+            "forces": [
+                {
+                    "name": "earth",
+                    "type": "PointMassGravity",
+                    "enabled": True,
+                    "params": {"body": "EARTH", "mu": 398600.435507},
+                },
+                {
+                    "name": "moon",
+                    "type": "PointMassGravity",
+                    "enabled": True,
+                    "params": {"body": "MOON", "mu": 4902.800118},
+                },
+            ],
+        }
+        result = propagate_orbit(
+            initial_state=np.array([7000.0, 0.0, 0.0, 0.0, 7.5, 0.0]),
+            epoch=reference_epoch,
+            duration=86400.0,
+            force_config=force_config,
+            output_step=3600.0,
+        )
+        assert len(result) == 25

--- a/tests/algorithm/test_spacetime_convert.py
+++ b/tests/algorithm/test_spacetime_convert.py
@@ -1,0 +1,149 @@
+"""algorithm/coordinate spacetime_convert 统一入口测试。"""
+
+from __future__ import annotations
+
+import os
+
+import numpy as np
+import pytest
+
+from e2m2e.algorithm.coordinate import spacetime_convert
+
+# ---------------------------------------------------------------------------
+# SPICE 与 kernel 可用性检测（与 tests/algorithms/normal_form/test_hamiltonian.py 一致）
+# ---------------------------------------------------------------------------
+
+_SPICE_KERNEL_DIR = os.environ.get(
+    "SPICE_KERNEL_DIR",
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "..", "kernels"),
+)
+
+
+def _has_spice_kernels() -> bool:
+    """检查 SPICE .tls + .bsp 都可用。"""
+    if not os.path.isdir(_SPICE_KERNEL_DIR):
+        return False
+    has_tls = any(f.endswith(".tls") for f in os.listdir(_SPICE_KERNEL_DIR))
+    has_bsp = any(f.endswith(".bsp") for f in os.listdir(_SPICE_KERNEL_DIR))
+    return has_tls and has_bsp
+
+
+_requires_spice = pytest.mark.skipif(
+    not _has_spice_kernels(),
+    reason="SPICE kernels (.tls + .bsp) not available",
+)
+
+
+@pytest.fixture
+def _spice_loaded():
+    """加载 leapseconds + 任一可用 SPK；不可用时跳过。"""
+    if not _has_spice_kernels():
+        pytest.skip("SPICE kernels not available")
+    import spiceypy as spice
+
+    for fname in ("naif0012.tls", "naif0011.tls"):
+        path = os.path.join(_SPICE_KERNEL_DIR, fname)
+        if os.path.exists(path):
+            spice.furnsh(path)
+    for fname in ("de440.bsp", "de440s.bsp", "de438.bsp", "de435.bsp", "de430.bsp"):
+        path = os.path.join(_SPICE_KERNEL_DIR, fname)
+        if os.path.exists(path):
+            spice.furnsh(path)
+            return path
+    pytest.skip("No SPICE ephemeris kernel (.bsp) found")
+
+
+def _time_ephemeris_available() -> bool:
+    """检查 de440t.bsp 是否存在（含时间星历的历表）。"""
+    if not os.path.isdir(_SPICE_KERNEL_DIR):
+        return False
+    return os.path.exists(os.path.join(_SPICE_KERNEL_DIR, "de440t.bsp"))
+
+
+@_requires_spice
+class TestSpacetimeConvertSynodic:
+    def test_j2000_to_synodic_and_back(self, _spice_loaded, earth_moon_system):
+        et0_jd = 2459000.0
+        j2000_state = np.array([380000.0, 0.0, 0.0, 0.0, 1.0, 0.0])
+
+        result_syn = spacetime_convert(
+            "j2000_to_synodic",
+            j2000_state,
+            epoch=0.0,
+            et0_jd=et0_jd,
+        )
+        assert result_syn["state"].shape == (6,)
+        assert result_syn["transform_type"] == "j2000_to_synodic"
+
+        result_back = spacetime_convert(
+            "synodic_to_j2000",
+            result_syn["state"],
+            epoch=0.0,
+            et0_jd=et0_jd,
+        )
+        np.testing.assert_allclose(result_back["state"], j2000_state, rtol=1e-6)
+
+    def test_unknown_transform_type(self):
+        with pytest.raises(ValueError, match="未知"):
+            spacetime_convert(
+                "bad_type",
+                np.zeros(6),
+                epoch=0.0,
+                et0_jd=2459000.0,
+            )
+
+    def test_state_must_be_1d(self):
+        with pytest.raises(ValueError, match="state"):
+            spacetime_convert(
+                "j2000_to_synodic",
+                np.zeros((2, 6)),
+                epoch=0.0,
+                et0_jd=2459000.0,
+            )
+
+
+_time_ephemeris_available_mark = pytest.mark.skipif(
+    not _time_ephemeris_available(),
+    reason="de440t.bsp not available",
+)
+
+
+@_time_ephemeris_available_mark
+class TestSpacetimeConvertGcrsEbcrs:
+    def test_gcrs_to_ebcrs_round_trip(self):
+        ephemeris_path = os.path.join(_SPICE_KERNEL_DIR, "de440t.bsp")
+        position = np.array([7000.0, 0.0, 0.0])
+        jd_tt = 2459000.0
+
+        result_eb = spacetime_convert(
+            "gcrs_to_ebcrs",
+            position,
+            epoch=jd_tt,
+            ephemeris_path=ephemeris_path,
+        )
+        assert result_eb["state"].shape == (3,)
+
+        result_gc = spacetime_convert(
+            "ebcrs_to_gcrs",
+            result_eb["state"],
+            epoch=result_eb["time"],
+            ephemeris_path=ephemeris_path,
+        )
+        np.testing.assert_allclose(result_gc["state"], position, rtol=1e-6)
+
+    def test_missing_ephemeris_path(self):
+        with pytest.raises(ValueError, match="ephemeris_path"):
+            spacetime_convert(
+                "gcrs_to_ebcrs",
+                np.zeros(3),
+                epoch=2459000.0,
+            )
+
+    def test_gcrs_requires_3d_position(self):
+        with pytest.raises(ValueError, match="3 维"):
+            spacetime_convert(
+                "gcrs_to_ebcrs",
+                np.zeros(6),
+                epoch=2459000.0,
+                ephemeris_path="dummy.bsp",
+            )

--- a/tests/api/test_facade.py
+++ b/tests/api/test_facade.py
@@ -76,12 +76,13 @@ class TestPropagationRequest:
             )
 
     def test_invalid_state_shape(self):
-        # Pydantic 只校验 list[float]；算法层会校验长度 6
-        PropagationRequest(
-            initial_state=[0.0] * 5,
-            epoch="2025-06-21T11:00:00",
-            duration=3600.0,
-        )
+        # Pydantic 在 API 边界强制长度为 6
+        with pytest.raises(ValidationError):
+            PropagationRequest(
+                initial_state=[0.0] * 5,
+                epoch="2025-06-21T11:00:00",
+                duration=3600.0,
+            )
 
 
 class TestSpacetimeTransformRequest:
@@ -182,7 +183,7 @@ class TestFacadeCallChain:
 
     def test_transfer_design_invalid_type_call_chain(self):
         facade = Facade()
-        with pytest.raises(OrbitError, match="TRANSFER_FAILED"):
+        with pytest.raises(OrbitError, match="NOT_IMPLEMENTED"):
             facade.transfer_design(
                 transfer_type="UNKNOWN_TYPE",
                 tli_epoch="2025-06-21T11:00:00",

--- a/tests/api/test_facade.py
+++ b/tests/api/test_facade.py
@@ -2,11 +2,19 @@
 
 from __future__ import annotations
 
+import numpy as np
 import pytest
 from pydantic import ValidationError
 
 from e2m2e.api.facade import Facade, mcp_tools
-from e2m2e.api.models import ControlOrbitRequest, DesignOrbitRequest, OrbitError
+from e2m2e.api.models import (
+    ControlOrbitRequest,
+    DesignOrbitRequest,
+    OrbitError,
+    PropagationRequest,
+    SpacetimeTransformRequest,
+    TransferDesignRequest,
+)
 
 
 class TestDesignOrbitRequest:
@@ -37,6 +45,65 @@ class TestControlOrbitRequest:
         assert req.control_mode == 4
 
 
+class TestTransferDesignRequest:
+    def test_defaults(self):
+        req = TransferDesignRequest(transfer_type="HMN", tli_epoch="2025-06-21T11:00:00")
+        assert req.parking_alt_km == 200.0
+        assert req.incl_deg == 28.5
+        assert req.flight_path_deg == 0.0
+
+    def test_invalid_transfer_type_type(self):
+        with pytest.raises(ValidationError):
+            TransferDesignRequest(transfer_type=123, tli_epoch="2025-06-21T11:00:00")
+
+
+class TestPropagationRequest:
+    def test_defaults(self):
+        req = PropagationRequest(
+            initial_state=[0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            epoch="2025-06-21T11:00:00",
+            duration=3600.0,
+        )
+        assert req.output_step == 3600.0
+        assert req.force_config is None
+
+    def test_duration_must_be_positive(self):
+        with pytest.raises(ValidationError):
+            PropagationRequest(
+                initial_state=[0.0] * 6,
+                epoch="2025-06-21T11:00:00",
+                duration=0.0,
+            )
+
+    def test_invalid_state_shape(self):
+        # Pydantic 只校验 list[float]；算法层会校验长度 6
+        PropagationRequest(
+            initial_state=[0.0] * 5,
+            epoch="2025-06-21T11:00:00",
+            duration=3600.0,
+        )
+
+
+class TestSpacetimeTransformRequest:
+    def test_defaults(self):
+        req = SpacetimeTransformRequest(
+            states=[[1.0] * 6],
+            times=[0.0],
+            transform_type="j2000_to_synodic",
+            et0_jd=2459000.0,
+        )
+        assert req.ephemeris_path is None
+
+    def test_unknown_transform_type_type(self):
+        with pytest.raises(ValidationError):
+            SpacetimeTransformRequest(
+                states=[[1.0] * 6],
+                times=[0.0],
+                transform_type=123,
+                et0_jd=2459000.0,
+            )
+
+
 class TestFacade:
     def test_construct(self):
         facade = Facade()
@@ -57,11 +124,29 @@ class TestFacade:
         with pytest.raises(OrbitError, match="INVALID_PARAMS"):
             facade.control_orbit(control_mode=9)
 
-    def test_placeholder_methods(self):
+    def test_transfer_design_invalid_params(self):
         facade = Facade()
-        for name in ("transfer_design", "orbit_propagation", "spacetime_transform"):
-            with pytest.raises(NotImplementedError):
-                getattr(facade, name)()
+        with pytest.raises(OrbitError, match="INVALID_PARAMS"):
+            facade.transfer_design(transfer_type="HMN")
+
+    def test_orbit_propagation_invalid_params(self):
+        facade = Facade()
+        with pytest.raises(OrbitError, match="INVALID_PARAMS"):
+            facade.orbit_propagation(
+                initial_state=[0.0] * 6,
+                epoch="2025-06-21T11:00:00",
+                duration=0.0,
+            )
+
+    def test_spacetime_transform_invalid_params(self):
+        facade = Facade()
+        with pytest.raises(OrbitError, match="INVALID_PARAMS"):
+            facade.spacetime_transform(
+                states=[[1.0] * 6],
+                times=[0.0],
+                transform_type="unknown",
+                et0_jd=2459000.0,
+            )
 
     def test_orbit_family_generation_unknown(self):
         facade = Facade()
@@ -75,4 +160,55 @@ class TestMcpTools:
         names = mcp_tools(facade)
         assert "design_orbit" in names
         assert "control_orbit" in names
+        assert "transfer_design" in names
+        assert "orbit_propagation" in names
+        assert "spacetime_transform" in names
         assert "orbit_family_generation" in names
+
+
+class TestFacadeCallChain:
+    """无需 SPICE 的轻量调用链：仅验证错误码与序列化路径。"""
+
+    def test_transfer_design_hmn_call_chain(self):
+        facade = Facade()
+        response = facade.transfer_design(
+            transfer_type="HMN",
+            tli_epoch="2025-06-21T11:00:00",
+            target_orbit_radius_km=42164.0,
+        )
+        assert response.transfer_type == "HMN"
+        assert response.delta_v > 0.0
+        assert "departure_state" in response.details or "delta_v_theory" in response.details
+
+    def test_transfer_design_invalid_type_call_chain(self):
+        facade = Facade()
+        with pytest.raises(OrbitError, match="TRANSFER_FAILED"):
+            facade.transfer_design(
+                transfer_type="UNKNOWN_TYPE",
+                tli_epoch="2025-06-21T11:00:00",
+                target_orbit_radius_km=42164.0,
+            )
+
+    def test_spacetime_transform_mismatched_lengths(self):
+        facade = Facade()
+        with pytest.raises(OrbitError, match="INVALID_PARAMS"):
+            facade.spacetime_transform(
+                states=[[1.0] * 6, [2.0] * 6],
+                times=[0.0],
+                transform_type="j2000_to_synodic",
+                et0_jd=2459000.0,
+            )
+
+    def test_details_to_dict_with_ndarray(self):
+        from e2m2e.api.facade import _details_to_dict
+
+        class DummyDataclass:
+            pass
+
+        details = {
+            "array": np.array([1.0, 2.0]),
+            "nested": {"tuple": (np.array([3.0]), 4.0)},
+        }
+        result = _details_to_dict(details)
+        assert result["array"] == [1.0, 2.0]
+        assert result["nested"]["tuple"] == [[3.0], 4.0]

--- a/tests/architecture/test_placeholder.py
+++ b/tests/architecture/test_placeholder.py
@@ -1,8 +1,9 @@
 """架构骨架占位/行为测试。
 
-未实现能力（角动量管理、ECOM 光压、LGA/WSB、transfer_orbit、MCP/tools/logging）
+未实现能力（MCP/tools 服务器占位）
 断言抛 NotImplementedError 且错误信息含能力名；已实现能力（design_orbit/
-control_orbit/propagate_orbit/family 初猜、Facade 一档接入）改行为冒烟测试。
+control_orbit/propagate_orbit/family 初猜、transfer_orbit、momentum_management、
+Facade 一档接入）改行为冒烟测试。
 """
 
 from __future__ import annotations
@@ -26,19 +27,25 @@ def test_control_orbit_implemented():
         control_orbit(None, control_mode=9)
 
 
-def test_momentum_management_placeholder():
-    """角动量管理（原 #261）占位：对外承诺能力。"""
-    from e2m2e.algorithm.station_keeping import momentum_management
+def test_momentum_management_implemented():
+    """角动量管理（原 #261）已实现：发动机布局校验先于占位抛错。"""
+    import numpy as np
 
-    with pytest.raises(NotImplementedError, match="角动量管理"):
-        momentum_management(None)
+    from e2m2e.algorithm.station_keeping import EngineLayout
+
+    # N=3 发动机布局不足 6 约束，EngineLayout 构造抛 ValueError（非占位）。
+    with pytest.raises(ValueError, match="不足 6"):
+        EngineLayout(
+            positions_m=np.zeros((3, 3)),
+            directions=np.tile([1.0, 0.0, 0.0], (3, 1)),
+        )
 
 
-def test_transfer_orbit_placeholder():
-    """transfer_orbit 占位。"""
+def test_transfer_orbit_implemented():
+    """transfer_orbit 已实现：HMN 缺参校验先于占位抛错。"""
     from e2m2e.algorithm.transfer import transfer_orbit
 
-    with pytest.raises(NotImplementedError, match="transfer_orbit"):
+    with pytest.raises(ValueError, match="HMN 转移需要 tli_params"):
         transfer_orbit("HMN")
 
 
@@ -91,11 +98,23 @@ def test_facade_placeholder():
         facade.design_orbit(orbit_type="DRO", duration=0.0)
     with pytest.raises(OrbitError, match="INVALID_PARAMS"):
         facade.control_orbit(control_mode=9)
-    # 未实现：保持占位
-    with pytest.raises(NotImplementedError, match="transfer_design"):
+    with pytest.raises(OrbitError, match="INVALID_PARAMS"):
         facade.transfer_design(transfer_type="HMN")
-    with pytest.raises(NotImplementedError, match="orbit_propagation"):
+    with pytest.raises(OrbitError, match="INVALID_PARAMS"):
         facade.orbit_propagation()
+    with pytest.raises(OrbitError, match="INVALID_PARAMS"):
+        facade.spacetime_transform()
+    # 未实现：保持占位
+    with pytest.raises(NotImplementedError, match="transfer_search"):
+        facade.transfer_search()
+    with pytest.raises(NotImplementedError, match="low_thrust_design"):
+        facade.low_thrust_design()
+    with pytest.raises(NotImplementedError, match="manifold_analysis"):
+        facade.manifold_analysis()
+    with pytest.raises(NotImplementedError, match="low_energy_transfer"):
+        facade.low_energy_transfer()
+    with pytest.raises(NotImplementedError, match="relative_motion"):
+        facade.relative_motion()
 
 
 def test_mcp_server_placeholder():

--- a/uv.lock
+++ b/uv.lock
@@ -745,7 +745,7 @@ wheels = [
 
 [[package]]
 name = "e2m2e"
-version = "5.4.0"
+version = "5.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## 关联

Closes #291 — DFH 功能对齐总览：轨道族 + FR3 转移设计

#291 列出的最后 3 个 Facade 占位方法落地。此前 8 个子 issue（#287/#288/#289/#290/#256/#258/#259/#260）已全部 CLOSED，本次消除对外 API 的最后 3 个 `NotImplementedError`，五档一档 MCP 工具全部可用。

## 改了什么

- **models**: 新增 6 个 Pydantic 模型（`TransferDesignRequest/Response`、`PropagationRequest/Response`、`SpacetimeTransformRequest/Response`），含字段约束（ge/le 边界、min/max_length 等）
- **facade**: `transfer_design`/`orbit_propagation`/`spacetime_transform` 三个一档方法从 `NotImplementedError` 占位升级为薄封装（Pydantic 校验 → 调 algorithm 层 → 序列化为 Response），含 `_details_to_dict()`/`_serialize_value()` 递归 numpy→list 序列化工具
- **propagation**: `propagate_orbit()` 落地——走 ForceModel 路径（与 `design_orbit` 同构），默认三体力模型（地月日点质量引力）、SPICE 内核加载（de440s/de430）、ET↔UTC 时间转换，输出 `EphemerisTable`。完全支持 `force_config`
- **coordinate**: 新增 `spacetime_convert()` 统一入口，按 `transform_type` 分发到 `SynodicJ2000System`（synodic↔J2000）或 `GCRSEBCRSSystem`（GCRS↔EBCRS），含参数校验与历元换算
- **tests**: 补齐 facade 调用链（24 测试）、propagation（8 测试）、spacetime_convert（7 测试）；`test_placeholder.py` 同步翻转占位契约为实现冒烟测试

## 测试

```
# 关键测试（本 PR 改动）
uv run pytest tests/architecture/test_placeholder.py tests/api/ tests/algorithm/test_propagation.py tests/algorithm/test_spacetime_convert.py -n auto
→ 38 passed, 11 skipped

# lint / format / typecheck
uv run ruff check .          → All checks passed!
uv run ruff format --check . → 454 files already formatted
uv run mypy e2m2e/ --ignore-missing-imports → Success: no issues found in 211 source files
```

skip 的 11 个是依赖 SPICE `.bsp` 内核的集成测试（CI 有内核配置时会跑）。

## 设计依据

详见 `docs/plans/issue291-facade-implementation-plan.md`（v2，含调研结论）。

关键设计决策：
1. propagate 走 ForceModel 路径（非 EphemerisDynamics），因 ForceModel.from_config 直接支持 force_config
2. details 序列化用手动 dict + .tolist()（非 dataclasses.asdict，后者不转换 ndarray）
3. spacetime_convert 不缓存转换器实例（r2s2 历表句柄是进程全局状态）