### PR TITLE
issue #317 code review 收尾：Jacobian ∂a/∂v 接口 ADR + Python STM 同步 + 可维护性

### DIFF
--- a/crates/e2m2e-forces/src/cr3bp.rs
+++ b/crates/e2m2e-forces/src/cr3bp.rs
@@ -19,6 +19,12 @@ use e2m2e_propagation::rk_methods::RkMethod;
 pub const MIN_DISTANCE: f64 = 1e-10;
 
 /// 最小步长（相对于积分区间），防止步长坍缩。
+///
+/// 步长塌缩时本模块返回 ``Err("step size collapsed below minimum ...")``。
+/// 该前缀 ``"step size collapsed"`` 是 Python↔Rust 跨语言契约：Python
+/// ``EphemerisDynamics._propagate_state_only``（dynamics.py，
+/// ``_RUST_STEP_COLLAPSED_MARKER``）据此识别失败并转成空 states。改写本错误
+/// 消息须同步 Python 侧标记（issue #317 第 3.1 项）。
 const MIN_STEP: f64 = 1e-12;
 
 /// CR3BP 6 维运动方程右端项 `[vx, vy, vz, ax, ay, az]`。

--- a/crates/e2m2e-forces/src/forces/drag.rs
+++ b/crates/e2m2e-forces/src/forces/drag.rs
@@ -1,9 +1,11 @@
 //! 大气阻力力模型 Rust 移植（仅 `spice` feature 下编译）。
 //!
 //! 1:1 移植自 Python `drag.py:DragModel.compute_acceleration`：
-//! - ITRF93 pxform 帧旋转（替代原 ITRFApproxAxes，决策 1b）
+//! - ITRF93 pxform 帧旋转（替代原 ITRFApproxAxes，见 ADR 0019；Python 路径仍用
+//!   ITRFApproxAxes，差异由 ADR 0019 记录）
 //! - 密度：`atmosphere::density(altitude_km, f107, ap)`
 //! - 雅可比：中心差分 FD，扰动 J2000 状态 6 分量计算 ∂a/∂r 与 ∂a/∂v
+//!   （drag 依赖速度，∂a/∂v ≠ 0，接口扩三元组见 ADR 0018）
 
 use crate::atmosphere;
 use e2m2e_spice::spice_ffi::{mat3_mul_vec, mat3_t_mul_vec, pxform, SpiceFfiError};
@@ -105,9 +107,10 @@ pub fn drag_accel(
     let r_itrf = mat3_t_mul_vec(&r_itrf_to_prop, &r_j2000);
     let v_itrf = mat3_t_mul_vec(&r_itrf_to_prop, &v_j2000);
 
+    // Step 3: ITRF 系内阻力（纯物理公式，见 drag_accel_in_body_fixed）。
     let a_itrf = drag_accel_in_body_fixed(&r_itrf, &v_itrf, area, mass, cd, f107, ap);
 
-    // Step 5: 旋转回 propagation frame。
+    // Step 4: 旋转回 propagation frame。
     let a_prop = mat3_mul_vec(&r_itrf_to_prop, &a_itrf);
     Ok(a_prop)
 }

--- a/crates/e2m2e-integrators/src/lib.rs
+++ b/crates/e2m2e-integrators/src/lib.rs
@@ -313,6 +313,20 @@ const fn parse_abi_version(s: &str) -> u32 {
 }
 
 /// 从 abi-version.txt 读取（单一来源），build.rs 同步生成 Python 侧 _rust_abi.py。
+///
+/// # 版本沿革（issue #317 第 3.3 项）
+///
+/// abi-version 只在**新增/改 pyfunction 边界**时 bump（Rust 内部函数签名
+/// 变更不 bump——它们不是 Python 可见的 ABI）。每次 bump 须在本节补行：
+///
+/// - **v1**（#300，5b616cc）：初始 ABI 版本戳 + 统一网关 ``_check_rust_abi``。
+/// - **v2**（3b28353）：新增 ``propagate_with_state_py``（EphemerisDynamics
+///   纯状态 Rust 路径）。
+/// - **v3**（ff63403）：新增 ``transfer_grid_search_serial_py`` +
+///   ``TransferPointResult`` pyclass（转移网格搜索串行评估）。
+///
+/// 「1→3 跳号」实为 1→2→3 两次单步 bump，分别在上述两 commit；不存在跳过的
+/// 中间版本。ADR 0018 记录的 ∂a/∂v 雅可比接口扩是 Rust 内部签名变更，未 bump。
 const RUST_PY_ABI: u32 = parse_abi_version(include_str!("../abi-version.txt"));
 
 /// 返回 Rust↔Python ABI 版本号（编译期常量，反映此 .pyd/.so 真实状态）。

