### PR TITLE
fix(ci): calcephpy smoke test 加 --no-deps，跳过误声明的构建期依赖

### DIFF
--- a/.github/workflows/calcephpy-wheel.yml
+++ b/.github/workflows/calcephpy-wheel.yml
@@ -49,9 +49,10 @@ jobs:
       - name: Smoke test（安装并 import）
         shell: pwsh
         run: |
-          # calcephpy 运行时依赖 numpy（install_requires 声明），先装再 import。
+          # calcephpy 的 install_requires 误把 cython/setuptools 当 runtime
+          # 依赖（实为构建期），--no-deps 只装 wheel 本身验证；numpy 是真 runtime 依赖，预装。
           pip install numpy
-          pip install --no-index --find-links wheelhouse/ calcephpy
+          pip install --no-deps --no-index --find-links wheelhouse/ calcephpy
           python -c "import calcephpy; print('calcephpy import OK')"
       - uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
首次运行 calcephpy-wheel workflow，4 个 matrix 的 wheel 均成功构建，但 smoke test 全失败：```ERROR: Could not find a version that satisfies the requirement setuptools>=20.4 (from calcephpy)```calcephpy 的 install_requires 把 setuptools/cython 误当 runtime 依赖（实为构建期），--no-index 下找不到。加 --no-deps 只验证 wheel 本身能 import；numpy 是真 runtime 依赖，预装。