### PR TITLE
fix(integrators): CR3BP/BCR4BP STM 积分释放 GIL（#313）+ spice 升默认 feature 与开发入口自动化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,16 +22,15 @@ jobs:
         with:
           components: rustfmt, clippy
       - uses: astral-sh/setup-uv@v7
-      # Rust 格式与风格（无 spice）
+      # spice 为默认 feature（crates/*/Cargo.toml default=["spice"]）：cargo fmt
+      # 不编译、无需 CSPICE；cargo clippy 编译 spice 代码，须先下 CSPICE 编译包
+      # 并设 CSPICE_DIR（cspice-v1 release，cspice-sys 据此跳过国内不可达的 NAIF 下载）。
       - run: cargo fmt --all -- --check
-      - run: cargo clippy --workspace -- -D warnings
-      # spice-gated 代码的编译与 lint：编译包来自 cspice-v1 release，
-      # 设好 CSPICE_DIR 后 cspice-sys 跳过 NAIF 下载（国内网络常不可达）。
       - name: 下载 SPICE 编译包（cspice-v1 release）
         run: uv run python scripts/download_cspice.py >> "$GITHUB_ENV"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: cargo clippy --workspace --features spice -- -D warnings
+      - run: cargo clippy --workspace -- -D warnings
       # Python 格式与风格
       - run: uv sync --group dev
       - run: uv run ruff check .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,19 +27,19 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: astral-sh/setup-uv@v7
-      # 无 spice 的常规测试
-      - run: cargo test --workspace
-      # 下载 SPICE 编译包 + 内核，跑 spice-gated 测试（forces 等）
+      # spice 为默认 feature：cargo test --workspace 编译并跑 spice-gated 代码，
+      # 须先下 CSPICE 编译包（CSPICE_DIR）与 SPICE 内核（kernels/）。
       - name: 下载 SPICE 编译包（cspice-v1 release）
         run: uv run python scripts/download_cspice.py >> "$GITHUB_ENV"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: 下载 SPICE 内核（kernels-v1 release）
-        run: gh release download kernels-v1 --pattern '*.bsp' --pattern '*.tls' --pattern '*.tpc' --pattern '*.bpc' --pattern '*.tf' --dir kernels/ --clobber
+        run: uv run python scripts/download_kernels.py
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # --test-threads=1 因 cspice 有全局线程锁
-      - run: cargo test -p e2m2e-forces --features spice -- --test-threads=1
+      # --test-threads=1：CSPICE 全局线程锁，spice-gated 测试串行避免竞争。
+      # spice 默认开启后单趟 cargo test --workspace 即覆盖原 forces 单独 spice 趟。
+      - run: cargo test --workspace -- --test-threads=1
 
   build:
     needs: [lint, test]
@@ -96,9 +96,11 @@ jobs:
         with:
           target: ${{ matrix.target }}
           command: build