--- a/docs/adr/0018-jacobian-dadv-interface.md
+++ b/docs/adr/0018-jacobian-dadv-interface.md
@@ -1,0 +1,87 @@
+# ADR 0018：Jacobian 接口扩 ∂a/∂v，状态转移矩阵纳入速度依赖
+
+**状态**：已接受
+**日期**：2026-08-07
+**关联**：ADR 0002（Rust 积分器内核）、ADR 0003（ITRF93 默认值）、ADR 0017（网格搜索 Rayon）、issue #317
+**关联代码**：`crates/e2m2e-forces/src/forces/{compiled,nbody_stm,augmented_state,compiled_stm}.rs`、`crates/e2m2e-integrators/src/multiple_shooting.rs`
+
+## 背景
+
+状态转移矩阵（STM）满足变分方程 ``Φ̇ = A·Φ``，其中
+
+```text
+A = | 0₃ₓ₃   I₃ₓ₃ |
+    | ∂a/∂r  ∂a/∂v |
+```
+
+左下块 ``∂a/∂r``（加速度对位置）由各力雅可比叠加；右下块 ``∂a/∂v``（加速度对速度）在纯 N 体引力模型里恒为零——所有天体引力只依赖位置。本仓 STM 传播（CR3BP / EphemerisDynamics / N 体 STM / compiled STM / 多重打靶）长期基于这一假设。
+
+大气阻力打破它：``a_drag = −½·ρ(|r|)·BC·|v|·v``，既依赖位置（通过大气密度 ρ）又依赖速度（相对速度本身）。drag 一旦进入 STM 传播，``A`` 的右下块 ``∂a/∂v`` 非零，旧的「``∂a/∂v = 0``」隐式假设会让 STM 静默出错——不抛错，只给出错误的灵敏度。
+
+drag Rust 移植（issue #315 系列）把 ``DragModel`` 纳入 compiled 力模型，STM 路径首次出现速度依赖力。这迫使力-雅可比接口从「返回 ``∂a/∂r``」扩为「返回 ``(∂a/∂r, ∂a/∂v)``」。
+
+## 决策
+
+把 Rust 力模型雅可比接口的返回值从二元组 ``(acc, ∂a/∂r)`` 扩为**三元组** ``(acc, ∂a/∂r, ∂a/∂v)``，全链路透传 ``∂a/∂v`` 到变分方程。
+
+1. **``acceleration_and_jacobian`` 返回三元组。**
+   - 类型别名 ``AccelJacobiResult = Result<([f64;3], [[f64;3];3], [[f64;3];3]), String>``（compiled.rs）。
+   - 每个 ``CompiledForce`` variant 在自身语义下给出 ``∂a/∂v``：
+     - ``PointMass`` / ``ThirdBody`` / ``IndirectTerm`` / ``GravityField`` / ``SRP``：解析 ``[[0.0;3];3]``（位置型力，速度无关）。
+     - ``Drag``：与 ``∂a/∂r`` 同源的中心差分 FD，扰动 J2000 全 6 分量（12 次 accel 评估），``∂a/∂v`` 为真值。
+   - ``compute_total_acceleration_and_jacobian`` 逐力叠加 ``total_dadv``（与 ``total_jac`` 同构）。
+
+2. **``stm_derivative`` 接收 ``dadv``。**
+   - 签名 ``stm_derivative(stm, jac_da_dr, dadv) -> [f64;36]``，后 3 行 ``A`` 用 ``∂a/∂r·Φ[:3] + ∂a/∂v·Φ[3:]``。
+   - ``nbody_stm``、``augmented_state``、``compiled_stm``、``multiple_shooting`` 全部跟进调用签名。
+
+3. **N 体路径 ``dadv`` 恒零。**
+   - ``compute_nbody_acceleration_and_jacobian`` 返回 ``dadv = [[0.0;3];3]``（N 体引力不依赖速度）。这条路径行为不变，三元组只是显式写出原本的隐式零。
+
+4. **Python 侧 ``ForceModel`` STM 回退路径同步（issue #317 第 2.1 项）。**
+   - ``_compute_total_jacobian`` 返回 ``(∂a/∂r, ∂a/∂v)``；``_eom_func_with_stm`` 组装 ``A[3:,3:] = ∂a/∂v``。
+   - 解析雅可比力（``compute_jacobian`` 非 ``None``）``∂a/∂v = 0``；无解析雅可比力（``None``）走有限差分，同时对位置与速度扰动，给出真值。
+   - 当前 drag 因需 SPICE 必走 Rust，Python 回退路径不可达；本项消除「未来无 SPICE 下的速度依赖力静默出错」的隐患。
+
+## 影响面
+
+接口扩三元组触及所有 STM 相关 Rust 模块，ABI 不变（内部函数签名变更，非 pyfunction 边界）：
+
+| 模块 | 变更 |
+|---|---|
+| `compiled.rs` | `AccelJacobiResult` 类型别名；`acceleration_and_jacobian` / `compute_total_acceleration_and_jacobian` 三元组 |
+| `nbody_stm.rs` | `compute_nbody_acceleration_and_jacobian` 返回恒零 `dadv`；`stm_derivative` 加 `dadv` 参数 |
+| `augmented_state.rs` | 42 维增广右端项透传 `dadv` 给 `stm_derivative` |
+| `compiled_stm.rs` | `augmented_eom` 解三元组、透传 `dadv` |
+| `multiple_shooting.rs` | STM 打靶段透传 `dadv` |
+| `e2m2e/algorithm/forces/force_model.py` | Python 回退路径同步（第 2.1 项） |
+
+## 先例与定位
+
+- **比 ADR 0017 更基础。** 0017 是「网格搜索的并行执行策略」（Rayon），只影响转移搜索一条算法路径；本 ADR 是「力-雅可比契约」，所有 STM 传播（打靶、修正、STM 采样、网格搜索内的积分）都依赖它。0017 引用的 ``multiple_shooting`` / ``propagate_compiled`` 先例本身就是本契约的消费者。
+- **与 ADR 0002 的关系。** ADR 0002 修订 2 已确立「SPICE 相关传播必须编进 Rust 扩展」（cspice 内核池是进程级单例）。本 ADR 不改那条边界，只把「Rust 内部的力-雅可比数据结构」从二维扩到三维——是 ADR 0002 Rust 内核内部的数据契约细化，不跨界。
+- **与 ADR 0003 的关系。** drag 的 ``∂a/∂v`` 非零源于其物理（相对速度），与坐标系无关；坐标侧的 ``ITRF93`` 选择另由 ADR 0019 记录。
+
+## 为什么不是别的形状
+
+- **不改成结构体字段。** ``(acc, ∂a/∂r, ∂a/∂v)`` 三元组与 GMAT ``CompleteDerivativeCalculations`` 的「力只供 Ã 左下块」分工一致——只是把「左下块」从 ``3×3`` 细化为 ``(∂a/∂r, ∂a/∂v)`` 两块。结构体（如 ``AccelJacobi { acc, dadr, dadv }``）可读性略好，但会动所有解构点；三元组对齐已有 ``AccelDrag`` / ``AccelJacobiResult`` 风格，改动面最小。
+- **不把 ``∂a/∂v`` 留作可选。** 可选 ``Option<[[f64;3];3]>`` 会让「速度依赖力忘了填」重新变成静默错误——正是本 ADR 要消除的失败模式。强制三元组让缺项编译不过。
+
+## 结果
+
+### 新增
+
+- 力-雅可比接口显式包含 ``∂a/∂v``，STM 变分方程对速度依赖力正确。
+- drag 进入 compiled STM 路径后灵敏度不再静默出错。
+- Python ``ForceModel`` 回退路径同步（第 2.1 项），消除未来无 SPICE 下的隐患。
+
+### 不变
+
+- N 体 / CR3BP / EphemerisDynamics STM 行为（``dadv`` 恒零，等价于旧隐式零）。
+- pyfunction ABI（``propagate_compiled_stm_py`` 等入参与返回形状不变）。
+- ``PhysicalModel.compute_jacobian`` 仍只返回 ``∂a/∂r``（3×3）——Python 解析雅可比契约不变；``∂a/∂v`` 在 ``ForceModel`` 层按「解析力→零、无解析力→FD」推导。
+
+### 取舍
+
+- **FD 评估数翻倍（drag）。** ``drag_accel_and_jacobian`` 从扰动位置 3 分量（6 次 accel）扩到全 6 分量（12 次 accel）。drag 的 FD 本就是 STM 路径里最重的单力，但 STM 传播主要成本在 RK 步进而非单次雅可比，且 drag 量级小（高度衰减快），实测无感。
+- **Python FD 路径成本。** 无解析雅可比力在 Python 回退路径下 FD 从 6 次 accel（位置）扩到 12 次（位置+速度）。该路径是降级路径，drag 不可达，当前唯一消费者是球谐 ``GravityField``（位置型，速度 FD 给零）——额外 6 次 accel 是球谐评估，可接受。

