### PR TITLE
feat(api): Facade Response 补齐轨道几何字段 mu/states/times/ephemeris/controlled_ephemeris（#312）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+- **Facade Response 补齐轨道几何字段**（#312）：`DesignOrbitResponse` 增 `mu` / `states` / `times` / `ephemeris`（CR3BP 参考轨道 + 标称星历），`ControlOrbitResponse` 增 `controlled_ephemeris` / `mu`（请求透传）。下游（transfer-orbit-design）可退回 Facade、移除 algorithm 层直调（下游 ADR 0011 缓解措施 3 / ADR 0012）。`ephemeris`/`controlled_ephemeris` 为 `EphemerisTable` 全字段 dict，重建容器过滤 None 值即可。
+
 ## [5.6.0] - 2026-08-07
 
 ### Added

--- a/e2m2e/api/facade.py
+++ b/e2m2e/api/facade.py
@@ -12,7 +12,7 @@ transfer_design/orbit_propagation/spacetime_transform），二档子任务已接
 from __future__ import annotations
 
 import dataclasses
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -32,6 +32,12 @@ from .models import (
 )
 
 __all__ = ["Facade", "mcp_tools"]
+
+if TYPE_CHECKING:
+    # 仅类型检查用：算法/数据层结果类型（运行时懒加载，见各 Facade 方法内 import）。
+    from e2m2e.algorithm.design import OrbitDesignResult
+    from e2m2e.algorithm.station_keeping import ControlOrbitResult
+    from e2m2e.data.types.trajectory import EphemerisTable
 
 
 def mcp_exposed(func):
@@ -62,6 +68,72 @@ def _serialize_value(value: Any) -> Any:
     if isinstance(value, dict):
         return {k: _serialize_value(v) for k, v in value.items()}
     return value
+
+
+def _ephemeris_to_dict(ephemeris: EphemerisTable | None) -> dict[str, Any] | None:
+    """把 ``EphemerisTable`` 序列化为 JSON 兼容 dict（ndarray → list）。
+
+    迭代 ``dataclasses.fields(EphemerisTable)`` 取全字段（自动跟随容器
+    演进），跳过 ``raw_text``（原始文件文本，程序生成时为空串、读入时为
+    大字符串，下游重建容器不需要）。``times_jd_tdb`` 设计链路不填 → None。
+    下游过滤 None 值即可重建 ``EphemerisTable``。``None`` 输入返回 ``None``
+    （control 全样本失败时受控星历缺失）。
+    """
+    if ephemeris is None:
+        return None
+    return {
+        f.name: _serialize_value(getattr(ephemeris, f.name))
+        for f in dataclasses.fields(ephemeris)
+        if f.name != "raw_text"
+    }
+
+
+def _design_result_to_response(result: OrbitDesignResult) -> DesignOrbitResponse:
+    """把 ``OrbitDesignResult`` 翻译为 ``DesignOrbitResponse``（含几何字段，#312）。
+
+    纯翻译、无副作用、不依赖 SPICE：从 ``cr3bp_orbit`` 提取 ``states`` /
+    ``times`` / ``mu``（mu 防御 getattr——``Orbit.system`` 缺省 None，
+    未绑定时 mu 回退 None，同下游 ``facade_bridge`` 约定），``ephemeris``
+    走 :func:`_ephemeris_to_dict`。提取为独立函数便于单测。
+    """
+    cr3bp_orbit = result.cr3bp_orbit
+    return DesignOrbitResponse(
+        orbit_type=result.orbit_type,
+        epoch_utc=result.epoch_utc,
+        duration_day=result.duration_day,
+        initial_state=result.initial_state.tolist(),
+        cr3bp_jacobi=result.cr3bp_jacobi,
+        correction_converged=result.correction.converged,
+        correction_iterations=result.correction.iterations,
+        force_config=result.force_config,
+        mu=getattr(cr3bp_orbit.system, "mu", None),
+        states=cr3bp_orbit.states.tolist(),
+        times=cr3bp_orbit.times.tolist(),
+        ephemeris=_ephemeris_to_dict(result.ephemeris),
+    )
+
+
+def _control_result_to_response(
+    result: ControlOrbitResult, *, mu: float | None
+) -> ControlOrbitResponse:
+    """把 ``ControlOrbitResult`` 翻译为 ``ControlOrbitResponse``（含几何字段，#312）。
+
+    ``controlled_ephemeris`` 来自最后一次蒙特卡洛样本（全失败时 None）；
+    ``mu`` 由请求透传——算法层不产 mu，design→control 链式时由调用方注入。
+    """
+    return ControlOrbitResponse(
+        num_failed=result.num_failed,
+        sk_statistic={
+            "rows": result.sk_statistic.rows.tolist(),
+            "num_failed": result.sk_statistic.num_failed,
+        },
+        maneuvers={
+            "mjd_tdb": result.maneuvers.mjd_tdb.tolist(),
+            "delta_v_mps": result.maneuvers.delta_v_mps.tolist(),
+        },
+        controlled_ephemeris=_ephemeris_to_dict(result.controlled_ephemeris),
+        mu=mu,
+    )
 
 
 class Facade:
