### PR TITLE
fix(integrators): propagate_compiled 主循环补 py.allow_threads，长期预报段释放 GIL（#318）

### DIFF
--- a/crates/e2m2e-integrators/src/lib.rs
+++ b/crates/e2m2e-integrators/src/lib.rs
@@ -1063,6 +1063,11 @@ pub(crate) fn parse_force_tuple(
 
 /// `propagate_compiled` 主循环（释 GIL 段）的输出：time / states / 步数统计。
 /// 独立成 type alias 修 clippy `type_complexity`（与 `AccelJacobiResult` 同法）。
+///
+/// 与唯一使用者 `propagate_compiled` 同步 cfg：无 spice feature 时该函数被
+/// 编译期剔除，alias 须一并剔除，否则 `cargo clippy --workspace`（默认无 spice）
+/// 报 dead_code（#318 CI）。
+#[cfg(feature = "spice")]
 type CompiledPropResult = (Vec<f64>, Vec<Vec<f64>>, usize, usize, usize);
 
 /// 全 Rust 力模型传播器（消除 Python↔Rust 跨界）。

--- a/crates/e2m2e-integrators/src/lib.rs
+++ b/crates/e2m2e-integrators/src/lib.rs
@@ -1061,6 +1061,10 @@ pub(crate) fn parse_force_tuple(
     }
 }
 
+/// `propagate_compiled` 主循环（释 GIL 段）的输出：time / states / 步数统计。
+/// 独立成 type alias 修 clippy `type_complexity`（与 `AccelJacobiResult` 同法）。
+type CompiledPropResult = (Vec<f64>, Vec<Vec<f64>>, usize, usize, usize);
+
 /// 全 Rust 力模型传播器（消除 Python↔Rust 跨界）。
 ///
 /// Python 侧把所有 force 序列化为元组列表，Rust 在内部循环里直接调
@@ -1118,94 +1122,97 @@ fn propagate_compiled(
         forces.push(parse_force_tuple(&item)?);
     }
 