--- a/docs/adr/0019-drag-rust-itrf93-frame-rotation.md
+++ b/docs/adr/0019-drag-rust-itrf93-frame-rotation.md
@@ -1,0 +1,66 @@
+# ADR 0019：drag Rust 移植用 ITRF93 pxform 帧旋转（替 ITRFApproxAxes）
+
+**状态**：已接受
+**日期**：2026-08-07
+**关联**：ADR 0003（ITRF93 默认值与 GMAT 兼容）、ADR 0018（Jacobian ∂a/∂v）、issue #315、issue #317
+**关联代码**：`crates/e2m2e-forces/src/forces/drag.rs`、`e2m2e/algorithm/forces/drag.py`
+
+## 背景
+
+大气阻力的物理在**地固系**（ITRF）中计算：大气随地球自转，相对速度 = 航天器 ITRF 速度。阻力管线因此是「J2000 传播系 → ITRF → 阻力公式 → J2000」的帧旋转往返。
+
+Python ``DragModel.compute_acceleration``（`drag.py`）用 ``ITRFApproxAxes`` 做这次旋转——ADR 0003 第 1 条已把 ``ITRFApproxAxes`` 明确标注为「低精度/教学」，高精度默认是 SPICE 支撑的 ``ITRF93``。Python drag 沿用近似轴是历史遗留：drag 长期是教学/LEO 量级示例，``ITRFApproxAxes`` 够用。
+
+drag Rust 移植（issue #315 系列）把 ``DragModel`` 纳入 compiled 力模型，与 ``GravityField`` 共享同一套 SPICE FFI（``pxform`` / 内核池）。此时 drag 的帧旋转有两个选择：
+
+- **A. 照搬 Python**：在 Rust 侧重新实现 ``ITRFApproxAxes`` 的近似归约（IAU 2006 简化 + 线性 LOD 等），仅为「与 Python 逐位一致」。
+- **B. 对齐 ADR 0003 默认**：drag 直接用 ``ITRF93`` 的 ``pxform``（与 ``GravityField`` 同一帧旋转路径）。
+
+`drag.rs` 顶部注释称此为「决策 1b」，但该决策此前无文档落点（issue #317 第 1.2 项指出）。本 ADR 补上。
+
+## 决策
+
+**选 B**：drag Rust 路径用 ``ITRF93`` ``pxform`` 帧旋转，不重新实现 ``ITRFApproxAxes``。
+
+1. **``drag_accel`` 帧旋转走 ITRF93。**
+   - ``lookup_frame_matrix("ITRF93", propagation_frame, et)`` 优先走星历预采样缓存（ADR 0016），未命中走 ``pxform("ITRF93", propagation_frame, et)``。
+   - 与 ``GravityField`` 的 ``pxform`` 模式一致（``r_itrf = Rᵀ·r_j2000``，``a_j2000 = R·a_itrf``）。
+
+2. **Python 路径不改。**
+   - ``DragModel.compute_acceleration`` 仍用 ``ITRFApproxAxes``。两条路径在「drag 需 SPICE 必走 Rust」的现状下不并存：``DragModel.to_rust_spec`` 在 ``system.spice`` 缺失时返回 ``None``，``ForceModel`` 回退 Python 路径——此时没有 SPICE 也谈不上 ``ITRF93``，``ITRFApproxAxes`` 是合理的降级。
+
+3. **``∂a/∂v`` 与坐标系正交。**
+   - drag 的速度依赖（``a ∝ |v|·v``）是物理，与帧旋转选择无关。``∂a/∂v`` 接口扩三元组见 ADR 0018，不在本 ADR 范围。
+
+## 理由
+
+1. **避免在 Rust 里重实现一个明确标注「低精度」的轴系。** ADR 0003 已定 ``ITRFApproxAxes`` 仅用于低精度/教学。Rust compiled 路径是高精度生产路径，重新移植一个被自家 ADR 划为「低精度」的归约，方向自相矛盾；维护两套地球定向（ITRF93 + 近似）也加倍负担。
+
+2. **与 ``GravityField`` 共享帧旋转路径。** drag 与 ``GravityField`` 都是 body-fixed 力（一个用密度，一个用球谐），都需 J2000↔ITRF 旋转。两者用同一 ``pxform`` 路径，共享星历缓存命中（ADR 0016），减少 SPICE FFI 调用。分叉反而浪费已落地的缓存基础设施。
+
+3. **Python「逐位一致」并非目标。** Rust compiled 路径的定位是「更快且不劣于 Python」（ADR 0002 修订 2），不是「Python 的逐位复刻」。``ITRF93`` 比 ``ITRFApproxAxes`` 更准，分歧方向是「Rust 更接近真值」，符合 ADR 0003 的精度阶梯。
+
+4. **降级语义自洽。** Python 路径只在无 SPICE 时启用；无 SPICE 时 ``ITRF93`` 本就不可用（ADR 0003 第 7 条「缺失 ITRF93 内核抛坐标错误，绝不自动降精度」）。``ITRFApproxAxes`` 在这条降级路径上是唯一可用选项，不违反 ADR 0003——它本就是为「无 SPICE」保留的低精度退路。
+
+## 边界
+
+- **仅 drag。** 本决策只针对 drag 的帧旋转。其他 body-fixed 力（``GravityField``、``EarthTide``）的坐标系选择各自遵循 ADR 0003，不受本 ADR 影响。
+- **不改 Python ``DragModel``。** Python 路径的 ``ITRFApproxAxes`` 保留作无 SPICE 降级。若日后 Python drag 也切 ``ITRF93``，需单独评估（届时两条路径精度一致，可考虑移除本 ADR 的「双路径」说明）。
+- **不引入 GMAT 原生 ITRF。** ADR 0003 第 2 条的 ``GMATITRFAxes`` 是独立的 GMAT 兼容轴系，drag 不用它。
+
+## 结果
+
+### 新增
+
+- drag Rust 路径用 ``ITRF93`` ``pxform``，与 ADR 0003 默认对齐。
+- 「决策 1b」有了文档落点（本 ADR），`drag.rs` 注释引用不再悬空。
+
+### 不变
+
+- Python ``DragModel.compute_acceleration`` 的 ``ITRFApproxAxes`` 路径（无 SPICE 降级）。
+- drag 的物理公式、大气密度接口、``∂a/∂v`` 雅可比（属 ADR 0018）。
+- ADR 0003 全部决策（本 ADR 是其在 drag 上的具体化，不修订母决策）。
+
+### 取舍
+
+- **双路径精度分歧。** Rust（``ITRF93``）与 Python（``ITRFApproxAxes``）drag 加速度在有 SPICE 时理论上略有差异。实测在 LEO 教学量级可忽略（``ITRFApproxAxes`` 的旋转误差对阻力量级是高阶小量）；且现状下两者不并存（有 SPICE 必走 Rust）。若未来需要 Python 路径也达 ``ITRF93`` 精度，再开单独改动。