@@ -111,16 +183,7 @@ class Facade:
                 correction_method=request.correction_method,
                 kernel_dir=self._config.kernel_dir,
             )
-            return DesignOrbitResponse(
-                orbit_type=result.orbit_type,
-                epoch_utc=result.epoch_utc,
-                duration_day=result.duration_day,
-                initial_state=result.initial_state.tolist(),
-                cr3bp_jacobi=result.cr3bp_jacobi,
-                correction_converged=result.correction.converged,
-                correction_iterations=result.correction.iterations,
-                force_config=result.force_config,
-            )
+            return _design_result_to_response(result)
         except OrbitError:
             raise
         except (ValueError, TypeError) as exc:
@@ -153,17 +216,7 @@ class Facade:
                 spacecraft_mass=request.spacecraft_mass,
                 srp_torque=request.srp_torque,
             )
-            return ControlOrbitResponse(
-                num_failed=result.num_failed,
-                sk_statistic={
-                    "rows": result.sk_statistic.rows.tolist(),
-                    "num_failed": result.sk_statistic.num_failed,
-                },
-                maneuvers={
-                    "mjd_tdb": result.maneuvers.mjd_tdb.tolist(),
-                    "delta_v_mps": result.maneuvers.delta_v_mps.tolist(),
-                },
-            )
+            return _control_result_to_response(result, mu=request.mu)
         except OrbitError:
             raise
         except (ValueError, TypeError) as exc:

--- a/e2m2e/api/models.py
+++ b/e2m2e/api/models.py
@@ -76,7 +76,14 @@ class DesignOrbitRequest(_ApiModel):
 
 
 class DesignOrbitResponse(_ApiModel):
-    """任务轨道设计输出。"""
+    """任务轨道设计输出。
+
+    几何字段（``mu`` / ``states`` / ``times`` / ``ephemeris``，#312）让下游
+    （画图 / 落盘 / design→control 链式）可仅依赖 Facade，不必穿透 algorithm
+    层。``states`` / ``times`` 为 CR3BP 参考周期轨道（无量纲会合系），
+    ``ephemeris`` 为标称星历（GCRS km / 速度 m/s + 会合系，``EphemerisTable``
+    全字段）。同 ``PropagationResponse``，Response 带大数组是本仓库既有约定。
+    """
 
     orbit_type: str
     epoch_utc: str
@@ -86,6 +93,22 @@ class DesignOrbitResponse(_ApiModel):
     correction_converged: bool
     correction_iterations: int
     force_config: dict[str, Any]
+    mu: float | None = Field(
+        default=None,
+        description="CR3BP 质量比 μ = m₂/(m₁+m₂)；构造 CR3BP_System、画地月/L 点标注用",
+    )
+    states: list[list[float]] = Field(
+        default_factory=list,
+        description="CR3BP 参考周期轨道状态序列 (n,6)，无量纲会合系",
+    )
+    times: list[float] = Field(
+        default_factory=list,
+        description="CR3BP 参考周期轨道时间序列 (n,)，无量纲",
+    )
+    ephemeris: dict[str, Any] | None = Field(
+        default=None,
+        description="标称星历（EphemerisTable 全字段：UTC + GCRS km/m/s + 会合系）",
+    )
 
 
 class ControlOrbitRequest(_ApiModel):
@@ -105,14 +128,31 @@ class ControlOrbitRequest(_ApiModel):
     srp_torque: list[float] | None = Field(
         default=None, description="常值 SRP 力矩 [τx,τy,τz]（N·m）"
     )
