### PR TITLE
refactor(spice): rename spice_poc_furnsh to spice_furnsh

### DIFF
--- a/crates/e2m2e-integrators/src/lib.rs
+++ b/crates/e2m2e-integrators/src/lib.rs
@@ -657,7 +657,7 @@ fn spice_poc_body_position(et: f64, target: &str, observer: &str) -> PyResult<Ve
     Ok(vec![state.position.x, state.position.y, state.position.z])
 }
 
-/// PoC：在 Rust cspice 内核池加载一个内核文件。
+/// 在 Rust cspice 内核池加载一个内核文件。
 ///
 /// Rust cspice 与 Python spiceypy 是**独立的 CSPICE 实例**（静态链接，全局状态
 /// 不共享）。Python 侧 furnsh 的内核，Rust 看不见；反之亦然。要让 Rust 查询
@@ -669,7 +669,7 @@ fn spice_poc_body_position(et: f64, target: &str, observer: &str) -> PyResult<Ve
 /// "MARS" 解析成不存在的本体 499。
 #[cfg(feature = "spice")]
 #[pyfunction]
-fn spice_poc_furnsh(path: &str) -> PyResult<()> {
+fn spice_furnsh(path: &str) -> PyResult<()> {
     static REGISTERED: std::sync::Once = std::sync::Once::new();
     REGISTERED.call_once(e2m2e_spice::spice_ffi::register_bodies);
     cspice::data::furnish(path)
@@ -2872,7 +2872,7 @@ fn _integrators(m: &Bound<PyModule>) -> PyResult<()> {
     #[cfg(feature = "spice")]
     m.add_function(wrap_pyfunction!(spice_poc_body_position, m)?)?;
     #[cfg(feature = "spice")]
-    m.add_function(wrap_pyfunction!(spice_poc_furnsh, m)?)?;
+    m.add_function(wrap_pyfunction!(spice_furnsh, m)?)?;
     #[cfg(feature = "spice")]
     m.add_function(wrap_pyfunction!(third_body_acceleration, m)?)?;
     #[cfg(feature = "spice")]

--- a/crates/e2m2e-spice/src/spice_ffi.rs
+++ b/crates/e2m2e-spice/src/spice_ffi.rs
@@ -135,7 +135,7 @@ const BODY_ALIASES: &[(&str, SpiceInt)] = &[
 /// spiceypy.boddef）。`boddef_c` 只改名字→ID 映射表，不需要内核加载，
 /// 对同一 (name, id) 重复调用幂等。
 ///
-/// 应在任何 `spkezr`/`bodvrd` 之前调用一次（见 `spice_poc_furnsh` 里的
+/// 应在任何 `spkezr`/`bodvrd` 之前调用一次（见 `spice_furnsh` 里的
 /// `Once` 触发）。
 pub fn register_bodies() {
     for (name, code) in BODY_ALIASES {

--- a/crates/e2m2e-spice/src/spk_accel.rs
+++ b/crates/e2m2e-spice/src/spk_accel.rs
@@ -4,7 +4,7 @@
 //! "SPICE 查扰动体位置 + 第三体摄动加速度公式" 合并为一次 Rust 调用，
 //! 消除每步 Python↔cspice 跨界 + numpy 数组分配开销。
 //!
-//! 设计：Python 侧 ``ThirdBodyGravity`` 在初始化时调 ``spice_poc_furnsh``
+//! 设计：Python 侧 ``ThirdBodyGravity`` 在初始化时调 ``spice_furnsh``
 //! 加载内核（与 Python spiceypy 双 furnsh），运行时直接调本模块函数。
 
 use cspice::common::AberrationCorrection;

--- a/e2m2e/data/kernels/manager.py
+++ b/e2m2e/data/kernels/manager.py
@@ -223,11 +223,11 @@ class SPICEManager(EphemerisProvider):
         # 此处为内核加载的跨层桥接（ADR 0012 的 data/ → 仅外部库例外，
         # 迁移期保留，第 5 批评估归属）。
         try:
-            from e2m2e.integrators import spice_poc_furnsh  # noqa: F401
+            from e2m2e.integrators import spice_furnsh  # noqa: F401
 
-            if spice_poc_furnsh is None:
+            if spice_furnsh is None:
                 raise ImportError
-            spice_poc_furnsh(path)
+            spice_furnsh(path)
         except ImportError:
             pass
 

--- a/e2m2e/integrators.py
+++ b/e2m2e/integrators.py
@@ -58,7 +58,7 @@ try:
             propagate_with_stm_py,
             reset_ephem_ffi_call_count,
             segmented_shooting_correct_py,
-            spice_poc_furnsh,
+            spice_furnsh,
             third_body_acceleration,
         )
     except ImportError:
@@ -76,7 +76,7 @@ try:
         propagate_with_stm_py = None  # type: ignore[misc,assignment]
         reset_ephem_ffi_call_count = None  # type: ignore[misc,assignment]
         segmented_shooting_correct_py = None  # type: ignore[misc,assignment]
-        spice_poc_furnsh = None  # type: ignore[misc,assignment]
+        spice_furnsh = None  # type: ignore[misc,assignment]
         third_body_acceleration = None  # type: ignore[misc,assignment]
 except ModuleNotFoundError:
     # _integrators is a compiled Rust extension; allow import for doc builds
@@ -124,7 +124,7 @@ except ModuleNotFoundError:
     propagate_with_stm_py = None  # type: ignore[misc,assignment]
     reset_ephem_ffi_call_count = None  # type: ignore[misc,assignment]
     segmented_shooting_correct_py = None  # type: ignore[misc,assignment]
-    spice_poc_furnsh = None  # type: ignore[misc,assignment]
+    spice_furnsh = None  # type: ignore[misc,assignment]
     third_body_acceleration = None  # type: ignore[misc,assignment]
 
 # ---- Python↔Rust ABI 版本校验 ----
@@ -206,7 +206,7 @@ __all__ = [
     "solid_tide_step2",
     "solve_ivp_events",
     "solve_ivp_events_py",
-    "spice_poc_furnsh",
+    "spice_furnsh",
     "spherical_harmonic_accel",
     "third_body_acceleration",
     "TransferPointResult",

--- a/tests/core/spice/test_spice_branches.py
+++ b/tests/core/spice/test_spice_branches.py
@@ -81,7 +81,7 @@ class TestLoadKernelAutoLoadsLeapseconds:
         with (
             patch("e2m2e.data.kernels.manager.get_spiceypy", return_value=fake_spice),
             # 屏蔽 Rust cspice furnsh：假 bsp 进 cspice 会报错，且与闰秒逻辑无关。
-            patch("e2m2e.integrators.spice_poc_furnsh", None),
+            patch("e2m2e.integrators.spice_furnsh", None),
         ):
             mgr = SPICEManager()
             mgr.load_kernel(str(bsp_path))
@@ -103,7 +103,7 @@ class TestLoadKernelAutoLoadsLeapseconds:
         fake_spice = MagicMock()
         with (
             patch("e2m2e.data.kernels.manager.get_spiceypy", return_value=fake_spice),
-            patch("e2m2e.integrators.spice_poc_furnsh", None),
+            patch("e2m2e.integrators.spice_furnsh", None),
         ):
             mgr = SPICEManager()
             with caplog.at_level(logging.WARNING, logger="e2m2e.data.kernels.manager"):
@@ -116,3 +116,17 @@ class TestLoadKernelAutoLoadsLeapseconds:
         assert loaded == [str(bsp_path)]
         assert any("naif0012.tls" in r.message for r in caplog.records)
         assert any("NOLEAPSECONDS" in r.message for r in caplog.records)
+
+
+class TestSpiceFurnshSmoke:
+    """spice_furnsh 将内核文件加载到 Rust cspice 内核池（与 Python spiceypy 独立）。"""
+
+    @pytest.mark.spice
+    def test_furnsh_loads_kernel_successfully(self):
+        """furnsh 一个真实内核文件不抛异常（Rust cspice 静默加载）。"""
+        from e2m2e.integrators import spice_furnsh
+
+        # naif0012.tls 是项目仓库内置的闰秒内核
+        kernel_path = "kernels/naif0012.tls"
+        spice_furnsh(kernel_path)
+        # 函数签名返回 ()，不抛异常即成功。


### PR DESCRIPTION
Closes #332

## 改动
- Rust：函数定义、注册、文档注释清理（`spice_poc_furnsh` → `spice_furnsh`）
- Python：`integrators.py` 中 import/fallback/`__all__`；`manager.py` 中调用方同步
- 测试：patch 字符串更新 + 新 smoke test（furnsh 真实内核文件）

## 测试
- SPICE 测试：10/10 全过
- 全测试套件：1110 通过（1 个预存无关失败: `test_invalid_orbit_type`）