--- a/e2m2e/algorithm/dynamics/dynamics.py
+++ b/e2m2e/algorithm/dynamics/dynamics.py
@@ -45,6 +45,14 @@ try:
 except ImportError:
     _HAS_RUST_CR3BP_STM = False
 
+# 跨语言契约（issue #317 第 3.1 项）：Rust ``propagate_cr3bp``（cr3bp.rs）步长
+# 塌缩错误形如 "step size collapsed below minimum ..."。``EphemerisDynamics
+# ._propagate_state_only`` 据此前缀识别该失败并转成空 states（对齐 scipy 失败
+# 语义，让上层 NLP 走 dv=1e10 惩罚）。改 Rust 该错误消息须同步本标记——Rust
+# 侧对应注释见 cr3bp.rs ``MIN_STEP`` 处。本字符串是 Python↔Rust 的稳定契约，
+# 勿当作普通文案随意改写。
+_RUST_STEP_COLLAPSED_MARKER = "step size collapsed"
+
 
 class Dynamics:
     """通用天体系统动力学基类
@@ -612,7 +620,7 @@ class CR3BP_Dynamics(Dynamics):
                         f"requested time points; the trajectory is truncated"
                     )
             except RuntimeError as e:
-                if "step size collapsed" in str(e):
+                if _RUST_STEP_COLLAPSED_MARKER in str(e):
                     return {"time": np.array([]), "states": np.empty((0, 6))}
                 raise
 

--- a/e2m2e/algorithm/forces/force_model.py
+++ b/e2m2e/algorithm/forces/force_model.py
@@ -225,47 +225,88 @@ class ForceModel:
         self,
         t: float,
         state: npt.NDArray[np.floating],
-    ) -> npt.NDArray[np.floating]:
-        """计算所有启用力模型的叠加雅可比 ∂a/∂r（3×3）。
+    ) -> tuple[npt.NDArray[np.floating], npt.NDArray[np.floating]]:
+        """计算所有启用力模型的叠加雅可比 ``(∂a/∂r, ∂a/∂v)``，各 3×3。
 
-        对齐 GMAT ``ODEModel::GetDerivatives``：组合模型的雅可比是各力雅可比
-        之和（``∂(a₁+a₂)/∂r = ∂a₁/∂r + ∂a₂/∂r``，无交叉耦合）。返回 ``None``
-        雅可比的力用三点中心差分兜底（调 ``compute_acceleration``）。
+        对齐 GMAT ``ODEModel::GetDerivatives`` 与 Rust
+        ``acceleration_and_jacobian`` 三元组（ADR 0018）：组合模型的雅可比
+        是各力雅可比之和（``∂(a₁+a₂)/∂r = ∂a₁/∂r + ∂a₂/∂r``，速度块同理），
+        无交叉耦合。
+
+        - 解析雅可比力（``compute_jacobian`` 返回 ``∂a/∂r`` 非 ``None``）：
+          ``∂a/∂v = 0``。``compute_jacobian`` 契约只覆盖 ``∂a/∂r``（见
+          :class:`PhysicalModel`），现有解析力（点质量、第三体、间接项、SRP）
+          均为位置型，速度块为零正确。
+        - 无解析雅可比力（返回 ``None``）：位置与速度均走三点中心差分，给出
+          ``∂a/∂r`` 与 ``∂a/∂v`` 真值。速度依赖力（如 drag）的 ``∂a/∂v``
+          由此捕获，不再静默置零（issue #317 第 2.1 项，详见 ADR 0018）。
         """