+    mu: float | None = Field(
+        default=None,
+        description="CR3BP 质量比 μ（透传到响应，画地月/L 点标注用）；算法层不产 mu",
+    )
 
 
 class ControlOrbitResponse(_ApiModel):
-    """轨道保持输出。"""
+    """轨道保持输出。
+
+    几何字段（``controlled_ephemeris`` / ``mu``，#312）：``controlled_ephemeris``
+    为最后一次蒙特卡洛样本的受控真实轨道星历（``EphemerisTable`` 全字段；
+    全失败时 ``None``）；``mu`` 由请求透传（算法层不产 mu）。
+    """
 
     num_failed: int
     sk_statistic: dict[str, Any]
     maneuvers: dict[str, Any]
+    controlled_ephemeris: dict[str, Any] | None = Field(
+        default=None,
+        description="受控星历（EphemerisTable 全字段）；所有蒙特卡洛样本失败时 None",
+    )
+    mu: float | None = Field(
+        default=None,
+        description="CR3BP 质量比 μ（请求透传，画地月/L 点标注用）",
+    )
 
 
 class TransferDesignRequest(_ApiModel):

--- a/tests/api/test_facade.py
+++ b/tests/api/test_facade.py
@@ -9,12 +9,15 @@ from pydantic import ValidationError
 from e2m2e.api.facade import Facade, mcp_tools
 from e2m2e.api.models import (
     ControlOrbitRequest,
+    ControlOrbitResponse,
     DesignOrbitRequest,
+    DesignOrbitResponse,
     OrbitError,
     PropagationRequest,
     SpacetimeTransformRequest,
     TransferDesignRequest,
 )
+from e2m2e.data.types.trajectory import EphemerisTable
 
 
 class TestDesignOrbitRequest:
@@ -213,3 +216,213 @@ class TestFacadeCallChain:
         result = _details_to_dict(details)
         assert result["array"] == [1.0, 2.0]
         assert result["nested"]["tuple"] == [[3.0], 4.0]
