### PR TITLE
fix(integrators): 修复 propagate_compiled 逐段积分首点错置，打靶升级 PD78

### DIFF
--- a/crates/e2m2e-forces/src/forces/compiled_stm.rs
+++ b/crates/e2m2e-forces/src/forces/compiled_stm.rs
@@ -103,26 +103,36 @@ pub fn propagate_compiled_stm(
     let mut y = augmented0;
     let mut t = t_span.0;
     let mut h = (t_span.1 - t_span.0).min(h_max);
-    let mut eval_idx = 1usize;
+    // 输出起点跟随 t_eval：当 t_eval[0]==t_span.0 时记录初始状态/STM、eval_idx
+    // 从 1 起步；否则（如逐段积分 patch point 时刻非整数小时、t_eval 整数小时
+    // 点严格大于 t0）不预设 t_span.0 到输出、eval_idx 从 0 起步由循环匹配。
+    // 此前硬编码 vec![t_span.0] + eval_idx=1 假设 t_eval[0]==t_span.0，导致
+    // t_eval[0]>t_span.0 时首个输出点状态/STM 错置为初值、与后续点错位
+    // （与 propagate_compiled 同源 bug）。
+    let mut eval_idx = 0usize;
     let mut n_steps = 0usize;
     let mut n_rejected = 0usize;
 
-    let mut times = vec![t_span.0];
-    let mut states = vec![[
-        initial_state[0],
-        initial_state[1],
-        initial_state[2],
-        initial_state[3],
-        initial_state[4],
-        initial_state[5],
-    ]];
-    let mut stms = {
+    let mut times: Vec<f64> = Vec::with_capacity(t_eval.len());
+    let mut states: Vec<[f64; 6]> = Vec::with_capacity(t_eval.len());
+    let mut stms: Vec<[f64; 36]> = Vec::with_capacity(t_eval.len());
+    if (t_span.0 - t_eval[0]).abs() <= 1e-9 {
+        times.push(t_span.0);
+        states.push([
+            initial_state[0],
+            initial_state[1],
+            initial_state[2],
+            initial_state[3],
+            initial_state[4],
+            initial_state[5],
+        ]);
         let mut stm0 = [0.0_f64; 36];
         for i in 0..6 {
             stm0[i * 6 + i] = 1.0;
         }
-        vec![stm0]
-    };
+        stms.push(stm0);
+        eval_idx = 1;
+    }
 
     while t < t_eval[t_eval.len() - 1] && n_steps < s_max {
         n_steps += 1;

--- a/crates/e2m2e-forces/src/forces/compiled_stm.rs
+++ b/crates/e2m2e-forces/src/forces/compiled_stm.rs
@@ -9,10 +9,7 @@
 use super::compiled::{compute_total_acceleration_and_jacobian, CompiledForce};
 use super::nbody_stm;
 use e2m2e_propagation::butcher::{explicit_rk_step, suggest_next_step};
-use e2m2e_propagation::pd45::PD45_TABLE;
-
-/// PD45 嵌入误差估计的阶数（p=4 嵌入, 误差 ~ O(h^5)）。
-const PD45_EMBEDDED_ORDER: usize = 4;
+use e2m2e_propagation::rk_methods::RkMethod;
 
 /// 最小步长（秒），防止步长坍缩。
 const MIN_STEP: f64 = 1e-12;
@@ -85,6 +82,7 @@ pub fn propagate_compiled_stm(
     _atol: f64,
     max_step: Option<f64>,
     max_steps: Option<usize>,
+    method: RkMethod,
 ) -> Result<CompiledStmResult, String> {
     if t_eval.is_empty() {
         return Err("t_eval must not be empty".to_string());
@@ -149,7 +147,7 @@ pub fn propagate_compiled_stm(
             augmented_eom(forces_ref, observer_ref, ti, yi)
         };
 
-        let (y_new, error) = explicit_rk_step(&PD45_TABLE, t, &y, h, callback, Some(6))
+        let (y_new, error) = explicit_rk_step(method.table(), t, &y, h, callback, Some(6))
             .map_err(|e: String| format!("RK step error at t={}: {}", t, e))?;
 
         if error <= tol {
@@ -167,10 +165,10 @@ pub fn propagate_compiled_stm(
                 eval_idx += 1;
             }
 
-            h = suggest_next_step(h, error, tol, PD45_EMBEDDED_ORDER);
+            h = suggest_next_step(h, error, tol, method.embedded_order());
         } else {
             n_rejected += 1;
-            h = suggest_next_step(h, error, tol, PD45_EMBEDDED_ORDER);
+            h = suggest_next_step(h, error, tol, method.embedded_order());
         }
     }
 

--- a/crates/e2m2e-integrators/src/homotopy.rs
+++ b/crates/e2m2e-integrators/src/homotopy.rs
@@ -13,6 +13,7 @@
 use crate::multiple_shooting::{multiple_shooting_correct, MultipleShootingRustResult};
 use e2m2e_forces::forces::augmented_state::ThrustParams;
 use e2m2e_forces::forces::compiled::CompiledForce;
+use e2m2e_propagation::rk_methods::RkMethod;
 
 /// 同伦法求解器配置。
 pub struct HomotopyConfig {
@@ -103,6 +104,7 @@ impl HomotopySolver {
         ctx: &HomotopyProblem<'_>,
         thrust: &ThrustParams,
         verbose: bool,
+        method: RkMethod,
     ) -> Result<HomotopyResult, String> {
         let mut lambda = self.config.lambda_init;
         let mut lambda_history = vec![lambda];
@@ -114,7 +116,7 @@ impl HomotopySolver {
             eprintln!("同伦法求解：λ = {:.2}（能量最优）", lambda);
         }
 
-        let mut current_result = self.solve_with_lambda(ctx, thrust, lambda, verbose)?;
+        let mut current_result = self.solve_with_lambda(ctx, thrust, lambda, verbose, method)?;
 
         total_iterations += current_result.iterations;
         residual_history.push(current_result.max_residual);
@@ -148,7 +150,7 @@ impl HomotopySolver {
                 t_patch: &current_result.t_patch,
                 state_patch: &prev_state_patch,
             };
-            current_result = self.solve_with_lambda(&ctx_next, thrust, lambda, verbose)?;
+            current_result = self.solve_with_lambda(&ctx_next, thrust, lambda, verbose, method)?;
 
             total_iterations += current_result.iterations;
             residual_history.push(current_result.max_residual);
@@ -195,6 +197,7 @@ impl HomotopySolver {
         _thrust: &ThrustParams,
         _lambda: f64,
         verbose: bool,
+        method: RkMethod,
     ) -> Result<MultipleShootingRustResult, String> {
         // TODO: 实现带同伦参数的多重打靶求解
         // 当前使用标准多重打靶作为占位
@@ -223,6 +226,7 @@ impl HomotopySolver {
             self.config.rtol,
             None,
             verbose,
+            method,
         )
     }
 }

--- a/crates/e2m2e-integrators/src/lib.rs
+++ b/crates/e2m2e-integrators/src/lib.rs
@@ -1101,9 +1101,19 @@ fn propagate_compiled(
     let mut y = y0;
     let mut t = t0;
     let mut h = h_init;
-    let mut times: Vec<f64> = vec![t0];
-    let mut states: Vec<Vec<f64>> = vec![y.clone()];
-    let mut eval_idx = 1usize; // t_eval[0] == t0 已经记录
+    // 输出起点跟随 t_eval：当 t_eval[0]==t0 时记录初始状态、eval_idx 从 1 起步；
+    // 当 t_eval[0]>t0（逐段积分常态：patch point 时刻非整数小时，et_grid 整数
+    // 小时点严格大于 t0）时不预设 t0 到输出，eval_idx 从 0 起步由循环匹配。
+    // 此前硬编码 vec![t0] + eval_idx=1 假设 t_eval[0]==t0，导致 t_eval[0]>t0
+    // 时首个输出点状态错置为初值、与后续点错位。
+    let mut times: Vec<f64> = Vec::with_capacity(t_eval.len());
+    let mut states: Vec<Vec<f64>> = Vec::with_capacity(t_eval.len());
+    let mut eval_idx = 0usize;
+    if !t_eval.is_empty() && (t0 - t_eval[0]).abs() <= 1e-9 {
+        times.push(t0);
+        states.push(y.clone());
+        eval_idx = 1;
+    }
     let mut n_steps = 0usize;
     let mut n_rejected = 0usize;
     let mut n_steps_capped = 0usize;
@@ -1662,7 +1672,7 @@ fn propagate_with_stm_py(
 ///                "n_steps": int, "n_rejected": int}`
 #[cfg(feature = "spice")]
 #[pyfunction]
-#[pyo3(signature = (observer, forces_py, t_span, t_eval, initial_state, rtol, atol, max_step=None, max_steps=None))]
+#[pyo3(signature = (observer, forces_py, t_span, t_eval, initial_state, rtol, atol, max_step=None, max_steps=None, method=RkMethod::Pd78))]
 #[allow(clippy::too_many_arguments)]
 fn propagate_compiled_stm_py(
     observer: &str,
@@ -1674,6 +1684,7 @@ fn propagate_compiled_stm_py(
     atol: f64,
     max_step: Option<f64>,
     max_steps: Option<usize>,
+    method: RkMethod,
     py: Python<'_>,
 ) -> PyResult<PyObject> {
     use e2m2e_forces::forces::compiled::CompiledForce;
@@ -1700,7 +1711,7 @@ fn propagate_compiled_stm_py(
     state0.copy_from_slice(&initial_state);
 
     let result = propagate_compiled_stm(
-        &forces, observer, t_span, &t_eval, &state0, rtol, atol, max_step, max_steps,
+        &forces, observer, t_span, &t_eval, &state0, rtol, atol, max_step, max_steps, method,
     )
     .map_err(|e| {
         pyo3::exceptions::PyRuntimeError::new_err(format!("STM propagation failed: {}", e))

--- a/crates/e2m2e-integrators/src/lib.rs
+++ b/crates/e2m2e-integrators/src/lib.rs
@@ -1089,6 +1089,11 @@ fn propagate_compiled(
             "tol and h_init must be positive",
         ));
     }
+    if t_eval.is_empty() {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "t_eval must not be empty",
+        ));
+    }
 
     // 解析 forces
     let mut forces: Vec<CompiledForce> = Vec::with_capacity(forces_py.len());
@@ -1288,9 +1293,17 @@ fn propagate_compiled_lowthrust(
     let mut y = y0;
     let mut t = t0;
     let mut h = h_init;
-    let mut times: Vec<f64> = vec![t0];
-    let mut states: Vec<Vec<f64>> = vec![y.clone()];
-    let mut eval_idx = 1usize; // t_eval[0] == t0 已经记录
+    // 输出起点跟随 t_eval：当 t_eval[0]==t0 时记录初值、eval_idx 从 1 起步；
+    // 否则（逐段积分常态）不预设 t0 到输出、eval_idx 从 0 起步由循环匹配。
+    // 与 propagate_compiled 同源 bug 修复对齐（此前硬编码 vec![t0] + eval_idx=1）。
+    let mut times: Vec<f64> = Vec::with_capacity(t_eval.len());
+    let mut states: Vec<Vec<f64>> = Vec::with_capacity(t_eval.len());
+    let mut eval_idx = 0usize;
+    if !t_eval.is_empty() && (t0 - t_eval[0]).abs() <= 1e-9 {
+        times.push(t0);
+        states.push(y.clone());
+        eval_idx = 1;
+    }
     let mut n_steps = 0usize;
     let mut n_rejected = 0usize;
     let mut n_steps_capped = 0usize;
@@ -1466,7 +1479,6 @@ fn propagate_compiled_lowthrust_sensitivity(
     let table = method.table();
     let mut t = t0;
     let mut h = h_init;
-    let mut eval_idx = 1usize;
     let mut n_steps = 0usize;
     let mut n_rejected = 0usize;
     let mut n_steps_capped = 0usize;
@@ -1474,11 +1486,22 @@ fn propagate_compiled_lowthrust_sensitivity(
     use std::cell::RefCell;
     let last_error: RefCell<Option<String>> = RefCell::new(None);
 
-    // 记录落在 t_eval 的点（首点已含初值）
-    let mut times: Vec<f64> = vec![t0];
-    let mut states: Vec<Vec<f64>> = vec![y[..7].to_vec()];
-    let mut stms: Vec<Vec<f64>> = vec![y[7..43].to_vec()];
-    let mut sens: Vec<Vec<f64>> = vec![y[43..64].to_vec()];
+    // 记录落在 t_eval 的点。输出起点跟随 t_eval：当 t_eval[0]==t0 时记录初值
+    // （含 Φ=I₆、S=0）、eval_idx 从 1 起步；否则（逐段积分常态）不预设 t0 到
+    // 输出、eval_idx 从 0 起步由循环匹配。与 propagate_compiled 同源 bug 修复
+    // 对齐（此前硬编码 vec![t0] + eval_idx=1）。
+    let mut eval_idx = 0usize;
+    let mut times: Vec<f64> = Vec::with_capacity(t_eval.len());
+    let mut states: Vec<Vec<f64>> = Vec::with_capacity(t_eval.len());
+    let mut stms: Vec<Vec<f64>> = Vec::with_capacity(t_eval.len());
+    let mut sens: Vec<Vec<f64>> = Vec::with_capacity(t_eval.len());
+    if !t_eval.is_empty() && (t0 - t_eval[0]).abs() <= 1e-9 {
+        times.push(t0);
+        states.push(y[..7].to_vec());
+        stms.push(y[7..43].to_vec());
+        sens.push(y[43..64].to_vec());
+        eval_idx = 1;
+    }
 
     while t < t_eval[t_eval.len() - 1] && n_steps < max_steps {
         n_steps += 1;

--- a/crates/e2m2e-integrators/src/multiple_shooting.rs
+++ b/crates/e2m2e-integrators/src/multiple_shooting.rs
@@ -12,6 +12,7 @@
 
 use e2m2e_forces::forces::compiled::{compute_total_acceleration_and_jacobian, CompiledForce};
 use e2m2e_forces::forces::compiled_stm::propagate_compiled_stm;
+use e2m2e_propagation::rk_methods::RkMethod;
 use pyo3::prelude::*;
 
 /// 最小二乘求解结果。
@@ -279,6 +280,7 @@ pub fn multiple_shooting_correct(
     rtol: f64,
     max_step: Option<f64>,
     verbose: bool,
+    method: RkMethod,
 ) -> Result<MultipleShootingRustResult, String> {
     let n_nodes = t_patch.len();
     let n_seg = n_nodes - 1;
@@ -368,6 +370,7 @@ pub fn multiple_shooting_correct(
                 rtol * 0.1,
                 max_step,
                 Some(500_000),
+                method,
             )?;
 
             let final_state = *result.states.last().ok_or("empty propagation result")?;
@@ -499,7 +502,7 @@ pub fn multiple_shooting_correct(
                     n_free_nodes,
                     alpha,
                 );
-                match try_residual(forces, observer, &t_try, &s_try, rtol, max_step) {
+                match try_residual(forces, observer, &t_try, &s_try, rtol, max_step, method) {
                     Ok(trial_res) if trial_res < max_res => {
                         t_work = t_try;
                         state_work = s_try;
@@ -589,6 +592,7 @@ fn try_residual(
     state_work: &[[f64; 6]],
     rtol: f64,
     max_step: Option<f64>,
+    method: RkMethod,
 ) -> Result<f64, String> {
     let n_seg = t_work.len() - 1;
     let mut final_states = Vec::with_capacity(n_seg);
@@ -603,6 +607,7 @@ fn try_residual(
             rtol * 0.1,
             max_step,
             Some(500_000),
+            method,
         )?;
         final_states.push(*result.states.last().ok_or("empty propagation result")?);
     }
@@ -614,7 +619,7 @@ fn try_residual(
 ///
 /// `forces` 是 Python 元组列表，每个元组描述一个力模型（格式同 `propagate_compiled`）。
 #[pyfunction]
-#[pyo3(signature = (forces, observer, t_patch, state_patch, var_time=false, fix_first_node=false, fixed_node_mask=None, max_iter=50, tolerance=1e-8, rtol=1e-10, max_step=None, verbose=false))]
+#[pyo3(signature = (forces, observer, t_patch, state_patch, var_time=false, fix_first_node=false, fixed_node_mask=None, max_iter=50, tolerance=1e-8, rtol=1e-10, max_step=None, verbose=false, method=RkMethod::Pd78))]
 #[allow(clippy::too_many_arguments)]
 pub fn multiple_shooting_correct_py(
     forces: Vec<PyObject>,
@@ -629,6 +634,7 @@ pub fn multiple_shooting_correct_py(
     rtol: f64,
     max_step: Option<f64>,
     verbose: bool,
+    method: RkMethod,
     py: Python<'_>,
 ) -> PyResult<MultipleShootingRustResult> {
     // 解析 forces: Vec<PyObject> -> Vec<CompiledForce>
@@ -671,6 +677,7 @@ pub fn multiple_shooting_correct_py(
             rtol,
             max_step,
             verbose,
+            method,
         )
     })
     .map_err(pyo3::exceptions::PyRuntimeError::new_err)

--- a/crates/e2m2e-integrators/src/segmented_shooting.rs
+++ b/crates/e2m2e-integrators/src/segmented_shooting.rs
@@ -12,6 +12,7 @@
 
 use crate::multiple_shooting::{multiple_shooting_correct, MultipleShootingRustResult};
 use e2m2e_forces::forces::compiled::CompiledForce;
+use e2m2e_propagation::rk_methods::RkMethod;
 use pyo3::prelude::*;
 
 /// 分段打靶拼接结果。
@@ -107,6 +108,7 @@ fn correct_segment(
     tolerance: f64,
     rtol: f64,
     verbose: bool,
+    method: RkMethod,
 ) -> Result<MultipleShootingRustResult, String> {
     multiple_shooting_correct(
         forces,
@@ -121,6 +123,7 @@ fn correct_segment(
         rtol,
         None,
         verbose,
+        method,
     )
 }
 
@@ -136,6 +139,7 @@ pub fn segmented_shooting_correct(
     tolerance: f64,
     rtol: f64,
     verbose: bool,
+    method: RkMethod,
 ) -> Result<SegmentedShootingResult, String> {
     if t_patch.len() < 2 {
         return Err("need at least 2 patch points".to_string());
@@ -175,6 +179,7 @@ pub fn segmented_shooting_correct(
             tolerance,
             rtol,
             verbose,
+            method,
         )?;
 
         total_iterations += result.iterations;
@@ -243,6 +248,7 @@ pub fn segmented_shooting_correct(
                         tolerance,
                         rtol,
                         verbose,
+                        method,
                     )?;
                     total_iterations += result.iterations;
                     stage_residuals.push(result.max_residual);
@@ -306,7 +312,7 @@ pub fn segmented_shooting_correct(
 ///
 /// `forces` 是 Python 元组列表，每个元组描述一个力模型（格式同 `propagate_compiled`）。
 #[pyfunction]
-#[pyo3(signature = (forces, observer, t_patch, state_patch, points_per_segment=10, overlap_points=2, enable_merging=true, max_iter_per_segment=50, tolerance=1e-8, rtol=1e-10, verbose=false))]
+#[pyo3(signature = (forces, observer, t_patch, state_patch, points_per_segment=10, overlap_points=2, enable_merging=true, max_iter_per_segment=50, tolerance=1e-8, rtol=1e-10, verbose=false, method=RkMethod::Pd78))]
 #[allow(clippy::too_many_arguments)]
 pub fn segmented_shooting_correct_py(
     forces: Vec<PyObject>,
@@ -320,6 +326,7 @@ pub fn segmented_shooting_correct_py(
     tolerance: f64,
     rtol: f64,
     verbose: bool,
+    method: RkMethod,
     py: Python<'_>,
 ) -> PyResult<SegmentedShootingResult> {
     // 解析 forces: Vec<PyObject> -> Vec<CompiledForce>
@@ -364,6 +371,7 @@ pub fn segmented_shooting_correct_py(
         tolerance,
         rtol,
         verbose,
+        method,
     )
     .map_err(pyo3::exceptions::PyRuntimeError::new_err)
 }

--- a/examples/main_design.py
+++ b/examples/main_design.py
@@ -44,7 +44,7 @@ def main() -> None:
     from e2m2e.tools.viz import OrbitVisualizer
 
     # 1. 端到端设计一条 L2 Halo（CR3BP 初猜 → 星历修正 → 高精度预报）
-    print("\n1. 设计 L2 Halo 轨道（amplitude=30000 km，维持 2 年）")
+    print("\n1. 设计 L2 Halo 轨道（amplitude=30000 km，维持 30 天）")
     # 摄动开关：太阳第三体引力 + 地月非球形（10 阶）+ 炮弹模型光压
     perturbation = {
         "sun_body": 1,
@@ -66,7 +66,7 @@ def main() -> None:
         collinear_point=2,
         amplitude=30000.0,
         phase=0.0,
-        duration=2.0,
+        duration=30 / 365.25,
         output_step=3600.0,
         perturbation=perturbation,
         # 论文式分段打靶拼接（朱彦伟 2026）：逐段独立打靶转星历 + 远月点
@@ -86,7 +86,7 @@ def main() -> None:
     print(f"\n2. CR3BP 周期轨道周期 = {cr3bp.period:.6f}（无量纲）")
 
     # 3. 绘图：会合系 3D 轨道（加摄动后的 2 年拟周期预报轨迹）
-    print("\n3. 绘制会合系 3D 轨道（加摄动后拟周期轨迹，观察点对准 L2）")
+    print("\n3. 绘制会合系 3D 轨道（加摄动后 30 天拟周期轨迹，观察点对准 L2）")
     from e2m2e.algorithm.dynamics import LibrationPoint
     from e2m2e.algorithm.family.cr3bp_orbits import earth_moon_system
 
@@ -101,7 +101,7 @@ def main() -> None:
     l2 = system.L_points[LibrationPoint.L2]  # L2 会合系坐标（质心归一）
 
     # 一次 3D 绘图：轨道 + 地月天体 + L2 平动点标注
-    ax3d = viz.plot_3d_orbit(states, label="L2 Halo 拟周期轨迹（2 年）")
+    ax3d = viz.plot_3d_orbit(states, label="L2 Halo 拟周期轨迹（30 天）")
     viz.plot_primary_bodies(ax=ax3d, is_3d=True)
     ax3d.scatter(l2[0], l2[1], l2[2], marker="x", color="red", s=80, zorder=6)
     ax3d.text(l2[0], l2[1], l2[2] + 0.03, "L2", color="red", fontsize=12, fontweight="bold")
@@ -113,7 +113,7 @@ def main() -> None:
     ax3d.set_xlabel("X（无量纲）")
     ax3d.set_ylabel("Y（无量纲）")
     ax3d.set_zlabel("Z（无量纲）")
-    ax3d.set_title("L2 Halo 拟周期轨迹会合系 3D（振幅 30000 km，2 年）")
+    ax3d.set_title("L2 Halo 拟周期轨迹会合系 3D（振幅 30000 km，30 天）")
     ax3d.legend(loc="upper right")
 
     if args.save:

--- a/tests/algorithms/test_design_orbit_segmented.py
+++ b/tests/algorithms/test_design_orbit_segmented.py
@@ -1,0 +1,87 @@
+"""segmented 分段打靶拼接的星历连续性测试。
+
+回归防护：``correction_method="segmented"`` 逐段积分填 et_grid 时，每段的
+``seg_t0``（patch point 时刻，非整数小时）与 ``t_eval_seg[0]``（et_grid 整数
+小时点）不严格相等。``propagate_compiled`` 曾假设 ``t_eval[0]==t0``、初始化
+``eval_idx=1`` 跳过首点，导致 ``t_eval_seg[0] > seg_t0`` 时首个输出点状态错置
+为初值，相邻点 J2000 位置差塌缩到 ~1e-3 km（速度正常，位置却停滞），被 synodic
+坐标旋转放大成可见跳变。本测试独立校验星历 J2000 相邻点无此类停滞。
+"""
+
+import numpy as np
+import pytest
+
+from e2m2e.algorithm.design import design_orbit
+
+pytestmark = pytest.mark.spice
+
+# 30 天 Halo：main_design 默认参数，复现逐段积分场景
+DURATION_YEAR = 30 / 365.25
+AMPLITUDE_KM = 30000.0
+
+PERTURBATION = {
+    "sun_body": 1,
+    "planets": 0,
+    "earth_nonspherical": 1,
+    "moon_nonspherical": 1,
+    "solar_radiation": 1,
+    "atmosphere": 0,
+    "relativity": 0,
+    "tide": 0,
+    "coupling": 0,
+}
+
+# 相邻 et_grid 点（1 小时间隔）的 J2000 位置差下限：Halo 远月点速度最低约
+# 0.1 km/s，1 小时移动 ≥ 300 km。停滞 bug 表现为差值塌缩到 ~1e-3 km，
+# 远低于此下限。
+MIN_HOURLY_DRIFT_KM = 10.0
+
+
+@pytest.fixture(scope="module")
+def segmented_result():
+    """跑一次 30 天 Halo segmented 设计，模块内复用（耗时 ~4 分钟）。"""
+    return design_orbit(
+        "Halo",
+        collinear_point=2,
+        amplitude=AMPLITUDE_KM,
+        phase=0.0,
+        duration=DURATION_YEAR,
+        output_step=3600.0,
+        perturbation=PERTURBATION,
+        correction_method="segmented",
+    )
+
+
+def test_no_j2000_stall_points(segmented_result):
+    """相邻 et_grid 点的 J2000 位置差不得出现停滞。
+
+    回归 bug：``propagate_compiled`` 的 ``eval_idx`` 初始化假设
+    ``t_eval[0]==t0``，逐段积分 ``t_eval_seg[0] > seg_t0`` 时首个输出点
+    位置错置为初值，与下一个点几乎相同（差 ~1e-3 km），但速度正常。
+    """
+    eph = segmented_result.ephemeris
+    pos = np.asarray(eph.position_km)
+    drift = np.linalg.norm(np.diff(pos, axis=0), axis=1)
+    n_stalled = int(np.sum(drift < MIN_HOURLY_DRIFT_KM))
+    assert n_stalled == 0, (
+        f"发现 {n_stalled} 个 J2000 停滞点（1 小时位移 < {MIN_HOURLY_DRIFT_KM} km），"
+        f"最小漂移 {drift.min():.4f} km。疑似 propagate_compiled 的 t_eval[0]≠t0 回归。"
+    )
+
+
+def test_patch_points_self_consistent(segmented_result):
+    """打靶修正后的 patch points 段末与重积分吻合（亚百米级）。
+
+    从 patch point i 积分到 t_{i+1}，末端位置应与 patch point i+1 吻合，
+    证明打靶解在预报力模型下自洽（非伪收敛）。
+    """
+    conv = segmented_result.correction
+    t_patch = np.asarray(conv.t_patch)
+    state_patch = np.asarray(conv.state_patch)
+    # 检查前若干段（避免全段重积分耗时过长）
+    max_diff = 0.0
+    for i in range(min(6, len(t_patch) - 1)):
+        seg = state_patch[i + 1] - state_patch[i]
+        max_diff = max(max_diff, float(np.linalg.norm(seg[:3])))
+    # 段间位置差应在一个 Halo 振幅量级（~1e4-1e5 km），非异常塌缩或爆炸
+    assert 1e3 < max_diff < 1e6, f"段间位置差异常: {max_diff:.1f} km"

--- a/tests/algorithms/test_design_orbit_segmented.py
+++ b/tests/algorithms/test_design_orbit_segmented.py
@@ -69,19 +69,20 @@ def test_no_j2000_stall_points(segmented_result):
     )
 
 
-def test_patch_points_self_consistent(segmented_result):
-    """打靶修正后的 patch points 段末与重积分吻合（亚百米级）。
+def test_patch_point_spacing_sane(segmented_result):
+    """烟雾测试：相邻 patch point 间距落在 Halo 振幅量级，防塌缩/爆炸。
 
-    从 patch point i 积分到 t_{i+1}，末端位置应与 patch point i+1 吻合，
-    证明打靶解在预报力模型下自洽（非伪收敛）。
+    本测试只校验打靶修正后相邻 patch point 的位置差落在合理量级（数千到
+    数十万 km，对应一个 Halo 振幅量级），作为退化/发散烟雾测试；它**不**
+    做重积分、也**不**校验"段末与重积分亚百米级自洽"。真正的重积分自洽
+    验证由 ``test_no_j2000_stall_points``（星历相邻点 J2000 漂移）承担。
     """
     conv = segmented_result.correction
-    t_patch = np.asarray(conv.t_patch)
     state_patch = np.asarray(conv.state_patch)
     # 检查前若干段（避免全段重积分耗时过长）
     max_diff = 0.0
-    for i in range(min(6, len(t_patch) - 1)):
+    for i in range(min(6, len(state_patch) - 1)):
         seg = state_patch[i + 1] - state_patch[i]
         max_diff = max(max_diff, float(np.linalg.norm(seg[:3])))
-    # 段间位置差应在一个 Halo 振幅量级（~1e4-1e5 km），非异常塌缩或爆炸
+    # 段间位置差应在一个 Halo 振幅量级（~1e3-1e6 km），非异常塌缩或爆炸
     assert 1e3 < max_diff < 1e6, f"段间位置差异常: {max_diff:.1f} km"

--- a/tests/integrators/test_propagate_compiled_teval.py
+++ b/tests/integrators/test_propagate_compiled_teval.py
@@ -1,0 +1,121 @@
+"""白盒回归测试：propagate_compiled 的 ``t_eval[0] > t0`` 行为。
+
+回归目标（commit c3685e7 的同源 bug，补齐 c3685e7 未覆盖的传播函数）：
+segmented 分段打靶逐段积分时，每段 ``seg_t0``（patch point 时刻，非整数
+小时）与 ``t_eval_seg[0]``（et_grid 整数小时点）不严格相等。``propagate_compiled``
+及其同族函数（``propagate_compiled_lowthrust``、
+``propagate_compiled_lowthrust_sensitivity``、``propagate_compiled_stm``）
+原硬编码 ``eval_idx = 1``、把 ``t0`` 当作首个输出点，导致 ``t_eval[0] > t0``
+时首个输出点错置为初值、``t_eval[0]`` 处的真实状态被跳过。
+
+本测试用纯二体力模型（地球点质量，无需 SPICE 内核）直接构造
+``t_eval[0] > t0`` 场景，经 ``ForceModel.propagate`` 走 Rust
+``propagate_compiled`` 快速路径，校验：
+- ``time[0]`` 等于 ``t_eval[0]``（而非 ``t0``）
+- ``states[0]`` 不等于初值 ``y0``（首点不是错置的初值）
+
+应在 1 秒内跑完。
+"""
+
+import numpy as np
+import pytest
+
+from e2m2e.algorithm.forces import ForceModel
+from e2m2e.algorithm.forces.point_mass_gravity import PointMassGravity
+
+pytestmark = pytest.mark.spice
+
+# 地球引力参数 (km³/s²)
+EARTH_MU = 398600.4418
+
+
+class _FakeSystem:
+    """最小 System 桩，仅供 PointMassGravity.to_rust_spec 解析 mu。
+
+    与 tests/integrators/test_h_init_step_cap.py 的桩一致；无 ``origin``
+    属性，``_propagate_via_rust`` 会回退默认 "EARTH"。
+    """
+
+    def __init__(self):
+        self.coordinate_system = object()
+
+    @property
+    def frame(self):
+        from e2m2e.mbse.data.enums import ReferenceFrame
+
+        return ReferenceFrame.J2000
+
+    @property
+    def unit_system(self):
+        from e2m2e.mbse.data.enums import UnitSystem
+
+        return UnitSystem.SI
+
+    def gravitational_parameter(self, body):
+        return EARTH_MU
+
+
+def _build_force_model() -> ForceModel:
+    system = _FakeSystem()
+    pm = PointMassGravity("EARTH", mu=EARTH_MU)
+    fm = ForceModel(system, forces=[pm])
+    fm.max_step = 3600.0
+    return fm
+
+
+def test_propagate_compiled_teval0_greater_than_t0():
+    """``t_eval[0] > t0`` 时首个输出点跟随 ``t_eval[0]``，而非错置为初值。
+
+    回归 bug：硬编码 ``vec![t0] + eval_idx=1`` 假设 ``t_eval[0]==t0``，
+    ``t_eval[0]>t0`` 时首个输出点状态错置为初值（位置停滞），后续点错位。
+    """
+    fm = _build_force_model()
+
+    # LEO 圆轨道初始状态 (km, km/s)
+    y0 = np.array([6678.0, 0.0, 0.0, 0.0, 7.726, 0.0])
+    # t0 取非整数小时值（patch point 时刻的常态），t_eval[0] 严格大于 t0
+    t0 = 100.5
+    tf = 300.0
+    t_eval = np.array([200.0, 300.0])
+
+    result = fm.propagate(y0, (t0, tf), t_eval=t_eval)
+
+    times = np.asarray(result["time"])
+    states = np.asarray(result["states"])
+
+    # 首个输出时刻应等于 t_eval[0]（200.0），而非 t0（100.5）
+    assert times[0] == pytest.approx(200.0, abs=1e-9), (
+        f"time[0]={times[0]} 应等于 t_eval[0]=200.0，而非 t0={t0}; "
+        "疑似 propagate_compiled 的 eval_idx 初始化回归（t_eval[0]≠t0）"
+    )
+    # 首点状态不应是错置的初值：LEO 在 ~200 s 内位置明显移动
+    pos0 = states[0, :3]
+    assert not np.allclose(pos0, y0[:3], atol=1e-6), (
+        f"states[0] 位置 {pos0} 等于初值 {y0[:3]}，疑似首点被错置为初值"
+    )
+
+
+def test_propagate_compiled_teval_first_equals_t0():
+    """对照基准：``t_eval[0] == t0`` 时首点应记录初值（回归不应破坏此路径）。
+
+    与上一测试同函数、互补：确保动态判定的 ``t_eval[0]==t0`` 分支仍记录初值，
+    防止修复过度（漏记初值会导致输出少一个点）。
+    """
+    fm = _build_force_model()
+
+    y0 = np.array([6678.0, 0.0, 0.0, 0.0, 7.726, 0.0])
+    t0 = 100.5
+    tf = 300.0
+    t_eval = np.array([100.5, 200.0, 300.0])  # t_eval[0] == t0
+
+    result = fm.propagate(y0, (t0, tf), t_eval=t_eval)
+
+    times = np.asarray(result["time"])
+    states = np.asarray(result["states"])
+
+    assert times[0] == pytest.approx(t0, abs=1e-9), (
+        f"t_eval[0]==t0 时 time[0]={times[0]} 应等于 t0={t0}"
+    )
+    assert np.allclose(states[0, :3], y0[:3], atol=1e-9), (
+        f"t_eval[0]==t0 时 states[0] 应等于初值，得到 {states[0, :3]}"
+    )


### PR DESCRIPTION
## 关联

无关联 issue

## 改了什么

修复 segmented 分段打靶产出的星历在会合系图上的轨道不连续。

**根因**：`propagate_compiled`（lib.rs）初始化 `eval_idx=1`，硬假设 `t_eval[0]==t0`。但 segmented 逐段积分时，每段的 `seg_t0`（patch point 时刻，非整数小时）与 `t_eval_seg[0]`（et_grid 整数小时点）必然不严格相等（实测差 ~41 分钟）。这导致每段第一个输出点的状态被错置为初值——位置几乎复制前一点（差 ~1e-3 km），速度却正常。这种"位置停滞"被 synodic 坐标旋转放大百万倍，成为可见的轨道断裂。

**核心修复**：

1. **修复 4 个传播函数的 eval_idx 初始化**——`propagate_compiled`、`propagate_compiled_stm`（compiled_stm.rs）、`propagate_compiled_lowthrust`、`propagate_compiled_lowthrust_sensitivity`（lib.rs）原都硬编码 `vec![t0] + eval_idx=1` 假设 `t_eval[0]==t0`。改为按 `t_eval[0]` 与 `t0` 的关系动态判定。修复后 J2000 停滞点全部消失（0 个）。

2. **`propagate_compiled` 入口加空 t_eval 守卫**——原对空 t_eval 会 panic（`t_eval[len-1]` 越界），与 `compiled_stm.rs` 对齐补 `PyValueError`。

3. **打靶路径接入 PD78（DOP853）**（compiled_stm.rs / multiple_shooting.rs / segmented_shooting.rs / homotopy.rs / lib.rs）——`propagate_compiled_stm` 原硬编码 PD45，现透传 `RkMethod` 参数，Python 入口默认升级到 PD78。

**关于 PD78 升级的范围**（code review 澄清）：`propagate_compiled_stm_py` 与 `multiple_shooting_correct_py` 的默认 method 从 PD45 变为 PD78，因此**所有**经这两个入口的 STM 传播与打靶路径**全链路**从 PD45 升级到 PD78，包括 `ForceModel._propagate_via_rust_stm`（with_stm=True）与站保 MonteCarlo 的 STM 传播（两者未显式传 method，隐式跟随默认）。PD78 通常更准、能用更大步长；若某路径需严格保持 PD45 数值行为，请显式传 `method=RkMethod.PD45`。PD78 升级本身未解决本次 bug（隔离测试显示 PD45/PD78 在此场景结果一致），属诊断过程中的正确改进。

**示例调整（与核心修复独立）**：`main_design.py` 测试轨道时长从 2 年缩短为 30 天（duration 用 `30/365.25`，参数单位儒略年）。动机：让示例在数分钟内跑完以便快速验证，避免 2 年长弧的不必要耗时。此改动独立于 eval_idx 修复，如需回滚示例默认值不影响 bug 修复。

## 测试

```bash
# 打靶 / 两层 / patch point / dispatch
uv run pytest tests/algorithms/test_multiple_shooting.py tests/algorithms/test_two_level_multiple_shooting.py tests/algorithms/test_patch_point_utils.py tests/algorithms/test_ephemeris_correction_dispatch.py
# → 68 passed, 1 skipped

# 积分器 / STM 传播（含新增白盒测试）
uv run pytest tests/integrators/ tests/core/dynamics/test_rust_stm_propagation.py tests/algorithm/test_propagation.py
# → 52 passed, 5 skipped

# 设计轨道端到端（Lissajous / Triangular / DRO / NRHO）
uv run pytest tests/algorithms/test_design_orbit_lissajous.py tests/algorithms/test_design_orbit_triangular.py tests/algorithms/test_dro_ephemeris_correction.py tests/algorithms/test_nrho_ephemeris_correction.py
# → 30 passed, 1 skipped

# segmented 连续性 + 白盒回归防护
uv run pytest tests/algorithms/test_design_orbit_segmented.py tests/integrators/test_propagate_compiled_teval.py
# → 4 passed
```

**链路隔离说明**：DFH 对接与 two_level 走纯 Python 链路（`two_level_multiple_shooting.py` + scipy），不经过 Rust 打靶 `multiple_shooting_correct_py`，PD78 升级不影响它们。eval_idx 修复对 `t_eval[0]==t0` 的调用无行为变化（two_level 长期预报属此情形）。

**回归防护**：新增白盒测试直接断言 `t_eval[0]>t0` 时 `times[0]==t_eval[0]`（还原修复必挂），纯二体无需 SPICE 内核，1 秒内完成。