-        total = np.zeros((3, 3), dtype=float)
+        total_dr = np.zeros((3, 3), dtype=float)
+        total_dv = np.zeros((3, 3), dtype=float)
         r_norm = float(np.linalg.norm(state[:3]))
-        # 有限差分步长：sqrt(eps) * r_norm，保证相对扰动在机器精度量级
-        delta = max(np.sqrt(np.finfo(float).eps) * r_norm, 1e-6)
+        v_norm = float(np.linalg.norm(state[3:6]))
+        # 有限差分步长：sqrt(eps)·norm，floor 1e-6 保证 v=0 时仍有有效步长
+        delta_r = max(np.sqrt(np.finfo(float).eps) * r_norm, 1e-6)
+        delta_v = max(np.sqrt(np.finfo(float).eps) * v_norm, 1e-6)
         for entry in self._entries:
             if not entry.enabled:
                 continue
             jac = entry.force.compute_jacobian(t, state, self.system)
             if jac is None:
-                jac = self._finite_diff_jacobian(entry.force, t, state, delta)
-            total = total + jac
-        return total
+                dadr, dadv = self._finite_diff_jacobians(
+                    entry.force, t, state, delta_r, delta_v
+                )
+            else:
+                dadr = jac
+                dadv = np.zeros((3, 3), dtype=float)
+            total_dr = total_dr + dadr
+            total_dv = total_dv + dadv
+        return total_dr, total_dv
 