+
+
+# ---------------------------------------------------------------------------
+# 几何字段补齐（#312）：Facade Response 须带 mu/states/times/ephemeris，
+# 让下游（transfer-orbit-design）可退回 Facade、移除 algorithm 层直调。
+# 这些测试不依赖 SPICE：直接验证序列化助手 + 纯翻译函数 + Pydantic 模型。
+# ---------------------------------------------------------------------------
+
+
+def _make_ephemeris(n: int = 3, with_jd: bool = False) -> EphemerisTable:
+    """构造一个小型 EphemerisTable（无 SPICE 依赖），供翻译测试用。"""
+    return EphemerisTable(
+        year=np.full(n, 2024, dtype=int),
+        month=np.full(n, 1, dtype=int),
+        day=np.full(n, 1, dtype=int),
+        hour=np.arange(n, dtype=int),
+        minute=np.zeros(n, dtype=int),
+        second=np.zeros(n, dtype=float),
+        position_km=np.arange(n * 3, dtype=float).reshape(n, 3),
+        velocity_mps=np.full((n, 3), 1000.0),
+        synodic_position=np.full((n, 3), 0.5),
+        times_jd_tdb=np.linspace(2460310.0, 2460311.0, n) if with_jd else None,
+    )
+
+
+class TestEphemerisToDict:
+    def test_serializes_ndarrays_to_lists(self):
+        from e2m2e.api.facade import _ephemeris_to_dict
+
+        d = _ephemeris_to_dict(_make_ephemeris(n=2))
+        assert d is not None
+        # ndarray → list
+        assert d["position_km"] == [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
+        assert d["velocity_mps"] == [[1000.0, 1000.0, 1000.0]] * 2
+        assert d["synodic_position"] == [[0.5, 0.5, 0.5]] * 2
+        assert d["year"] == [2024, 2024]
+        assert d["hour"] == [0, 1]
+        # 全字段在列（EphemerisTable 数据列）
+        assert set(d) == {
+            "year",
+            "month",
+            "day",
+            "hour",
+            "minute",
+            "second",
+            "position_km",
+            "velocity_mps",
+            "synodic_position",
+            "times_jd_tdb",
+        }
+
+    def test_times_jd_tdb_none_and_populated(self):
+        from e2m2e.api.facade import _ephemeris_to_dict
+
+        # design 链路不填 times_jd_tdb → None
+        d_none = _ephemeris_to_dict(_make_ephemeris(with_jd=False))
+        assert d_none["times_jd_tdb"] is None
+        # 传播链路填了 times_jd_tdb → list
+        d_jd = _ephemeris_to_dict(_make_ephemeris(with_jd=True))
+        assert d_jd["times_jd_tdb"] == pytest.approx([2460310.0, 2460310.5, 2460311.0])
+
+    def test_none_input_returns_none(self):
+        from e2m2e.api.facade import _ephemeris_to_dict
+
+        assert _ephemeris_to_dict(None) is None
+
+
+class TestDesignResultToResponse:
+    def _mock_result(self, *, with_system: bool = True):
+        """构造一个鸭子类型的 OrbitDesignResult（不调算法层、不需 SPICE）。"""
+        from types import SimpleNamespace
+
+        system = SimpleNamespace(mu=0.0121506683) if with_system else None
+        cr3bp_orbit = SimpleNamespace(
+            states=np.array([[0.0, 0.0, 0.0, 0.0, 0.0, 0.0], [1.0, 1.0, 1.0, 0.1, 0.1, 0.1]]),
+            times=np.array([0.0, 1.234]),
+            system=system,
+        )
+        correction = SimpleNamespace(converged=True, iterations=4)
+        return SimpleNamespace(
+            orbit_type="DRO",
+            epoch_utc="2024-01-01T00:00:00.000",
+            duration_day=365.25,
+            output_step_sec=3600.0,
+            initial_state=np.zeros(6),
+            ephemeris=_make_ephemeris(n=3),
+            cr3bp_orbit=cr3bp_orbit,
+            cr3bp_jacobi=3.16,
+            correction=correction,
+            force_config={"sun_body": 1},
+        )
+
+    def test_extracts_geometry_fields(self):
+        from e2m2e.api.facade import _design_result_to_response
+
+        resp = _design_result_to_response(self._mock_result())
+        # 摘要字段保留
+        assert resp.orbit_type == "DRO"
+        assert resp.cr3bp_jacobi == pytest.approx(3.16)
+        assert resp.correction_converged is True
+        assert resp.correction_iterations == 4
+        assert resp.initial_state == [0.0] * 6
+        # 新增几何字段
+        assert resp.mu == pytest.approx(0.0121506683)
+        assert resp.states == [[0.0] * 6, [1.0, 1.0, 1.0, 0.1, 0.1, 0.1]]
+        assert resp.times == [0.0, 1.234]
+        assert resp.ephemeris is not None
+        assert resp.ephemeris["position_km"] == [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]
+
+    def test_mu_none_when_system_missing(self):
+        """system 未绑定时 mu 防御性回退为 None（同下游 getattr 约定）。"""
+        from e2m2e.api.facade import _design_result_to_response
+
+        resp = _design_result_to_response(self._mock_result(with_system=False))
+        assert resp.mu is None
+        # 其余几何字段仍正常
+        assert resp.states == [[0.0] * 6, [1.0, 1.0, 1.0, 0.1, 0.1, 0.1]]
+
+
+class TestControlResultToResponse:
+    def _mock_result(self, *, controlled):
+        from types import SimpleNamespace
+
+        from e2m2e.data.types.maneuver import ManeuverTable
+        from e2m2e.data.types.sk_statistic import SKStatistic
+
+        return SimpleNamespace(
+            num_failed=1,
+            sk_statistic=SKStatistic(rows=np.zeros((2, 3)), num_failed=1),
+            maneuvers=ManeuverTable(mjd_tdb=np.array([60000.0]), delta_v_mps=np.array([1.0])),
+            controlled_ephemeris=_make_ephemeris(n=2) if controlled else None,
+        )
+
+    def test_with_controlled_ephemeris_and_mu_echo(self):
+        from e2m2e.api.facade import _control_result_to_response
+
+        resp = _control_result_to_response(self._mock_result(controlled=True), mu=0.0121506683)
+        assert resp.num_failed == 1
+        assert resp.controlled_ephemeris is not None
+        assert resp.controlled_ephemeris["synodic_position"] == [[0.5, 0.5, 0.5]] * 2
+        # mu 由请求透传（算法层不产 mu）
+        assert resp.mu == pytest.approx(0.0121506683)
+
+    def test_all_failed_no_controlled_ephemeris(self):
+        from e2m2e.api.facade import _control_result_to_response
+
+        resp = _control_result_to_response(self._mock_result(controlled=False), mu=None)
+        assert resp.controlled_ephemeris is None
+        assert resp.mu is None
+
+
+class TestGeometryModelFields:
+    """Pydantic 模型字段验收（#312）。"""
+
+    def test_design_response_carries_geometry(self):
+        resp = DesignOrbitResponse(
+            orbit_type="DRO",
+            epoch_utc="2024-01-01T00:00:00.000",
+            duration_day=365.25,
+            initial_state=[0.0] * 6,
+            cr3bp_jacobi=3.16,
+            correction_converged=True,
+            correction_iterations=4,
+            force_config={"sun_body": 1},
+            mu=0.0121506683,
+            states=[[0.0] * 6],
+            times=[0.0],
+            ephemeris={"position_km": [[0.0, 0.0, 0.0]]},
+        )
+        # 序列化往返：ndarray-free dict/list 可 JSON 化
+        dumped = resp.model_dump()
+        assert dumped["mu"] == pytest.approx(0.0121506683)
+        assert dumped["states"] == [[0.0] * 6]
+        assert dumped["ephemeris"]["position_km"] == [[0.0, 0.0, 0.0]]
+
+    def test_design_response_mu_optional(self):
+        """mu 防御性可空（system 未绑定时）。"""
+        resp = DesignOrbitResponse(
+            orbit_type="DRO",
+            epoch_utc="2024-01-01T00:00:00.000",
+            duration_day=365.25,
+            initial_state=[0.0] * 6,
+            cr3bp_jacobi=3.16,
+            correction_converged=True,
+            correction_iterations=4,
+            force_config={},
+            mu=None,
+            states=[],
+            times=[],
+            ephemeris={},
+        )
+        assert resp.mu is None
+
+    def test_control_response_backward_compatible(self):
+        """新增字段带默认值：旧路径（仅摘要）构造不报错。"""
+        resp = ControlOrbitResponse(
+            num_failed=0,
+            sk_statistic={"rows": [[0.0]], "num_failed": 0},
+            maneuvers={"mjd_tdb": [60000.0], "delta_v_mps": [1.0]},
+        )
+        assert resp.controlled_ephemeris is None
+        assert resp.mu is None
+
+    def test_control_request_accepts_mu(self):
+        """mu 透传字段（画地月/L 点标注用）。"""
+        req = ControlOrbitRequest(input_ephemeris="x", mu=0.0121506683)
+        assert req.mu == pytest.approx(0.0121506683)
+        # 缺省 None
+        req_default = ControlOrbitRequest(input_ephemeris="x")
+        assert req_default.mu is None


### PR DESCRIPTION
## 关联

Closes #312

## 改了什么

补齐 Facade Response 的轨道几何字段，让下游（transfer-orbit-design）可退回 Facade、移除 algorithm 层直调（下游 ADR 0011 缓解措施 3 / ADR 0012）。

- `DesignOrbitResponse` += `mu` / `states` / `times` / `ephemeris`（CR3BP 参考周期轨道 + 标称星历）
- `ControlOrbitResponse` += `controlled_ephemeris` / `mu`；`ControlOrbitRequest` 透传 `mu`（算法层不产 mu，design→control 链式时注入）
- `facade.py` 抽 `_ephemeris_to_dict` / `_design_result_to_response` / `_control_result_to_response` 三个纯翻译助手（`TYPE_CHECKING` 类型注解、`dataclasses.fields` 序列化），design/control 方法改调它们，便于单测
- control 不另设 `controlled_states`/`controlled_times`，只给更富的 `controlled_ephemeris`（与 design 的 `ephemeris` 对称）—— 维护者确认的选项 A

## 测试

- `uv run ruff check` / `ruff format --check`（e2m2e/api/、tests/api/）✓
- `uv run python scripts/check_layer_imports.py`（五层依赖方向，ADR 0012）✓
- `uv run mypy e2m2e/ --ignore-missing-imports`（204 文件）✓
- `uv run pytest tests/api/`（35 测试，+11 新增，均不依赖 SPICE）✓
- 真实 SPICE 端到端冒烟：`Facade.design_orbit("DRO", ...)` → `mu=0.0121506683`、`states (1000,6)`、`ephemeris position_km (439,3)` ✓