-          # spice feature：内含 CSPICE（经 CSPICE_DIR 指向 cspice-v1 release
-          # 预编译包，见上方下载步骤），提供 STM 传播/打靶等 Rust 快速路径，署名见 NOTICE
-          args: --release --out dist --features spice
+          # spice 为默认 feature（crates/*/Cargo.toml default=["spice"]，pyproject
+          # [tool.maturin] features 再声明一次），含 CSPICE（经 CSPICE_DIR 指向
+          # cspice-v1 release 预编译包，见上方下载步骤），提供 STM 传播/打靶等 Rust
+          # 快速路径，署名见 NOTICE。故 args 无需再显式 --features spice。
+          args: --release --out dist
           manylinux: 2_28
           before-script-linux: |
             set -eux

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,61 @@
+# e2m2e 开发入口（唯一）。
+#
+# spice 为必选 feature（crates/*/Cargo.toml default=["spice"]），普通 cargo/maturin
+# 构建都依赖 CSPICE。CSPICE_DIR 由 scripts/download_cspice.py 解析缓存目录后导出，
+# cspice-sys 据此跳过 NAIF 源码下载（国内网络常不可达）。故裸 cargo / maturin 命令
+# 需经本 Makefile，或自行 `export CSPICE_DIR=$(python3 scripts/download_cspice.py --print-cspice-dir)`。
+
+PYTHON := python3
+UV     := uv run
+
+# 首次即自动落盘并解析路径：已缓存时 download_cspice.py 仅 stat（近乎零开销）。
+CSPICE_DIR := $(shell $(PYTHON) scripts/download_cspice.py --print-cspice-dir 2>/dev/null)
+export CSPICE_DIR
+
+# libclang（cspice-sys 的 bindgen 需要）：用 := 覆盖环境里可能失效的旧值
+# （命令行 make LIBCLANG_PATH=... 仍可覆盖）。优先 llvm-config --libdir（版本无关，
+# 其次版本化 llvm-config-*），回退 /usr/lib 探测。
+LLVM_CONFIG   := $(shell command -v llvm-config 2>/dev/null || ls /usr/bin/llvm-config-* 2>/dev/null | head -1)
+LIBCLANG_PATH := $(or $(shell $(LLVM_CONFIG) --libdir 2>/dev/null),$(shell find /usr/lib -maxdepth 4 -name libclang.so 2>/dev/null | head -1 | xargs dirname 2>/dev/null))
+export LIBCLANG_PATH
+
+.DEFAULT_GOAL := help
+
+.PHONY: help setup dev dev-release test test-rust test-python check fmt clean
+
+help:  ## 显示本帮助
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  \033[36m%-14s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+setup:  ## 首次拉取：CSPICE 编译包 + SPICE 内核（kernels/）
+	$(PYTHON) scripts/download_cspice.py
+	$(PYTHON) scripts/download_kernels.py
+
+dev:  ## 构建并安装开发版扩展（maturin develop，spice 默认）
+	$(UV) maturin develop
+
+dev-release:  ## 同 dev 但 --release（性能基准 / 长期预报用）
+	$(UV) maturin develop --release
+
+test: test-rust test-python  ## 全量测试（Rust 工作区 + Python）
+
+# --test-threads=1：CSPICE 有全局线程锁，forces/integrators 的 spice-gated
+# 测试串行执行避免竞争；非 spice 测试一并串行（略慢但稳妥）。
+test-rust:  ## Rust 工作区测试（spice 默认；串行）
+	cargo test --workspace -- --test-threads=1
+
+test-python:  ## Python 测试（含 spice-gated，需先 make setup 拉内核）
+	$(UV) pytest tests/
+
+check:  ## 格式 + lint（Rust + Python）
+	cargo fmt --all -- --check
+	cargo clippy --workspace -- -D warnings
+	$(UV) ruff check .
+	$(UV) ruff format --check .
+
+fmt:  ## 就地格式化（Rust + Python）
+	cargo fmt --all
+	$(UV) ruff format .
+	$(UV) ruff check --fix .
+
+clean:  ## 清理 Rust 构建产物（保留 .cspice / kernels 缓存）
+	cargo clean

--- a/README.md
+++ b/README.md
@@ -30,7 +30,11 @@ uv add e2m2e
 git clone https://github.com/cislunarspace/e2m2e.git
 cd e2m2e
 uv sync
+make setup   # 拉取 CSPICE 编译包 + SPICE 内核（cspice-v1 / kernels-v1 release，首次必跑）
+make dev     # maturin develop 构建并安装 Rust 扩展（spice 默认开启）
 ```
+
+> 开发入口统一走 `Makefile`：它自动从 `scripts/download_cspice.py` 解析并 `export CSPICE_DIR`，让 spice（默认 feature）的构建跳过国内不可达的 NAIF 源码下载。常用目标：`make dev` / `make test` / `make check` / `make setup`（`make help` 列全部）。裸 `cargo` / `maturin` 命令需自行 `export CSPICE_DIR=$(python3 scripts/download_cspice.py --print-cspice-dir)`。
 
 ### conda
 
@@ -58,7 +62,7 @@ pip install e2m2e[normal-form]
 
 星历动力学需要 NASA SPICE 内核文件，放置在 `kernels/` 目录或 `$SPICE_KERNEL_DIR` 指定的路径。
 
-国内用户推荐从项目的 [GitHub Release](https://github.com/cislunarspace/e2m2e/releases) 下载：`kernels-v1` 中打包了全部必需内核（行星星历、地球自转、月球姿态、闰秒与行星常数），下载后放入 `kernels/` 目录即可。官方来源（网络可达时）：[NASA NAIF](https://naif.jpl.nasa.gov/naif/data.html)。
+国内用户推荐从项目的 [GitHub Release](https://github.com/cislunarspace/e2m2e/releases) 下载：`kernels-v1` 中打包了全部必需内核（行星星历、地球自转、月球姿态、闰秒与行星常数），下载后放入 `kernels/` 目录即可——`make setup` 已自动完成此步（见 `scripts/download_kernels.py`）。官方来源（网络可达时）：[NASA NAIF](https://naif.jpl.nasa.gov/naif/data.html)。
 
 ## 快速开始
 
@@ -162,8 +166,9 @@ uv run sphinx-build -b html docs docs/_build/html
 ## 测试与代码规范
 
 ```bash
-uv run pytest tests/
-uv run ruff check .
+make test     # = cargo test --workspace + pytest（spice 默认，需先 make setup 拉内核）
+make check    # cargo fmt/clippy + ruff
+# 或单独：uv run pytest tests/、uv run ruff check .
 ```
 
 ## 贡献

--- a/crates/e2m2e-forces/Cargo.toml
+++ b/crates/e2m2e-forces/Cargo.toml
@@ -9,7 +9,10 @@ name = "e2m2e_forces"
 crate-type = ["rlib"]
 
 [features]
-default = []
+# spice 默认开启：drag/星历等力模型依赖 CSPICE FFI，与 e2m2e-integrators 的
+# default=["spice"] 对齐（见该 crate 注释）。单独 cargo build -p e2m2e-forces
+# 也带 spice。CSPICE 由 scripts/download_cspice.py 提供（CSPICE_DIR）。
+default = ["spice"]
 spice = [
     "dep:cspice",
     "dep:e2m2e-spice",

--- a/crates/e2m2e-integrators/Cargo.toml
+++ b/crates/e2m2e-integrators/Cargo.toml
@@ -8,7 +8,11 @@ name = "e2m2e_integrators"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = []
+# spice 默认开启：STM 传播/多重打靶/受控动力学等 Rust 快速路径均依赖 CSPICE，
+# 普通构建（cargo build / maturin develop）必须含 spice，不再产无 spice 子集。
+# CSPICE 经 scripts/download_cspice.py 从 cspice-v1 release 取预编译包（设 CSPICE_DIR），
+# cspice-sys 据此跳过 NAIF 源码下载（国内常不可达）。见 Makefile / README。
+default = ["spice"]
 spice = ["dep:cspice", "dep:cspice-sys", "e2m2e-forces/spice", "e2m2e-spice/spice"]
 
 [dependencies]

--- a/crates/e2m2e-integrators/src/lib.rs
+++ b/crates/e2m2e-integrators/src/lib.rs
@@ -1913,12 +1913,18 @@ fn propagate_cr3bp_py(
     let mut state0 = [0.0_f64; 6];
     state0.copy_from_slice(&initial_state);
 
-    let result = propagate_cr3bp(
-        mu, t_span, &t_eval, &state0, rtol, atol, max_step, max_steps,
-    )
-    .map_err(|e| {
-        pyo3::exceptions::PyRuntimeError::new_err(format!("CR3BP propagation failed: {}", e))
-    })?;
+    // 积分包进 py.allow_threads 释放 GIL：PD78 纯 Rust（不回调 Python），与
+    // propagate_compiled / multiple_shooting_correct 同理（#313）。释 GIL 段 =
+    // propagate_cr3bp 主循环；持 GIL 段 = 上面的入参校验 + 下面的 PyDict 构造。
+    // 闭包内不构造 PyErr，仅回传 String，闭包外 map_err 转 PyErr。
+    let result = py
+        .allow_threads(|| {
+            propagate_cr3bp(
+                mu, t_span, &t_eval, &state0, rtol, atol, max_step, max_steps,
+            )
+            .map_err(|e| format!("CR3BP propagation failed: {e}"))
+        })
+        .map_err(pyo3::exceptions::PyRuntimeError::new_err)?;
 
     let states_list: Vec<Vec<f64>> = result.states.iter().map(|s| s.to_vec()).collect();
 
@@ -1972,12 +1978,17 @@ fn propagate_cr3bp_stm_py(
     let mut state0 = [0.0_f64; 6];
     state0.copy_from_slice(&initial_state);
 
-    let result = propagate_cr3bp_stm(
-        mu, t_span, &t_eval, &state0, rtol, atol, max_step, max_steps,
-    )
-    .map_err(|e| {
-        pyo3::exceptions::PyRuntimeError::new_err(format!("CR3BP STM propagation failed: {}", e))
-    })?;
+    // 积分包进 py.allow_threads 释放 GIL：PD78 纯 Rust（不回调 Python），与
+    // propagate_compiled 同理（#313，design_dro STM 修正段冻结主线程的根因）。
+    // 释 GIL 段 = propagate_cr3bp_stm 主循环；持 GIL 段 = 入参校验 + PyDict 构造。
+    let result = py
+        .allow_threads(|| {
+            propagate_cr3bp_stm(
+                mu, t_span, &t_eval, &state0, rtol, atol, max_step, max_steps,
+            )
+            .map_err(|e| format!("CR3BP STM propagation failed: {e}"))
+        })
+        .map_err(pyo3::exceptions::PyRuntimeError::new_err)?;
 
     let states_list: Vec<Vec<f64>> = result.states.iter().map(|s| s.to_vec()).collect();
     let stm_list: Vec<Vec<f64>> = result.stms.iter().map(|s| s.to_vec()).collect();
@@ -2048,23 +2059,28 @@ fn propagate_bcr4bp_py(
     let mut state0 = [0.0_f64; 6];
     state0.copy_from_slice(&initial_state);
 
-    let result = propagate_bcr4bp(
-        mu,
-        mu_sun,
-        sun_distance,
-        sun_angular_rate,
-        sun_phase0,
-        t_span,
-        &t_eval,
-        &state0,
-        rtol,
-        atol,
-        max_step,
-        max_steps,
-    )
-    .map_err(|e| {
-        pyo3::exceptions::PyRuntimeError::new_err(format!("BCR4BP propagation failed: {}", e))
-    })?;
+    // 积分包进 py.allow_threads 释放 GIL：PD78 纯 Rust（不回调 Python），与
+    // propagate_compiled 同理（#313）。释 GIL 段 = propagate_bcr4bp 主循环；
+    // 持 GIL 段 = 入参校验 + PyDict 构造。
+    let result = py
+        .allow_threads(|| {
+            propagate_bcr4bp(
+                mu,
+                mu_sun,
+                sun_distance,
+                sun_angular_rate,
+                sun_phase0,
+                t_span,
+                &t_eval,
+                &state0,
+                rtol,
+                atol,
+                max_step,
+                max_steps,
+            )
+            .map_err(|e| format!("BCR4BP propagation failed: {e}"))
+        })
+        .map_err(pyo3::exceptions::PyRuntimeError::new_err)?;
 
     let states_list: Vec<Vec<f64>> = result.states.iter().map(|s| s.to_vec()).collect();
 
@@ -2119,23 +2135,28 @@ fn propagate_bcr4bp_stm_py(
     let mut state0 = [0.0_f64; 6];
     state0.copy_from_slice(&initial_state);
 
-    let result = propagate_bcr4bp_stm(
-        mu,
-        mu_sun,
-        sun_distance,
-        sun_angular_rate,
-        sun_phase0,
-        t_span,
-        &t_eval,
-        &state0,
-        rtol,
-        atol,
-        max_step,
-        max_steps,
-    )
-    .map_err(|e| {
-        pyo3::exceptions::PyRuntimeError::new_err(format!("BCR4BP STM propagation failed: {}", e))
-    })?;
+    // 积分包进 py.allow_threads 释放 GIL：PD78 纯 Rust（不回调 Python），与
+    // propagate_compiled 同理（#313）。释 GIL 段 = propagate_bcr4bp_stm 主循环；
+    // 持 GIL 段 = 入参校验 + PyDict 构造。
+    let result = py
+        .allow_threads(|| {
+            propagate_bcr4bp_stm(
+                mu,
+                mu_sun,
+                sun_distance,
+                sun_angular_rate,
+                sun_phase0,
+                t_span,
+                &t_eval,
+                &state0,
+                rtol,
+                atol,
+                max_step,
+                max_steps,
+            )
+            .map_err(|e| format!("BCR4BP STM propagation failed: {e}"))
+        })
+        .map_err(pyo3::exceptions::PyRuntimeError::new_err)?;
 
     let states_list: Vec<Vec<f64>> = result.states.iter().map(|s| s.to_vec()).collect();
     let stm_list: Vec<Vec<f64>> = result.stms.iter().map(|s| s.to_vec()).collect();

--- a/crates/e2m2e-spice/Cargo.toml
+++ b/crates/e2m2e-spice/Cargo.toml
@@ -9,7 +9,10 @@ name = "e2m2e_spice"
 crate-type = ["rlib"]
 
 [features]
-default = []
+# spice 默认开启：本 crate 即 SPICE FFI 绑定，无 spice feature 则为空壳。
+# 与 workspace 其余 crate 的 default=["spice"] 对齐。CSPICE 由
+# scripts/download_cspice.py 提供（CSPICE_DIR）。
+default = ["spice"]
 spice = ["dep:cspice", "dep:cspice-sys"]
 
 [dependencies]

--- a/e2m2e/algorithm/dynamics/dynamics.py
+++ b/e2m2e/algorithm/dynamics/dynamics.py
@@ -542,6 +542,11 @@ class CR3BP_Dynamics(Dynamics):
         mu = float(self.system.mu)
         if t_eval is not None:
             t_eval_list = [float(t) for t in np.asarray(t_eval, dtype=float).ravel()]
+        elif t_span[0] == t_span[1]:
+            # 零跨度（如 compute_state_transition_matrix(t=0)）：合成 [t0, t0] 会让
+            # Rust 核心输出点去重只产 1 点、触发长度校验；退化为单点 [t0]，与 scipy
+            # t_eval=None 的零跨度行为一致（STM 即单位阵、状态即初值，无需积分）。
+            t_eval_list = [float(t_span[0])]
         else:
             t_eval_list = [float(t_span[0]), float(t_span[1])]
 
@@ -592,6 +597,9 @@ class CR3BP_Dynamics(Dynamics):
             mu = float(self.system.mu)
             if t_eval is not None:
                 t_eval_list = [float(t) for t in np.asarray(t_eval, dtype=float).ravel()]
+            elif t_span[0] == t_span[1]:
+                # 零跨度：同 _propagate_with_stm_rust，退化为单点避免重复点触发长度校验。
+                t_eval_list = [float(t_span[0])]
             else:
                 t_eval_list = [float(t_span[0]), float(t_span[1])]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,10 @@ Issues = "https://github.com/cislunarspace/e2m2e/issues"
 manifest-path = "crates/e2m2e-integrators/Cargo.toml"
 module-name = "e2m2e._integrators"
 python-source = "."
+# spice 为必选 feature（ crates/*/Cargo.toml 的 default 已含 spice，此处显式
+# 再声明一次作双保险）：maturin build/develop 永远带 CSPICE，不产无 spice 子集。
+# 构建前需 export CSPICE_DIR（见 Makefile / scripts/download_cspice.py）。
+features = ["spice"]
 
 [tool.ruff]
 line-length = 100

--- a/scripts/download_kernels.py
+++ b/scripts/download_kernels.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import pathlib
 import sys
 import urllib.request
@@ -36,7 +37,7 @@ ROOT = pathlib.Path(__file__).resolve().parents[1]
 
 def _api_headers() -> dict[str, str]:
     headers = {"Accept": "application/vnd.github+json"}
-    token = __import__("os").environ.get("GH_TOKEN") or __import__("os").environ.get("GITHUB_TOKEN")
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
     if token:
         headers["Authorization"] = f"Bearer {token}"
     return headers

--- a/scripts/download_kernels.py
+++ b/scripts/download_kernels.py
@@ -1,0 +1,92 @@
+"""下载 SPICE 内核文件到 ``kernels/``，供星历动力学测试与运行使用。
+
+与 :mod:`scripts.download_cspice` 对称：后者取 CSPICE 编译包（构建期），
+本脚本取星历/姿态/闰秒等内核（运行期）。来源同为项目 GitHub Release
+``kernels-v1``，国内网络可达（NAIF 官方源常不可达）。
+
+仓库已提交体积小的内核（.tls/.tpc/.bpc/.tf），仅星历 ``.bsp``（百 MB 级、
+``.gitignore`` 忽略）需补。本脚本无差别按扩展名拉取 release 内的全部内核资产，
+已存在的文件跳过（幂等），故重复运行零下载。
+
+用法：
+    python scripts/download_kernels.py [--kernel-dir DIR]
+
+默认内核目录：仓库根 ``kernels/``（与 ``tests/kernel_helpers.py`` 的
+``SPICE_KERNEL_DIR`` 默认一致）。
+
+鉴权：GitHub API 未鉴权限速 60 次/小时，单次 setup 足够；CI 或受限环境设
+``GH_TOKEN`` 走鉴权通道（与 download_cspice.py 同）。
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+import urllib.request
+
+REPO = "cislunarspace/e2m2e"
+RELEASE = "kernels-v1"
+# release.yml 同款 pattern：星历/闰秒/常数/姿态/帧
+EXTENSIONS = (".bsp", ".tls", ".tpc", ".bpc", ".tf")
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def _api_headers() -> dict[str, str]:
+    headers = {"Accept": "application/vnd.github+json"}
+    token = __import__("os").environ.get("GH_TOKEN") or __import__("os").environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _list_release_assets() -> list[dict]:
+    """列 ``kernels-v1`` release 的全部资产（name + browser_download_url）。"""
+    url = f"https://api.github.com/repos/{REPO}/releases/tags/{RELEASE}"
+    req = urllib.request.Request(url, headers=_api_headers())
+    with urllib.request.urlopen(req) as resp:  # noqa: S310 — 固定 https API URL
+        data = json.loads(resp.read().decode("utf-8"))
+    return data.get("assets", [])
+
+
+def _download(url: str, dest: pathlib.Path) -> None:
+    print(f"下载 {url} → {dest}", file=sys.stderr)
+    with urllib.request.urlopen(url) as resp, dest.open("wb") as fh:  # noqa: S310 — 固定 https URL
+        fh.write(resp.read())
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="从 kernels-v1 release 下载 SPICE 内核到 kernels/（幂等）"
+    )
+    parser.add_argument("--kernel-dir", type=pathlib.Path, default=ROOT / "kernels")
+    args = parser.parse_args()
+
+    kernel_dir = args.kernel_dir
+    kernel_dir.mkdir(parents=True, exist_ok=True)
+
+    assets = _list_release_assets()
+    targets = [a for a in assets if a["name"].lower().endswith(EXTENSIONS)]
+    if not targets:
+        raise SystemExit(f"release {RELEASE} 未找到内核资产（扩展名 {EXTENSIONS}）")
+
+    fetched = 0
+    skipped = 0
+    for asset in targets:
+        dest = kernel_dir / asset["name"]
+        if dest.is_file():
+            skipped += 1
+            continue
+        _download(asset["browser_download_url"], dest)
+        fetched += 1
+
+    print(
+        f"kernels-v1: 下载 {fetched} 个内核，跳过 {skipped} 个（已存在）→ {kernel_dir}",
+        file=sys.stderr,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integrators/test_propagate_cr3bp_stm_gil.py
+++ b/tests/integrators/test_propagate_cr3bp_stm_gil.py
@@ -1,0 +1,104 @@
+"""``propagate_cr3bp_stm_py`` 释放 GIL 回归测试（#313）。
+
+CR3BP 修正段（``design_dro`` / ``design_halo`` / ``design_lissajous`` 共用
+``_propagate_with_stm``）切到 Rust ``propagate_cr3bp_stm_py`` 后，积分循环仍持
+GIL，下游 worker 线程跑 ``design_orbit`` 时主线程（GUI / QTimer tick）被冻结
+66s+。本测试守住"积分循环包进 ``py.allow_threads``"：主线程积分期间，另一个
+Python 线程应能持续推进（心跳打点）。
+
+判别原理同 ``test_propagate_compiled_gil.py``（#318）：心跳线程循环
+``ticks += 1; time.sleep(0.005)``。``time.sleep`` 释 GIL，醒来执行 ``ticks += 1``
+必须重新获取 GIL——
+
+- 主循环已用 ``py.allow_threads`` 释 GIL：心跳 reacquire 立即成功，按 ~5 ms 节奏
+  持续打点，dt 秒内 ~dt/0.005 次。
+- 主循环持 GIL（回归）：心跳 reacquire 阻塞到积分返回，期间打点 ≈ 0。
+
+两者相差 1~2 个数量级，阈值取 3，判别稳健。传播段太短（dt < 0.10 s）信号不足
+则 skip。
+
+CR3BP STM 路径是无量纲纯数学（不依赖 SPICE 内核），故本测试直连 Rust 绑定，
+不参与 ``pytest.mark.spice`` 门控。用 L4（三角平动点，地月 μ < Routh 临界故线性
+稳定）邻近初值，``max_step`` 钳位强制 ~10⁵ 步，保证积分耗时稳超判别下限。
+"""
+
+import threading
+import time
+
+import numpy as np
+import pytest
+
+pytest.importorskip("e2m2e._integrators")
+
+from e2m2e.integrators import propagate_cr3bp_stm_py
+
+if propagate_cr3bp_stm_py is None:
+    pytest.skip("propagate_cr3bp_stm_py 需要 Rust 扩展构建", allow_module_level=True)
+
+# 地月质量参数（无量纲）
+MU_EARTH_MOON = 0.0121505856
+
+
+def _l4_state() -> list[float]:
+    """L4 邻近初值（CR3BP 旋转系，无量纲）。
+
+    L4 = (1/2 - μ, √3/2, 0)；x 方向偏置 0.01 激发有界天平动（线性稳定，
+    长时间不发散），保证 100 无量纲时间积分数值良态。
+    """
+    return [0.5 - MU_EARTH_MOON + 0.01, np.sqrt(3.0) / 2.0, 0.0, 0.0, 0.0, 0.0]
+
+
+def test_propagate_cr3bp_stm_releases_gil():
+    """主线程 STM 积分期间，心跳线程持续打点 → propagate_cr3bp_stm_py 已释放 GIL。
+
+    回归 #313：积分循环漏包 ``py.allow_threads``，全程持 GIL 使心跳饿死
+    （ticks ≈ 0）。修复后释 GIL，ticks 随 dt 线性增长。
+    """
+    y0 = _l4_state()
+    # max_step=1e-3 钳位 → ≥ 1e5 步（rtol 1e-12 下自适应步长远大于 1e-3 被钳），
+    # 100 无量纲时间 ≈ 16 个月，L4 天平动有界。release 构建约 0.2~0.4 s。
+    t0, tf = 0.0, 100.0
+    t_eval = np.linspace(t0, tf, 100)
+
+    ticks = [0]
+    stop = [False]
+
+    def heartbeat() -> None:
+        while not stop[0]:
+            ticks[0] += 1
+            time.sleep(0.005)
+
+    th = threading.Thread(target=heartbeat, daemon=True)
+    th.start()
+    try:
+        time.sleep(0.05)  # 让心跳起步，确保它已在 sleep→reacquire 循环中
+        ticks_before = ticks[0]
+        t_start = time.perf_counter()
+        propagate_cr3bp_stm_py(
+            mu=MU_EARTH_MOON,
+            t_span=(t0, tf),
+            t_eval=[float(t) for t in t_eval],
+            initial_state=y0,
+            rtol=1e-12,
+            atol=1e-12,
+            max_step=1e-3,
+        )
+        dt = time.perf_counter() - t_start
+    finally:
+        stop[0] = True
+        th.join(timeout=2.0)
+
+    ticks_during = ticks[0] - ticks_before
+
+    # 积分段太短 → 信号不足，快机上可能误判，跳过（罕见）。
+    if dt < 0.10:
+        pytest.skip(f"propagation too short ({dt:.3f}s) to assert GIL release")
+
+    # 释 GIL 时 dt≈0.3 s → ~60 ticks；持 GIL（回归）→ 0~1 ticks。
+    # 阈值 3 兼顾：远低于释 GIL 实测（数十次），远高于持 GIL（0~1 次），
+    # 对单核 / CI 调度抖动留 ~10× 余量。
+    assert ticks_during >= 3, (
+        f"heartbeat ticked only {ticks_during} times during {dt:.2f}s STM propagation "
+        f"(expected ~{dt / 0.005:.0f} if GIL released); "
+        "propagate_cr3bp_stm_py may be holding the GIL — 积分循环漏了 py.allow_threads (#313)"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -745,7 +745,7 @@ wheels = [
 
 [[package]]
 name = "e2m2e"
-version = "5.5.0"
+version = "5.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## 背景

issue #313：`design_dro` 的 STM 积分切到 Rust `propagate_cr3bp_stm_py` 后，积分主循环仍持 GIL 整段，下游 worker 线程跑 `design_orbit` 时主线程（GUI / QTimer tick）被冻结 66s+。

本 PR 同时落实两件事：
1. **GIL 修复（#313 核心）**
2. **构建/测试套件架构决策**：spice 升为默认 feature + cspice/内核获取自动化

## 改动

### 1. CR3BP/BCR4BP STM 积分释放 GIL — `fix(integrators)`

4 个 PD78 绑定的积分主循环整段包进 `py.allow_threads`（镜像 #318 对 `propagate_compiled` 的范式）：
`propagate_cr3bp_py` / `propagate_cr3bp_stm_py` / `propagate_bcr4bp_py` / `propagate_bcr4bp_stm_py`。
闭包内纯 Rust 不回调 Python，回传 `String`；闭包外 `map_err` 转 `PyRuntimeError`，错误消息逐字保留。

顺带修一个**被构建暴露的预存 latent bug**：CR3BP Rust STM/状态路径对零跨度 `t_span`（如 `compute_state_transition_matrix(t=0)`）合成重复 `t_eval=[t0,t0]`，经 Rust 核心输出点去重只产 1 点触发长度校验失败。加零跨度守卫退化为单点 `[t0]`，与 scipy `t_eval=None` 行为一致。

新增回归测试 `tests/integrators/test_propagate_cr3bp_stm_gil.py`（心跳打点判别，镜像 #318）。

### 2. spice 必选化 + 开发入口自动化 — `chore(build)`

- `crates/{integrators,forces,spice}/Cargo.toml`：`default = ["spice"]`；`pyproject.toml [tool.maturin] features = ["spice"]`。普通 `cargo build` / `maturin develop` 永远带 CSPICE，**不再产无 spice 子集**。
- 新增 `Makefile`（唯一开发入口）：自动 `export CSPICE_DIR`（解析 `download_cspice.py`）+ 探测 `LIBCLANG_PATH`，targets `setup/dev/test/check/fmt`。
- 新增 `scripts/download_kernels.py`：从 `kernels-v1` release 幂等下载 SPICE 内核到 `kernels/`。
- CI 简化：`ci.yml` / `release.yml` 把 SPICE 下载前移到所有 cargo 命令之前、双趟 clippy/test 合并为单趟；`release.yml` 内核下载改用 `download_kernels.py`、maturin args 去掉显式 `--features spice`。
- README 开发段补 `make setup && make dev`。

**动机**：SPICE 从 GitHub release（`cspice-v1` / `kernels-v1`，已上传）易获取，不再当可选——消灭"依赖 spice 却 build 出无 spice 子集"的歧义构建，并统一开发入口为一条命令。

## 验证

- `cargo check --workspace`（默认 spice，无 `--features spice`）+ `cargo clippy --workspace -- -D warnings`：✅
- 新增 GIL 回归测试：✅
- `tests/core` + `tests/algorithms`：**1283 passed**；`tests/integrators` + `tests/core/forces`：**340 passed**；`tests/algorithms`（correction/stm，直击 design_dro 链）：**163 passed**。
- `make setup` / `make dev`（含强制 cspice-sys 重建验证 LIBCLANG_PATH 自动探测）：✅

## 开发流程变化

```bash
git clone ... && cd e2m2e
uv sync
make setup   # 拉取 CSPICE 编译包 + SPICE 内核（cspice-v1 / kernels-v1 release）
make dev     # maturin develop（spice 默认）
make test    # cargo test --workspace + pytest
```

Closes #313