-    let table = method.table();
-    let n = y0.len();
-    let mut y = y0;
-    let mut t = t0;
-    let mut h = h_init;
-    // 输出起点跟随 t_eval：当 t_eval[0]==t0 时记录初始状态、eval_idx 从 1 起步；
-    // 当 t_eval[0]>t0（逐段积分常态：patch point 时刻非整数小时，et_grid 整数
-    // 小时点严格大于 t0）时不预设 t0 到输出，eval_idx 从 0 起步由循环匹配。
-    // 此前硬编码 vec![t0] + eval_idx=1 假设 t_eval[0]==t0，导致 t_eval[0]>t0
-    // 时首个输出点状态错置为初值、与后续点错位。
-    let mut times: Vec<f64> = Vec::with_capacity(t_eval.len());
-    let mut states: Vec<Vec<f64>> = Vec::with_capacity(t_eval.len());
-    let mut eval_idx = 0usize;
-    if !t_eval.is_empty() && (t0 - t_eval[0]).abs() <= 1e-9 {
-        times.push(t0);
-        states.push(y.clone());
-        eval_idx = 1;
-    }
-    let mut n_steps = 0usize;
-    let mut n_rejected = 0usize;
-    let mut n_steps_capped = 0usize;
-
-    // 用 RefCell 包装 cspice 错误状态（不能直接通过 explicit_rk_step 的 E 传）
-    use std::cell::RefCell;
-    let last_error: RefCell<Option<String>> = RefCell::new(None);
-
-    while t < t_eval[t_eval.len() - 1] && n_steps < max_steps {
-        n_steps += 1;
-        // 限制步长不超过下一个评估点（提高 t_eval 命中率），且不超过
-        // h_init（作为最大步长：稀疏 t_eval 下自适应步长失控，实测
-        // 2 点 vs 31 点网格的 30 天结果差 22 万 km）
-        if eval_idx < t_eval.len() {
-            let t_next_eval = t_eval[eval_idx];
-            if t + h > t_next_eval {
-                h = t_next_eval - t;
-            }
-        }
-        if h > h_init {
-            n_steps_capped += 1;
-            h = h_init;
-        }
-
-        // RK 单步：用 Rust 闭包调 compute_total_acceleration
-        let forces_ref = &forces;
-        let observer_ref = observer;
-        let err_cell = &last_error;
-        let callback = |ti: f64, yi: &[f64]| -> Result<Vec<f64>, String> {
-            let state6 = [yi[0], yi[1], yi[2], yi[3], yi[4], yi[5]];
-            compute_total_acceleration(forces_ref, ti, &state6, observer_ref)
-                .map(|a| vec![yi[3], yi[4], yi[5], a[0], a[1], a[2]])
-                .inspect_err(|e| {
-                    *err_cell.borrow_mut() = Some(e.clone());
-                })
-        };
-
-        let (y_new, error) = match explicit_rk_step(table, t, &y, h, callback, None) {
-            Ok(r) => r,
-            Err(msg) => {
-                return Err(pyo3::exceptions::PyRuntimeError::new_err(format!(
-                    "RK step force error: {}",
-                    msg
-                )));
-            }
-        };
-        let _ = n;
-
-        if error <= tol {
-            t += h;
-            y = y_new;
-            // 输出落在 t_eval 的点
-            while eval_idx < t_eval.len() && t >= t_eval[eval_idx] - 1e-9 {
-                times.push(t_eval[eval_idx]);
+    // 主积分循环包进 py.allow_threads 释放 GIL：compiled 力模型为纯 Rust
+    // （compute_total_acceleration 不回调 Python，cspice 走 FFI），与
+    // multiple_shooting_correct / transfer_grid_search 路径同理（#318）。
+    // 释 GIL 段（闭包内）：RK 主循环 + 每步 compute_total_acceleration；
+    // 持 GIL 段（闭包外）：上面的 force 元组解析 + 下面的 PyDict 返回构造。
+    // 闭包内不构造 PyErr（不借 Python 对象），仅回传 String，闭包外 map_err 转 PyErr。
+    let (times, states, n_steps, n_rejected, n_steps_capped) = py
+        .allow_threads(move || -> Result<CompiledPropResult, String> {
+            let table = method.table();
+            let mut y = y0;
+            let mut t = t0;
+            let mut h = h_init;
+            // 输出起点跟随 t_eval：当 t_eval[0]==t0 时记录初始状态、eval_idx 从 1 起步；
+            // 当 t_eval[0]>t0（逐段积分常态：patch point 时刻非整数小时，et_grid 整数
+            // 小时点严格大于 t0）时不预设 t0 到输出，eval_idx 从 0 起步由循环匹配。
+            // 此前硬编码 vec![t0] + eval_idx=1 假设 t_eval[0]==t0，导致 t_eval[0]>t0
+            // 时首个输出点状态错置为初值、与后续点错位。
+            let mut times: Vec<f64> = Vec::with_capacity(t_eval.len());
+            let mut states: Vec<Vec<f64>> = Vec::with_capacity(t_eval.len());
+            let mut eval_idx = 0usize;
+            if !t_eval.is_empty() && (t0 - t_eval[0]).abs() <= 1e-9 {
+                times.push(t0);
                 states.push(y.clone());
-                eval_idx += 1;
+                eval_idx = 1;
             }
-            let h_next = suggest_next_step(h, error, tol, method.embedded_order());
-            h = h_next;
-        } else {
-            n_rejected += 1;
-            let h_next = suggest_next_step(h, error, tol, method.embedded_order());
-            h = h_next;
-            if h < 1e-12 * (t_eval[t_eval.len() - 1] - t0).abs() {
-                return Err(pyo3::exceptions::PyRuntimeError::new_err(
-                    "step size collapsed below minimum",
-                ));
+            let mut n_steps = 0usize;
+            let mut n_rejected = 0usize;
+            let mut n_steps_capped = 0usize;
+
+            // 用 RefCell 包装 cspice 错误状态（不能直接通过 explicit_rk_step 的 E 传）
+            use std::cell::RefCell;
+            let last_error: RefCell<Option<String>> = RefCell::new(None);
+
+            while t < t_eval[t_eval.len() - 1] && n_steps < max_steps {
+                n_steps += 1;
+                // 限制步长不超过下一个评估点（提高 t_eval 命中率），且不超过
+                // h_init（作为最大步长：稀疏 t_eval 下自适应步长失控，实测
+                // 2 点 vs 31 点网格的 30 天结果差 22 万 km）
+                if eval_idx < t_eval.len() {
+                    let t_next_eval = t_eval[eval_idx];
+                    if t + h > t_next_eval {
+                        h = t_next_eval - t;
+                    }
+                }
+                if h > h_init {
+                    n_steps_capped += 1;
+                    h = h_init;
+                }
+
+                // RK 单步：用 Rust 闭包调 compute_total_acceleration
+                let forces_ref = &forces;
+                let observer_ref = observer;
+                let err_cell = &last_error;
+                let callback = |ti: f64, yi: &[f64]| -> Result<Vec<f64>, String> {
+                    let state6 = [yi[0], yi[1], yi[2], yi[3], yi[4], yi[5]];
+                    compute_total_acceleration(forces_ref, ti, &state6, observer_ref)
+                        .map(|a| vec![yi[3], yi[4], yi[5], a[0], a[1], a[2]])
+                        .inspect_err(|e| {
+                            *err_cell.borrow_mut() = Some(e.clone());
+                        })
+                };
+
+                let (y_new, error) = match explicit_rk_step(table, t, &y, h, callback, None) {
+                    Ok(r) => r,
+                    Err(msg) => return Err(format!("RK step force error: {}", msg)),
+                };
+
+                if error <= tol {
+                    t += h;
+                    y = y_new;
+                    // 输出落在 t_eval 的点
+                    while eval_idx < t_eval.len() && t >= t_eval[eval_idx] - 1e-9 {
+                        times.push(t_eval[eval_idx]);
+                        states.push(y.clone());
+                        eval_idx += 1;
+                    }
+                    let h_next = suggest_next_step(h, error, tol, method.embedded_order());
+                    h = h_next;
+                } else {
+                    n_rejected += 1;
+                    let h_next = suggest_next_step(h, error, tol, method.embedded_order());
+                    h = h_next;
+                    if h < 1e-12 * (t_eval[t_eval.len() - 1] - t0).abs() {
+                        return Err("step size collapsed below minimum".to_string());
+                    }
+                }
             }
-        }
-    }
+
+            Ok((times, states, n_steps, n_rejected, n_steps_capped))
+        })
+        .map_err(pyo3::exceptions::PyRuntimeError::new_err)?;
 
     // 返回 dict
     let dict = PyDict::new(py);

--- a/tests/integrators/test_propagate_compiled_gil.py
+++ b/tests/integrators/test_propagate_compiled_gil.py
@@ -1,0 +1,102 @@
+"""``propagate_compiled`` 释放 GIL 回归测试（#318）。
+
+长期预报段必须释放 GIL：主线程跑 ``propagate_compiled`` 时，另一个 Python
+线程应能继续推进（心跳打点）。修复前主积分循环全程持 GIL，心跳线程
+reacquire GIL 阻塞、饿死，对应 transfer-orbit-design GUI 设计 DRO 时窗口
+冻死（cProfile 显示 ``propagate_compiled`` cumtime 占 96%、~225 s 连续持 GIL）。
+
+判别原理：心跳线程循环 ``ticks += 1; time.sleep(0.005)``。``time.sleep``
+释放 GIL，醒来后要执行 ``ticks += 1`` 必须重新获取 GIL——
+
+- 主线程已用 ``py.allow_threads`` 释放 GIL：心跳线程 reacquire 立即成功，
+  按 ~5 ms 节奏持续打点，dt 秒内打点 ~dt/0.005 次。
+- 主线程持 GIL（回归）：心跳线程 reacquire 阻塞到主线程返回，期间打点 ≈ 0。
+
+两者相差 1~2 个数量级，阈值取 3（远低于释 GIL 的 ~48 次/0.24 s，远高于
+持 GIL 的 0~1 次），判别稳健。传播段太短（dt < 0.15 s）信号不足则 skip，
+不在快机上误判。
+
+用纯二体 ``point_mass`` 力模型（无 SPICE 内核依赖），经 Rust
+``propagate_compiled`` 直连快路径触发主积分循环。
+"""
+
+import threading
+import time
+
+import numpy as np
+import pytest
+
+pytest.importorskip("e2m2e._integrators")
+
+from e2m2e.integrators import RkMethod, propagate_compiled
+
+if propagate_compiled is None:
+    pytest.skip("propagate_compiled 需要 spice-feature 构建", allow_module_level=True)
+
+# 地球引力参数 (km³/s²)
+EARTH_MU = 398600.4418
+
+
+def _leo_y0() -> list[float]:
+    """6778 km 圆轨道初始状态 (km, km/s)。"""
+    r = 6778.0
+    v = float(np.sqrt(EARTH_MU / r))
+    return [r, 0.0, 0.0, 0.0, v, 0.0]
+
+
+def test_propagate_compiled_releases_gil():
+    """主线程长期预报期间，心跳线程持续打点 → propagate_compiled 已释放 GIL。
+
+    回归 #318：主积分循环漏包 ``py.allow_threads``，全程持 GIL 使心跳饿死
+    （ticks ≈ 0）。修复后释 GIL，ticks 随 dt 线性增长。
+    """
+    y0 = _leo_y0()
+    # 8 天两体传播 ≈ 44 万步、~0.24 s（release 构建），稳超 0.10 s 判别下限。
+    days = 8.0
+    t0, tf = 0.0, days * 86400.0
+    t_eval = np.linspace(t0, tf, 50)
+
+    ticks = [0]
+    stop = [False]
+
+    def heartbeat() -> None:
+        while not stop[0]:
+            ticks[0] += 1
+            time.sleep(0.005)
+
+    th = threading.Thread(target=heartbeat, daemon=True)
+    th.start()
+    try:
+        time.sleep(0.05)  # 让心跳起步，确保它已在 sleep→reacquire 循环中
+        ticks_before = ticks[0]
+        t_start = time.perf_counter()
+        propagate_compiled(
+            RkMethod.PD45,
+            t0,
+            y0,
+            3600.0,
+            1e-12,
+            [float(x) for x in t_eval],
+            "EARTH",
+            [("point_mass", EARTH_MU)],
+            2_000_000,
+        )
+        dt = time.perf_counter() - t_start
+    finally:
+        stop[0] = True
+        th.join(timeout=2.0)
+
+    ticks_during = ticks[0] - ticks_before
+
+    # 传播段太短 → 信号不足，快机上可能误判，跳过（罕见）。
+    if dt < 0.10:
+        pytest.skip(f"propagation too short ({dt:.3f}s) to assert GIL release")
+
+    # 释 GIL 时 dt≈0.24 s → ~48 ticks；持 GIL（回归）→ 0~1 ticks。
+    # 阈值 3 兼顾：远低于释 GIL 实测（数十次），远高于持 GIL（0~1 次），
+    # 且对单核 / CI 调度抖动留有 ~10× 余量。
+    assert ticks_during >= 3, (
+        f"heartbeat ticked only {ticks_during} times during {dt:.2f}s propagation "
+        f"(expected ~{dt / 0.005:.0f} if GIL released); "
+        "propagate_compiled may be holding the GIL — 主循环漏了 py.allow_threads (#318)"
+    )


### PR DESCRIPTION
## 关联

#318（issue 已先行关闭：be35ef0）

## 改了什么

- **`crates/e2m2e-integrators/src/lib.rs`**：`propagate_compiled` 主积分循环整段包进 `py.allow_threads(move || -> Result<CompiledPropResult, String> { ... })`，长期预报段释放 GIL。compiled 力模型纯 Rust（`compute_total_acceleration` 不回调 Python、cspice 走 FFI），与 `multiple_shooting_correct` / `transfer_grid_search` 路径同理。
  - **持 GIL 段（闭包外）**：force 元组解析 + `PyDict` 返回构造。
  - **释 GIL 段（闭包内）**：`while` 主循环 + 每步 `compute_total_acceleration`。
  - 闭包内回传 `String`，闭包外 `.map_err(PyRuntimeError::new_err)?` 转 `PyErr`，错误消息逐字保留（`"RK step force error: {}"`、`"step size collapsed below minimum"`）。
  - 新增 `type CompiledPropResult` alias 修 clippy `type_complexity`（与 `AccelJacobiResult` 同法）；顺带删死变量 `let n = y0.len()` + `let _ = n`。
- **`tests/integrators/test_propagate_compiled_gil.py`**（新）：心跳回归测试。

## 背景

transfer-orbit-design GUI 设计 DRO 时窗口冻死；cProfile 显示 `propagate_compiled` cumtime 占 96%、~225 s 连续持 GIL。#313 已修 CR3BP STM 路径，本 PR 修主状态积分路径（同源问题第二层）。

## 测试

构建（spice feature，naif 不通走本地 CSPICE_DIR）：

```
CSPICE_DIR=/tmp/cspice-linux/mice_linux LIBCLANG_PATH=/usr/lib/llvm-21/lib \
  maturin develop --release --features spice
```

新增 GIL 回归测试（红绿验证：临时去掉 allow_threads → FAIL `ticked only 1 times`；还原 → PASS）：

```
pytest tests/integrators/test_propagate_compiled_gil.py -v   # PASSED，5× 重复稳定
```

既有力模型 / 积分器正确性（数值未变）：

```
pytest tests/integrators/                                      # 41 passed
pytest tests/core/forces/test_force_model_propagation.py \
       tests/core/forces/test_leo_drag_propagation.py \
       tests/core/forces/test_relativistic_correction.py -q   # 11 passed, 5 skipped（缺 SPICE 内核）
```

`cargo clippy -p e2m2e-integrators --features spice` 干净，无 warning。