-    def _finite_diff_jacobian(
+    def _finite_diff_jacobians(
         self,
         force: PhysicalModel,
         t: float,
         state: npt.NDArray[np.floating],
+        delta_r: float,
+        delta_v: float,
+    ) -> tuple[npt.NDArray[np.floating], npt.NDArray[np.floating]]:
+        """三点中心差分估算单个力的 ``(∂a/∂r, ∂a/∂v)``，各 3×3。
+
+        对位置三分量以 ``delta_r``、速度三分量以 ``delta_v`` 各扰动 ±，调
+        ``compute_acceleration`` 取差分。与 Rust ``drag_accel_and_jacobian``
+        的全 6 分量 FD 同构（ADR 0018）：速度块对位置型力恒为零（加速度不
+        依赖速度，扰动速度给出相同加速度），速度依赖力（drag）给出真值。
+        """
+        dadr = self._fd_block(force, t, state, 0, delta_r)
+        dadv = self._fd_block(force, t, state, 3, delta_v)
+        return dadr, dadv
+
+    def _fd_block(
+        self,
+        force: PhysicalModel,
+        t: float,
+        state: npt.NDArray[np.floating],
+        offset: int,
         delta: float,
     ) -> npt.NDArray[np.floating]:
-        """三点中心差分估算单个力的 ∂a/∂r（3×3）。
+        """三点中心差分估算单个力的一个 3×3 块（``offset=0`` → ∂a/∂r，
+        ``offset=3`` → ∂a/∂v）。
 
-        对位置三分量各扰动 ±delta，调 ``compute_acceleration`` 取差分。
+        对 ``state[offset:offset+3]`` 三分量各扰动 ±delta，调
+        ``compute_acceleration`` 取差分。位置块与速度块形状同构，抽此助手
+        复用以消除重复（Fowler 重复代码坏味）。
         """
-        jac = np.zeros((3, 3), dtype=float)
+        block = np.zeros((3, 3), dtype=float)
         for i in range(3):
             state_plus = state.copy()
             state_minus = state.copy()
-            state_plus[i] += delta
-            state_minus[i] -= delta
+            state_plus[offset + i] += delta
+            state_minus[offset + i] -= delta
             a_plus = force.compute_acceleration(t, state_plus, self.system)
             a_minus = force.compute_acceleration(t, state_minus, self.system)
-            jac[:, i] = (a_plus - a_minus) / (2.0 * delta)
-        return jac
+            block[:, i] = (a_plus - a_minus) / (2.0 * delta)
+        return block
 
     def equations_of_motion(
         self, t: float, state: npt.NDArray[np.floating]
@@ -284,18 +325,20 @@ class ForceModel:
         """增广运动方程闭包（42 维 [v, a, Φ̇]）。
 
         拆出状态与 STM，算加速度和雅可比，组装
-        ``A = [[0, I], [∂a/∂r, 0]]``，返回 ``[v, a, (A@Φ).flatten()]``。
-        对齐 GMAT ``CompleteDerivativeCalculations``：力模型只供 Ã 的左下块，
-        变分方程 Φ̇ = AΦ 在此集中求解。
+        ``A = [[0, I], [∂a/∂r, ∂a/∂v]]``，返回 ``[v, a, (A@Φ).flatten()]``。
+        对齐 GMAT ``CompleteDerivativeCalculations``：力模型只供 Ã 的左下两块
+        （``∂a/∂r``、``∂a/∂v``），变分方程 Φ̇ = AΦ 在此集中求解。``∂a/∂v``
+        对位置型力为零、对速度依赖力（drag）非零（ADR 0018）。
         """
         state = augmented_state[:6]
         stm = augmented_state[6:].reshape((6, 6))
         acceleration = self._compute_total_acceleration(t, state)
-        dacc_dr = self._compute_total_jacobian(t, state)
+        dacc_dr, dacc_dv = self._compute_total_jacobian(t, state)
 
         A = np.zeros((6, 6))
         A[:3, 3:] = np.eye(3)
         A[3:, :3] = dacc_dr
+        A[3:, 3:] = dacc_dv
         stm_dot = A @ stm
         return np.concatenate([state[3:6], acceleration, stm_dot.flatten()])
 

--- a/e2m2e/algorithm/forces/force_model.py
+++ b/e2m2e/algorithm/forces/force_model.py
@@ -253,9 +253,7 @@ class ForceModel:
                 continue
             jac = entry.force.compute_jacobian(t, state, self.system)
             if jac is None:
-                dadr, dadv = self._finite_diff_jacobians(
-                    entry.force, t, state, delta_r, delta_v
-                )
+                dadr, dadv = self._finite_diff_jacobians(entry.force, t, state, delta_r, delta_v)
             else:
                 dadr = jac
                 dadv = np.zeros((3, 3), dtype=float)

--- a/e2m2e/algorithm/forces/physical_model.py
+++ b/e2m2e/algorithm/forces/physical_model.py
@@ -66,11 +66,14 @@ class PhysicalModel(abc.ABC):
     ) -> npt.NDArray[np.floating] | None:
         """返回加速度对位置的偏导 ∂a/∂r（3×3）。
 
-        供 STM 变分方程组装雅可比矩阵 A = [[0, I], [∂a/∂r, 0]] 用。
-        N 体问题中无速度相关力，故 ∂a/∂v = 0，只需位置块。
+        供 STM 变分方程组装雅可比矩阵 ``A = [[0, I], [∂a/∂r, ∂a/∂v]]`` 的左下
+        位置块用。本方法只覆盖 ``∂a/∂r``；``∂a/∂v`` 由 ``ForceModel`` 按力的
+        性质推导（位置型力为零、速度依赖力走有限差分），不在此契约内——
+        详见 ADR 0018 与 ``ForceModel._compute_total_jacobian``。
 
         默认返回 ``None``，表示该力不提供解析雅可比，由 ``ForceModel``
-        走有限差分兜底（三点中心差分调 ``compute_acceleration``）。
+        走有限差分兜底（三点中心差分调 ``compute_acceleration``，同时给出
+        ``∂a/∂r`` 与 ``∂a/∂v``）。
 
         Args:
             t: 时间，单位为 SPICE et（秒 past J2000）。

--- a/tests/core/forces/test_force_model_jacobian_dadv.py
+++ b/tests/core/forces/test_force_model_jacobian_dadv.py
@@ -191,9 +191,7 @@ class TestStmPropagationUsesDadv:
         fm.atol = 1e-12
 
         state0 = np.array([1.0, 0.0, 0.0, 1.0, 0.0, 0.0])
-        stm = fm.propagate(
-            state0, (0.0, 1.0), with_stm=True, initial_step=0.05
-        )["stm"][-1]
+        stm = fm.propagate(state0, (0.0, 1.0), with_stm=True, initial_step=0.05)["stm"][-1]
 
         block_vv = stm[3:6, 3:6]
         assert not np.allclose(block_vv, np.eye(3), atol=1e-3), (
@@ -220,9 +218,7 @@ class TestStmPropagationUsesDadv:
         fm.atol = 1e-12
 
         state0 = np.array([1.0, 0.0, 0.0, 1.0, 0.0, 0.0])
-        stm = fm.propagate(
-            state0, (0.0, 1.0), with_stm=True, initial_step=0.05
-        )["stm"][-1]
+        stm = fm.propagate(state0, (0.0, 1.0), with_stm=True, initial_step=0.05)["stm"][-1]
 
         # 恒力：δv(t)=δv0（速度不演化），故 Φ[3:,3:]=I、Φ[3:,:3]=0
         assert_allclose(stm[3:6, 3:6], np.eye(3), atol=1e-9, err_msg="恒力 Φ[3:,3:] 应 = I")

--- a/tests/core/forces/test_force_model_jacobian_dadv.py
+++ b/tests/core/forces/test_force_model_jacobian_dadv.py
@@ -1,0 +1,229 @@
+"""ForceModel Python STM 路径 ∂a/∂v 同步测试（issue #317 第 2.1 项，ADR 0018）。
+
+验证 ``ForceModel`` 的 Python 回退 STM 路径不再把 ``∂a/∂v`` 静默置零：
+
+- ``_compute_total_jacobian`` 返回 ``(∂a/∂r, ∂a/∂v)`` 二元组；速度依赖力
+  （阻尼型）的 ``∂a/∂v`` 由有限差分给出真值。
+- 整条 STM 传播把 ``∂a/∂v`` 纳入 ``A[3:,3:]``：纯阻尼力的 STM
+  ``Φ[3:6, 3:6] = e^{-k·Δt}·I``（旧代码 ``A[3:,3:]=0`` 会给出 ``I``，错误）。
+
+这些测试不需要 SPICE——测试力忽略 system，``to_rust_spec`` 返回 None 确保
+走 Python 回退路径（直接覆盖 ``_eom_func_with_stm``）。
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from e2m2e.algorithm.forces import ForceModel
+from e2m2e.algorithm.forces.physical_model import PhysicalModel
+
+
+class _FakeSystem:
+    """最小 system 桩：提供 coordinate_system 占位即可（测试力不查 system）。"""
+
+    def __init__(self) -> None:
+        self.coordinate_system = object()
+
+
+class _DampingForce(PhysicalModel):
+    """速度依赖力 ``a = -k·v``（无解析雅可比，走有限差分）。
+
+    解析 ``∂a/∂r = 0``、``∂a/∂v = -k·I``。不覆写 ``compute_jacobian`` →
+    继承基类返回 None，由 ``ForceModel`` 有限差分兜底，同时对位置与速度扰动。
+    """
+
+    def __init__(self, k: float = 0.5) -> None:
+        self._k = float(k)
+
+    def compute_acceleration(self, t, state, system):  # noqa: ANN001
+        v = np.asarray(state, dtype=float)[3:6]
+        return -self._k * v
+
+
+class _PositionOnlyNoJacForce(PhysicalModel):
+    """位置型力 ``a = -k·r``（无解析雅可比，走有限差分）。
+
+    解析 ``∂a/∂r = -k·I``、``∂a/∂v = 0``。验证位置型力的速度 FD 仍给零，
+    即重构不改变既有位置型力的 STM 行为（回归）。
+    """
+
+    def __init__(self, k: float = 1.0) -> None:
+        self._k = float(k)
+
+    def compute_acceleration(self, t, state, system):  # noqa: ANN001
+        r = np.asarray(state, dtype=float)[:3]
+        return -self._k * r
+
+
+class _PositionOnlyAnalyticForce(PhysicalModel):
+    """位置型力 ``a = -k·r``，带解析 ``∂a/∂r``。验证解析力 ``∂a/∂v = 0``。"""
+
+    def __init__(self, k: float = 1.0) -> None:
+        self._k = float(k)
+
+    def compute_acceleration(self, t, state, system):  # noqa: ANN001
+        r = np.asarray(state, dtype=float)[:3]
+        return -self._k * r
+
+    def compute_jacobian(self, t, state, system):  # noqa: ANN001
+        return -self._k * np.eye(3)
+
+
+# =============================================================================
+# _compute_total_jacobian 二元组正确性
+# =============================================================================
+class TestComputeTotalJacobianDadv:
+    """``_compute_total_jacobian`` 返回 (∂a/∂r, ∂a/∂v)，速度依赖力给真值。"""
+
+    def test_velocity_dependent_force_yields_nonzero_dadv(self):
+        """阻尼力 a=-k·v → ∂a/∂v=-k·I、∂a/∂r=0（有限差分路径）。"""
+        k = 0.5
+        fm = ForceModel(_FakeSystem(), forces=[_DampingForce(k=k)])
+        state = np.array([1.0, 0.0, 0.0, 0.0, 1.0, 0.0])
+
+        dadr, dadv = fm._compute_total_jacobian(0.0, state)
+
+        assert_allclose(dadr, np.zeros((3, 3)), atol=1e-10, err_msg="阻尼力 ∂a/∂r 应为零")
+        assert_allclose(
+            dadv,
+            -k * np.eye(3),
+            atol=1e-6,
+            err_msg="阻尼力 ∂a/∂v 应为 -k·I（有限差分）",
+        )
+
+    def test_position_only_fd_force_yields_zero_dadv(self):
+        """位置型力（无解析雅可比）→ ∂a/∂v=0、∂a/∂r=-k·I（回归）。"""
+        k = 1.0
+        fm = ForceModel(_FakeSystem(), forces=[_PositionOnlyNoJacForce(k=k)])
+        state = np.array([1.0, 0.0, 0.0, 0.0, 1.0, 0.0])
+
+        dadr, dadv = fm._compute_total_jacobian(0.0, state)
+
+        assert_allclose(dadr, -k * np.eye(3), atol=1e-6, err_msg="位置型力 ∂a/∂r 应为 -k·I")
+        assert_allclose(
+            dadv,
+            np.zeros((3, 3)),
+            atol=1e-10,
+            err_msg="位置型力 ∂a/∂v 应严格为零（扰动速度不改变加速度）",
+        )
+
+    def test_position_only_analytic_force_yields_zero_dadv(self):
+        """位置型力（解析雅可比）→ ∂a/∂v=0（解析力按契约速度块置零）。"""
+        k = 1.0
+        fm = ForceModel(_FakeSystem(), forces=[_PositionOnlyAnalyticForce(k=k)])
+        state = np.array([1.0, 0.0, 0.0, 0.0, 1.0, 0.0])
+
+        dadr, dadv = fm._compute_total_jacobian(0.0, state)
+
+        assert_allclose(dadr, -k * np.eye(3), atol=1e-12)
+        assert_allclose(dadv, np.zeros((3, 3)), atol=1e-12)
+
+    def test_mixed_forces_dadv_superposes(self):
+        """组合力 ∂a/∂v 逐力叠加（阻尼 + 位置型 = -k·I + 0）。"""
+        k = 0.4
+        fm = ForceModel(
+            _FakeSystem(),
+            forces=[_DampingForce(k=k), _PositionOnlyAnalyticForce(k=1.0)],
+        )
+        state = np.array([1.0, 0.0, 0.0, 0.0, 1.0, 0.0])
+
+        dadr, dadv = fm._compute_total_jacobian(0.0, state)
+
+        # ∂a/∂r：仅位置型贡献 -1·I
+        assert_allclose(dadr, -1.0 * np.eye(3), atol=1e-6)
+        # ∂a/∂v：仅阻尼贡献 -k·I
+        assert_allclose(dadv, -k * np.eye(3), atol=1e-6)
+
+
+# =============================================================================
+# 整条 STM 传播：∂a/∂v 进入 A[3:,3:]
+# =============================================================================
+class TestStmPropagationUsesDadv:
+    """速度依赖力的 STM 反映 ``A[3:,3:] = ∂a/∂v``，不再静默置零。
+
+    纯阻尼力 ``a = -k·v`` 的解析 STM：``Φ[3:6, 3:6] = e^{-k·Δt}·I``、
+    ``Φ[0:3, 3:6] = (1-e^{-k·Δt})/k · I``。旧代码 ``A[3:,3:]=0`` 会给出
+    ``Φ[3:6,3:6]=I``（无阻尼），是静默错误——本测试直接区分两者。
+    """
+
+    @pytest.mark.parametrize("k", [0.25, 0.5, 1.0])
+    def test_damping_stm_velocity_block_decays(self, k):
+        """Φ 的速度-速度块按 e^{-k·Δt} 衰减，证明 ∂a/∂v 已纳入 A。"""
+        dt = 1.0
+        fm = ForceModel(_FakeSystem(), forces=[_DampingForce(k=k)])
+        fm.rtol = 1e-12
+        fm.atol = 1e-12
+
+        state0 = np.array([1.0, 0.0, 0.0, 1.0, 0.0, 0.0])
+        result = fm.propagate(state0, (0.0, dt), with_stm=True, initial_step=0.05)
+        stm = result["stm"][-1]
+
+        expected_decay = np.exp(-k * dt)
+        # 速度-速度块对角：Φ[3,3]=Φ[4,4]=Φ[5,5]=e^{-k·dt}；非对角为零（各轴解耦）
+        assert_allclose(
+            np.diag(stm)[3:6],
+            expected_decay,
+            atol=1e-7,
+            err_msg=(
+                f"Φ 速度-速度块应 = e^(-k·dt)={expected_decay:.6f}；"
+                "若 ≈1 则 ∂a/∂v 未纳入 A（旧 A[3:,3:]=0 bug）"
+            ),
+        )
+        # 位置-速度块对角（Φ[0:3, 3:6] 的对角，即 stm[i, i+3]）：
+        # (1-e^{-k·dt})/k —— δv0 映射到 δr 的积分核
+        expected_cross = (1.0 - expected_decay) / k
+        cross_diag = np.array([stm[i, i + 3] for i in range(3)])
+        assert_allclose(
+            cross_diag,
+            expected_cross,
+            atol=1e-6,
+            err_msg="Φ 位置-速度块对角应 = (1-e^{-k·dt})/k",
+        )
+
+    def test_damping_stm_velocity_block_not_identity(self):
+        """显式断言 Φ[3:,3:] ≠ I：旧 bug 下会是单位阵。"""
+        k = 0.5
+        fm = ForceModel(_FakeSystem(), forces=[_DampingForce(k=k)])
+        fm.rtol = 1e-12
+        fm.atol = 1e-12
+
+        state0 = np.array([1.0, 0.0, 0.0, 1.0, 0.0, 0.0])
+        stm = fm.propagate(
+            state0, (0.0, 1.0), with_stm=True, initial_step=0.05
+        )["stm"][-1]
+
+        block_vv = stm[3:6, 3:6]
+        assert not np.allclose(block_vv, np.eye(3), atol=1e-3), (
+            f"Φ[3:,3:] ≈ I 意味着 ∂a/∂v 被置零（旧 bug）；got {block_vv}"
+        )
+
+    def test_position_only_stm_velocity_block_is_identity(self):
+        """回归：位置型力的 Φ[3:,3:] = I（无速度阻尼），重构后仍成立。
+
+        位置型力 ``a=-k·r`` 的解析 STM 速度-速度块 = ``cos(√k·Δt)·I`` ≠ I
+        一般；这里改用恒力（``a=const``，不依赖 r 也不依赖 v）验证 ``∂a/∂v=0``
+        时速度块对初始速度的映射保持单位（δv 不变）。
+        """
+
+        class _ConstantAccel(PhysicalModel):
+            def __init__(self, a):
+                self._a = np.asarray(a, dtype=float)
+
+            def compute_acceleration(self, t, state, system):  # noqa: ANN001
+                return self._a.copy()
+
+        fm = ForceModel(_FakeSystem(), forces=[_ConstantAccel([0.1, 0.0, 0.0])])
+        fm.rtol = 1e-12
+        fm.atol = 1e-12
+
+        state0 = np.array([1.0, 0.0, 0.0, 1.0, 0.0, 0.0])
+        stm = fm.propagate(
+            state0, (0.0, 1.0), with_stm=True, initial_step=0.05
+        )["stm"][-1]
+
+        # 恒力：δv(t)=δv0（速度不演化），故 Φ[3:,3:]=I、Φ[3:,:3]=0
+        assert_allclose(stm[3:6, 3:6], np.eye(3), atol=1e-9, err_msg="恒力 Φ[3:,3:] 应 = I")
+        assert_allclose(stm[3:6, :3], np.zeros((3, 3)), atol=1e-9, err_msg="恒力 Φ[3:,:3] 应 = 0")


### PR DESCRIPTION
## 来源

code review 后续收尾（#317）。对「Jacobian ∂a/∂v 接口扩」补 ADR、同步 Python STM 回退路径、清理一批可维护性条目。

## 改动（3 commit）

**`feat(forces)` — Python STM 纳入 ∂a/∂v（#317 1.1+2.1）**
`ForceModel._compute_total_jacobian` 返回值由 `∂a/∂r` 扩为 `(∂a/∂r, ∂a/∂v)`，`_eom_func_with_stm` 组装 `A[3:,3:]=∂a/∂v`。解析雅可比力 `∂a/∂v=0`；无解析雅可比力走双块有限差分（`_fd_block` 助手消除位置/速度块重复）。新增 ADR 0018 记录动机（drag 速度依赖）与影响面；新增 `test_force_model_jacobian_dadv` 用阻尼型力（`Φ[3:,3:]=e^{-k·Δt}·I`）与位置型力验证。当前 drag 必走 Rust、Python 回退不可达，本项消除「未来无 SPICE 下速度依赖力静默出错」隐患。

**`refactor(dynamics)` — 步长塌缩标记常量（#317 3.1）**
`dynamics.py` 把 `"step size collapsed"` 提为模块级 `_RUST_STEP_COLLAPSED_MARKER`；`cr3bp.rs MIN_STEP` 处补跨语言契约双向注释。行为不变。

**`docs(forces)` — ADR 0019 + 注释沿革（#317 1.2+3.2+3.3）**
新增 ADR 0019 为 drag 的「决策 1b」（Rust 用 ITRF93 pxform）补文档落点；`drag.rs` 注释改引 ADR、修正 Step 编号（补 Step 3、Step 5→4）；`lib.rs` 补 abi-version v1→v3 沿革注释（说明「1→3」实为两次单步 bump）。

## 验证

- 9 个新测试通过（`test_force_model_jacobian_dadv`：阻尼/位置/解析/混合 + STM 传播衰减）。
- spice-gated STM 套件全过（ForceModel↔EphemerisDynamics 一致性、FD 回退、GravityField STM）——重构对位置型力是 no-op。
- Rust forces crate 61 测试通过（单线程）；mypy 干净。
- 详见 code review：规范轴（修了 1 条重复代码）、规格轴（0 条）。

Resolves #317.
