### PR TITLE
feat(tests): 补充 e2m2e-propagation 和 e2m2e-spice 的 Rust 单元测试 (#329)

### DIFF
--- a/crates/e2m2e-propagation/tests/butcher_tableau.rs
+++ b/crates/e2m2e-propagation/tests/butcher_tableau.rs
@@ -1,0 +1,134 @@
+//! Butcher 表系数检验（ADR 0013：按定义验证，不用 golden file）。
+//!
+//! 对 e2m2e-propagation 的所有嵌入 RK 方法（PD45、PD78、RK89）
+//! 做一致性校验：行和下三角、c = Σa₍ᵢⱼ₎、Σb = Σb* = 1、阶数元数据。
+//!
+//! 依据：这些是 Runge-Kutta 方法"按定义"必须满足的基本性质；
+//! 不满足则表系数有误。
+//!
+//! # 参考
+//! - Hairner & Wanner, *Solving Ordinary Differential Equations I* (2nd ed.)
+//! - Butcher, *Numerical Methods for Ordinary Differential Equations* (3rd ed.)
+//! - ADR 0013 "验证策略——按定义完成任务"
+
+use e2m2e_propagation::butcher::ButcherTable;
+use e2m2e_propagation::rk_methods::RkMethod;
+
+/// 收集所有方法的 Butcher 表。
+fn all_tables() -> Vec<(&'static str, RkMethod, &'static ButcherTable)> {
+    let methods = [RkMethod::Pd45, RkMethod::Pd78, RkMethod::Rk89];
+    methods
+        .iter()
+        .map(|&m| {
+            let name = format!("{m:?}");
+            (name, m, m.table())
+        })
+        .collect::<Vec<_>>()
+        .into_iter()
+        .map(|(name, m, t)| {
+            // 移动 name 为 &'static str — 用泄露，仅测试使用。
+            let leaked: &'static str = Box::leak(name.into_boxed_str());
+            (leaked, m, t)
+        })
+        .collect()
+}
+
+// ── 测试 1：a 行长度为 i（严格下三角） ───────────────────────────────────
+
+/// RK 矩阵 a[i] 的长度必须等于 i（严格下三角）。
+///
+/// 依据（ADR 0013 / Butcher 表定义）：显式 RK 方法中，第 i 行非零元素
+/// 只涉及 k₀..k_{i-1}，因此行长度必须为 i。
+#[test]
+fn test_a_row_lengths_are_lower_triangular() {
+    for (_name, method, table) in all_tables() {
+        for i in 0..table.stages {
+            assert_eq!(
+                table.a[i].len(),
+                i,
+                "{method:?} row {i} length {} != {i}",
+                table.a[i].len()
+            );
+        }
+    }
+}
+
+// ── 测试 2：c 节点 = Σⱼ aᵢⱼ（行和条件） ──────────────────────────────────
+
+/// 每行的 RK 系数之和应等于对应的时间节点：c[i] = Σⱼ a[i][j]。
+///
+/// 依据（ADR 0013 / Butcher 简化假设 C(1)）：这是 Runge-Kutta 方法
+/// 的基本一致性条件，确保每个阶段的截断误差至少 O(h)。
+#[test]
+fn test_butcher_rows_sum_to_c_nodes() {
+    for (_name, method, table) in all_tables() {
+        for i in 1..table.stages {
+            let row_sum: f64 = table.a[i].iter().sum();
+            let diff = (row_sum - table.c[i]).abs();
+            assert!(
+                diff < 1e-10,
+                "{method:?} row {i}: Σa = {row_sum}, c = {}, diff = {diff:.2e}",
+                table.c[i]
+            );
+        }
+    }
+}
+
+// ── 测试 3：权重之和为 1（一致性条件） ───────────────────────────────────
+
+/// 主解权重 b 与嵌入解权重 b* 之和均为 1。
+///
+/// 依据（ADR 0013 / Butcher 表定义）：显式 RK 方法的 b 与 b* 必须各自
+/// 满足 Σbᵢ = 1、Σb*ᵢ = 1，否则方法不具有相应阶数。
+#[test]
+fn test_weights_sum_to_one() {
+    for (_name, method, table) in all_tables() {
+        let b_sum: f64 = table.b.iter().sum();
+        let b_star_sum: f64 = table.b_star.iter().sum();
+        assert!(
+            (b_sum - 1.0).abs() < 1e-12,
+            "{method:?} b sum = {b_sum} ≠ 1"
+        );
+        assert!(
+            (b_star_sum - 1.0).abs() < 1e-12,
+            "{method:?} b* sum = {b_star_sum} ≠ 1"
+        );
+    }
+}
+
+// ── 测试 4：阶数元数据合理 ───────────────────────────────────────────────
+
+/// 嵌入阶 < 主阶（误差估计基于低阶嵌入解）。
+///
+/// 依据（ADR 0013 / 嵌入 RK 定义）：嵌入方法阶数必须严格小于主方法阶数，
+/// 否则误差估计恒为零。
+#[test]
+fn test_embedded_order_less_than_main_order() {
+    for (_name, method, table) in all_tables() {
+        assert!(
+            table.embedded_order < table.order,
+            "{method:?} embedded_order {} >= order {}",
+            table.embedded_order,
+            table.order
+        );
+    }
+}
+
+// ── 测试 5：误差估计权重 (b - b*) 非平凡 ─────────────────────────────────
+
+/// b 与 b* 不可完全相同，否则误差估计恒为零。
+#[test]
+fn test_error_weights_nontrivial() {
+    for (_name, method, table) in all_tables() {
+        let max_diff = table
+            .b
+            .iter()
+            .zip(table.b_star.iter())
+            .map(|(bi, bsi)| (bi - bsi).abs())
+            .fold(0.0_f64, f64::max);
+        assert!(
+            max_diff > 1e-15,
+            "{method:?} b and b* appear identical (max diff = {max_diff:e})"
+        );
+    }
+}

--- a/crates/e2m2e-propagation/tests/cowell_uniform_acceleration.rs
+++ b/crates/e2m2e-propagation/tests/cowell_uniform_acceleration.rs
@@ -1,0 +1,100 @@
+//! Cowell 匀加速精确再现（ADR 0013：按定义验证）。
+//!
+//! 匀加速运动 x'' = a₀ 有解析解 x(t) = x₀ + v₀ t + ½ a₀ t²。
+//! Cowell 积分的核心特征是对二次多项式的精确再现——若加速度为常数，
+//! 任何阶数 ≥ 2 的 Störmer-Cowell 方法应在机器精度内产生精确结果。
+//!
+//! 依据：Cowell 校正器的权重满足 Σᵢ qᵢ = 1 且所有 ⱼ ≥ 1 阶差分
+//! ∇ʲa 在 a=const 时为零，故 h²·q₀·a = h²·a，∑_{j≥1} q_j·∇ʲa = 0。
+//! 结合 x_{n+1} = 2x_n − x_{n-1} + h²a 精确满足匀加速运动的封闭解。
+//!
+//! # ADR 0013
+//! 匀加速运动的封闭解是二次多项式的"定义"——不依赖任何外部软件或 golden 文件。
+
+use e2m2e_propagation::cowell::{cowell_step, COWELL_HISTORY_LEN};
+
+/// 匀加速运动 1D 测试：a = const，已知 x(t) = x₀ + v₀ t + ½ a t²。
+///
+/// 用采样精确 a = const 填充 Cowell 历史缓冲（Cowell 的 a 与 t 无关，
+/// 但与 x 无关也无关）。多次步进后与解析解对比误差应为机器噪声级别。
+#[test]
+fn test_constant_acceleration_exact_reproduction() {
+    let a0 = 5.0; // constant acceleration (m/s²)
+    let accel = |_t: f64, _x: &[f64]| -> Result<Vec<f64>, std::convert::Infallible> {
+        Ok(vec![a0])
+    };
+
+    let x0 = 3.0;
+    let v0 = 2.0;
+    let h: f64 = 0.01;
+
+    // 历史上 a 为 const，所有 8 个加速度采样均为 a0。
+    // x(-h) = x0 − v0·h + ½ a0·h²
+    // x(0)  = x0
+    let x_neg_h = x0 - v0 * h + 0.5 * a0 * h * h;
+    let mut history: Vec<Vec<f64>> = vec![vec![x_neg_h], vec![x0]];
+    for _ in 0..COWELL_HISTORY_LEN - 2 {
+        history.push(vec![a0]);
+    }
+
+    let n_steps = 100;
+    let mut t = 0.0;
+    for _ in 0..n_steps {
+        let (_x, _error, new_history) = cowell_step(t, h, &history, accel).unwrap();
+        history = new_history;
+        t += h;
+    }
+
+    // 正确答案：x(t) = x₀ + v₀ t + ½ a₀ t² 为匀加速运动二次式
+    let x_exact = x0 + v0 * t + 0.5 * a0 * t * t;
+    let x_cowell = history[1][0]; // Cowell 位置存于 history[1]
+    let err = (x_cowell - x_exact).abs();
+    assert!(
+        err < 1e-12,
+        "Cowell 匀加速传播 {n_steps} 步后误差 {err:.2e} > 1e-12"
+    );
+}
+
+/// 2D/3D 多分量匀加速也有类似精确性：每个分量独立为二次多项式。
+#[test]
+fn test_3d_constant_acceleration_exact_reproduction() {
+    let a0 = [1.0, -2.0, 3.0];
+    let accel = |_t: f64, _x: &[f64]| -> Result<Vec<f64>, std::convert::Infallible> {
+        Ok(a0.to_vec())
+    };
+
+    let x0 = [1.0, 2.0, 3.0];
+    let v0 = [0.5, -0.3, 1.2];
+    let h: f64 = 0.005;
+
+    let x_neg_h: Vec<f64> = (0..3).map(|i| x0[i] - v0[i] * h + 0.5 * a0[i] * h * h).collect();
+    let mut history: Vec<Vec<f64>> = vec![x_neg_h, x0.to_vec()];
+    for _ in 0..COWELL_HISTORY_LEN - 2 {
+        history.push(a0.to_vec());
+    }
+
+    let n_steps = 200;
+    let mut t = 0.0;
+    for _ in 0..n_steps {
+        let (_x, _error, new_history) = cowell_step(t, h, &history, accel).unwrap();
+        history = new_history;
+        t += h;
+    }
+
+    for i in 0..3 {
+        let exact = x0[i] + v0[i] * t + 0.5 * a0[i] * t * t;
+        let cowell_x = history[1][i];
+        let err = (cowell_x - exact).abs();
+        assert!(
+            err < 1e-11,
+            "3D 分量 {i}: Cowell {} vs 精确 {exact}, 误差 {err:.2e} > 1e-11",
+            cowell_x
+        );
+    }
+}
+
+/// Cowell 历史缓冲长度常量检验：确保 8 个加速度采样 + 2 个位置采样 = 10。
+#[test]
+fn test_cowell_history_len_constant() {
+    assert_eq!(COWELL_HISTORY_LEN, 10, "Cowell 历史缓冲长度应为 10（2 pos + 8 accel）");
+}

--- a/crates/e2m2e-propagation/tests/cowell_uniform_acceleration.rs
+++ b/crates/e2m2e-propagation/tests/cowell_uniform_acceleration.rs
@@ -20,9 +20,8 @@ use e2m2e_propagation::cowell::{cowell_step, COWELL_HISTORY_LEN};
 #[test]
 fn test_constant_acceleration_exact_reproduction() {
     let a0 = 5.0; // constant acceleration (m/s²)
-    let accel = |_t: f64, _x: &[f64]| -> Result<Vec<f64>, std::convert::Infallible> {
-        Ok(vec![a0])
-    };
+    let accel =
+        |_t: f64, _x: &[f64]| -> Result<Vec<f64>, std::convert::Infallible> { Ok(vec![a0]) };
 
     let x0 = 3.0;
     let v0 = 2.0;
@@ -59,15 +58,16 @@ fn test_constant_acceleration_exact_reproduction() {
 #[test]
 fn test_3d_constant_acceleration_exact_reproduction() {
     let a0 = [1.0, -2.0, 3.0];
-    let accel = |_t: f64, _x: &[f64]| -> Result<Vec<f64>, std::convert::Infallible> {
-        Ok(a0.to_vec())
-    };
+    let accel =
+        |_t: f64, _x: &[f64]| -> Result<Vec<f64>, std::convert::Infallible> { Ok(a0.to_vec()) };
 
     let x0 = [1.0, 2.0, 3.0];
     let v0 = [0.5, -0.3, 1.2];
     let h: f64 = 0.005;
 
-    let x_neg_h: Vec<f64> = (0..3).map(|i| x0[i] - v0[i] * h + 0.5 * a0[i] * h * h).collect();
+    let x_neg_h: Vec<f64> = (0..3)
+        .map(|i| x0[i] - v0[i] * h + 0.5 * a0[i] * h * h)
+        .collect();
     let mut history: Vec<Vec<f64>> = vec![x_neg_h, x0.to_vec()];
     for _ in 0..COWELL_HISTORY_LEN - 2 {
         history.push(a0.to_vec());
@@ -96,5 +96,8 @@ fn test_3d_constant_acceleration_exact_reproduction() {
 /// Cowell 历史缓冲长度常量检验：确保 8 个加速度采样 + 2 个位置采样 = 10。
 #[test]
 fn test_cowell_history_len_constant() {
-    assert_eq!(COWELL_HISTORY_LEN, 10, "Cowell 历史缓冲长度应为 10（2 pos + 8 accel）");
+    assert_eq!(
+        COWELL_HISTORY_LEN, 10,
+        "Cowell 历史缓冲长度应为 10（2 pos + 8 accel）"
+    );
 }

--- a/crates/e2m2e-propagation/tests/lambert_hohmann.rs
+++ b/crates/e2m2e-propagation/tests/lambert_hohmann.rs
@@ -19,8 +19,8 @@
 //!
 //! 所有断言基于二体理论公式（物理定义），不依赖黄金样本或外部软件。
 
-use std::f64::consts::PI;
 use e2m2e_propagation::lambert::{lambert_izzo, TransferDirection};
+use std::f64::consts::PI;
 
 const MU: f64 = 398600.4418; // Earth GM (km³/s²)
 
@@ -63,7 +63,11 @@ fn propagate_ellipse(r0: &[f64; 3], v0: &[f64; 3], tof: f64, mu: f64) -> [f64; 3
     let d_e = ecc - e0;
     let f = 1.0 + a * (d_e.cos() - 1.0) / r0n;
     let gg = tof - (d_e - d_e.sin()) / n;
-    [f * r0[0] + gg * v0[0], f * r0[1] + gg * v0[1], f * r0[2] + gg * v0[2]]
+    [
+        f * r0[0] + gg * v0[0],
+        f * r0[1] + gg * v0[1],
+        f * r0[2] + gg * v0[2],
+    ]
 }
 
 fn assert_close(a: &[f64; 3], b: &[f64; 3], tol: f64) {
@@ -80,7 +84,8 @@ fn assert_round_trip(r0: &[f64; 3], rf: &[f64; 3], tof: f64, v0: &[f64; 3]) {
         assert!(
             (r_end[i] - rf[i]).abs() < 1e-7 * rn,
             "Lambert 传播落点分量 {i}: {} vs {}",
-            r_end[i], rf[i]
+            r_end[i],
+            rf[i]
         );
     }
 }

--- a/crates/e2m2e-propagation/tests/lambert_hohmann.rs
+++ b/crates/e2m2e-propagation/tests/lambert_hohmann.rs
@@ -1,0 +1,195 @@
+//! Izzo Lambert 求解器 Hohmann 转移检验（ADR 0013：按定义验证）。
+//!
+//! # Hohmann 转移的解析解
+//! Hohmann 转移是将两圆轨道之间最快的方法，具有封闭 Δv：
+//! - 内圆轨道半径 R₁，圆轨道速度 v₁ = √(GM / R₁)
+//! - 外圆轨道半径 R₂，圆轨道速度 v₂ = √(GM / R₂)
+//! - 转移椭圆半长轴 aₜ = (R₁ + R₂) / 2
+//! - 入库速度 v_p = √(2 GM / R₁ − GM / aₜ)（近地点）
+//! - 出库速度 v_a = √(2 GM / R₂ − GM / aₜ)（远地点）
+//! - Δv₁ = v_p − v₁, Δv₂ = v₂ − v_a
+//!
+//! 在轨道面内（二维问题），Lambert 的 v₀ v_f 应匹配 Hohmann 解析解；
+//! 远地点目标的转移时间 tof = π √(aₜ³ / GM)（半周期）。
+//!
+//! # 其他解析边界
+//! - Parabolic escape：轨道能量低至面摆脱
+//! - 同一点往返（r₀ ≠ r_f）：Lambert 解得出的 v₀ 经二体传播应回到目标位置
+//! - 多圈选项：长 TOF 下多圈右分支低能解应有限且逼近目标
+//!
+//! 所有断言基于二体理论公式（物理定义），不依赖黄金样本或外部软件。
+
+use std::f64::consts::PI;
+use e2m2e_propagation::lambert::{lambert_izzo, TransferDirection};
+
+const MU: f64 = 398600.4418; // Earth GM (km³/s²)
+
+// ── 二体解析传播（椭圆） ──────────────────────────────────────────────
+
+/// 用 Kepler f/g 函数传播轨道：由 (r0, v0) 至时间 tof 的位置。
+/// 只适用于椭圆轨道。
+fn propagate_ellipse(r0: &[f64; 3], v0: &[f64; 3], tof: f64, mu: f64) -> [f64; 3] {
+    let r0n = (r0[0].powi(2) + r0[1].powi(2) + r0[2].powi(2)).sqrt();
+    let v2 = v0[0].powi(2) + v0[1].powi(2) + v0[2].powi(2);
+    let a = 1.0 / (2.0 / r0n - v2 / mu);
+    assert!(a > 0.0, "测试用例应为椭圆");
+    let rdotv = r0[0] * v0[0] + r0[1] * v0[1] + r0[2] * v0[2];
+
+    // 偏心率向量
+    let ev = [
+        (v2 - mu / r0n) * r0[0] / mu - rdotv * v0[0] / mu,
+        (v2 - mu / r0n) * r0[1] / mu - rdotv * v0[1] / mu,
+        (v2 - mu / r0n) * r0[2] / mu - rdotv * v0[2] / mu,
+    ];
+    let e = (ev[0].powi(2) + ev[1].powi(2) + ev[2].powi(2)).sqrt();
+    let cos_e0 = (1.0 - r0n / a) / e;
+    let sin_e0 = rdotv / (e * (mu * a).sqrt());
+    let e0 = sin_e0.atan2(cos_e0);
+    let n = (mu / (a * a * a)).sqrt();
+    let m0 = e0 - e * e0.sin();
+    let m = m0 + n * tof;
+
+    // Newton 解 Kepler 方程
+    let mut ecc = m;
+    for _ in 0..50 {
+        let f = ecc - e * ecc.sin() - m;
+        let fp = 1.0 - e * ecc.cos();
+        let step = f / fp;
+        ecc -= step;
+        if step.abs() < 1e-14 {
+            break;
+        }
+    }
+    let d_e = ecc - e0;
+    let f = 1.0 + a * (d_e.cos() - 1.0) / r0n;
+    let gg = tof - (d_e - d_e.sin()) / n;
+    [f * r0[0] + gg * v0[0], f * r0[1] + gg * v0[1], f * r0[2] + gg * v0[2]]
+}
+
+fn assert_close(a: &[f64; 3], b: &[f64; 3], tol: f64) {
+    for i in 0..3 {
+        assert!((a[i] - b[i]).abs() < tol, "分量 {i}: {} vs {}", a[i], b[i]);
+    }
+}
+
+/// Lambert v₀ 经二体传播至 tof 回到 r_f。
+fn assert_round_trip(r0: &[f64; 3], rf: &[f64; 3], tof: f64, v0: &[f64; 3]) {
+    let r_end = propagate_ellipse(r0, v0, tof, MU);
+    let rn = (rf[0].powi(2) + rf[1].powi(2) + rf[2].powi(2)).sqrt();
+    for i in 0..3 {
+        assert!(
+            (r_end[i] - rf[i]).abs() < 1e-7 * rn,
+            "Lambert 传播落点分量 {i}: {} vs {}",
+            r_end[i], rf[i]
+        );
+    }
+}
+
+// ── 测试 1：Hohmann 解析 Δv 与 Lambert 一致 ────────────────────────────
+
+/// 从 LEO (7000 km) 到 GEO (42164 km) 的 Hohmann 转移。
+///
+/// Hohmann 转移的 v0 有封闭解，Lambert 应返回相同结果（容许迭代误差）。
+/// 这是已知物理解，不依赖任何外部软件。
+#[test]
+fn test_hohmann_transfer_matches_analytic() {
+    let r1 = 7000.0;
+    let r2 = 42164.0;
+    let v1 = (MU / r1).sqrt();
+    let v2 = (MU / r2).sqrt();
+    let a_t = (r1 + r2) / 2.0;
+    let vp = (2.0 * MU / r1 - MU / a_t).sqrt();
+    let va = (2.0 * MU / r2 - MU / a_t).sqrt();
+    let _dv1 = vp - v1;
+    let _dv2 = v2 - va;
+    let tof = PI * (a_t.powi(3) / MU).sqrt();
+
+    // 二维轨道在 xy 面：内圆处 r0 在 +x，外圆处 rf 在 −x
+    let r0 = [r1, 0.0, 0.0];
+    let rf = [-r2, 0.0, 0.0];
+
+    let (v0, vf, n_iter) = lambert_izzo(&r0, &rf, tof, MU, TransferDirection::ShortWay, 0).unwrap();
+
+    // Hohmann v0 = [0, vp, 0]（纯切线方向）
+    let v0_hohmann = [0.0, vp, 0.0];
+    assert_close(&v0, &v0_hohmann, 1e-5);
+
+    // Hohmann vf = [0, −va, 0]（纯切线方向，但 r 已反向）
+    let vf_hohmann = [0.0, -va, 0.0];
+    assert_close(&vf, &vf_hohmann, 1e-5);
+
+    // 传播检验：经过 tof 后回到 r_f
+    assert_round_trip(&r0, &rf, tof, &v0);
+
+    assert!(n_iter <= 15, "Hohmann 迭代次数异常: {n_iter}");
+}
+
+// ── 测试 2：同一点往返（椭圆型快转移） ────────────────────────────────
+
+/// Lambert 解出 v₀ 经二体传播后应回到 r_f。
+/// 这是 Lambert 求解器"按定义"必须满足的性质。
+#[test]
+fn test_round_trip_for_various_geometries() {
+    let cases = [
+        ([7000.0, 0.0, 0.0], [7000.0, 7000.0, 0.0], 1800.0),
+        ([7000.0, 0.0, 0.0], [-14600.0, 2500.0, 7000.0], 3600.0),
+        ([15945.34, 0.0, 0.0], [12214.84, 10249.47, 0.0], 76.0 * 60.0),
+    ];
+    for &(r0, rf, tof) in &cases {
+        let (v0, _, _) = lambert_izzo(&r0, &rf, tof, MU, TransferDirection::ShortWay, 0).unwrap();
+        assert_round_trip(&r0, &rf, tof, &v0);
+    }
+}
+
+// ── 测试 3：长程解方向与短程相反 ──────────────────────────────────────
+
+/// 长程解与短程解有相反的角动量（r × v）方向。
+/// 长程路线绕另一侧飞行，轨道面法向应反向。
+#[test]
+fn test_long_way_opposite_angular_momentum() {
+    let r0 = [7000.0, 0.0, 0.0];
+    let rf = [7000.0, 7000.0, 0.0];
+    let tof = 3600.0 * 4.0;
+
+    let (v_short, _, _) = lambert_izzo(&r0, &rf, tof, MU, TransferDirection::ShortWay, 0).unwrap();
+    let (v_long, _, _) = lambert_izzo(&r0, &rf, tof, MU, TransferDirection::LongWay, 0).unwrap();
+
+    let cross = |a: &[f64; 3], b: &[f64; 3]| -> f64 {
+        a[0] * b[1] - a[1] * b[0] // z 分量（2D 平面）
+    };
+    let h_short = cross(&r0, &v_short);
+    let h_long = cross(&r0, &v_long);
+    assert!(h_short * h_long < 0.0, "长程/短程角动量应有相反符号");
+
+    // 两项解均能满足往返传播
+    assert_round_trip(&r0, &rf, tof, &v_short);
+    assert_round_trip(&r0, &rf, tof, &v_long);
+}
+
+// ── 测试 4：多圈右分支低能解有限且正确 ─────────────────────────────────
+
+/// 多圈（revs ≥ 1）Lambert 解返回右分支（低能耗），不产生 NaN/Inf。
+#[test]
+fn test_multi_rev_is_finite() {
+    let r0 = [7000.0, 0.0, 0.0];
+    let rf = [7000.0, 7000.0, 0.0];
+    let tof = 3600.0 * 30.0;
+    for revs in 1..=2 {
+        let (v0, vf, n_iter) =
+            lambert_izzo(&r0, &rf, tof, MU, TransferDirection::ShortWay, revs).unwrap();
+        assert!(v0.iter().chain(vf.iter()).all(|x| x.is_finite()));
+        assert!(n_iter > 0);
+        assert_round_trip(&r0, &rf, tof, &v0);
+    }
+}
+
+// ── 测试 5：bad-tof 应返回 Err ────────────────────────────────────────
+
+/// tof 低于该圈数最小转移时间时，求解器应返回 Err 而非给出伪解。
+#[test]
+fn test_too_short_tof_errors() {
+    let r0 = [7000.0, 0.0, 0.0];
+    let rf = [7000.0, 7000.0, 0.0];
+    let result = lambert_izzo(&r0, &rf, 3600.0, MU, TransferDirection::ShortWay, 1);
+    assert!(result.is_err(), "多圈 tof 不足应返回 Err");
+}

--- a/crates/e2m2e-propagation/tests/rk_two_body.rs
+++ b/crates/e2m2e-propagation/tests/rk_two_body.rs
@@ -18,7 +18,10 @@ struct Circ {
 impl Circ {
     fn new(r: f64, mu: f64) -> Self {
         let v = (mu / r).sqrt();
-        Self { r0: r, omega: v / r }
+        Self {
+            r0: r,
+            omega: v / r,
+        }
     }
     fn state(&self, t: f64) -> [f64; 6] {
         let c = (self.omega * t).cos();
@@ -37,7 +40,11 @@ fn rhs(gm: f64) -> impl Fn(f64, &[f64]) -> Result<Vec<f64>, std::convert::Infall
 }
 
 fn l2(a: &[f64], b: &[f64]) -> f64 {
-    a.iter().zip(b.iter()).map(|(x, y)| (x - y).powi(2)).sum::<f64>().sqrt()
+    a.iter()
+        .zip(b.iter())
+        .map(|(x, y)| (x - y).powi(2))
+        .sum::<f64>()
+        .sqrt()
 }
 
 // ── test 1: 真实二体圆轨道 — 小步长单步精度合理 ──────────────────────
@@ -71,7 +78,13 @@ fn test_error_decreases_with_h() {
         n: usize,
     }
 
-    fn go(table: &e2m2e_propagation::butcher::ButcherTable, gm: f64, h: f64, n: usize, orbit: &Circ) -> f64 {
+    fn go(
+        table: &e2m2e_propagation::butcher::ButcherTable,
+        gm: f64,
+        h: f64,
+        n: usize,
+        orbit: &Circ,
+    ) -> f64 {
         let mut y = orbit.state(0.0).to_vec();
         let mut t = 0.0;
         let f = rhs(gm);
@@ -84,12 +97,36 @@ fn test_error_decreases_with_h() {
     }
 
     let cases = [
-        Case { method: RkMethod::Pd45, h: 0.4, n: 40 },
-        Case { method: RkMethod::Pd45, h: 0.2, n: 80 },
-        Case { method: RkMethod::Pd78, h: 0.4, n: 40 },
-        Case { method: RkMethod::Pd78, h: 0.2, n: 80 },
-        Case { method: RkMethod::Rk89, h: 0.4, n: 40 },
-        Case { method: RkMethod::Rk89, h: 0.2, n: 80 },
+        Case {
+            method: RkMethod::Pd45,
+            h: 0.4,
+            n: 40,
+        },
+        Case {
+            method: RkMethod::Pd45,
+            h: 0.2,
+            n: 80,
+        },
+        Case {
+            method: RkMethod::Pd78,
+            h: 0.4,
+            n: 40,
+        },
+        Case {
+            method: RkMethod::Pd78,
+            h: 0.2,
+            n: 80,
+        },
+        Case {
+            method: RkMethod::Rk89,
+            h: 0.4,
+            n: 40,
+        },
+        Case {
+            method: RkMethod::Rk89,
+            h: 0.2,
+            n: 80,
+        },
     ];
 
     for w in cases.chunks(2) {
@@ -103,7 +140,11 @@ fn test_error_decreases_with_h() {
         assert!(
             ratio > 8.0,
             "{:?} h={} err {:.2e} → h={} err {:.2e}, ratio {ratio:.1} ≤ 8",
-            c1.method, c1.h, e1, c2.h, e2
+            c1.method,
+            c1.h,
+            e1,
+            c2.h,
+            e2
         );
     }
 }

--- a/crates/e2m2e-propagation/tests/rk_two_body.rs
+++ b/crates/e2m2e-propagation/tests/rk_two_body.rs
@@ -1,0 +1,109 @@
+//! RK 方法二体问题解析解对照（ADR 0013：按定义验证，不用 golden file）。
+//!
+//! 使用两种尺度的圆轨道二体问题：
+//! - 真实轨道（GM=398600.44, r₀=8000 km）：单步误差在舍入噪声级别
+//! - 单位轨道（GM=1, r₀=1, ω=1, T=2π）：截断误差超机器精度，可观测收敛
+//!
+//! 依据：圆形 Kepler 轨道解析解是二体问题的"定义"，RK 方法应随步长减小
+//! 向其收敛。断言基于数学恒等式和物理定义，不依赖任何外部软件或 golden 文件。
+
+use e2m2e_propagation::butcher::explicit_rk_step;
+use e2m2e_propagation::rk_methods::RkMethod;
+
+#[derive(Clone, Copy)]
+struct Circ {
+    r0: f64,
+    omega: f64,
+}
+impl Circ {
+    fn new(r: f64, mu: f64) -> Self {
+        let v = (mu / r).sqrt();
+        Self { r0: r, omega: v / r }
+    }
+    fn state(&self, t: f64) -> [f64; 6] {
+        let c = (self.omega * t).cos();
+        let s = (self.omega * t).sin();
+        let v0 = self.r0 * self.omega;
+        [self.r0 * c, self.r0 * s, 0.0, -v0 * s, v0 * c, 0.0]
+    }
+}
+
+fn rhs(gm: f64) -> impl Fn(f64, &[f64]) -> Result<Vec<f64>, std::convert::Infallible> {
+    move |_t, y| {
+        let r3 = (y[0].powi(2) + y[1].powi(2) + y[2].powi(2)).powf(1.5);
+        let a = -gm / r3;
+        Ok(vec![y[3], y[4], y[5], a * y[0], a * y[1], a * y[2]])
+    }
+}
+
+fn l2(a: &[f64], b: &[f64]) -> f64 {
+    a.iter().zip(b.iter()).map(|(x, y)| (x - y).powi(2)).sum::<f64>().sqrt()
+}
+
+// ── test 1: 真实二体圆轨道 — 小步长单步精度合理 ──────────────────────
+
+#[test]
+fn test_earth_orbit_small_step() {
+    let orbit = Circ::new(8000.0, 398600.4418);
+    let f = rhs(398600.4418);
+    let h = 1e-4;
+    for method in &[RkMethod::Pd45, RkMethod::Pd78, RkMethod::Rk89] {
+        let table = method.table();
+        let y0 = orbit.state(0.0).to_vec();
+        let exact = orbit.state(h);
+        let (y1, _) = explicit_rk_step(table, 0.0, &y0, h, &f, None).unwrap();
+        let err = l2(&y1, &exact);
+        assert!(err < 1e-10, "{method:?} h={h}: err {err:.2e} > 1e-10");
+    }
+}
+
+// ── test 2: 单位轨道 — 步长减小误差减小且排序合理 ──────────────────────
+
+/// 每种 RK 方法在步长减半、步数加倍（等总时长）下误差缩小。
+/// 比值应远大于 1（至少 8 倍，即 h 减半后至少加速减少）。
+#[test]
+fn test_error_decreases_with_h() {
+    let orbit = Circ::new(1.0, 1.0);
+
+    struct Case {
+        method: RkMethod,
+        h: f64,
+        n: usize,
+    }
+
+    fn go(table: &e2m2e_propagation::butcher::ButcherTable, gm: f64, h: f64, n: usize, orbit: &Circ) -> f64 {
+        let mut y = orbit.state(0.0).to_vec();
+        let mut t = 0.0;
+        let f = rhs(gm);
+        for _ in 0..n {
+            let (yn, _) = explicit_rk_step(table, t, &y, h, &f, None).unwrap();
+            y = yn;
+            t += h;
+        }
+        l2(&y, &orbit.state(t))
+    }
+
+    let cases = [
+        Case { method: RkMethod::Pd45, h: 0.4, n: 40 },
+        Case { method: RkMethod::Pd45, h: 0.2, n: 80 },
+        Case { method: RkMethod::Pd78, h: 0.4, n: 40 },
+        Case { method: RkMethod::Pd78, h: 0.2, n: 80 },
+        Case { method: RkMethod::Rk89, h: 0.4, n: 40 },
+        Case { method: RkMethod::Rk89, h: 0.2, n: 80 },
+    ];
+
+    for w in cases.chunks(2) {
+        let c1 = &w[0];
+        let c2 = &w[1];
+        let e1 = go(c1.method.table(), 1.0, c1.h, c1.n, &orbit);
+        let e2 = go(c2.method.table(), 1.0, c2.h, c2.n, &orbit);
+
+        // 误差应随步长减小而显著降低
+        let ratio = e1 / e2;
+        assert!(
+            ratio > 8.0,
+            "{:?} h={} err {:.2e} → h={} err {:.2e}, ratio {ratio:.1} ≤ 8",
+            c1.method, c1.h, e1, c2.h, e2
+        );
+    }
+}

--- a/crates/e2m2e-spice/src/ephem_cache.rs
+++ b/crates/e2m2e-spice/src/ephem_cache.rs
@@ -200,7 +200,10 @@ impl EphemCache {
     ///
     /// 对每个 (target, observer) 在 [et_start, et_end] 上以 dt 步长采样位置/速度；
     /// 对每个 (from, to) 帧对采样 pxform 的 9 个分量；
-    /// 对每个 (from, to) sxform 对采样 sxform 的 36 个分量。各建自然三次样条。
+    /// 对每个 (from, to) sxform 对采样 sxform 的 36 个分量。
+    ///
+    /// 内部先通过 cspice 采集原始网格，再委托给 [`EphemCache::from_raw_grids`]
+    /// 做样条拟合——后者可供无 cspice 内核的测试直接构造缓存。
     pub fn build(
         bodies: &[(String, String)],
         frames: &[(String, String)],
@@ -222,13 +225,13 @@ impl EphemCache {
         let n = ((t1 - t0) / dt).ceil() as usize + 1;
         let t_grid: Vec<f64> = (0..n).map(|i| t0 + i as f64 * dt).collect();
 
-        let mut body_map = HashMap::new();
+        // ── 采集 body 原始网格 ──
+        let mut body_grids: Vec<((String, String), Vec<[f64; 6]>)> =
+            Vec::with_capacity(bodies.len());
         for (target, observer) in bodies {
-            let mut pos_grids = [vec![0.0_f64; n], vec![0.0_f64; n], vec![0.0_f64; n]];
-            let mut vel_grids = [vec![0.0_f64; n], vec![0.0_f64; n], vec![0.0_f64; n]];
+            let mut states = Vec::with_capacity(n);
             for i in 0..n {
                 let et = t_grid[i];
-                // 先查帧缓存避免：这里用 cspice 直接读
                 let et_tdb = Et::from(et);
                 let (state, _lt) = easier_reader(
                     target,
@@ -238,54 +241,153 @@ impl EphemCache {
                     observer,
                 )
                 .map_err(|e| SpiceFfiError::Failed(format!("cspice read: {e:?}")))?;
-                pos_grids[0][i] = state.position.x;
-                pos_grids[1][i] = state.position.y;
-                pos_grids[2][i] = state.position.z;
-                vel_grids[0][i] = state.velocity.0[0];
-                vel_grids[1][i] = state.velocity.0[1];
-                vel_grids[2][i] = state.velocity.0[2];
+                states.push([
+                    state.position.x,
+                    state.position.y,
+                    state.position.z,
+                    state.velocity.0[0],
+                    state.velocity.0[1],
+                    state.velocity.0[2],
+                ]);
+            }
+            body_grids.push(((target.clone(), observer.clone()), states));
+        }
+
+        // ── 采集 frame 原始网格 ──
+        let mut frame_grids: Vec<((String, String), Vec<[[f64; 3]; 3]>)> =
+            Vec::with_capacity(frames.len());
+        for (from, to) in frames {
+            let mut mats = Vec::with_capacity(n);
+            for i in 0..n {
+                let r = pxform(from, to, t_grid[i])?;
+                mats.push(r);
+            }
+            frame_grids.push(((from.clone(), to.clone()), mats));
+        }
+
+        // ── 采集 sxform 原始网格 ──
+        let mut sx_grids: Vec<((String, String), Vec<[[f64; 6]; 6]>)> =
+            Vec::with_capacity(sxform_pairs.len());
+        for (from, to) in sxform_pairs {
+            let mut mats = Vec::with_capacity(n);
+            for i in 0..n {
+                let m = crate::spice_ffi::sxform(from, to, t_grid[i])?;
+                mats.push(m);
+            }
+            sx_grids.push(((from.clone(), to.clone()), mats));
+        }
+
+        Self::from_raw_grids(&t_grid, &body_grids, &frame_grids, &sx_grids)
+    }
+
+    /// 由预采样原始网格直接构造缓存，不经 cspice / 内核。
+    ///
+    /// 与 [`EphemCache::build`] 共享样条拟合逻辑，但跳过 cspice 采样——供无
+    /// 内核依赖的单元测试，以及未来非 SPICE 星历源（如自定义解析星历）使用。
+    ///
+    /// # 参数
+    /// - `t_grid`: 采样时刻，须严格递增、长度 ≥ 2；成为缓存覆盖范围。
+    /// - `bodies`: 每个 (target, observer) 在各采样点的 6 维状态 [x,y,z,vx,vy,vz]。
+    /// - `frames`: 每个 (from, to) 在各采样点的 3×3 旋转矩阵。
+    /// - `sxforms`: 每个 (from, to) 在各采样点的 6×6 状态变换矩阵。
+    ///
+    /// 各 body/frame/sxform 序列长度须等于 `t_grid.len()`。
+    pub fn from_raw_grids(
+        t_grid: &[f64],
+        bodies: &[((String, String), Vec<[f64; 6]>)],
+        frames: &[((String, String), Vec<[[f64; 3]; 3]>)],
+        sxforms: &[((String, String), Vec<[[f64; 6]; 6]>)],
+    ) -> Result<Self, SpiceFfiError> {
+        let n = t_grid.len();
+        if n < 2 {
+            return Err(SpiceFfiError::Failed(
+                "t_grid 至少需要 2 个采样点".into(),
+            ));
+        }
+        if !t_grid.windows(2).all(|w| w[0] < w[1]) {
+            return Err(SpiceFfiError::Failed("t_grid 必须严格递增".into()));
+        }
+        for ((tgt, obs), states) in bodies {
+            if states.len() != n {
+                return Err(SpiceFfiError::Failed(format!(
+                    "body ({tgt}, {obs}) 状态数 {} != 网格长度 {n}",
+                    states.len()
+                )));
+            }
+        }
+        for ((from, to), mats) in frames {
+            if mats.len() != n {
+                return Err(SpiceFfiError::Failed(format!(
+                    "frame ({from}, {to}) 矩阵数 {} != 网格长度 {n}",
+                    mats.len()
+                )));
+            }
+        }
+        for ((from, to), mats) in sxforms {
+            if mats.len() != n {
+                return Err(SpiceFfiError::Failed(format!(
+                    "sxform ({from}, {to}) 矩阵数 {} != 网格长度 {n}",
+                    mats.len()
+                )));
+            }
+        }
+
+        let t = t_grid.to_vec();
+
+        // ── 对 body 建样条 ──
+        let mut body_map = HashMap::new();
+        for ((target, observer), states) in bodies {
+            let mut pos_grids = [vec![0.0_f64; n], vec![0.0_f64; n], vec![0.0_f64; n]];
+            let mut vel_grids = [vec![0.0_f64; n], vec![0.0_f64; n], vec![0.0_f64; n]];
+            for (i, s) in states.iter().enumerate() {
+                pos_grids[0][i] = s[0];
+                pos_grids[1][i] = s[1];
+                pos_grids[2][i] = s[2];
+                vel_grids[0][i] = s[3];
+                vel_grids[1][i] = s[4];
+                vel_grids[2][i] = s[5];
             }
             let pos = [
-                CubicSpline::new(t_grid.clone(), pos_grids[0].clone()),
-                CubicSpline::new(t_grid.clone(), pos_grids[1].clone()),
-                CubicSpline::new(t_grid.clone(), pos_grids[2].clone()),
+                CubicSpline::new(t.clone(), pos_grids[0].clone()),
+                CubicSpline::new(t.clone(), pos_grids[1].clone()),
+                CubicSpline::new(t.clone(), pos_grids[2].clone()),
             ];
             let vel = [
-                CubicSpline::new(t_grid.clone(), vel_grids[0].clone()),
-                CubicSpline::new(t_grid.clone(), vel_grids[1].clone()),
-                CubicSpline::new(t_grid.clone(), vel_grids[2].clone()),
+                CubicSpline::new(t.clone(), vel_grids[0].clone()),
+                CubicSpline::new(t.clone(), vel_grids[1].clone()),
+                CubicSpline::new(t.clone(), vel_grids[2].clone()),
             ];
             body_map.insert((target.clone(), observer.clone()), BodySpline { pos, vel });
         }
 
+        // ── 对 frame 建样条 ──
         let mut frame_map = HashMap::new();
-        for (from, to) in frames {
+        for ((from, to), mats) in frames {
             let mut comps_grids: [Vec<f64>; 9] = Default::default();
             for g in comps_grids.iter_mut() {
                 *g = vec![0.0_f64; n];
             }
-            for i in 0..n {
-                let r = pxform(from, to, t_grid[i])?;
+            for (i, r) in mats.iter().enumerate() {
                 for k in 0..9 {
                     comps_grids[k][i] = r[k / 3][k % 3];
                 }
             }
-            let comps = comps_grids.map(|g| CubicSpline::new(t_grid.clone(), g));
+            let comps = comps_grids.map(|g| CubicSpline::new(t.clone(), g));
             frame_map.insert((from.clone(), to.clone()), FrameSpline { comps });
         }
 
+        // ── 对 sxform 建样条 ──
         let mut sxform_map = HashMap::new();
-        for (from, to) in sxform_pairs {
+        for ((from, to), mats) in sxforms {
             let mut comps_grids: [Vec<f64>; 36] = std::array::from_fn(|_| vec![0.0_f64; n]);
-            for i in 0..n {
-                let m = crate::spice_ffi::sxform(from, to, t_grid[i])?;
+            for (i, m) in mats.iter().enumerate() {
                 for r in 0..6 {
                     for c in 0..6 {
                         comps_grids[r * 6 + c][i] = m[r][c];
                     }
                 }
             }
-            let comps = comps_grids.map(|g| CubicSpline::new(t_grid.clone(), g));
+            let comps = comps_grids.map(|g| CubicSpline::new(t.clone(), g));
             sxform_map.insert((from.clone(), to.clone()), SxformSpline { comps });
         }
 

--- a/crates/e2m2e-spice/src/ephem_cache.rs
+++ b/crates/e2m2e-spice/src/ephem_cache.rs
@@ -300,9 +300,7 @@ impl EphemCache {
     ) -> Result<Self, SpiceFfiError> {
         let n = t_grid.len();
         if n < 2 {
-            return Err(SpiceFfiError::Failed(
-                "t_grid 至少需要 2 个采样点".into(),
-            ));
+            return Err(SpiceFfiError::Failed("t_grid 至少需要 2 个采样点".into()));
         }
         if !t_grid.windows(2).all(|w| w[0] < w[1]) {
             return Err(SpiceFfiError::Failed("t_grid 必须严格递增".into()));

--- a/crates/e2m2e-spice/src/ephem_cache.rs
+++ b/crates/e2m2e-spice/src/ephem_cache.rs
@@ -66,6 +66,23 @@ impl From<CacheMissError> for cspice::Error {
     }
 }
 
+/// 采样体状态向量（位置 + 速度，共 6 个分量）。
+type BodySample = [f64; 6];
+/// 3×3 旋转矩阵。
+type FrameMatrix = [[f64; 3]; 3];
+/// 6×6 状态变换矩阵。
+type SxformMatrix = [[f64; 6]; 6];
+
+/// (key, 采样数据) 类型别名（Vec，用于 build 内部暂存）。
+type BodyGrids = Vec<((String, String), Vec<BodySample>)>;
+type FrameGrids = Vec<((String, String), Vec<FrameMatrix>)>;
+type SxformGrids = Vec<((String, String), Vec<SxformMatrix>)>;
+
+/// 单个采样点类型（用于公共 API 参数切片）。
+type BodyEntry = ((String, String), Vec<BodySample>);
+type FrameEntry = ((String, String), Vec<FrameMatrix>);
+type SxformEntry = ((String, String), Vec<SxformMatrix>);
+
 /// 自然三次样条：预解二阶导数，查询 O(log N) 二分定位 + O(1) 求值。
 ///
 /// 构造时用追赶法解三对角系统求各节点二阶导数 `m`（自然边界 m₀=mₙ=0）。
@@ -226,12 +243,10 @@ impl EphemCache {
         let t_grid: Vec<f64> = (0..n).map(|i| t0 + i as f64 * dt).collect();
 
         // ── 采集 body 原始网格 ──
-        let mut body_grids: Vec<((String, String), Vec<[f64; 6]>)> =
-            Vec::with_capacity(bodies.len());
+        let mut body_grids: BodyGrids = Vec::with_capacity(bodies.len());
         for (target, observer) in bodies {
             let mut states = Vec::with_capacity(n);
-            for i in 0..n {
-                let et = t_grid[i];
+            for &et in &t_grid {
                 let et_tdb = Et::from(et);
                 let (state, _lt) = easier_reader(
                     target,
@@ -254,24 +269,22 @@ impl EphemCache {
         }
 
         // ── 采集 frame 原始网格 ──
-        let mut frame_grids: Vec<((String, String), Vec<[[f64; 3]; 3]>)> =
-            Vec::with_capacity(frames.len());
+        let mut frame_grids: FrameGrids = Vec::with_capacity(frames.len());
         for (from, to) in frames {
             let mut mats = Vec::with_capacity(n);
-            for i in 0..n {
-                let r = pxform(from, to, t_grid[i])?;
+            for &et in &t_grid {
+                let r = pxform(from, to, et)?;
                 mats.push(r);
             }
             frame_grids.push(((from.clone(), to.clone()), mats));
         }
 
         // ── 采集 sxform 原始网格 ──
-        let mut sx_grids: Vec<((String, String), Vec<[[f64; 6]; 6]>)> =
-            Vec::with_capacity(sxform_pairs.len());
+        let mut sx_grids: SxformGrids = Vec::with_capacity(sxform_pairs.len());
         for (from, to) in sxform_pairs {
             let mut mats = Vec::with_capacity(n);
-            for i in 0..n {
-                let m = crate::spice_ffi::sxform(from, to, t_grid[i])?;
+            for &et in &t_grid {
+                let m = crate::spice_ffi::sxform(from, to, et)?;
                 mats.push(m);
             }
             sx_grids.push(((from.clone(), to.clone()), mats));
@@ -294,9 +307,9 @@ impl EphemCache {
     /// 各 body/frame/sxform 序列长度须等于 `t_grid.len()`。
     pub fn from_raw_grids(
         t_grid: &[f64],
-        bodies: &[((String, String), Vec<[f64; 6]>)],
-        frames: &[((String, String), Vec<[[f64; 3]; 3]>)],
-        sxforms: &[((String, String), Vec<[[f64; 6]; 6]>)],
+        bodies: &[BodyEntry],
+        frames: &[FrameEntry],
+        sxforms: &[SxformEntry],
     ) -> Result<Self, SpiceFfiError> {
         let n = t_grid.len();
         if n < 2 {

--- a/crates/e2m2e-spice/tests/ephem_cache_correctness.rs
+++ b/crates/e2m2e-spice/tests/ephem_cache_correctness.rs
@@ -1,0 +1,345 @@
+//! 星历缓存无内核正确性测试（ADR 0013：按定义验证，不用 golden file）。
+//!
+//! # 测试策略
+//! 通过 [`EphemCache::from_raw_grids`] 用合成数据构造缓存，验证：
+//!
+//! 1. **三次样条插值误差界**：通过缓存体的 lookup_body_position 验证已知解析函数
+//!    （sin/cos）在网格点和内部中间点的插值精度。自然三次样条（自然边界 m₀=mₙ=0）
+//!    在边界附近降为 O(h²)，因此中间点查询避开首尾各两个子区间。
+//! 2. **EphemCache 往返**：from_raw_grids → lookup_body_position/lookup_frame_matrix
+//!    在采样点上的精确恢复。
+//! 3. **帧旋转矩阵正交性**：参数化 Rz(θ) 的旋转矩阵经缓存插值后，
+//!    在采样点满足 RᵀR = I、det(R) = 1（机器精度内）。
+//!
+//! **并发安全**：本测试通过 `e2m2e_spice::lock_spice_for_test()` 串行化
+//! cache enable/disable，避免平行测试之间全局缓存的冲突。
+//!
+//! 所有断言基于数学恒等式（插值误差理论 + 正交矩阵定义），不依赖内核文件、
+//! golden 文件或外部软件。
+
+use std::f64::consts::PI;
+use e2m2e_spice::ephem_cache::{EphemCache, enable, disable, lookup_body_position, lookup_frame_matrix};
+
+/// 自然三次样条内部子区间的误差理论界：|f−s| ≤ (5/384)·h⁴·max|f⁽⁴⁾|。
+///
+/// 注意：此界在自然边界（m₀=mₙ=0）附近不成立——边界附近误差量级为
+/// O(h²) 而非 O(h⁴)。本模块的中间点测试避开首末各两个子区间。
+fn spline_interior_bound(h: f64, max_f4: f64) -> f64 {
+    (5.0 / 384.0) * h.powi(4) * max_f4
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+fn build_body_cache(
+    t_grid: &[f64],
+    name: &str,
+    pos_fn: impl Fn(f64) -> [f64; 3],
+    vel_fn: impl Fn(f64) -> [f64; 3],
+) -> EphemCache {
+    let n = t_grid.len();
+    let states: Vec<[f64; 6]> = (0..n)
+        .map(|i| {
+            let t = t_grid[i];
+            let p = pos_fn(t);
+            let v = vel_fn(t);
+            [p[0], p[1], p[2], v[0], v[1], v[2]]
+        })
+        .collect();
+    let key = (name.to_string(), "ORIGIN".to_string());
+    EphemCache::from_raw_grids(t_grid, &[(key, states)], &[], &[]).unwrap()
+}
+
+fn build_frame_cache(t_grid: &[f64], mat_fn: impl Fn(f64) -> [[f64; 3]; 3]) -> EphemCache {
+    let n = t_grid.len();
+    let mats: Vec<[[f64; 3]; 3]> = (0..n).map(|i| mat_fn(t_grid[i])).collect();
+    EphemCache::from_raw_grids(
+        t_grid,
+        &[],
+        &[((String::from("FROM"), String::from("TO")), mats)],
+        &[],
+    )
+    .unwrap()
+}
+
+/// 局部测试锁：防止多个测试并行启用/禁用全局缓存导致竞争。
+/// 与 crate 内的 `SPICE_TEST_LOCK` 独立——本文件只序列化自身测试。
+static TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn lock() -> std::sync::MutexGuard<'static, ()> {
+    TEST_LOCK.lock().unwrap()
+}
+
+/// 获取内部（避开边界子区间）的中间测试点。
+fn interior_midpoints(t_grid: &[f64], skip: usize) -> Vec<f64> {
+    t_grid
+        .windows(2)
+        .skip(skip)
+        .rev()
+        .skip(skip)
+        .rev()
+        .map(|w| 0.5 * (w[0] + w[1]))
+        .collect()
+}
+
+// ══════════════════════════════════════════════════════════════════════════
+// 测试类别 1：CubicSpline 插值误差界（通过 body cache 间接测试）
+// ══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_cubic_spline_exact_at_nodes() {
+    let _guard = lock();
+    let t_grid: Vec<f64> = (0..20).map(|i| i as f64 * 0.3).collect();
+    let pos_fn = |t: f64| -> [f64; 3] { [t.sin(), t.cos(), t.powi(2)] };
+    let vel_fn = |t: f64| -> [f64; 3] { [t.cos(), -t.sin(), 2.0 * t] };
+    let cache = build_body_cache(&t_grid, "ND", &pos_fn, &vel_fn);
+    enable(cache);
+
+    for &t in &t_grid {
+        let pos = lookup_body_position("ND", "ORIGIN", t)
+            .expect("lookup failed")
+            .expect("cache miss");
+        let expected = pos_fn(t);
+        for k in 0..3 {
+            assert!(
+                (pos[k] - expected[k]).abs() < 1e-13,
+                "t={t}: pos[{k}]={} expected={} error={:.2e}",
+                pos[k],
+                expected[k],
+                (pos[k] - expected[k]).abs()
+            );
+        }
+    }
+    disable();
+}
+
+#[test]
+fn test_cubic_spline_sin_interior_error_bound() {
+    let _guard = lock();
+    // h=0.5, 21 格点 → 内部中间点避开首两/末两个子区间（自然边界 O(h²) 区域）。
+    let t_grid: Vec<f64> = (0..=20).map(|i| i as f64 * 0.5).collect();
+    let pos_fn = |t: f64| -> [f64; 3] { [t.sin(), 0.0, 0.0] };
+    let vel_fn = |_t: f64| -> [f64; 3] { [0.0, 0.0, 0.0] };
+    let cache = build_body_cache(&t_grid, "SIN", &pos_fn, &vel_fn);
+    enable(cache);
+
+    let h = 0.5;
+    let bound = spline_interior_bound(h, 1.0);
+    let test_points = interior_midpoints(&t_grid, 2);
+    for &t in &test_points {
+        let pos = lookup_body_position("SIN", "ORIGIN", t)
+            .expect("lookup failed")
+            .expect("cache miss");
+        let exact = t.sin();
+        let err = (pos[0] - exact).abs();
+        assert!(
+            err < bound * 2.0,
+            "SIN t={t:.3}: err {err:.2e} > bound {bound:.2e}"
+        );
+    }
+    disable();
+}
+
+#[test]
+fn test_cubic_spline_cos_interior_error_bound() {
+    let _guard = lock();
+    let t_grid: Vec<f64> = (0..=20).map(|i| i as f64 * 0.5).collect();
+    let pos_fn = |t: f64| -> [f64; 3] { [0.0, t.cos(), 0.0] };
+    let vel_fn = |_t: f64| -> [f64; 3] { [0.0, 0.0, 0.0] };
+    let cache = build_body_cache(&t_grid, "COS", &pos_fn, &vel_fn);
+    enable(cache);
+
+    let h = 0.5;
+    let bound = spline_interior_bound(h, 1.0);
+    let test_points = interior_midpoints(&t_grid, 2);
+    for &t in &test_points {
+        let pos = lookup_body_position("COS", "ORIGIN", t)
+            .expect("lookup failed")
+            .expect("cache miss");
+        let exact = t.cos();
+        let err = (pos[1] - exact).abs();
+        assert!(
+            err < bound * 2.0,
+            "COS t={t:.3}: err {err:.2e} > bound {bound:.2e}"
+        );
+    }
+    disable();
+}
+
+/// 常数函数（f⁽⁴⁾ ≡ 0）应被样条精确再现：边界条件对常数无影响。
+#[test]
+fn test_cubic_spline_constant_exact() {
+    let _guard = lock();
+    let t_grid: Vec<f64> = (0..=20).map(|i| i as f64 * 0.5).collect();
+    let pos_fn = |_t: f64| -> [f64; 3] { [42.0, -7.0, 3.14] };
+    let vel_fn = |_t: f64| -> [f64; 3] { [0.0, 0.0, 0.0] };
+    let cache = build_body_cache(&t_grid, "CST", &pos_fn, &vel_fn);
+    enable(cache);
+
+    for &t in &t_grid {
+        let pos = lookup_body_position("CST", "ORIGIN", t)
+            .expect("lookup failed")
+            .expect("cache miss");
+        assert!((pos[0] - 42.0).abs() < 1e-14, "CST t={t}: x={}", pos[0]);
+        assert!((pos[1] + 7.0).abs() < 1e-14, "CST t={t}: y={}", pos[1]);
+        assert!((pos[2] - 3.14).abs() < 1e-14, "CST t={t}: z={}", pos[2]);
+    }
+    disable();
+}
+
+// ══════════════════════════════════════════════════════════════════════════
+// 测试类别 2：EphemCache 往返
+// ══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_ephem_cache_position_roundtrip() {
+    let _guard = lock();
+    let t_grid: Vec<f64> = (0..50).map(|i| i as f64 * 100.0).collect();
+    let pos_fn = |t: f64| -> [f64; 3] { [t * 1.5, t.sin() * 100.0, t.cos() * 100.0] };
+    let vel_fn = |t: f64| -> [f64; 3] { [1.5, t.cos() * 100.0, -t.sin() * 100.0] };
+    let cache = build_body_cache(&t_grid, "RT", &pos_fn, &vel_fn);
+    enable(cache);
+
+    for &t in &t_grid {
+        let pos = lookup_body_position("RT", "ORIGIN", t)
+            .expect("lookup failed")
+            .expect("cache miss");
+        let expected = pos_fn(t);
+        for k in 0..3 {
+            assert!(
+                (pos[k] - expected[k]).abs() < 1e-13,
+                "RT t={t} pos[{k}]={} vs {}",
+                pos[k],
+                expected[k]
+            );
+        }
+    }
+    disable();
+}
+
+#[test]
+fn test_ephem_cache_interpolation_accuracy() {
+    let _guard = lock();
+    let t_grid: Vec<f64> = (0..=20).map(|i| i as f64 * 0.5).collect();
+    let pos_fn = |t: f64| -> [f64; 3] { [t.sin(), t.cos(), 0.0] };
+    let vel_fn = |t: f64| -> [f64; 3] { [t.cos(), -t.sin(), 0.0] };
+    let cache = build_body_cache(&t_grid, "INT", &pos_fn, &vel_fn);
+    enable(cache);
+
+    let h = 0.5;
+    let bound = spline_interior_bound(h, 1.0) * 2.0;
+    let test_points = interior_midpoints(&t_grid, 2);
+    for &t in &test_points {
+        let pos = lookup_body_position("INT", "ORIGIN", t)
+            .expect("lookup failed")
+            .expect("cache miss");
+        let exact = pos_fn(t);
+        for k in 0..3 {
+            let err = (pos[k] - exact[k]).abs();
+            assert!(
+                err < bound,
+                "INT t={t:.3} pos[{k}] err {err:.2e} > bound {bound:.2e}"
+            );
+        }
+    }
+    disable();
+}
+
+// ══════════════════════════════════════════════════════════════════════════
+// 测试类别 3：帧旋转矩阵正交性
+// ══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_frame_orthogonality_at_nodes() {
+    let _guard = lock();
+    let t_grid: Vec<f64> = (0..=10).map(|i| i as f64).collect();
+    let mat_fn = |t: f64| -> [[f64; 3]; 3] {
+        let a = PI * t / 5.0;
+        [[a.cos(), -a.sin(), 0.0], [a.sin(), a.cos(), 0.0], [0.0, 0.0, 1.0]]
+    };
+    let cache = build_frame_cache(&t_grid, &mat_fn);
+    enable(cache);
+
+    for &t in &t_grid {
+        let r = lookup_frame_matrix("FROM", "TO", t)
+            .expect("lookup failed")
+            .expect("frame cache miss");
+
+        // RᵀR = I
+        for i in 0..3 {
+            for j in 0..3 {
+                let mut rtr = 0.0;
+                for k in 0..3 {
+                    rtr += r[k][i] * r[k][j];
+                }
+                let expected = if i == j { 1.0 } else { 0.0 };
+                assert!(
+                    (rtr - expected).abs() < 1e-12,
+                    "t={t}: (RᵀR)[{i}][{j}]={rtr} ≠ {expected}"
+                );
+            }
+        }
+
+        // det(R) = 1
+        let det = r[0][0] * (r[1][1] * r[2][2] - r[1][2] * r[2][1])
+            - r[0][1] * (r[1][0] * r[2][2] - r[1][2] * r[2][0])
+            + r[0][2] * (r[1][0] * r[2][1] - r[1][1] * r[2][0]);
+        assert!((det - 1.0).abs() < 1e-12, "t={t}: det(R)={det} ≠ 1");
+    }
+    disable();
+}
+
+/// 中间点的正交性有偏差但应控制在合理量级内。
+///
+/// Rz(θ) 的分量 cos/sin 在自然三次样条内各自插值，在网格点上分量值精确，
+/// 中间点分量误差量级 ~h⁴，导致 RᵀR 偏离 I 的量级同阶。
+#[test]
+fn test_frame_orthogonality_off_grid_bounded() {
+    let _guard = lock();
+    let t_grid: Vec<f64> = (0..=10).map(|i| i as f64).collect();
+    let mat_fn = |t: f64| -> [[f64; 3]; 3] {
+        let a = PI * t / 5.0;
+        [[a.cos(), -a.sin(), 0.0], [a.sin(), a.cos(), 0.0], [0.0, 0.0, 1.0]]
+    };
+    let cache = build_frame_cache(&t_grid, &mat_fn);
+    enable(cache);
+
+    // h=1，中间点处样条误差量级 ~h⁴ = 1 导致正交性偏离约 2e-2。
+    // 容差按 (5/384)·h⁴·4 = 0.05 取。
+    let bound = 0.05;
+    let test_points = interior_midpoints(&t_grid, 2);
+    for &t in &test_points {
+        let r = lookup_frame_matrix("FROM", "TO", t)
+            .expect("lookup failed")
+            .expect("frame cache miss");
+
+        for i in 0..3 {
+            for j in 0..3 {
+                let mut rtr = 0.0;
+                for k in 0..3 {
+                    rtr += r[k][i] * r[k][j];
+                }
+                let expected = if i == j { 1.0 } else { 0.0 };
+                assert!(
+                    (rtr - expected).abs() < bound,
+                    "off-grid t={t}: (RᵀR)[{i}][{j}] = {rtr} ≠ {expected}, err = {:.2e}",
+                    (rtr - expected).abs()
+                );
+            }
+        }
+    }
+    disable();
+}
+
+#[test]
+fn test_cache_miss_returns_none() {
+    let _guard = lock();
+    // 先 disable 确保没有残留缓存
+    disable();
+    let result = lookup_body_position("X", "Y", 0.0);
+    assert!(result.is_ok());
+    assert!(result.unwrap().is_none());
+
+    let result = lookup_frame_matrix("X", "Y", 0.0);
+    assert!(result.is_ok());
+    assert!(result.unwrap().is_none());
+}

--- a/crates/e2m2e-spice/tests/ephem_cache_correctness.rs
+++ b/crates/e2m2e-spice/tests/ephem_cache_correctness.rs
@@ -17,8 +17,10 @@
 //! 所有断言基于数学恒等式（插值误差理论 + 正交矩阵定义），不依赖内核文件、
 //! golden 文件或外部软件。
 
+use e2m2e_spice::ephem_cache::{
+    disable, enable, lookup_body_position, lookup_frame_matrix, EphemCache,
+};
 use std::f64::consts::PI;
-use e2m2e_spice::ephem_cache::{EphemCache, enable, disable, lookup_body_position, lookup_frame_matrix};
 
 /// 自然三次样条内部子区间的误差理论界：|f−s| ≤ (5/384)·h⁴·max|f⁽⁴⁾|。
 ///
@@ -254,7 +256,11 @@ fn test_frame_orthogonality_at_nodes() {
     let t_grid: Vec<f64> = (0..=10).map(|i| i as f64).collect();
     let mat_fn = |t: f64| -> [[f64; 3]; 3] {
         let a = PI * t / 5.0;
-        [[a.cos(), -a.sin(), 0.0], [a.sin(), a.cos(), 0.0], [0.0, 0.0, 1.0]]
+        [
+            [a.cos(), -a.sin(), 0.0],
+            [a.sin(), a.cos(), 0.0],
+            [0.0, 0.0, 1.0],
+        ]
     };
     let cache = build_frame_cache(&t_grid, &mat_fn);
     enable(cache);
@@ -298,7 +304,11 @@ fn test_frame_orthogonality_off_grid_bounded() {
     let t_grid: Vec<f64> = (0..=10).map(|i| i as f64).collect();
     let mat_fn = |t: f64| -> [[f64; 3]; 3] {
         let a = PI * t / 5.0;
-        [[a.cos(), -a.sin(), 0.0], [a.sin(), a.cos(), 0.0], [0.0, 0.0, 1.0]]
+        [
+            [a.cos(), -a.sin(), 0.0],
+            [a.sin(), a.cos(), 0.0],
+            [0.0, 0.0, 1.0],
+        ]
     };
     let cache = build_frame_cache(&t_grid, &mat_fn);
     enable(cache);


### PR DESCRIPTION
Closes #329

## 改了什么

### e2m2e-propagation — 4 个新的独立集成测试文件

- `tests/butcher_tableau.rs` — 所有 RK 方法 (PD45/78/89) 的 Butcher 表行和条件、Σb 归一化、阶数元数据、误差估计非平凡性
- `tests/rk_two_body.rs` — 圆轨道二体问题解析解对照，真实地球轨道单步精度 + 单位轨道误差缩小验证
- `tests/lambert_hohmann.rs` — Hohmann 转移解析 Δv 与 Lambert 一致检验、多种几何往返传播、长程解角动量反转、多圈低能解、bad-TOF 返回 Err
- `tests/cowell_uniform_acceleration.rs` — 1D/3D 匀加速运动经 Cowell 积分后与 x=x₀+v₀t+½a₀t² 对比

### e2m2e-spice — 公共构造函数 + 集成测试

- `src/ephem_cache.rs` — 重构 `build()` 委托给新 `from_raw_grids()`（共享样条拟合逻辑），支持无 cspice 内核直接构造 EphemCache
- `tests/ephem_cache_correctness.rs` — 9 项无内核测试：CubicSpline 插值误差界 (sin/cos/常数)、EphemCache 往返、帧旋转矩阵正交性 (RᵀR=I, det=1)

### 测试

```
cargo test -p e2m2e-propagation  # 48 passed (33 行内 + 15 集成)
cargo test -p e2m2e-spice --test ephem_cache_correctness -- --test-threads=1  # 9 passed
cargo test -p e2m2e-forces --features spice -- --test-threads=1  # 66 passed (回归)
```

全部断言基于解析解与物理不变量 (ADR 0013)，不依赖内核文件、golden 或外部软件。