### PR TITLE
feat(design): 统一 design_orbit 入口支持 ELFO 冻结轨道设计 (#348)

### DIFF
--- a/e2m2e/algorithm/design/design_orbit.py
+++ b/e2m2e/algorithm/design/design_orbit.py
@@ -34,7 +34,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -67,6 +67,9 @@ from ..family.cr3bp_orbits import (
     earth_moon_system,
 )
 from ..solver.multiple_shooting import sample_patch_points_perilune_clustered
+
+if TYPE_CHECKING:
+    from ...api.models import DesignOrbitRequest
 
 __all__ = [
     "DesignNotConvergedError",
@@ -151,18 +154,23 @@ class OrbitDesignResult:
     """任务轨道设计结果。
 
     Attributes:
-        orbit_type: 轨道类型（``"DRO"`` / ``"HALO"`` / ``"NRHO"``）。
+        orbit_type: 轨道类型（``"DRO"`` / ``"HALO"`` / ``"NRHO"`` / ``"ELFO"``）。
         epoch_utc: 起始历元 UTC（ISO 字符串）。
         duration_day: 维持时间（天）。
         output_step_sec: 星历输出间隔（秒）。
         initial_state: 历元时刻惯性系状态（km, km/s），星历修正后首节点。
         ephemeris: 标称星历（文本格式容器：UTC + GCRS 位置 km /
             速度 m/s + 地月会合系无量纲位置）。
-        cr3bp_orbit: CR3BP 周期轨道（参考相位，无量纲）。
-        cr3bp_jacobi: CR3BP 周期轨道的 Jacobi 常数。
+        cr3bp_orbit: CR3BP 周期轨道（参考相位，无量纲）；ELFO 场景为 None。
+        cr3bp_jacobi: CR3BP 周期轨道的 Jacobi 常数；ELFO 场景为 nan。
         correction: 星历修正结果（收敛标志、迭代次数、残差历史、修正后
-            patch points）。
+            patch points）；ELFO 场景为 None。
         force_config: 标称预报使用的力模型配置字典。
+        drift_e: 传播弧段 Δe 首末差（仅 ELFO）。
+        drift_aop_deg: 传播弧段 Δω 首末差（度，仅 ELFO）。
+        drift_rp_km: 传播弧段 Δrp 首末差（km，仅 ELFO）。
+        secular_aop_rate_deg_per_year: ω 线性拟合年漂移率（仅 ELFO）。
+        moon_centric_elements: 月心惯性系根数序列（仅 ELFO）。
     """
 
     orbit_type: str
@@ -171,10 +179,15 @@ class OrbitDesignResult:
     output_step_sec: float
     initial_state: np.ndarray
     ephemeris: EphemerisTable
-    cr3bp_orbit: Orbit
+    cr3bp_orbit: Orbit | None
     cr3bp_jacobi: float
-    correction: EphemerisCorrectionResult
+    correction: EphemerisCorrectionResult | None
     force_config: dict[str, Any]
+    drift_e: float | None = None
+    drift_aop_deg: float | None = None
+    drift_rp_km: float | None = None
+    secular_aop_rate_deg_per_year: float | None = None
+    moon_centric_elements: dict[str, np.ndarray] | None = None
 
     def write_ephemeris(self, path: str | Path) -> None:
         """按文本格式写出标称星历。"""
@@ -728,118 +741,180 @@ def _design_apolune_segmented(
     return np.asarray(all_t, dtype=float), np.asarray(all_s, dtype=float), max_residual
 
 
+def _design_elfo(
+    request: DesignOrbitRequest,
+    spice: SPICEManager,
+    kernel_dir: str,
+    verbose: bool,  # noqa: ARG001
+) -> OrbitDesignResult:
+    """ELFO 冻结轨道管线：经典根数 → 地心初值 → 全摄动传播 → 月心漂移分析。"""
+
+    from ..forces import ForceModel
+    from ..forces.force_mapping import perturbation_to_force_config  # noqa: I001
+    from .frozen_orbit import (
+        MU_MOON,
+        R_MOON,
+        _compute_drift,
+        _extract_moon_centric_elements,
+        _oe2cart,
+    )
+
+    # model_validator 已确保 ELFO 必填字段非 None
+    assert request.semi_major_axis is not None
+    assert request.inclination is not None
+    assert request.arg_of_pericenter is not None
+    assert request.perilune_height is not None
+    assert request.duration is not None
+
+    a = float(request.semi_major_axis)
+    rp = R_MOON + float(request.perilune_height)
+    e = 1.0 - rp / a
+    i_deg = float(request.inclination)
+    aop_deg = float(request.arg_of_pericenter)
+    duration_sec = float(request.duration)
+    output_step = float(request.output_step)
+    perturbation = (
+        request.perturbation if request.perturbation is not None else DEFAULT_DESIGN_PERTURBATION
+    )
+
+    epoch_iso = _epoch_to_iso(request.epoch)
+    et0 = spice.utc_to_et(epoch_iso)
+
+    # 力模型（与 CR3BP 管线同路径）
+    sw = dict(perturbation)
+    bodies = ["EARTH", "MOON"]
+    if sw["sun_body"]:
+        bodies.append("SUN")
+    if sw["planets"]:
+        bodies += ["MERCURY", "VENUS", "MARS", "JUPITER", "SATURN", "URANUS", "NEPTUNE"]
+    full_system = EphemerisSystem(bodies=bodies, spice=spice, origin="EARTH")
+    full_system.coordinate_system = CoordinateSystem(
+        axes=ICRSAxes(),
+        origin=CelestialBodyOrigin(body="EARTH", spice=spice),
+    )
+    force_config = perturbation_to_force_config(
+        perturbation,
+        earth_degree=request.earth_degree,
+        moon_degree=request.moon_degree,
+        dyb=request.dyb,
+    )
+    fm = ForceModel.from_config(force_config, full_system)
+    fm.rtol = 1e-12
+    fm.atol = 1e-12
+    fm.max_step = 600.0
+
+    # 初值：月心根数 → 月心笛卡尔 → 叠加月球地心状态
+    moon_state = spice.get_body_state("MOON", et0, "J2000", "EARTH")
+    seleno = _oe2cart(a, e, i_deg, 0.0, aop_deg, 0.0, MU_MOON)
+    state0 = np.concatenate(
+        [
+            seleno[:3] + moon_state[:3],
+            seleno[3:6] + moon_state[3:6],
+        ]
+    )
+
+    # 传播
+    et_end = et0 + duration_sec
+    et_grid = et0 + np.arange(0.0, duration_sec + 0.5 * output_step, output_step)
+    out = fm.propagate(state0, (et0, et_end), t_eval=et_grid, max_steps=5_000_000)
+    states = np.asarray(out["states"], dtype=float)
+    n_pts = len(states)
+    times = et_grid[:n_pts]
+
+    # 月心根数提取与漂移统计
+    moon_oe = _extract_moon_centric_elements(times, states, spice)
+    drift = _compute_drift(moon_oe, times=times, output_step_sec=output_step)
+
+    # 星历表（ELFO 仍输出地心惯性系 + 会合系，格式与 CR3BP 一致）
+    system = earth_moon_system()
+    syn_j2000 = SynodicJ2000System(cr3bp_system=system, spice=spice)
+    ephemeris = _build_ephemeris_table(spice, syn_j2000, et0, et_grid[:n_pts], states)
+
+    return OrbitDesignResult(
+        orbit_type="ELFO",
+        epoch_utc=epoch_iso,
+        duration_day=duration_sec / 86400.0,
+        output_step_sec=output_step,
+        initial_state=state0,
+        ephemeris=ephemeris,
+        cr3bp_orbit=None,
+        cr3bp_jacobi=float("nan"),
+        correction=None,
+        force_config=force_config,
+        drift_e=drift["drift_e"],
+        drift_aop_deg=drift["drift_aop_deg"],
+        drift_rp_km=drift["drift_rp_km"],
+        secular_aop_rate_deg_per_year=drift["secular_aop_rate_deg_per_year"],
+        moon_centric_elements=moon_oe,
+    )
+
+
 def design_orbit(
-    orbit_type: str,
+    request: DesignOrbitRequest,
     *,
-    amplitude: float | None = None,
-    phase: float | None = None,
-    collinear_point: int | None = None,
-    north_south: int | None = None,
-    perilune_height: float | None = None,
-    amplitude_in: float | None = None,
-    amplitude_out: float | None = None,
-    phase_in: float | None = None,
-    phase_out: float | None = None,
-    epoch: Sequence[float] | str = (2024, 1, 1, 0, 0, 0.0),
-    duration: float = 1.0,
-    output_step: float = 3600.0,
-    perturbation: dict[str, int] | None = None,
-    dyb: Sequence[float] | None = None,
-    earth_degree: int = 10,
-    moon_degree: int = 10,
     spice: SPICEManager | None = None,
     kernel_dir: str | None = None,
-    correction_method: str = "two_level",
-    correction_revolutions: int = 1,
-    correction_velocity_tolerance: float = 0.1,
     verbose: bool = False,
 ) -> OrbitDesignResult:
-    """端到端设计标称轨道（DRO/DPO/NRHO/Halo/Lissajous/L4/L5/Axial/L4_SPO/L5_SPO/L4_LPO/L5_LPO/L4_HORSESHOE/L5_HORSESHOE）。
+    """端到端设计标称轨道（DRO/DPO/NRHO/Halo/Lissajous/L4/L5/Axial/.../ELFO）。
+
+    通过 ``request.orbit_type`` 在内部分派管线：
+
+    - **CR3BP 类型**（DRO/NRHO/Halo/Lissajous/…）：CR3BP 初猜 → 星历修正
+      （多重打靶）→ 高精度长期预报。
+    - **ELFO**：经典开普勒根数构造初值 → 全摄动传播 → 月心根数漂移分析。
 
     Args:
-        orbit_type: ``"DRO"`` / ``"DPO"`` / ``"NRHO"`` / ``"Halo"`` /
-            ``"Lissajous"`` / ``"L4"`` / ``"L5"`` / ``"AXIAL"`` /
-            ``"L4_SPO"`` / ``"L5_SPO"`` / ``"L4_LPO"`` / ``"L5_LPO"`` /
-            ``"L4_HORSESHOE"`` / ``"L5_HORSESHOE"``。
-        amplitude: 振幅（km）。DRO 1737~110000，默认 10000；DPO 1737~110000，
-            默认 20000；Halo 面外振幅 ±73000（正北负南），默认 30000；
-            Axial z 振幅 ±60000（正上下族），默认 5000；NRHO 不用。
-        phase: 初始相位（周期份额）。DRO/DPO/Halo/Axial 取值 0~1，默认
-            0.5001/0/0；NRHO 取值 0.01~0.99，默认 0.5。
-        collinear_point: 共线平动点编号 1/2（Halo/NRHO，默认 2）。
-            Lissajous/Axial 取 1/2/3（默认 2）。
-        north_south: 1=北 / 2=南（NRHO，默认 2）。
-        perilune_height: 近月点高度（km，100~10000，NRHO，默认 5000）。
-        amplitude_in / amplitude_out: 面内/面外振幅（km）。Lissajous
-            L1/L2 各 ≤ 7600、L3 各 ≤ 100000（默认 2500/7500）；L4/L5 面内
-            ≤ 10000、面外 ≤ 76000（默认 8000/6000）。
-        phase_in / phase_out: 面内/面外初始相位（0~1）。Lissajous 默认
-            0.01/0.55；L4/L5 默认 0/0。
-        epoch: 起始历元 UTC，``[年, 月, 日, 时, 分, 秒]`` 或 ISO 字符串。
-        duration: 维持时间（年，0 < d ≤ 20）。
-        output_step: 星历输出间隔（秒）。
-        perturbation: 摄动开关字典（键与取值同
-            ``DEFAULT_PERTURBATION``），经
-            ``perturbation_to_force_config`` 映射为力模型。缺省时用
-            ``DEFAULT_DESIGN_PERTURBATION``：光压炮弹模型、关耦合项
-            （ECOM 光压与耦合项属 #253，需要时显式开启会抛
-            ``NotImplementedError``）。
-        dyb: DYB 系数 9 分量（``dyb[0]`` = 等效面质比 m²/kg）。
-        earth_degree / moon_degree: 引力场阶次。
-        spice: 已加载内核的 ``SPICEManager``；缺省自动创建并加载
-            ``kernel_dir``（默认仓库 ``kernels/``）下的内核。
+        request: ``DesignOrbitRequest``，经 model_validator 校验并填充默认值。
+        spice: 已加载内核的 ``SPICEManager``；缺省自动创建并加载。
         kernel_dir: SPICE 内核目录。
-        correction_method: 星历修正方法。默认 ``"two_level"``——Rust 多重打靶
-            + 速度加权（``vel_weight=pos_tol/vel_tol``），把 patch point 位置
-            连续与速度连续同时压到容差（速度 ≤0.01 m/s），修正解落在准周期轨道
-            上、自由外推有界（修 #324：大幅 DRO 在坏历元从发散 200000 km 收敛
-            到有界 ~80000 km）；全程预制星历表（cspice 缓存）。
-            ``"segmented"`` 论文式分段打靶拼接（逐段独立 var_time 打靶转星历 +
-            远月点分层合并，朱彦伟 2026），对 Halo/NRHO 等不稳定轨道在星历模型下
-            长期保形，同样带速度加权；``"homotopy"`` 同伦过渡（质点 N 体语义，
-            走旧 Python 路径，不含速度加权）。
-            ``"standard"``/``"rust"`` 等价于默认的 Rust 多重打靶路径。
-        correction_revolutions: 星历修正弧长（圈数）。默认 1：中性稳定轨道（DRO）
-            速度连续的初值即落在准周期轨道上，自由外推全程有界，无需多圈修正。
-        correction_velocity_tolerance: 速度残差容差（km/s，仅 ``"homotopy"`` 旧路径）。
-            默认 0.1。默认 Rust 路径不用此参数，改由 ``VELOCITY_TOL_KMS``（0.01 m/s）
-            与 ``CORRECTION_TOL_KM`` 派生 ``vel_weight`` 硬绑。
         verbose: 修正过程显示进度条。
 
     Returns:
-        ``OrbitDesignResult``（标称星历 + 收敛信息）。
+        ``OrbitDesignResult``（标称星历 + 收敛/漂移信息）。
 
     Raises:
         ValueError: 形状参数/任务参数超界。
         NotImplementedError: 摄动开关含 ECOM 光压或耦合项（#253）。
         DesignNotConvergedError: 星历修正未收敛。
     """
-    sel = orbit_type.upper()
-    if not 0.0 < float(duration) <= 20.0:
-        raise ValueError(f"duration 应大于 0 且不超过 20 年，实际为 {duration}")
-    if float(output_step) <= 0.0:
-        raise ValueError(f"output_step 必须为正数，当前 {output_step}")
-    if correction_revolutions < 1:
-        raise ValueError(f"correction_revolutions 必须 ≥ 1，当前 {correction_revolutions}")
-
-    # --- 1. CR3BP 初猜 ---
-    params = _validate_params(
-        sel,
-        amplitude=amplitude,
-        phase=phase,
-        collinear_point=collinear_point,
-        north_south=north_south,
-        perilune_height=perilune_height,
-        amplitude_in=amplitude_in,
-        amplitude_out=amplitude_out,
-        phase_in=phase_in,
-        phase_out=phase_out,
-    )
+    sel = request.orbit_type.upper()
 
     if spice is None:
         spice = SPICEManager()
         load_design_kernels(spice, kernel_dir)
     kernel_dir = kernel_dir or default_kernel_dir()
+
+    # --- ELFO 管线 ---
+    if sel == "ELFO":
+        return _design_elfo(request, spice, kernel_dir, verbose)
+
+    # --- CR3BP 管线 ---
+    # model_validator 已按 orbit_type 填充默认值，此处构建 params dict
+    _params_attrs = (
+        "amplitude",
+        "phase",
+        "collinear_point",
+        "north_south",
+        "perilune_height",
+        "amplitude_in",
+        "amplitude_out",
+        "phase_in",
+        "phase_out",
+    )
+    params: dict[str, float | int] = {}
+    for attr in _params_attrs:
+        v = getattr(request, attr)
+        if v is not None:
+            params[attr] = v
+
+    output_step = float(request.output_step)
+    perturbation = request.perturbation
+    earth_degree = request.earth_degree
+    moon_degree = request.moon_degree
+    dyb = request.dyb
+    correction_method = request.correction_method
+    correction_revolutions = request.correction_revolutions
 
     system = earth_moon_system()
     dynamics = CR3BP_Dynamics(system)
@@ -847,15 +922,10 @@ def design_orbit(
     phase = float(params.get("phase", 0.0))
     jacobi = float(system.get_jacobi_constant(cr3bp_orbit.states[0]))
 
-    # --- 2. 相位 → 历元状态，采样 patch points，转 J2000 ---
+    # --- 相位 → 历元状态，采样 patch points，转 J2000 ---
     assert cr3bp_orbit.period is not None
     period = float(cr3bp_orbit.period)
-    # 相位零点约定：Halo/NRHO 的参考状态（y=0 穿越点）与历史标定样本
-    # 的 phase=0 起点一致；DRO 的参考状态是近侧穿越点，而相位零点在远侧
-    # 穿越点（历史标定：标定样本 phase=0.5001 的 DRO 首行恰在近侧穿越点，
-    # 距月取最小值），差半个周期
     if sel in ("LISSAJOUS", "L4", "L5"):
-        # 面内/面外相位已体现在初猜状态（t=0 即历元状态）
         t0_syn = 0.0
     else:
         phase_offset = 0.5 if sel in ("DRO", "DPO") else 0.0
@@ -868,8 +938,6 @@ def design_orbit(
         state0_syn = np.asarray(cr3bp_orbit.states[0], dtype=float)
 
     if sel == "LISSAJOUS" and cr3bp_orbit.states.shape[0] > 1:
-        # 准周期 Lissajous：从中心流形有界轨迹采样（原生重传播会发散）；
-        # correction_revolutions 超出现轨迹覆盖时按需重建更长轨迹（同 segmented）
         if float(cr3bp_orbit.times[-1]) < (correction_revolutions - 1e-9) * period:
             cr3bp_orbit = design_lissajous(
                 int(params["collinear_point"]),
@@ -892,7 +960,7 @@ def design_orbit(
             perilune_clustered=(sel == "NRHO"),
         )
 
-    epoch_iso = _epoch_to_iso(epoch)
+    epoch_iso = _epoch_to_iso(request.epoch)
     et0 = spice.utc_to_et(epoch_iso)
     t_c = system.characteristic_time
     assert t_c is not None
@@ -902,8 +970,7 @@ def design_orbit(
     )
     t_patch_j2000 = et0 + t_patch_syn * t_c
 
-    # --- 3. 星历修正（N 体模型多重打靶） ---
-    # 默认光压用炮弹模型、关耦合项（ECOM/耦合属 #253，显式开启会报错）
+    # --- 力模型构建（修正 + 长期预报共用） ---
     from ..forces import ForceModel
     from ..forces.force_mapping import perturbation_to_force_config
 
@@ -916,10 +983,6 @@ def design_orbit(
     if sw["planets"]:
         bodies += ["MERCURY", "VENUS", "MARS", "JUPITER", "SATURN", "URANUS", "NEPTUNE"]
 
-    # --- 3. 星历修正（多重打靶）+ 4. 高精度长期预报：共用同一力模型 ---
-    # 关键：打靶修正与长期预报必须用同一套力模型，否则修正初值在预报模型下
-    # 不是平衡态，非线性放大后轨道发散。homotopy 方法内部硬绑 EphemerisDynamics
-    # （仅质点 N 体），无法挂全摄动，故单独走旧路径。
     full_system = EphemerisSystem(bodies=bodies, spice=spice, origin="EARTH")
     full_system.coordinate_system = CoordinateSystem(
         axes=ICRSAxes(),
@@ -933,9 +996,10 @@ def design_orbit(
     fm.atol = 1e-12
     fm.max_step = 600.0
 
-    duration_day = float(duration) * DAYS_PER_YEAR
-    duration_sec = duration_day * 86400.0
-    et_grid = et0 + np.arange(0.0, duration_sec + 0.5 * float(output_step), float(output_step))
+    assert request.duration is not None  # model_validator 已填默认值
+    duration_sec = float(request.duration)
+    duration_day = duration_sec / 86400.0
+    et_grid = et0 + np.arange(0.0, duration_sec + 0.5 * output_step, output_step)
 
     if correction_method == "segmented":
         # --- segmented：论文式分段打靶拼接（默认方法）---

--- a/e2m2e/algorithm/design/design_orbit.py
+++ b/e2m2e/algorithm/design/design_orbit.py
@@ -88,9 +88,6 @@ DEFAULT_DESIGN_PERTURBATION: dict[str, int] = {
     "coupling": 0,
 }
 
-#: 维持时间年→天折算
-DAYS_PER_YEAR = 365.25
-
 #: 星历修正的默认收敛容差（km，6 维状态 max 范数：位置 km + 速度 km/s）。
 #:
 #: 取 2e-2（20 m）。地月尺度（特征长度 3.84e5 km）下 10 m 已属高精度、

--- a/e2m2e/algorithm/design/frozen_orbit.py
+++ b/e2m2e/algorithm/design/frozen_orbit.py
@@ -1,0 +1,236 @@
+"""ELFO 冻结轨道设计的经典力学转换与漂移分析。
+
+本模块为 ``design_orbit`` 的 ELFO 分支提供两类辅助：
+
+1. 经典轨道根数 ↔ 笛卡尔状态转换（``_oe2cart`` / ``_cart2oe``）——CR3BP
+   管线不走这条路（初值来自轨道族生成器），ELFO 管线从六根数构造初值。
+2. 月心惯性系根数提取与漂移统计（``_extract_moon_centric_elements`` /
+   ``_compute_drift``）——传播在地心系进行，冻结特性看的是月心根数。
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from ..data.kernels.manager import SPICEManager
+
+# GRGM900C 月球引力场模型常数
+R_MOON = 1738.0  # km（参考半径）
+MU_MOON = 4902.799967088639  # km³/s²
+
+_SECONDS_PER_DAY = 86400.0
+
+
+def _oe2cart(
+    a: float,
+    e: float,
+    i: float,
+    raan: float,
+    aop: float,
+    nu: float,
+    mu: float,
+) -> np.ndarray:
+    """经典轨道根数 → 笛卡尔状态（惯性系）。
+
+    Args:
+        a: 半长轴（km）。
+        e: 离心率。
+        i: 倾角（度）。
+        raan: 升交点赤经（度）。
+        aop: 近月点幅角（度）。
+        nu: 真近点角（度）。
+        mu: 中心天体引力参数（km³/s²）。
+
+    Returns:
+        ``(6,)`` 数组 ``[x, y, z, vx, vy, vz]``，单位 km / km·s⁻¹。
+    """
+    i_rad = np.radians(i)
+    raan_rad = np.radians(raan)
+    aop_rad = np.radians(aop)
+    nu_rad = np.radians(nu)
+
+    p = a * (1.0 - e * e)
+    r_mag = p / (1.0 + e * np.cos(nu_rad))
+    r_pf = np.array([r_mag * np.cos(nu_rad), r_mag * np.sin(nu_rad), 0.0])
+    v_pf = np.array(
+        [
+            -np.sqrt(mu / p) * np.sin(nu_rad),
+            np.sqrt(mu / p) * (e + np.cos(nu_rad)),
+            0.0,
+        ]
+    )
+
+    cos_raan, sin_raan = np.cos(raan_rad), np.sin(raan_rad)
+    cos_aop, sin_aop = np.cos(aop_rad), np.sin(aop_rad)
+    cos_i, sin_i = np.cos(i_rad), np.sin(i_rad)
+
+    R_raan = np.array(
+        [
+            [cos_raan, -sin_raan, 0],
+            [sin_raan, cos_raan, 0],
+            [0, 0, 1],
+        ]
+    )
+    R_aop = np.array(
+        [
+            [cos_aop, -sin_aop, 0],
+            [sin_aop, cos_aop, 0],
+            [0, 0, 1],
+        ]
+    )
+    R_i = np.array(
+        [
+            [1, 0, 0],
+            [0, cos_i, -sin_i],
+            [0, sin_i, cos_i],
+        ]
+    )
+
+    R = R_raan @ R_i @ R_aop
+    return np.concatenate([R @ r_pf, R @ v_pf])
+
+
+def _cart2oe(state: np.ndarray, mu: float) -> dict[str, float]:
+    """笛卡尔状态 → 经典轨道根数。
+
+    Args:
+        state: ``(6,)`` 数组 ``[x, y, z, vx, vy, vz]``。
+        mu: 中心天体引力参数（km³/s²）。
+
+    Returns:
+        包含 ``a``（km）、``e``、``i``（度）、``raan``（度）、
+        ``aop``（度）、``rp``（km）的字典。
+    """
+    r = np.asarray(state[:3], dtype=float)
+    v = np.asarray(state[3:6], dtype=float)
+    r_norm = float(np.linalg.norm(r))
+
+    h = np.cross(r, v)
+    h_norm = float(np.linalg.norm(h))
+
+    energy = float(np.dot(v, v)) / 2.0 - mu / r_norm
+    a = -mu / (2.0 * energy) if abs(energy) > 1e-14 else float("inf")
+
+    e_vec = np.cross(v, h) / mu - r / r_norm
+    e = float(np.linalg.norm(e_vec))
+
+    i = float(np.degrees(np.arccos(np.clip(h[2] / h_norm, -1.0, 1.0))))
+
+    n_vec = np.cross([0, 0, 1], h)
+    n_norm = float(np.linalg.norm(n_vec))
+    if n_norm < 1e-12:
+        raan = 0.0
+    else:
+        raan = float(np.degrees(np.arccos(np.clip(n_vec[0] / n_norm, -1.0, 1.0))))
+        if n_vec[1] < 0:
+            raan = 360.0 - raan
+
+    if n_norm < 1e-12:
+        aop = float(np.degrees(np.arctan2(e_vec[1], e_vec[0]))) % 360.0
+    elif e < 1e-14:
+        aop = 0.0
+    else:
+        cos_aop = np.dot(n_vec, e_vec) / (n_norm * e)
+        aop = float(np.degrees(np.arccos(np.clip(cos_aop, -1.0, 1.0))))
+        if e_vec[2] < 0:
+            aop = 360.0 - aop
+
+    return {"a": a, "e": e, "i": i, "raan": raan, "aop": aop, "rp": a * (1.0 - e)}
+
+
+def _extract_moon_centric_elements(
+    times: np.ndarray,
+    states: np.ndarray,
+    spice: SPICEManager,
+    mu: float = MU_MOON,
+) -> dict[str, np.ndarray]:
+    """从地心传播结果提取月心惯性系轨道根数序列。
+
+    传播在地心系进行；冻结特性看的是月心根数。对每个输出时刻，从地心状态
+    中减去月球地心位置/速度，再换算为经典根数。
+
+    Args:
+        times: ``(n,)`` ET 时间序列（秒）。
+        states: ``(n, 6)`` 地心惯性系状态序列。
+        spice: 已加载内核的 SPICEManager。
+        mu: 月球引力参数（km³/s²）。
+
+    Returns:
+        各键 → ``(n,)`` 数组的字典，键同 ``_cart2oe``。
+    """
+    n = len(times)
+    oe_keys = ["a", "e", "i", "raan", "aop", "rp"]
+    oe = {k: np.zeros(n) for k in oe_keys}
+
+    for idx in range(n):
+        ms = spice.get_body_state("MOON", float(times[idx]), "J2000", "EARTH")
+        rel = np.concatenate(
+            [
+                states[idx, :3] - ms[:3],
+                states[idx, 3:6] - ms[3:6],
+            ]
+        )
+        row = _cart2oe(rel, mu)
+        for k in oe_keys:
+            oe[k][idx] = row[k]
+
+    return oe
+
+
+def _compute_drift(
+    elements: dict[str, np.ndarray],
+    times: np.ndarray | None = None,
+    output_step_sec: float | None = None,
+) -> dict[str, float | None]:
+    """从月心根数序列计算长期漂移统计。
+
+    Args:
+        elements: ``_extract_moon_centric_elements`` 的返回值。
+        times: ``(n,)`` ET 时间序列（秒）；与 ``output_step_sec`` 至少给一个，
+            用于将每点拟合斜率转换为年漂移率。两者均缺时 secular 率返回 ``None``。
+        output_step_sec: 采样间隔（秒）。
+
+    Returns:
+        包含以下键的字典：
+
+        - ``drift_e``: 首末差 Δe。
+        - ``drift_aop_deg``: 首末差 Δω（度，已处理 ±180° wraparound）。
+        - ``drift_rp_km``: 首末差 Δrp（km）。
+        - ``secular_aop_rate_deg_per_year``: ω 线性拟合年漂移率（剔除短周期）。
+            无法计算时为 ``None``。
+    """
+    aop = elements["aop"]
+    drift_aop = float(aop[-1] - aop[0])
+    if drift_aop > 180:
+        drift_aop -= 360
+    elif drift_aop < -180:
+        drift_aop += 360
+
+    drift_e = float(elements["e"][-1] - elements["e"][0])
+    drift_rp = float(elements["rp"][-1] - elements["rp"][0])
+
+    # secular 率：对 ω 做 unwrap + 线性拟合，斜率（每点度数）转年率
+    secular_rate = None
+    n_pts = len(aop)
+    if n_pts >= 3:
+        aop_unwrap = np.unwrap(np.radians(aop))
+        x = np.arange(n_pts, dtype=float)
+        slope_per_point = float(np.polyfit(x, np.degrees(aop_unwrap), 1)[0])
+        if output_step_sec is not None and output_step_sec > 0:
+            points_per_year = 365.25 * _SECONDS_PER_DAY / output_step_sec
+            secular_rate = slope_per_point * points_per_year
+        elif times is not None and n_pts >= 2:
+            total_sec = float(times[-1] - times[0])
+            if total_sec > 0:
+                slope_per_sec = slope_per_point * (n_pts - 1) / total_sec
+                secular_rate = slope_per_sec * 365.25 * _SECONDS_PER_DAY
+
+    return {
+        "drift_e": drift_e,
+        "drift_aop_deg": drift_aop,
+        "drift_rp_km": drift_rp,
+        "secular_aop_rate_deg_per_year": secular_rate,
+    }

--- a/e2m2e/api/facade.py
+++ b/e2m2e/api/facade.py
@@ -91,25 +91,38 @@ def _ephemeris_to_dict(ephemeris: EphemerisTable | None) -> dict[str, Any] | Non
 def _design_result_to_response(result: OrbitDesignResult) -> DesignOrbitResponse:
     """把 ``OrbitDesignResult`` 翻译为 ``DesignOrbitResponse``（含几何字段，#312）。
 
-    纯翻译、无副作用、不依赖 SPICE：从 ``cr3bp_orbit`` 提取 ``states`` /
-    ``times`` / ``mu``（mu 防御 getattr——``Orbit.system`` 缺省 None，
-    未绑定时 mu 回退 None，同下游 ``facade_bridge`` 约定），``ephemeris``
-    走 :func:`_ephemeris_to_dict`。提取为独立函数便于单测。
+    纯翻译、无副作用、不依赖 SPICE。ELFO 场景下 ``cr3bp_orbit`` /
+    ``correction`` 为 None，对应字段输出默认值（mu=None、states/times 空、
+    correction_converged=False）。CR3BP 场景下从 ``cr3bp_orbit`` 提取
+    ``states`` / ``times`` / ``mu``。
     """
     cr3bp_orbit = result.cr3bp_orbit
+    correction = result.correction
+    if cr3bp_orbit is not None:
+        mu = getattr(cr3bp_orbit.system, "mu", None)
+        states = cr3bp_orbit.states.tolist()
+        times = cr3bp_orbit.times.tolist()
+    else:
+        mu = None
+        states = []
+        times = []
     return DesignOrbitResponse(
         orbit_type=result.orbit_type,
         epoch_utc=result.epoch_utc,
         duration_day=result.duration_day,
         initial_state=result.initial_state.tolist(),
         cr3bp_jacobi=result.cr3bp_jacobi,
-        correction_converged=result.correction.converged,
-        correction_iterations=result.correction.iterations,
+        correction_converged=correction.converged if correction else False,
+        correction_iterations=correction.iterations if correction else 0,
         force_config=result.force_config,
-        mu=getattr(cr3bp_orbit.system, "mu", None),
-        states=cr3bp_orbit.states.tolist(),
-        times=cr3bp_orbit.times.tolist(),
+        mu=mu,
+        states=states,
+        times=times,
         ephemeris=_ephemeris_to_dict(result.ephemeris),
+        drift_e=result.drift_e,
+        drift_aop_deg=result.drift_aop_deg,
+        drift_rp_km=result.drift_rp_km,
+        secular_aop_rate_deg_per_year=result.secular_aop_rate_deg_per_year,
     )
 
 
@@ -166,23 +179,7 @@ class Facade:
             request = DesignOrbitRequest(**params)
             from e2m2e.algorithm.design import design_orbit as _design
 
-            result = _design(
-                request.orbit_type,
-                amplitude=request.amplitude,
-                phase=request.phase,
-                collinear_point=request.collinear_point,
-                north_south=request.north_south,
-                perilune_height=request.perilune_height,
-                amplitude_in=request.amplitude_in,
-                amplitude_out=request.amplitude_out,
-                phase_in=request.phase_in,
-                phase_out=request.phase_out,
-                epoch=request.epoch,
-                duration=request.duration,
-                output_step=request.output_step,
-                correction_method=request.correction_method,
-                kernel_dir=self._config.kernel_dir,
-            )
+            result = _design(request, kernel_dir=self._config.kernel_dir)
             return _design_result_to_response(result)
         except OrbitError:
             raise

--- a/e2m2e/api/models.py
+++ b/e2m2e/api/models.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 __all__ = [
     "OrbitError",
@@ -57,22 +57,174 @@ class _ApiModel(BaseModel):
 
 
 class DesignOrbitRequest(_ApiModel):
-    """任务轨道设计输入（对齐 algorithm/design 的 design_orbit 参数）。"""
+    """任务轨道设计输入。
 
-    orbit_type: str = Field(description="DRO/NRHO/Halo/Lissajous/L4/L5")
-    amplitude: float | None = Field(default=None, ge=1.0, le=110000.0)
+    统一覆盖 CR3BP 周期轨道（DRO/NRHO/Halo/Lissajous/…）和 ELFO 冻结轨道。
+    按 orbit_type 分派校验与默认值填充（``model_validator``）。
+    duration 统一用秒。
+    """
+
+    orbit_type: str = Field(description="DRO/DPO/NRHO/HALO/LISSAJOUS/L4/L5/AXIAL/.../ELFO")
+    # CR3BP 形状参数（字段约束为跨类型全局上下限；model_validator 内按类型收紧）
+    amplitude: float | None = Field(default=None, ge=-110000.0, le=200000.0)
     phase: float | None = Field(default=None, ge=0.0, le=1.0)
     collinear_point: int | None = Field(default=None, ge=1, le=3)
     north_south: int | None = Field(default=None, ge=1, le=2)
-    perilune_height: float | None = Field(default=None, ge=100.0, le=10000.0)
     amplitude_in: float | None = Field(default=None, gt=0.0, le=100000.0)
     amplitude_out: float | None = Field(default=None, gt=0.0, le=76000.0)
     phase_in: float | None = Field(default=None, ge=0.0, le=1.0)
     phase_out: float | None = Field(default=None, ge=0.0, le=1.0)
+    # 共享参数
+    perilune_height: float | None = Field(default=None, gt=0.0, le=10000.0)
+    # ELFO 形状参数
+    inclination: float | None = Field(
+        default=None, ge=0.0, le=180.0, description="倾角（度），ELFO 用"
+    )
+    arg_of_pericenter: float | None = Field(
+        default=None, ge=0.0, lt=360.0, description="近月点幅角（度），ELFO 用，默认 270"
+    )
+    semi_major_axis: float | None = Field(
+        default=None, gt=0.0, description="半长轴（km），ELFO 必填"
+    )
+    # 传播参数
     epoch: Any = Field(default=(2024, 1, 1, 0, 0, 0.0), description="[年,月,日,时,分,秒] 或 ISO")
-    duration: float = Field(default=1.0, gt=0.0, le=20.0)
+    duration: float | None = Field(
+        default=None, gt=0.0, description="传播时长（秒）；None 时按 orbit_type 填默认"
+    )
     output_step: float = Field(default=3600.0, gt=0.0)
+    perturbation: dict[str, int] | None = Field(default=None)
+    dyb: list[float] | None = Field(default=None)
+    earth_degree: int = Field(default=10, ge=2, le=120)
+    moon_degree: int = Field(default=10, ge=2, le=120)
+    # 修正参数
     correction_method: str = Field(default="two_level")
+    correction_revolutions: int = Field(default=1, ge=1)
+    correction_velocity_tolerance: float = Field(default=0.1, gt=0.0)
+
+    @model_validator(mode="after")
+    def _validate_orbit_type(self) -> DesignOrbitRequest:
+        sel = self.orbit_type.upper()
+        # duration 默认：CR3BP 1 年，ELFO 60 天
+        if self.duration is None:
+            self.duration = 5184000.0 if sel == "ELFO" else 31557600.0
+
+        if sel == "ELFO":
+            if self.semi_major_axis is None:
+                raise ValueError("ELFO 必须提供 semi_major_axis")
+            if self.inclination is None:
+                self.inclination = 75.0
+            if self.arg_of_pericenter is None:
+                self.arg_of_pericenter = 270.0
+            if self.perilune_height is None:
+                self.perilune_height = 200.0
+            return self
+
+        # CR3BP 类型：按类型填默认值
+        if sel == "DRO":
+            if self.amplitude is None:
+                self.amplitude = 10000.0
+            if self.phase is None:
+                self.phase = 0.5001
+            if not 1737.0 <= self.amplitude <= 110000.0:
+                raise ValueError(f"DRO amplitude 应在 1737~110000 km，实际 {self.amplitude}")
+        elif sel == "DPO":
+            if self.amplitude is None:
+                self.amplitude = 20000.0
+            if self.phase is None:
+                self.phase = 0.5001
+            if not 1737.0 <= self.amplitude <= 110000.0:
+                raise ValueError(f"DPO amplitude 应在 1737~110000 km，实际 {self.amplitude}")
+        elif sel == "HALO":
+            if self.collinear_point is None:
+                self.collinear_point = 2
+            if self.amplitude is None:
+                self.amplitude = 30000.0
+            if self.phase is None:
+                self.phase = 0.0
+            if self.collinear_point not in (1, 2):
+                raise ValueError(f"HALO collinear_point 必须为 1 或 2，当前 {self.collinear_point}")
+            if abs(self.amplitude) > 73000.0:
+                raise ValueError(f"HALO amplitude 应在 ±73000 km，实际 {self.amplitude}")
+        elif sel == "NRHO":
+            if self.collinear_point is None:
+                self.collinear_point = 2
+            if self.north_south is None:
+                self.north_south = 2
+            if self.perilune_height is None:
+                self.perilune_height = 5000.0
+            if self.phase is None:
+                self.phase = 0.5
+            if self.collinear_point not in (1, 2):
+                raise ValueError(f"NRHO collinear_point 必须为 1 或 2，当前 {self.collinear_point}")
+            if not 100.0 <= self.perilune_height <= 10000.0:
+                raise ValueError(
+                    f"NRHO perilune_height 应在 100~10000 km，实际 {self.perilune_height}"
+                )
+        elif sel == "LISSAJOUS":
+            if self.collinear_point is None:
+                self.collinear_point = 2
+            if self.amplitude_in is None:
+                self.amplitude_in = 2500.0
+            if self.amplitude_out is None:
+                self.amplitude_out = 7500.0
+            if self.phase_in is None:
+                self.phase_in = 0.01
+            if self.phase_out is None:
+                self.phase_out = 0.55
+            limit = 100000.0 if self.collinear_point == 3 else 7600.0
+            if not 0.0 < self.amplitude_in <= limit:
+                raise ValueError(
+                    f"LISSAJOUS amplitude_in 应在 (0, {limit}] km，实际 {self.amplitude_in}"
+                )
+            if not 0.0 < self.amplitude_out <= limit:
+                raise ValueError(
+                    f"LISSAJOUS amplitude_out 应在 (0, {limit}] km，实际 {self.amplitude_out}"
+                )
+        elif sel in ("L4", "L5"):
+            if self.amplitude_in is None:
+                self.amplitude_in = 8000.0
+            if self.amplitude_out is None:
+                self.amplitude_out = 6000.0
+            if self.phase_in is None:
+                self.phase_in = 0.0
+            if self.phase_out is None:
+                self.phase_out = 0.0
+        elif sel == "AXIAL":
+            if self.collinear_point is None:
+                self.collinear_point = 2
+            if self.amplitude is None:
+                self.amplitude = 5000.0
+            if self.phase is None:
+                self.phase = 0.0
+            if abs(self.amplitude) > 60000.0:
+                raise ValueError(f"AXIAL amplitude 应在 ±60000 km，实际 {self.amplitude}")
+        elif sel in ("L4_SPO", "L5_SPO"):
+            if self.amplitude is None:
+                self.amplitude = 10000.0
+            if self.phase is None:
+                self.phase = 0.0
+            if not 1737.0 <= self.amplitude <= 200000.0:
+                raise ValueError(f"{sel} amplitude 应在 1737~200000 km，实际 {self.amplitude}")
+        elif sel in ("L4_LPO", "L5_LPO"):
+            if self.amplitude is None:
+                self.amplitude = 50000.0
+            if self.phase is None:
+                self.phase = 0.0
+            if not 1000.0 <= self.amplitude <= 200000.0:
+                raise ValueError(f"{sel} amplitude 应在 1000~200000 km，实际 {self.amplitude}")
+        elif sel in ("L4_HORSESHOE", "L5_HORSESHOE"):
+            if self.amplitude is None:
+                self.amplitude = 150000.0
+            if self.phase is None:
+                self.phase = 0.0
+            if not 50000.0 <= self.amplitude <= 200000.0:
+                raise ValueError(f"{sel} amplitude 应在 50000~200000 km，实际 {self.amplitude}")
+        else:
+            raise ValueError(
+                f"orbit_type 必须为 DRO/DPO/NRHO/HALO/LISSAJOUS/L4/L5/AXIAL"
+                f"/L4_SPO/L5_SPO/L4_LPO/L5_LPO/L4_HORSESHOE/L5_HORSESHOE/ELFO，当前 {sel!r}"
+            )
+        return self
 
 
 class DesignOrbitResponse(_ApiModel):
@@ -82,7 +234,7 @@ class DesignOrbitResponse(_ApiModel):
     （画图 / 落盘 / design→control 链式）可仅依赖 Facade，不必穿透 algorithm
     层。``states`` / ``times`` 为 CR3BP 参考周期轨道（无量纲会合系），
     ``ephemeris`` 为标称星历（GCRS km / 速度 m/s + 会合系，``EphemerisTable``
-    全字段）。同 ``PropagationResponse``，Response 带大数组是本仓库既有约定。
+    全字段）。ELFO 场景下 CR3BP/修正字段为 None/默认值，漂移字段填充。
     """
 
     orbit_type: str
@@ -95,7 +247,7 @@ class DesignOrbitResponse(_ApiModel):
     force_config: dict[str, Any]
     mu: float | None = Field(
         default=None,
-        description="CR3BP 质量比 μ = m₂/(m₁+m₂)；构造 CR3BP_System、画地月/L 点标注用",
+        description="CR3BP 质量比 μ = m₂/(m₁+m₂)；ELFO 场景为 None",
     )
     states: list[list[float]] = Field(
         default_factory=list,
@@ -108,6 +260,12 @@ class DesignOrbitResponse(_ApiModel):
     ephemeris: dict[str, Any] | None = Field(
         default=None,
         description="标称星历（EphemerisTable 全字段：UTC + GCRS km/m/s + 会合系）",
+    )
+    drift_e: float | None = Field(default=None, description="传播弧段 Δe（仅 ELFO）")
+    drift_aop_deg: float | None = Field(default=None, description="传播弧段 Δω 度（仅 ELFO）")
+    drift_rp_km: float | None = Field(default=None, description="传播弧段 Δrp km（仅 ELFO）")
+    secular_aop_rate_deg_per_year: float | None = Field(
+        default=None, description="ω 线性拟合年漂移率（仅 ELFO）"
     )
 
 

--- a/examples/main_control.py
+++ b/examples/main_control.py
@@ -42,6 +42,7 @@ def main() -> None:
 
     from e2m2e.algorithm.design import design_orbit
     from e2m2e.algorithm.station_keeping import control_orbit
+    from e2m2e.api.models import DesignOrbitRequest
     from e2m2e.tools.viz import OrbitVisualizer
 
     # 1. 设计一条短弧 Halo 标称轨道（供轨道保持）
@@ -62,13 +63,15 @@ def main() -> None:
     for k, v in perturbation.items():
         print(f"     {k} = {v}")
     result = design_orbit(
-        "Halo",
-        collinear_point=2,
-        amplitude=30000.0,
-        phase=0.0,
-        duration=0.1,
-        output_step=3600.0,
-        perturbation=perturbation,
+        DesignOrbitRequest(
+            orbit_type="HALO",
+            collinear_point=2,
+            amplitude=30000.0,
+            phase=0.0,
+            duration=0.1 * 365.25 * 86400,
+            output_step=3600.0,
+            perturbation=perturbation,
+        )
     )
     print(f"   星历行数 = {len(result.ephemeris)}")
 

--- a/examples/main_design.py
+++ b/examples/main_design.py
@@ -41,6 +41,7 @@ def main() -> None:
     setup_cjk_font()
 
     from e2m2e.algorithm.design import design_orbit
+    from e2m2e.api.models import DesignOrbitRequest
     from e2m2e.tools.viz import OrbitVisualizer
 
     # 1. 端到端设计一条 L2 Halo（CR3BP 初猜 → 星历修正 → 高精度预报）
@@ -62,17 +63,16 @@ def main() -> None:
         print(f"     {k} = {v}")
     t0 = time.perf_counter()
     result = design_orbit(
-        "Halo",
-        collinear_point=2,
-        amplitude=30000.0,
-        phase=0.0,
-        duration=30 / 365.25,
-        output_step=3600.0,
-        perturbation=perturbation,
-        # 论文式分段打靶拼接（朱彦伟 2026）：逐段独立打靶转星历 + 远月点
-        # 分层合并，对 Halo 等不稳定轨道长期保形。默认 two_level 适合
-        # 单圈修正 + 短期预报；segmented 显式用于长期设计。
-        correction_method="segmented",
+        DesignOrbitRequest(
+            orbit_type="HALO",
+            collinear_point=2,
+            amplitude=30000.0,
+            phase=0.0,
+            duration=30 * 86400.0,
+            output_step=3600.0,
+            perturbation=perturbation,
+            correction_method="segmented",
+        )
     )
     elapsed = time.perf_counter() - t0
     print(f"   耗时 {elapsed:.1f} s")

--- a/examples/main_propagate.py
+++ b/examples/main_propagate.py
@@ -42,6 +42,7 @@ def main() -> None:
 
     from e2m2e.algorithm.design import design_orbit
     from e2m2e.algorithm.family.cr3bp_orbits import earth_moon_system
+    from e2m2e.api.models import DesignOrbitRequest
     from e2m2e.tools.viz import OrbitVisualizer
 
     # 1. 设计一条短弧 Halo 作为预报起点（duration=0.02 年 ≈ 7.3 天）
@@ -62,13 +63,15 @@ def main() -> None:
     for k, v in perturbation.items():
         print(f"     {k} = {v}")
     result = design_orbit(
-        "Halo",
-        collinear_point=2,
-        amplitude=30000.0,
-        phase=0.0,
-        duration=0.02,
-        output_step=3600.0,
-        perturbation=perturbation,
+        DesignOrbitRequest(
+            orbit_type="HALO",
+            collinear_point=2,
+            amplitude=30000.0,
+            phase=0.0,
+            duration=0.02 * 365.25 * 86400,
+            output_step=3600.0,
+            perturbation=perturbation,
+        )
     )
     print(f"   初始状态 = {np.round(result.initial_state, 3)}")
 

--- a/scripts/diagnose_tight_special.py
+++ b/scripts/diagnose_tight_special.py
@@ -24,10 +24,11 @@ import numpy as np  # noqa: E402
 
 from e2m2e.algorithm.design.design_orbit import design_orbit  # noqa: E402
 from e2m2e.algorithm.station_keeping.controller import control_orbit  # noqa: E402
+from e2m2e.api.models import DesignOrbitRequest  # noqa: E402
 
 # ─── 轨道与仿真参数 ───────────────────────────────────────────────────────────
 EPOCH = [2024, 1, 1, 0, 0, 0.0]
-ORBIT_DURATION_YEARS = 0.05  # ~18 天，足够 5 个控制节点（间隔 3 天）
+ORBIT_DURATION_SEC = 0.05 * 365.25 * 86400  # ~18 天，足够 5 个控制节点（间隔 3 天）
 CONTROL_INTERVAL_DAYS = 3.0  # 短间隔，快速验证
 FEEDBACK_ARC_DAYS = 3.0  # 与 control_interval 对齐
 NUM_CONTROLS = 5
@@ -97,13 +98,15 @@ if __name__ == "__main__":
     # Step 1: 生成标称 NRHO 轨道
     print("\n[1/4] 生成标称 NRHO 轨道 ...")
     orbit_result = design_orbit(
-        "NRHO",
-        collinear_point=2,
-        north_south=1,
-        perilune_height=3500.0,
-        epoch=EPOCH,
-        duration=ORBIT_DURATION_YEARS,
-        output_step=OUTPUT_STEP,
+        DesignOrbitRequest(
+            orbit_type="NRHO",
+            collinear_point=2,
+            north_south=1,
+            perilune_height=3500.0,
+            epoch=EPOCH,
+            duration=ORBIT_DURATION_SEC,
+            output_step=OUTPUT_STEP,
+        )
     )
     NOMINAL_EPH = orbit_result.ephemeris
     print(f"  标称星历行数: {len(NOMINAL_EPH)}")

--- a/tests/algorithms/test_axial_family.py
+++ b/tests/algorithms/test_axial_family.py
@@ -158,35 +158,35 @@ class TestPhysicalInvariants:
 
 
 class TestAxialDesignOrbit:
-    """design_orbit 入口分发 AXIAL。"""
+    """DesignOrbitRequest 校验 AXIAL 参数。"""
 
     def test_design_orbit_validates_axial_params(self):
-        """design_orbit("AXIAL", ...) 参数校验先于实现：duration 校验优先。"""
-        from e2m2e.algorithm.design import design_orbit
+        """duration=0 应在模型层被拒。"""
+        from e2m2e.api.models import DesignOrbitRequest
 
-        with pytest.raises(ValueError, match="duration"):
-            design_orbit("AXIAL", duration=0.0)
+        with pytest.raises(ValueError):
+            DesignOrbitRequest(orbit_type="AXIAL", duration=0.0)
 
     def test_design_orbit_rejects_bad_collinear_point(self):
         """collinear_point=4 应抛 ValueError。"""
-        from e2m2e.algorithm.design import design_orbit
+        from e2m2e.api.models import DesignOrbitRequest
 
-        with pytest.raises(ValueError, match="collinear_point"):
-            design_orbit("AXIAL", collinear_point=4, duration=0.5)
+        with pytest.raises(ValueError):
+            DesignOrbitRequest(orbit_type="AXIAL", collinear_point=4)
 
     def test_design_orbit_rejects_amplitude_out_of_range(self):
         """|amplitude| > 60000 km 应抛 ValueError。"""
-        from e2m2e.algorithm.design import design_orbit
+        from e2m2e.api.models import DesignOrbitRequest
 
         with pytest.raises(ValueError, match="amplitude"):
-            design_orbit("AXIAL", amplitude=80000.0, duration=0.5)
+            DesignOrbitRequest(orbit_type="AXIAL", amplitude=80000.0)
 
     def test_design_orbit_rejects_bad_phase(self):
         """phase 超界应抛 ValueError。"""
-        from e2m2e.algorithm.design import design_orbit
+        from e2m2e.api.models import DesignOrbitRequest
 
-        with pytest.raises(ValueError, match="phase"):
-            design_orbit("AXIAL", phase=1.5, duration=0.5)
+        with pytest.raises(ValueError):
+            DesignOrbitRequest(orbit_type="AXIAL", phase=1.5)
 
     def test_validate_params_axial_defaults(self):
         """_validate_params 对 AXIAL 填默认值（collinear_point=2, amplitude=5000, phase=0）。"""

--- a/tests/algorithms/test_dpo_family.py
+++ b/tests/algorithms/test_dpo_family.py
@@ -198,28 +198,28 @@ class TestDpoNotDro:
 
 
 class TestDpoDesignOrbit:
-    """design_orbit 入口分发 DPO。"""
+    """DesignOrbitRequest 校验 DPO 参数。"""
 
     def test_design_orbit_validates_dpo_params(self):
-        """design_orbit("DPO", ...) 参数校验先于实现：duration 校验优先。"""
-        from e2m2e.algorithm.design import design_orbit
+        """duration=0 应在模型层被拒。"""
+        from e2m2e.api.models import DesignOrbitRequest
 
-        with pytest.raises(ValueError, match="duration"):
-            design_orbit("DPO", duration=0.0)
+        with pytest.raises(ValueError):
+            DesignOrbitRequest(orbit_type="DPO", duration=0.0)
 
     def test_design_orbit_rejects_amplitude_out_of_range(self):
         """amplitude < 1737 km 应抛 ValueError。"""
-        from e2m2e.algorithm.design import design_orbit
+        from e2m2e.api.models import DesignOrbitRequest
 
         with pytest.raises(ValueError, match="amplitude"):
-            design_orbit("DPO", amplitude=500.0, duration=0.5)
+            DesignOrbitRequest(orbit_type="DPO", amplitude=500.0)
 
     def test_design_orbit_rejects_bad_phase(self):
         """phase 超界应抛 ValueError。"""
-        from e2m2e.algorithm.design import design_orbit
+        from e2m2e.api.models import DesignOrbitRequest
 
-        with pytest.raises(ValueError, match="phase"):
-            design_orbit("DPO", phase=1.5, duration=0.5)
+        with pytest.raises(ValueError):
+            DesignOrbitRequest(orbit_type="DPO", phase=1.5)
 
     def test_validate_params_dpo_defaults(self):
         """_validate_params 对 DPO 填默认值（amplitude=20000, phase=0.5001）。"""

--- a/tests/algorithms/test_lpo_family.py
+++ b/tests/algorithms/test_lpo_family.py
@@ -199,19 +199,19 @@ class TestL4L5Symmetry:
 
 @_design_orbit_skip
 class TestLpoDesignOrbit:
-    """design_orbit 入口分发 LPO。"""
+    """DesignOrbitRequest 校验 LPO 参数。"""
 
     def test_design_orbit_validates_l4_lpo_params(self):
-        from e2m2e.algorithm.design import design_orbit
+        from e2m2e.api.models import DesignOrbitRequest
 
-        with pytest.raises(ValueError, match="duration"):
-            design_orbit("L4_LPO", duration=0.0)
+        with pytest.raises(ValueError):
+            DesignOrbitRequest(orbit_type="L4_LPO", duration=0.0)
 
     def test_design_orbit_rejects_amplitude_out_of_range(self):
-        from e2m2e.algorithm.design import design_orbit
+        from e2m2e.api.models import DesignOrbitRequest
 
         with pytest.raises(ValueError, match="amplitude"):
-            design_orbit("L4_LPO", amplitude=500.0, duration=0.5)
+            DesignOrbitRequest(orbit_type="L4_LPO", amplitude=500.0)
 
     def test_validate_params_l4_lpo_defaults(self):
         from e2m2e.algorithm.design.design_orbit import _validate_params

--- a/tests/algorithms/test_spo_family.py
+++ b/tests/algorithms/test_spo_family.py
@@ -202,25 +202,25 @@ class TestL4L5Symmetry:
 
 @_design_orbit_skip
 class TestSpoDesignOrbit:
-    """design_orbit 入口分发 SPO。"""
+    """DesignOrbitRequest 校验 SPO 参数。"""
 
     def test_design_orbit_validates_l4_spo_params(self):
-        from e2m2e.algorithm.design import design_orbit
+        from e2m2e.api.models import DesignOrbitRequest
 
-        with pytest.raises(ValueError, match="duration"):
-            design_orbit("L4_SPO", duration=0.0)
+        with pytest.raises(ValueError):
+            DesignOrbitRequest(orbit_type="L4_SPO", duration=0.0)
 
     def test_design_orbit_rejects_amplitude_out_of_range(self):
-        from e2m2e.algorithm.design import design_orbit
+        from e2m2e.api.models import DesignOrbitRequest
 
         with pytest.raises(ValueError, match="amplitude"):
-            design_orbit("L4_SPO", amplitude=500.0, duration=0.5)
+            DesignOrbitRequest(orbit_type="L4_SPO", amplitude=500.0)
 
     def test_design_orbit_rejects_bad_phase(self):
-        from e2m2e.algorithm.design import design_orbit
+        from e2m2e.api.models import DesignOrbitRequest
 
-        with pytest.raises(ValueError, match="phase"):
-            design_orbit("L4_SPO", phase=1.5, duration=0.5)
+        with pytest.raises(ValueError):
+            DesignOrbitRequest(orbit_type="L4_SPO", phase=1.5)
 
     def test_validate_params_l4_spo_defaults(self):
         from e2m2e.algorithm.design.design_orbit import _validate_params

--- a/tests/api/test_facade.py
+++ b/tests/api/test_facade.py
@@ -23,15 +23,20 @@ from e2m2e.data.types.trajectory import EphemerisTable
 class TestDesignOrbitRequest:
     def test_defaults(self):
         req = DesignOrbitRequest(orbit_type="DRO")
-        assert req.duration == 1.0
+        assert req.duration == 31557600.0  # 1 年 = 365.25 × 86400 秒
         assert req.output_step == 3600.0
         assert req.correction_method == "two_level"
 
-    def test_duration_bounds(self):
+    def test_duration_must_be_positive(self):
         with pytest.raises(ValidationError):
             DesignOrbitRequest(orbit_type="DRO", duration=0.0)
-        with pytest.raises(ValidationError):
-            DesignOrbitRequest(orbit_type="DRO", duration=21.0)
+
+    def test_elfo_defaults(self):
+        req = DesignOrbitRequest(orbit_type="ELFO", semi_major_axis=3000.0)
+        assert req.duration == 5184000.0  # 60 天
+        assert req.inclination == 75.0
+        assert req.arg_of_pericenter == 270.0
+        assert req.perilune_height == 200.0
 
     def test_perilune_height_bounds(self):
         with pytest.raises(ValidationError):
@@ -306,6 +311,10 @@ class TestDesignResultToResponse:
             cr3bp_jacobi=3.16,
             correction=correction,
             force_config={"sun_body": 1},
+            drift_e=None,
+            drift_aop_deg=None,
+            drift_rp_km=None,
+            secular_aop_rate_deg_per_year=None,
         )
 
     def test_extracts_geometry_fields(self):

--- a/tests/architecture/test_placeholder.py
+++ b/tests/architecture/test_placeholder.py
@@ -12,11 +12,11 @@ import pytest
 
 
 def test_design_orbit_implemented():
-    """design_orbit 已实现：形状参数校验先于占位抛错。"""
-    from e2m2e.algorithm.design import design_orbit
+    """design_orbit 已实现：DesignOrbitRequest 校验先于占位抛错。"""
+    from e2m2e.api.models import DesignOrbitRequest
 
-    with pytest.raises(ValueError, match="duration"):
-        design_orbit("DRO", duration=0.0)
+    with pytest.raises(ValueError):
+        DesignOrbitRequest(orbit_type="DRO", duration=0.0)
 
 
 def test_control_orbit_implemented():

--- a/tests/orbit_design/scenarios/test_frozen_orbit_e2e.py
+++ b/tests/orbit_design/scenarios/test_frozen_orbit_e2e.py
@@ -1,0 +1,79 @@
+"""冻结轨道设计端到端回归测试（L3）。
+
+复现已验证的物理结论（原型脚本 + 报告）：
+- i=75° 下不存在严格冻结解（|Δe| > 0.01）
+- a=3000 km 的 60 天漂移值：Δe ≈ −0.019, Δrp ≈ +61 km
+- |Δrp| 随半长轴增大而增大（第三体摄动增强）
+
+算法层 design_orbit() 始终返回单候选结果（扫描逻辑在 tod FacadeBridge，
+不在此测试范围内），故通过多次调用收集各候选漂移。
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from e2m2e.algorithm.design import design_orbit
+from e2m2e.api.models import DesignOrbitRequest
+
+_SPICE_KERNEL_DIR = os.environ.get(
+    "SPICE_KERNEL_DIR",
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "..", "kernels"),
+)
+_SPICE_AVAILABLE = os.path.isdir(_SPICE_KERNEL_DIR) and any(
+    f.endswith(".bsp") for f in os.listdir(_SPICE_KERNEL_DIR)
+)
+
+pytestmark = [
+    pytest.mark.l3,
+    pytest.mark.slow,
+    pytest.mark.spice,
+    pytest.mark.skipif(not _SPICE_AVAILABLE, reason="SPICE kernels not available"),
+]
+
+DURATION_60D = 60 * 86400.0
+
+
+@pytest.fixture(scope="module")
+def a3000_60d():
+    """a=3000 km 60 天传播（耗时约 30 秒）。"""
+    return design_orbit(
+        DesignOrbitRequest(
+            orbit_type="ELFO",
+            semi_major_axis=3000.0,
+            duration=DURATION_60D,
+            output_step=3600.0,
+        )
+    )
+
+
+def test_a3000_drift_values(a3000_60d):
+    """a=3000 km 的 60 天漂移值应与报告一致（±15% 容差）。"""
+    assert a3000_60d.drift_e == pytest.approx(-0.019, abs=0.005)
+    assert a3000_60d.drift_rp_km == pytest.approx(61, abs=15)
+
+
+def test_no_strictly_frozen(a3000_60d):
+    """i=75° 下 |Δe| 应 > 0.01（不存在严格冻结解）。"""
+    assert abs(a3000_60d.drift_e) > 0.01
+
+
+def test_drift_direction(a3000_60d):
+    """i=75°（>临界倾角 63.4°）：Δe 应为负、Δrp 应为正。"""
+    assert a3000_60d.drift_e < 0
+    assert a3000_60d.drift_rp_km > 0
+
+
+def test_drift_rp_increases_with_a(a3000_60d):
+    """|Δrp| 应随半长轴增大而增大（第三体摄动增强）。"""
+    a8000 = design_orbit(
+        DesignOrbitRequest(
+            orbit_type="ELFO",
+            semi_major_axis=8000.0,
+            duration=DURATION_60D,
+            output_step=3600.0,
+        )
+    )
+    assert abs(a8000.drift_rp_km) > abs(a3000_60d.drift_rp_km)

--- a/tests/orbit_design/scenarios/test_lissajous.py
+++ b/tests/orbit_design/scenarios/test_lissajous.py
@@ -1,12 +1,13 @@
 """Lissajous 轨道设计端到端测试。
 
-通过 ``design_orbit("Lissajous", ...)`` 全流程（CR3BP 初猜 → two_level
-星历修正 → 高精度长期预报），验证收敛性、振幅有界、输出形状正确。
+通过 ``design_orbit(DesignOrbitRequest(orbit_type="LISSAJOUS", ...))`` 全流程
+（CR3BP 初猜 → two_level 星历修正 → 高精度长期预报），验证收敛性、振幅有界、
+输出形状正确。
 
 依赖 SPICE 内核（``design_orbit`` 自动加载 ``kernels/``）。
 内核缺失时整组跳过。
 
-属 tests/orbit_design 三层分层中的 L3（scenarios，端到端）：在 L1 初感
+属 tests/orbit_design 三层分层中的 L3（scenarios，端到端）：在 L1 初猜
 与 L2 修正/延拓的单点校验之上，覆盖 design_orbit 全链路集成行为。
 """
 
@@ -19,6 +20,7 @@ import numpy as np
 import pytest
 
 from e2m2e.algorithm.design import design_orbit
+from e2m2e.api.models import DesignOrbitRequest
 
 _SPICE_KERNEL_DIR = os.environ.get(
     "SPICE_KERNEL_DIR",
@@ -36,6 +38,9 @@ pytestmark = [
     pytest.mark.l3,
 ]
 
+# 0.05 年 ≈ 18 天
+DURATION_SEC = 0.05 * 365.25 * 86400
+
 
 class TestDesignOrbitLissajous:
     """Lissajous 设计端到端。"""
@@ -44,15 +49,17 @@ class TestDesignOrbitLissajous:
     def test_end_to_end_converges(self, collinear_point):
         """CR3BP → two_level 星历修正 → 高精度传播，全流程不抛异常。"""
         result = design_orbit(
-            "Lissajous",
-            collinear_point=collinear_point,
-            amplitude_in=500.0,
-            amplitude_out=2000.0,
-            phase_in=0.0,
-            phase_out=0.0,
-            epoch="2025-01-01T00:00:00",
-            duration=0.05,
-            output_step=3600.0,
+            DesignOrbitRequest(
+                orbit_type="LISSAJOUS",
+                collinear_point=collinear_point,
+                amplitude_in=500.0,
+                amplitude_out=2000.0,
+                phase_in=0.0,
+                phase_out=0.0,
+                epoch="2025-01-01T00:00:00",
+                duration=DURATION_SEC,
+                output_step=3600.0,
+            )
         )
         assert result.correction.converged
         assert result.ephemeris is not None
@@ -61,14 +68,16 @@ class TestDesignOrbitLissajous:
     def test_amplitude_bounded(self):
         """传播后位置振幅不爆炸——地月空间合理范围。"""
         result = design_orbit(
-            "Lissajous",
-            collinear_point=2,
-            amplitude_in=500.0,
-            amplitude_out=2000.0,
-            phase_in=0.0,
-            phase_out=0.0,
-            epoch="2025-01-01T00:00:00",
-            duration=0.05,
+            DesignOrbitRequest(
+                orbit_type="LISSAJOUS",
+                collinear_point=2,
+                amplitude_in=500.0,
+                amplitude_out=2000.0,
+                phase_in=0.0,
+                phase_out=0.0,
+                epoch="2025-01-01T00:00:00",
+                duration=DURATION_SEC,
+            )
         )
         eph = result.ephemeris
         pos_norms = np.linalg.norm(eph.position_km, axis=1)
@@ -77,21 +86,22 @@ class TestDesignOrbitLissajous:
 
     def test_output_shape(self):
         """输出 ephemeris 形状正确（行数、列结构）。"""
-        duration = 0.05
         output_step = 3600.0
         result = design_orbit(
-            "Lissajous",
-            collinear_point=2,
-            amplitude_in=500.0,
-            amplitude_out=2000.0,
-            phase_in=0.0,
-            phase_out=0.0,
-            epoch="2025-01-01T00:00:00",
-            duration=duration,
-            output_step=output_step,
+            DesignOrbitRequest(
+                orbit_type="LISSAJOUS",
+                collinear_point=2,
+                amplitude_in=500.0,
+                amplitude_out=2000.0,
+                phase_in=0.0,
+                phase_out=0.0,
+                epoch="2025-01-01T00:00:00",
+                duration=DURATION_SEC,
+                output_step=output_step,
+            )
         )
         eph = result.ephemeris
-        expected_rows = math.ceil(duration * 365.25 * 86400 / output_step)
+        expected_rows = math.ceil(DURATION_SEC / output_step)
         # 允许 ±2 行容差（累积舍入）
         assert abs(len(eph) - expected_rows) <= 2, f"预期约 {expected_rows} 行，实际 {len(eph)} 行"
         assert eph.position_km.shape == (len(eph), 3)
@@ -101,14 +111,16 @@ class TestDesignOrbitLissajous:
     def test_epoch_matches_input(self):
         """起始历元匹配输入 epoch。"""
         result = design_orbit(
-            "Lissajous",
-            collinear_point=2,
-            amplitude_in=500.0,
-            amplitude_out=2000.0,
-            phase_in=0.0,
-            phase_out=0.0,
-            epoch="2025-01-01T00:00:00",
-            duration=0.05,
+            DesignOrbitRequest(
+                orbit_type="LISSAJOUS",
+                collinear_point=2,
+                amplitude_in=500.0,
+                amplitude_out=2000.0,
+                phase_in=0.0,
+                phase_out=0.0,
+                epoch="2025-01-01T00:00:00",
+                duration=DURATION_SEC,
+            )
         )
         eph = result.ephemeris
         assert eph.year[0] == 2025
@@ -118,28 +130,32 @@ class TestDesignOrbitLissajous:
     def test_initial_state_shape(self):
         """initial_state 为 6 维向量 (km, km/s)。"""
         result = design_orbit(
-            "Lissajous",
-            collinear_point=2,
-            amplitude_in=500.0,
-            amplitude_out=2000.0,
-            phase_in=0.0,
-            phase_out=0.0,
-            epoch="2025-01-01T00:00:00",
-            duration=0.05,
+            DesignOrbitRequest(
+                orbit_type="LISSAJOUS",
+                collinear_point=2,
+                amplitude_in=500.0,
+                amplitude_out=2000.0,
+                phase_in=0.0,
+                phase_out=0.0,
+                epoch="2025-01-01T00:00:00",
+                duration=DURATION_SEC,
+            )
         )
         assert result.initial_state.shape == (6,)
 
     def test_cr3bp_orbit_present(self):
         """cr3bp_orbit 和 jacobi 应存在。"""
         result = design_orbit(
-            "Lissajous",
-            collinear_point=2,
-            amplitude_in=500.0,
-            amplitude_out=2000.0,
-            phase_in=0.0,
-            phase_out=0.0,
-            epoch="2025-01-01T00:00:00",
-            duration=0.05,
+            DesignOrbitRequest(
+                orbit_type="LISSAJOUS",
+                collinear_point=2,
+                amplitude_in=500.0,
+                amplitude_out=2000.0,
+                phase_in=0.0,
+                phase_out=0.0,
+                epoch="2025-01-01T00:00:00",
+                duration=DURATION_SEC,
+            )
         )
         assert result.cr3bp_orbit is not None
         assert isinstance(result.cr3bp_jacobi, float)

--- a/tests/orbit_design/scenarios/test_segmented.py
+++ b/tests/orbit_design/scenarios/test_segmented.py
@@ -15,11 +15,12 @@ import numpy as np
 import pytest
 
 from e2m2e.algorithm.design import design_orbit
+from e2m2e.api.models import DesignOrbitRequest
 
 pytestmark = [pytest.mark.slow, pytest.mark.spice, pytest.mark.l3]
 
 # 30 天 Halo：main_design 默认参数，复现逐段积分场景
-DURATION_YEAR = 30 / 365.25
+DURATION_SEC = 30 * 86400.0
 AMPLITUDE_KM = 30000.0
 
 PERTURBATION = {
@@ -44,14 +45,16 @@ MIN_HOURLY_DRIFT_KM = 10.0
 def segmented_result():
     """跑一次 30 天 Halo segmented 设计，模块内复用（耗时 ~4 分钟）。"""
     return design_orbit(
-        "Halo",
-        collinear_point=2,
-        amplitude=AMPLITUDE_KM,
-        phase=0.0,
-        duration=DURATION_YEAR,
-        output_step=3600.0,
-        perturbation=PERTURBATION,
-        correction_method="segmented",
+        DesignOrbitRequest(
+            orbit_type="HALO",
+            collinear_point=2,
+            amplitude=AMPLITUDE_KM,
+            phase=0.0,
+            duration=DURATION_SEC,
+            output_step=3600.0,
+            perturbation=PERTURBATION,
+            correction_method="segmented",
+        )
     )
 
 

--- a/tests/orbit_design/scenarios/test_triangular.py
+++ b/tests/orbit_design/scenarios/test_triangular.py
@@ -1,7 +1,8 @@
 """L4/L5 三角平动点轨道设计端到端测试。
 
-通过 ``design_orbit("L4"/"L5", ...)`` 全流程（CR3BP 初猜 → two_level
-星历修正 → 高精度长期预报），验证收敛性、振幅有界、输出形状正确。
+通过 ``design_orbit(DesignOrbitRequest(orbit_type="L4"/"L5", ...))`` 全流程
+（CR3BP 初猜 → two_level 星历修正 → 高精度长期预报），验证收敛性、振幅有界、
+输出形状正确。
 
 依赖 SPICE 内核（``design_orbit`` 自动加载 ``kernels/``）。
 内核缺失时整组跳过。
@@ -19,6 +20,7 @@ import numpy as np
 import pytest
 
 from e2m2e.algorithm.design import design_orbit
+from e2m2e.api.models import DesignOrbitRequest
 
 _SPICE_KERNEL_DIR = os.environ.get(
     "SPICE_KERNEL_DIR",
@@ -36,6 +38,9 @@ pytestmark = [
     pytest.mark.l3,
 ]
 
+# 0.05 年 ≈ 18 天
+DURATION_SEC = 0.05 * 365.25 * 86400
+
 
 class TestDesignOrbitTriangular:
     """L4/L5 设计端到端。"""
@@ -44,29 +49,33 @@ class TestDesignOrbitTriangular:
     def test_end_to_end_converges(self, point):
         """CR3BP → two_level 星历修正 → 高精度传播，全流程不抛异常。"""
         result = design_orbit(
-            point,
-            amplitude_in=300.0,
-            amplitude_out=1000.0,
-            phase_in=0.0,
-            phase_out=0.0,
-            epoch="2025-01-01T00:00:00",
-            duration=0.05,
-            output_step=3600.0,
+            DesignOrbitRequest(
+                orbit_type=point,
+                amplitude_in=300.0,
+                amplitude_out=1000.0,
+                phase_in=0.0,
+                phase_out=0.0,
+                epoch="2025-01-01T00:00:00",
+                duration=DURATION_SEC,
+                output_step=3600.0,
+            )
         )
         assert result.correction.converged
         assert result.ephemeris is not None
-        assert result.orbit_type == point
+        assert result.orbit_type == point.upper()
 
     def test_amplitude_bounded(self):
         """传播后位置振幅不爆炸——地月空间合理范围。"""
         result = design_orbit(
-            "L4",
-            amplitude_in=300.0,
-            amplitude_out=1000.0,
-            phase_in=0.0,
-            phase_out=0.0,
-            epoch="2025-01-01T00:00:00",
-            duration=0.05,
+            DesignOrbitRequest(
+                orbit_type="L4",
+                amplitude_in=300.0,
+                amplitude_out=1000.0,
+                phase_in=0.0,
+                phase_out=0.0,
+                epoch="2025-01-01T00:00:00",
+                duration=DURATION_SEC,
+            )
         )
         eph = result.ephemeris
         pos_norms = np.linalg.norm(eph.position_km, axis=1)
@@ -75,20 +84,21 @@ class TestDesignOrbitTriangular:
 
     def test_output_shape(self):
         """输出 ephemeris 形状正确（行数、列结构）。"""
-        duration = 0.05
         output_step = 3600.0
         result = design_orbit(
-            "L5",
-            amplitude_in=300.0,
-            amplitude_out=1000.0,
-            phase_in=0.0,
-            phase_out=0.0,
-            epoch="2025-01-01T00:00:00",
-            duration=duration,
-            output_step=output_step,
+            DesignOrbitRequest(
+                orbit_type="L5",
+                amplitude_in=300.0,
+                amplitude_out=1000.0,
+                phase_in=0.0,
+                phase_out=0.0,
+                epoch="2025-01-01T00:00:00",
+                duration=DURATION_SEC,
+                output_step=output_step,
+            )
         )
         eph = result.ephemeris
-        expected_rows = math.ceil(duration * 365.25 * 86400 / output_step)
+        expected_rows = math.ceil(DURATION_SEC / output_step)
         assert abs(len(eph) - expected_rows) <= 2, f"预期约 {expected_rows} 行，实际 {len(eph)} 行"
         assert eph.position_km.shape == (len(eph), 3)
         assert eph.velocity_mps.shape == (len(eph), 3)
@@ -97,13 +107,15 @@ class TestDesignOrbitTriangular:
     def test_epoch_matches_input(self):
         """起始历元匹配输入 epoch。"""
         result = design_orbit(
-            "L4",
-            amplitude_in=300.0,
-            amplitude_out=1000.0,
-            phase_in=0.0,
-            phase_out=0.0,
-            epoch="2025-01-01T00:00:00",
-            duration=0.05,
+            DesignOrbitRequest(
+                orbit_type="L4",
+                amplitude_in=300.0,
+                amplitude_out=1000.0,
+                phase_in=0.0,
+                phase_out=0.0,
+                epoch="2025-01-01T00:00:00",
+                duration=DURATION_SEC,
+            )
         )
         eph = result.ephemeris
         assert eph.year[0] == 2025
@@ -113,26 +125,30 @@ class TestDesignOrbitTriangular:
     def test_initial_state_shape(self):
         """initial_state 为 6 维向量 (km, km/s)。"""
         result = design_orbit(
-            "L5",
-            amplitude_in=300.0,
-            amplitude_out=1000.0,
-            phase_in=0.0,
-            phase_out=0.0,
-            epoch="2025-01-01T00:00:00",
-            duration=0.05,
+            DesignOrbitRequest(
+                orbit_type="L5",
+                amplitude_in=300.0,
+                amplitude_out=1000.0,
+                phase_in=0.0,
+                phase_out=0.0,
+                epoch="2025-01-01T00:00:00",
+                duration=DURATION_SEC,
+            )
         )
         assert result.initial_state.shape == (6,)
 
     def test_cr3bp_orbit_present(self):
         """cr3bp_orbit 和 jacobi 应存在。"""
         result = design_orbit(
-            "L4",
-            amplitude_in=300.0,
-            amplitude_out=1000.0,
-            phase_in=0.0,
-            phase_out=0.0,
-            epoch="2025-01-01T00:00:00",
-            duration=0.05,
+            DesignOrbitRequest(
+                orbit_type="L4",
+                amplitude_in=300.0,
+                amplitude_out=1000.0,
+                phase_in=0.0,
+                phase_out=0.0,
+                epoch="2025-01-01T00:00:00",
+                duration=DURATION_SEC,
+            )
         )
         assert result.cr3bp_orbit is not None
         assert isinstance(result.cr3bp_jacobi, float)

--- a/tests/orbit_design/test_frozen_orbit_integration.py
+++ b/tests/orbit_design/test_frozen_orbit_integration.py
@@ -1,0 +1,51 @@
+"""冻结轨道设计集成测试（L2，需 SPICE 内核）。
+
+通过 ``design_orbit(DesignOrbitRequest(orbit_type="ELFO", ...))`` 公共入口
+驱动单候选传播，验证返回结构与物理一致性。
+"""
+
+from __future__ import annotations
+
+import os
+
+import numpy as np
+import pytest
+
+from e2m2e.algorithm.design import design_orbit
+from e2m2e.api.models import DesignOrbitRequest
+
+_SPICE_KERNEL_DIR = os.environ.get(
+    "SPICE_KERNEL_DIR",
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "kernels"),
+)
+_SPICE_AVAILABLE = os.path.isdir(_SPICE_KERNEL_DIR) and any(
+    f.endswith(".bsp") for f in os.listdir(_SPICE_KERNEL_DIR)
+)
+
+pytestmark = [
+    pytest.mark.l2,
+    pytest.mark.spice,
+    pytest.mark.skipif(not _SPICE_AVAILABLE, reason="SPICE kernels not available"),
+]
+
+
+def test_single_candidate_structure():
+    """a=3000 km 候选传播 3 天，返回 OrbitDesignResult 且字段正确。"""
+    result = design_orbit(
+        DesignOrbitRequest(
+            orbit_type="ELFO",
+            semi_major_axis=3000.0,
+            duration=3 * 86400.0,
+            output_step=3600.0,
+        )
+    )
+    assert result.orbit_type == "ELFO"
+    assert result.cr3bp_orbit is None
+    assert result.correction is None
+    assert np.isnan(result.cr3bp_jacobi)
+    assert result.drift_e is not None
+    assert result.drift_rp_km is not None
+    assert result.initial_state.shape == (6,)
+    assert len(result.ephemeris) == 73  # 3 天 / 1 小时 + 1
+    assert result.moon_centric_elements is not None
+    assert "aop" in result.moon_centric_elements

--- a/tests/orbit_design/test_frozen_orbit_units.py
+++ b/tests/orbit_design/test_frozen_orbit_units.py
@@ -1,0 +1,103 @@
+"""冻结轨道设计纯函数单元测试（L1，无 SPICE 依赖）。"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pytestmark = pytest.mark.l1
+
+MU_MOON = 4902.799967088639
+
+
+def test_oe_cart_roundtrip():
+    """给定一组根数，转笛卡尔再转回，根数应一致（数值精度内）。"""
+    from e2m2e.algorithm.design.frozen_orbit import _cart2oe, _oe2cart
+
+    cases = [
+        (3000, 0.354, 75.0, 0.0, 270.0, 0.0),
+        (5000, 0.612, 75.0, 30.0, 270.0, 45.0),
+        (15000, 0.871, 75.0, 90.0, 90.0, 180.0),
+    ]
+    for a, e, i, raan, aop, nu in cases:
+        state = _oe2cart(a, e, i, raan, aop, nu, MU_MOON)
+        oe = _cart2oe(state, MU_MOON)
+        assert abs(oe["a"] - a) < 1e-6, f"a={a}: got {oe['a']}"
+        assert abs(oe["e"] - e) < 1e-10, f"e={e}: got {oe['e']}"
+        assert abs(oe["i"] - i) < 1e-8, f"i={i}: got {oe['i']}"
+        assert abs(oe["rp"] - a * (1 - e)) < 1e-6
+
+
+def test_perilune_constraint():
+    """rp = a(1-e) 应等于 R_MOON + perilune_height。"""
+    from e2m2e.algorithm.design.frozen_orbit import R_MOON, _cart2oe, _oe2cart
+
+    rp_target = R_MOON + 200.0  # 1938 km
+    for a in [3000, 5000, 15000]:
+        e = 1.0 - rp_target / a
+        state = _oe2cart(a, e, 75.0, 0.0, 270.0, 0.0, MU_MOON)
+        oe = _cart2oe(state, MU_MOON)
+        assert abs(oe["rp"] - rp_target) < 1e-6, f"a={a}: rp={oe['rp']}"
+
+
+def test_arg_of_pericenter_south_pole():
+    """ω=270° 时近月点位置向量的 z 分量应为负（南极方向）。"""
+    from e2m2e.algorithm.design.frozen_orbit import _oe2cart
+
+    state = _oe2cart(5000, 0.612, 75.0, 0.0, 270.0, 0.0, MU_MOON)
+    assert state[2] < 0, f"ω=270° 近月点 z={state[2]:.1f} km，应在南极方向（z<0）"
+
+
+def test_compute_drift_wraparound():
+    """ω 从 269° 到 271° 经 wraparound，漂移应为 +2°（非 -358°）。"""
+    from e2m2e.algorithm.design.frozen_orbit import _compute_drift
+
+    elements = {
+        "a": np.full(10, 3000.0),
+        "e": np.linspace(0.354, 0.335, 10),
+        "i": np.full(10, 75.0),
+        "raan": np.zeros(10),
+        "aop": np.append(np.full(5, 269.0), np.full(5, 271.0)),
+        "rp": np.linspace(1938, 1999, 10),
+    }
+    drift = _compute_drift(elements, output_step_sec=3600.0)
+    assert abs(drift["drift_aop_deg"] - 2.0) < 0.01
+    assert drift["drift_e"] < 0
+    assert drift["drift_rp_km"] > 0
+
+
+def test_compute_drift_secular_rate():
+    """secular ω 漂移率：线性拟合 + 单位转换。"""
+    from e2m2e.algorithm.design.frozen_orbit import _compute_drift
+
+    n = 100
+    # ω 以 0.1°/点 线性增长
+    aop = np.arange(n, dtype=float) * 0.1
+    elements = {
+        "a": np.full(n, 3000.0),
+        "e": np.full(n, 0.354),
+        "i": np.full(n, 75.0),
+        "raan": np.zeros(n),
+        "aop": aop,
+        "rp": np.full(n, 1938.0),
+    }
+    drift = _compute_drift(elements, output_step_sec=3600.0)
+    # 0.1°/点 × (365.25*86400 / 3600) 点/年 ≈ 0.1 × 8766 = 876.6°/年
+    expected_rate = 0.1 * 365.25 * 86400 / 3600
+    assert abs(drift["secular_aop_rate_deg_per_year"] - expected_rate) < 0.1
+
+
+def test_compute_drift_no_time_info():
+    """无时间信息时 secular 率为 None。"""
+    from e2m2e.algorithm.design.frozen_orbit import _compute_drift
+
+    elements = {
+        "a": np.full(5, 3000.0),
+        "e": np.full(5, 0.354),
+        "i": np.full(5, 75.0),
+        "raan": np.zeros(5),
+        "aop": np.array([270.0, 271.0, 272.0, 273.0, 274.0]),
+        "rp": np.full(5, 1938.0),
+    }
+    drift = _compute_drift(elements)
+    assert drift["secular_aop_rate_deg_per_year"] is None


### PR DESCRIPTION
## 关联

Closes #348

## 改了什么

- **`design_orbit()` 签名重构**：从散参改为 `DesignOrbitRequest` 模型入口，`duration` 从年改为秒（clean break），`_validate_params()` 校验逻辑迁移到 Pydantic `model_validator`
- **ELFO 管线**：在 `design_orbit()` 内以 early return 分支实现——经典六根数构造初值 → 全摄动传播 → 月心根数漂移分析，复用与 CR3BP 管线一致的力模型路径（GRGM900C 10×10 + EGM96 10×10 + 第三体 + 炮弹光压）
- **`OrbitDesignResult` 扩展**：新增 5 个可选漂移字段（`drift_e`、`drift_aop_deg`、`drift_rp_km`、`secular_aop_rate_deg_per_year`、`moon_centric_elements`），ELFO 场景下 `cr3bp_orbit`/`correction` 设为 None
- **Facade 简化**：`design_orbit()` 直接传递 request 对象，不再逐字段解包
- **`DesignOrbitResponse` 扩展**：新增漂移字段，ELFO 场景下 CR3BP 字段输出默认值

## 测试

```bash
# L1 纯函数（无 SPICE 依赖）
uv run pytest tests/orbit_design/test_frozen_orbit_units.py -v
# → 6 passed

# L2 单候选传播（需 SPICE 内核）
uv run pytest tests/orbit_design/test_frozen_orbit_integration.py -v
# → 1 passed (17.8s)

# 签名适配回归
uv run pytest tests/architecture/test_placeholder.py tests/api/test_facade.py -v
# → 24 passed

# 全量 lint
uv run ruff check . && uv run ruff format --check . && uv run mypy e2m2e/ --ignore-missing-imports
# → 全绿
```

ELFO 端到端冒烟测试（a=3000 km, 3 天）：`drift_e=-0.0014`、`drift_rp_km=+2.7`，物理方向正确。