### PR TITLE
refactor(tests): B 类 fixture 共享 + 参数化收敛（PR② of #361）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [5.6.4] - 2026-08-09
+
+### Added
+- **ELFO 冻结轨道设计**（#350，closes #348）：`design_orbit` 统一入口新增 ELFO 分支——经典六根数构造初值 → 全摄动传播 → 月心根数漂移分析，复用 CR3BP 管线的力模型路径（GRGM900C 10×10 + EGM96 10×10 + 第三体 + 炮弹光压）。`OrbitDesignResult`/`DesignOrbitResponse` 新增 5 个月心漂移字段（`drift_e`、`drift_aop_deg`、`drift_rp_km`、`secular_aop_rate_deg_per_year`、`moon_centric_elements`），ELFO 场景下 CR3BP 字段留空。
+- **双 CSPICE 实例双侧同步**（#357，closes #334）：Python（spiceypy）与 Rust（cspice-sys）是两个独立 CSPICE 实例，内核池与名字表互不共享；本 PR 强制 `furnsh`+`boddef` 双侧同步，补齐 Rust 侧错误处理与诊断入口——新增 `spice_spkezr`/`spice_pxform` pyfunction 供 Python 直接查 Rust 实例做双侧对拍（`e2m2e-integrators` ABI v3→v4）。
+- **测试套件按功能类目重组**（#359，ADR 0021）：7 类功能标记（`theory`/`integrator`/`force`/`data`/`orchestration`/`interface`/`aux`）+ `slow`/`spice` 正交标记，取代 L1–L4 速度分层；测试目录迁至镜像源包的 `tests/algorithm/`。CI 维持静态门，测试在 release 前跑全量。
+
+### Changed
+- **`design_orbit` 签名重构**（#350）：散参改为 `DesignOrbitRequest` 模型入口，`duration` 单位从年改为秒（clean break），参数校验迁移到 Pydantic `model_validator`；Facade 直接透传 request 对象，不再逐字段解包。
+- **Rust SPICE 错误处理加固**（#357）：`erract`/`errdev` 显式设 RETURN/NULL，消除对上游 cspice crate 初始化顺序的依赖（默认 ABORT 出错即 exit）；错误信息由 SHORT 升级为 SHORT+LONG+traceback；`spkezr`/`pxform` 入口经 `ktotal` 预检内核池，空时报项目语境错误（ADR 0020，不走 FFI、不字符串匹配）。
+- **SPICEManager 收口 boddef**（#357）：`_BODY_ID_ALIASES` 单一归属 `SPICEManager`（`design_orbit` 不再自带表），`load_kernel` 首次调用在 spiceypy 侧 boddef 全部别名，对称 Rust 侧 `register_bodies`；多进程 `_worker_init` 改走 `SPICEManager.load_kernel` 双侧 furnsh，不再直接 `spiceypy.furnsh`。
+- **ADR 0013「测试分层」标注已被 ADR 0021 取代**（#359）：0013 其余不变。
+
+### Docs
+- 修正 #359 测试目录迁移后失效的 tests 路径引用（ADR 0006/0007/0008、`manifolds.rst`、`lambert.rst`）。
+- README `design_orbit` 示例 `duration` 语义同步（年→秒）、bibtex 版本号同步。
+
 ## [5.6.3] - 2026-08-08
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "5.6.3"
+version = "5.6.4"
 edition = "2021"
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ result = facade.design_orbit(
     amplitude=30000.0,  # 面外振幅（km，取值 ±73000，正北负南）
     phase=0.0,  # 初始相位（周期份额 0~1）
     epoch=[2024, 1, 1, 0, 0, 0.0],  # 起始历元 UTC：[年,月,日,时,分,秒]
-    duration=1.0,  # 维持时间（年）
+    duration=365.25 * 86400.0,  # 维持时间（秒，约 1 年）
     output_step=3600.0,  # 星历输出间隔（秒）
 )
 
@@ -189,7 +189,7 @@ make check    # cargo fmt/clippy + ruff
   author = {ouyangjiahong},
   email = {ouyangjiahong22@nudt.edu.cn},
   url = {https://github.com/cislunarspace/e2m2e},
-  version = {5.6.2},
+  version = {5.6.4},
   year = {2026},
 }
 ```

--- a/docs/adr/0006-ephemeris-corrector-seam.md
+++ b/docs/adr/0006-ephemeris-corrector-seam.md
@@ -59,7 +59,7 @@ ADR-0005 把 `TwoLevelMultipleShooting` 作为独立算法加入，但分发层�
 
 - `e2m2e/algorithms/ephemeris_correction_types.py`：`EphemerisCorrectionResult`、`PatchPointCorrector` Protocol、`UnsupportedCorrectorMethodError`。
 - `e2m2e/algorithms/ephemeris_correction.py`：三个私有 `PatchPointCorrector` 实现（`_StandardPatchPointCorrector`、`_TwoLevelPatchPointCorrector`、`_HomotopyPatchPointCorrector`）、`_REGISTRY` 注册表。
-- `tests/algorithms/test_patch_point_corrector.py`：接缝协议、注册表、分发、错误处理测试（20 个）。
+- `tests/algorithm/correction/test_patch_point_corrector.py`：接缝协议、注册表、分发、错误处理测试（20 个）。
 - `docs/adr/0006-ephemeris-corrector-seam.md`。
 
 ### 变更

--- a/docs/adr/0007-dynamic-axes-state-injection.md
+++ b/docs/adr/0007-dynamic-axes-state-injection.md
@@ -101,7 +101,7 @@ VNB、LVLH 作为 `DynamicAxes` 子类实现。静态坐标轴不受影响。
 - `e2m2e/core/dynamic_axes.py`：`DynamicAxes` 抽象基类。
 - `e2m2e/core/vnb_axes.py`：`VNBAxes` 实现。
 - `e2m2e/core/lvlh_axes.py`：`LVLHAxes` 实现。
-- `tests/core/coordinate/test_dynamic_axes.py`：VNB/LVLH 方向正确性测试（与 GMAT 对比）。
+- `tests/algorithm/coordinate/test_dynamic_axes.py`：VNB/LVLH 方向正确性测试（与 GMAT 对比）。
 
 ### 变更
 

--- a/docs/adr/0008-axes-origin-freezing-reversal.md
+++ b/docs/adr/0008-axes-origin-freezing-reversal.md
@@ -56,7 +56,7 @@ wontfix 关闭。
    服务，得不偿失。
 
 4. **YAGNI。** 代码风格层面"作者不应主动写 mutate"已由
-   `tests/core/coordinate/test_coordinate_immutability.py` 的 grep
+   `tests/algorithm/coordinate/test_coordinate_immutability.py` 的 grep
    守门员覆盖（扫描 `e2m2e/algorithm/coordinate/` 内的 `cs.axes = X` 这类赋值）。
    运行时偷换防护与之不同，本就不在应用层。
 
@@ -74,7 +74,7 @@ wontfix 关闭。
 
 - `TestCoordinateSystemOrthogonality`、`TestCoordinateSystemTransformVector`
   （零向量）：与冻结无关，保留。
-- `tests/core/coordinate/test_coordinate_immutability.py` 的 grep
+- `tests/algorithm/coordinate/test_coordinate_immutability.py` 的 grep
   守门员：保留。它防的是"代码作者主动写 mutate"（静态代码风格），
   不是"运行时偷换"（动态防护）。两者职责不同，前者与冻结无关。
 

--- a/docs/algorithms/manifolds.rst
+++ b/docs/algorithms/manifolds.rst
@@ -123,7 +123,7 @@
 
 返回两段弧的 :class:`~e2m2e.algorithm.transfer.config.TransferSolution`，物理单位。
 当前仅支持 CR3BP 模型；星历转换（CR3BP 闭合解 → 星历模型）尚未接入，
-``epoch`` 参数为其预留入口。端到端基准见 ``tests/transfer/test_low_energy.py``：
+``epoch`` 参数为其预留入口。端到端基准见 ``tests/algorithm/transfer/test_low_energy.py``：
 L1 Lyapunov 族内中间轨道到大幅值轨道，拼接脉冲在几十 m/s 量级。
 
 .. automodule:: e2m2e.algorithm.manifold.manifolds

--- a/docs/plans/test-suite-slow-redesign.md
+++ b/docs/plans/test-suite-slow-redesign.md
@@ -1,0 +1,166 @@
+# 测试套件 slow 测试重设计 RFC
+
+**立项**：#361
+**关联**：ADR 0021（测试套件按功能类目组织）、ADR 0013（验证策略）、#359（标记重组落地）
+**日期**：2026-08-09
+
+## 一、问题
+
+#359 落地了 ADR 0021 的「目录迁移 + 标记重组」，但 **slow 测试的内容未动**——仍按已废的「L3 scenario」旧范式写。直接症状：默认套件（`-m "not slow"`）跑 18 分钟仍未完；54 个 slow 测试里大量是「每断言一次 e2e 管线」的债。
+
+逐文件审查后，根因不是「物理验证需要慢」，而是旧范式残留的六类病灶：
+
+1. **每断言一 e2e**：`design/scenarios/` 的 6 个测试各跑一次 18 天 `design_orbit`，其中 4 个断言的只是 `Ephemeris`/`DesignOrbitResponse` 字段形状——本质是数据结构契约，该归 `data`/`interface` 类，不该靠真传播验证。
+2. **fixture 不共享**：`pal_stagnation` 3 个方法各跑一次相同的 80 步延拓；`wsb` 2 个方法各搜一次相同的网格。
+3. **bug 回归靠 e2e 间接抓**：`segmented` 回归的 `propagate_compiled` 的 `t_eval[0]≠t0` 是积分器 bug，该有最小复现单元，不该靠 30 天 segmented 设计间接抓。
+4. **参数化覆盖 = 重复契约**：`initial_guess/test_lissajous` 的 4 组合断言同一组契约（形状/单调/有界），不是 4 个不同目标。
+5. **开发中 feat 占位**：`homotopy` 从未跑通，在默认套件里持续 F，是未完成功能的占位测试。
+6. **docstring 旧框架措辞**：4 个文件仍写「属 tests/orbit_design 三层分层中的 L3（scenarios，端到端）」，引用已被 ADR 0021 废除的分层。
+
+## 二、设计原则
+
+落实 ADR 0021，五条：
+
+1. **e2e 解散，按断言归类**（ADR 0021 理由 4）。一个 `design_orbit` 调用里，字段形状/类型 → `data`/`interface`；编排链路收敛 → `orchestration`；物理量取值 → `orchestration`/`theory`。三者分属不同类、不同手段，不塞进同一个 slow e2e。
+2. **一次管线调用，多断言共享 fixture**。`segmented`/`frozen_orbit` 已做对（module scope）；`pal`/`wsb` 做反了——纯浪费，与分类无关。
+3. **bug 回归找最小复现**。integrator bug 做 integrator 单元，不靠 e2e 间接抓（既慢，又会在 bug 以别的方式复现时漏掉）。
+4. **开发中 feat 标记跳过**。`homotopy` 未跑通，module-level skip，待功能完成后启用。
+5. **C 类保留，但审「最短弧/最少阶/最少点」**。物理结论（Δe、secular 斜率、Jacobi 守恒）需要足够计算量体现，但当前参数往往留了过大余量。
+
+## 三、「测到什么程度」的操作定义
+
+每个测试必须能回答「我证明了什么事实」，事实的性质决定它的类和手段。答不出「证明了什么」的（如「跑通不崩」），消除或跳过。
+
+| 证明的事实 | 功能类 | 手段 |
+|---|---|---|
+| 字段形状/类型对 | `data`/`interface` | 构造对象断言，零管线 |
+| 数值方法对解析解 | `theory` | 短弧 + 解析式 |
+| 编排链路不抛 + 收敛 | `orchestration` | 每类型 1 个瘦身真调用，共享 fixture |
+| 某物理量在 X 条件取 Y | `orchestration`/`theory` | 体现结论的最短弧 |
+| 某 bug 不再复现 | 视 bug 所属层 | 最小复现条件 |
+
+## 四、处置清单（逐文件，含新测试草图）
+
+### A 类：e2e 解散 + 契约下沉（先改，收益最大、风险最小）
+
+#### `design/scenarios/test_lissajous.py` + `test_triangular.py`（合并）
+
+**现状**：两文件逐行重复，各 6 个 slow 测试 = 12 个，每个跑一次 18 天 `design_orbit`。4 个断言字段形状契约（`output_shape`/`epoch_matches_input`/`initial_state_shape`/`cr3bp_orbit_present`），2 个真集成（`end_to_end_converges`/`amplitude_bounded`）。
+
+**新设计**：
+
+- 字段形状契约**删除**，下沉到：
+  - `Ephemeris` 契约（`position_km.shape`/`velocity_mps.shape`/`synodic_position.shape`/`year[0]`）→ `tests/data/test_types_trajectory.py`（已存在，补断言）。
+  - `DesignOrbitResponse` 契约（`initial_state.shape==(6,)`/`cr3bp_orbit_present`/`cr3bp_jacobi` 类型）→ `tests/api/`（构造 Response 断言字段，零管线）。
+- 集成收敛：1 个 `orchestration` 测试，参数化 `orbit_type ∈ {LISSAJOUS-L1, LISSAJOUS-L2, L4, L5}`，**共享 module fixture**（每个类型跑一次），`duration` 从 18 天缩到 3–5 天（够验证 `correction.converged`），断言收敛 + `ephemeris` 非空。
+- 有界性：并入收敛测试同一 fixture，断言 Jacobi 守恒漂移（比「位置 < 1e6 km」更严格、更物理）。
+
+**净效果**：12 slow → 4 个 orchestration 真调用（短弧、共享 fixture）+ 契约下沉 data/api。预计默认套件省下 ~12 次 18 天传播。
+
+#### `transfer/test_wsb.py`（2 个 slow）
+
+**现状**：两个 `@slow` 方法各搜一次相同的 WSB 网格（15 格点）。`test_returns_transfer_design_result` 断言返回类型 + `transfer_type`；`test_wsb_details_populated` 断言 `details` 各字段类型（`isinstance float/bool/int`）。
+
+**新设计**：
+
+- `details` 字段类型契约 → `tests/api/` 或 interface，构造 `WsbTransferDetails` 直接断言字段类型，零搜索。
+- 真搜索：1 个 `orchestration` 测试，**共享 module fixture**（搜一次），断言 `transfer_type=="WSB"` + `converged` + `dv` 合理量级（物理），同时复用 fixture 检查 details 非空。
+
+**净效果**：2 slow → 1 orchestration + 契约下沉。WSB 单格点 BCR4BP 多圈传播 inherent 慢，搜索次数减半。
+
+### B 类：fixture 共享 + 参数化收敛
+
+#### `correction/test_pal_stagnation.py`（24 个 slow）
+
+**现状**：8 组合（L1/L2 × 北/南 × 正/负）× 3 方法 = 24 个；3 个方法（`reaches_fold`/`no_stagnation_oscillation`/`extends_x_past_fold`）**各跑一次相同的 80 步延拓**，断言同一 family 的不同方面。8 组合里南北、正负物理对称冗余。
+
+**新设计**：
+
+- 3 方法共享 1 个 family fixture（parametrize 在 fixture 上，每组合跑一次 80 步延拓，三方面断言共用）→ 从 24 次延拓降到 8 次。
+- 组合 8 → 代表性 2（如 L1 北正、L2 北正）；南北对称、正负方向对称用少量组合覆盖即可。→ 8 次降到 2 次。
+- 三方面断言（z_amp 到折叠点 / z 振幅无 2-周期环 / x 穿过折叠点）合并到每组合一个测试的多断言，或保留 3 测试共享同一 fixture。
+
+**净效果**：24 slow → 2 组合 × 1 family = 2 次 80 步延拓，断言三方面。回归价值不减（bug 根因 `pal_plausible` 误判在代表性组合上同样暴露）。
+
+#### `design/initial_guess/test_lissajous.py::TestLissajousBoundedTrajectory`（4 个 slow）
+
+**现状**：4 组合（L ∈ {1,2} × 振幅 ∈ {(500,2000),(2500,7500)}），各走中心流形约化，断言同一组契约（三元组结构/形状/times 单调/period/有界性）。
+
+**新设计**：
+
+- 契约（三元组结构/形状/times 单调/period>0）→ 1 组合的单元测试，直接调 `compute_lissajous_bounded_trajectory` 断言结构。
+- 有界性物理（面内偏移 < 3× 振幅）→ 参数化 2 组合（小振幅 + 大振幅）验证有界性随振幅成立。
+
+**净效果**：4 slow → 1 契约单元 + 2 有界性。契约不再重复跑约化。
+
+### bug 下沉
+
+#### `design/scenarios/test_segmented.py`（2 个 slow）
+
+**现状**：fixture 共享做对（module scope，2 测试复用一次 4 分钟 segmented 设计）。但回归的 bug 是 `propagate_compiled` 的 `eval_idx` 初始化假设 `t_eval[0]==t0`——**积分器层 bug**。
+
+**新设计**：
+
+- bug 下沉：`tests/numerical/integrators/` 加单元测试——构造 `t_eval[0] > t0` 场景，直接调积分器，断言首个输出点状态非初值错置（相邻点 J2000 漂移正常）。秒级，直接抓根因。
+- segmented 集成：保留 1 个 `orchestration` 测试（共享 fixture，审 30 天 → 短弧是否够验证星历连续），断言星历相邻点无停滞 + patch point 间距量级。
+
+**净效果**：bug 用快单元直接抓（不再靠 4 分钟 e2e 间接）；segmented 集成保留但瘦身。
+
+### 开发中 feat
+
+#### `correction/test_homotopy_ephemeris_integration.py`
+
+**现状**：homotopy correction 是开发中 feat，从未跑通。文件无 skip 门，4 个测试在默认套件里持续 F。
+
+**新设计**：文件顶部加 module-level 跳过：
+
+```python
+pytest.skip(
+    "homotopy correction 开发中（feat 未完成），待功能跑通后启用",
+    allow_module_level=True,
+)
+```
+
+**净效果**：默认套件不再背 homotopy 的 F；功能完成后移除 skip、重设计测试（真种子验证残差收敛，而非平凡种子 + placeholder 判据）。
+
+### C 类：保留，审弧长/阶数
+
+#### `normal_form/test_lissajous_bounded.py`（2 个 slow）
+
+**保留**。验证中心流形约化的核心正确性（双曲耦合消除 + 6 周期有界），目标本身重，fixture 已缓存复用。order 5 不降（降阶影响约化质量，验证失意义）。
+
+#### `design/scenarios/test_frozen_orbit_e2e.py`（4 个 slow）
+
+**保留**，审弧长。fixture 已共享（module scope）。断言物理结论（i=75° 无严格冻结、Δe≈−0.019、Δrp≈+61 km、漂移方向、|Δrp| 随 a 增大）。60 天 → 审 30 天是否够体现结论方向（Δrp 减半但正负、单调性不变）；`test_drift_rp_increases_with_a` 的 a8000 第二次传播可同步缩短。
+
+#### `numerical/forces/test_low_thrust_propagation.py::test_low_thrust_spiral_orbit_evolution`（1 个 slow）
+
+**保留**，缩弧。30 天 → 7–10 天，够体现「半长轴 secular 斜率 > 0 + 偏心率 < 0.05」的物理结论。文件内已有的短弧解析对照（`a(t)` 解析解 5% 容差，`theory` 类）不动。
+
+## 五、docstring 旧框架措辞清理
+
+随 PR 一并清理 4 处对已废分层的引用：
+
+- `tests/algorithm/design/scenarios/test_lissajous.py:10-11`（「属 tests/orbit_design 三层分层中的 L3（scenarios，端到端）」）
+- `tests/algorithm/design/scenarios/test_triangular.py:10-11`（同上）
+- `tests/algorithm/design/scenarios/test_segmented.py:10`（同上）
+- `tests/algorithm/design/scenarios/test_frozen_orbit_e2e.py:1`（「（L3）」）
+
+替换为 ADR 0021 的功能类描述（`orchestration`：design_orbit 全链路集成），不引用已废分层。
+
+## 六、分批 PR 计划
+
+按「收益最大、风险最小」排序，每批独立合入：
+
+- **PR1（A 类 + docstring 清理）**：合并 lissajous/triangular、瘦身 wsb、契约下沉 data/api、清理 4 处 docstring。收益最大（默认套件省 ~14 次 e2e 传播），风险最小（契约下沉是搬运、不碰算法）。
+- **PR2（B 类）**：pal_stagnation fixture 共享 + 组合收敛、initial_guess/lissajous 契约下沉。
+- **PR3（bug 下沉 + homotopy skip + C 类微调）**：segmented bug 下沉 integrator 单元、homotopy module-level skip、frozen/low_thrust 弧长微调。
+
+每批合入后跑一次默认套件 + slow 套件，确认 `--durations` 下降、无回归。
+
+## 七、验收
+
+- 默认套件（`-m "not slow"`）wall time 显著下降（目标：去除 homotopy F + A/B 类 e2e 后，回到可日常迭代的量级）。
+- slow 套件从 54 个降到 ~10 个真物理测试（C 类 + 保留的瘦身集成）。
+- 每个保留下来的测试能一句话回答「证明了什么物理/契约事实」。
+- `grep -rn 'L3\|三层分层\|scenarios，端到端' tests/` 无残留。

--- a/docs/transfer/lambert.rst
+++ b/docs/transfer/lambert.rst
@@ -124,7 +124,7 @@ Lambert 问题，得到双脉冲 ΔV 网格，即 porkchop 图的数据层。出
 返回 :class:`~e2m2e.algorithm.transfer.config.TransferSolution`，单弧，物理单位；
 未收敛时 ``converged=False`` 且 ``message`` 说明残余误差。典型场景（同一周期
 轨道上两相位点间转移、Lyapunov → Halo 交会）的收敛行为见
-``tests/transfer/test_three_body_lambert.py``。
+``tests/algorithm/transfer/test_three_body_lambert.py``。
 
 多脉冲转移与主矢量检验
 ----------------------
@@ -189,7 +189,7 @@ p(t0) = Δv̂₀、p(tf) = Δv̂_f 确定主矢量初值，协态经 STM 携载�
        )
        sol3 = transfer.optimize(3, x0=x0)   # 三脉冲总 ΔV 低于双脉冲
 
-完整算例见 ``tests/transfer/test_multi_impulse.py``。
+完整算例见 ``tests/algorithm/transfer/test_multi_impulse.py``。
 
 .. automodule:: e2m2e.algorithm.transfer.lambert
    :members:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "e2m2e"
-version = "5.6.3"
+version = "5.6.4"
 description = "Earth to Moon, Moon to Earth — 地月空间转移轨道设计库"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/algorithm/correction/test_pal_stagnation.py
+++ b/tests/algorithm/correction/test_pal_stagnation.py
@@ -1,6 +1,6 @@
 """Halo PAL 延拓折叠点停滞回归测试。
 
-验证 L1/L2 北/南 Halo 在折叠点处不形成 2-周期环，
+验证 L1/L2 Halo 在折叠点处不形成 2-周期环，
 延拓能平稳穿过折叠点。
 """
 
@@ -62,17 +62,38 @@ def _state_distance(orbit_a: Orbit, orbit_b: Orbit) -> float:
     return float(np.linalg.norm(np.asarray(orbit_a.states[0]) - np.asarray(orbit_b.states[0])))
 
 
-# 所有(L1/L2) × (北/南) × (正/负) 共 8 个组合
-_ALL_PAL_CONFIGS = [
+# 代表性组合:L1 北正、L2 北正。
+# 北/南关于 z=0 平面对称、正/负沿同一族流形反向,停滞 bug 的根因
+# (pal_plausible 阈值误判)与对称选择无关,2 个代表性组合足以暴露回归。
+_PAL_CONFIGS = [
     (1, 0, "positive"),
-    (1, 0, "negative"),
-    (1, 1, "positive"),
-    (1, 1, "negative"),
     (2, 0, "positive"),
-    (2, 0, "negative"),
-    (2, 1, "positive"),
-    (2, 1, "negative"),
 ]
+
+
+@pytest.fixture(
+    scope="module",
+    params=_PAL_CONFIGS,
+    ids=[f"L{lp}-{'north' if hc == 0 else 'south'}-{d}" for lp, hc, d in _PAL_CONFIGS],
+)
+def pal_family(request):
+    """每组合跑一次 80 步 PAL 延拓,三方面断言共享同一 family。"""
+    libration_point, halo_class, direction = request.param
+    seed = _build_l_halo_seed(libration_point, halo_class, amplitude_z=0.001)
+
+    system = _build_earth_moon_system()
+    dynamics = CR3BP_Dynamics(system)
+    corrector = DifferentialCorrection(dynamic=dynamics)
+    continuation = Continuation(corrector=corrector)
+
+    family = continuation.halo_pseudo_arclength_continuation(
+        seed_orbit=seed,
+        n_orbits=80,
+        direction=direction,
+        step_size=0.0045,
+        verbose=False,
+    )
+    return libration_point, halo_class, direction, family
 
 
 class TestHaloPALStagnation:
@@ -90,31 +111,15 @@ class TestHaloPALStagnation:
     失去 PAL 的弧长推进能力。
     """
 
-    @pytest.mark.parametrize("libration_point,halo_class,direction", _ALL_PAL_CONFIGS)
-    def test_pal_reaches_fold_point(self, libration_point, halo_class, direction):
-        """PAL 延拓 80 步后应到达折叠点(各 LP/HC 组合)。
+    def test_pal_reaches_fold_point(self, pal_family):
+        """PAL 延拓 80 步后应到达折叠点。
 
         折叠点阈值因 LP/HC 而异,但所有组合下 z 振幅应明显超过种子(0.001)。
         折叠点具体位置:
         - L1 北/南: z_amp ≈ 0.085
         - L2 北/南: z_amp ≈ 0.30
         """
-        # 跳过 L2 暂时 — L2 折叠点较远,需要不同 n_orbits 阈值
-        # 但仍验证延拓没有早早停止
-        seed = _build_l_halo_seed(libration_point, halo_class, amplitude_z=0.001)
-
-        system = _build_earth_moon_system()
-        dynamics = CR3BP_Dynamics(system)
-        corrector = DifferentialCorrection(dynamic=dynamics)
-        continuation = Continuation(corrector=corrector)
-
-        family = continuation.halo_pseudo_arclength_continuation(
-            seed_orbit=seed,
-            n_orbits=80,
-            direction=direction,
-            step_size=0.0045,
-            verbose=False,
-        )
+        libration_point, halo_class, direction, family = pal_family
 
         assert len(family) >= 81, f"延拓未达到目标轨道数,实际 {len(family)}"
 
@@ -129,8 +134,7 @@ class TestHaloPALStagnation:
             f"延拓在 z={max_z_amp:.4f} 处即停,未达到预期折叠点位置 z≥{expected_min}"
         )
 
-    @pytest.mark.parametrize("libration_point,halo_class,direction", _ALL_PAL_CONFIGS)
-    def test_pal_no_stagnation_oscillation(self, libration_point, halo_class, direction):
+    def test_pal_no_stagnation_oscillation(self, pal_family):
         """PAL 延拓在折叠点附近应平稳穿过,不出现 2-周期环振荡。
 
         修复前:折叠点处连续多步轨道在两个几乎相同的 z 值间跳(2-周期环)。
@@ -138,20 +142,7 @@ class TestHaloPALStagnation:
         的非单调回退 — 这是 2-周期环的标志。修复后 z 振幅在折叠点前后
         是单调变化(过折叠点前后分别单调),不出现来回。
         """
-        seed = _build_l_halo_seed(libration_point, halo_class, amplitude_z=0.001)
-
-        system = _build_earth_moon_system()
-        dynamics = CR3BP_Dynamics(system)
-        corrector = DifferentialCorrection(dynamic=dynamics)
-        continuation = Continuation(corrector=corrector)
-
-        family = continuation.halo_pseudo_arclength_continuation(
-            seed_orbit=seed,
-            n_orbits=80,
-            direction=direction,
-            step_size=0.0045,
-            verbose=False,
-        )
+        libration_point, halo_class, direction, family = pal_family
 
         continuation_orbits = family.orbits[1:]
         assert len(continuation_orbits) >= 70
@@ -182,27 +173,13 @@ class TestHaloPALStagnation:
             f" (修复后应在过折叠点时反向 ≤ 2 次)"
         )
 
-    @pytest.mark.parametrize("libration_point,halo_class,direction", _ALL_PAL_CONFIGS)
-    def test_pal_extends_x_past_fold(self, libration_point, halo_class, direction):
+    def test_pal_extends_x_past_fold(self, pal_family):
         """PAL 延拓穿过折叠点后,x 振幅应继续增长(沿流形走弧长)。
 
         修复前:振荡在折叠点附近,x 振幅也卡死。
         修复后:穿过折叠后 x 从 ~0.94(L1)或 ~1.15(L2)增长。
         """
-        seed = _build_l_halo_seed(libration_point, halo_class, amplitude_z=0.001)
-
-        system = _build_earth_moon_system()
-        dynamics = CR3BP_Dynamics(system)
-        corrector = DifferentialCorrection(dynamic=dynamics)
-        continuation = Continuation(corrector=corrector)
-
-        family = continuation.halo_pseudo_arclength_continuation(
-            seed_orbit=seed,
-            n_orbits=80,
-            direction=direction,
-            step_size=0.0045,
-            verbose=False,
-        )
+        libration_point, halo_class, direction, family = pal_family
 
         continuation_orbits = family.orbits[1:]
         x_values = [float(o.states[0, 0]) for o in continuation_orbits]

--- a/tests/algorithm/design/initial_guess/test_lissajous.py
+++ b/tests/algorithm/design/initial_guess/test_lissajous.py
@@ -121,15 +121,18 @@ class TestLissajousInitialGuess:
 # =============================================================================
 
 
-@pytest.mark.slow
-class TestLissajousBoundedTrajectory:
-    """compute_lissajous_bounded_trajectory 返回中心流形约化的多点有界轨迹。"""
+class TestLissajousBoundedTrajectoryContract:
+    """compute_lissajous_bounded_trajectory 的返回结构契约。
 
-    @pytest.mark.parametrize("L", [1, 2])
-    @pytest.mark.parametrize("ain, aout", [(500.0, 2000.0), (2500.0, 7500.0)])
-    def test_bounded_trajectory(self, earth_moon_system, L: int, ain: float, aout: float):
-        """返回多点 synodic 质心系有界轨迹，面内偏移 ~2× 振幅量级。"""
-        result = compute_lissajous_bounded_trajectory(earth_moon_system, L, ain, aout, 0.01, 0.55)
+    单组合跑一次中心流形约化（约 3 秒），断言三元组结构/形状/times 单调/
+    period>0——这些契约与 L、振幅取值无关，不需参数化重复。
+    """
+
+    def test_bounded_trajectory_contract(self, earth_moon_system):
+        """返回 (states, times, period) 三元组，形状与单调性满足契约。"""
+        result = compute_lissajous_bounded_trajectory(
+            earth_moon_system, 1, 500.0, 2000.0, 0.01, 0.55
+        )
         # 三元组 (states, times, period)
         assert isinstance(result, tuple) and len(result) == 3
         states, times, period = result
@@ -149,6 +152,22 @@ class TestLissajousBoundedTrajectory:
 
         # period > 0
         assert period > 0
+
+
+@pytest.mark.slow
+class TestLissajousBoundedTrajectory:
+    """compute_lissajous_bounded_trajectory 的有界性物理。
+
+    小振幅 + 大振幅 2 组合，验证有界性随振幅成立。
+    """
+
+    @pytest.mark.parametrize("L,ain,aout", [(1, 500.0, 2000.0), (2, 2500.0, 7500.0)])
+    def test_bounded_trajectory_bounded(self, earth_moon_system, L: int, ain: float, aout: float):
+        """面内偏移相对平动点应 < 3× 面内振幅（量级 ~2×，留 3× 余量）。"""
+        states, _, _ = compute_lissajous_bounded_trajectory(
+            earth_moon_system, L, ain, aout, 0.01, 0.55
+        )
+        states = np.asarray(states)
 
         # 有界性：面内偏移相对平动点（km），量级 ~2× 振幅，留 3× 余量
         l_c = earth_moon_system.characteristic_length

--- a/uv.lock
+++ b/uv.lock
@@ -745,7 +745,7 @@ wheels = [
 
 [[package]]
 name = "e2m2e"
-version = "5.6.3"
+version = "5.6.4"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## 关联

- 关联：#361（PR②，B 类重设计；#361 为三批 PR 的母 issue，本 PR 不单独关闭）
- 上一批：#368（PR①，A 类 e2e 解散）

## 改动

按 `docs/plans/test-suite-slow-redesign.md` 重设计 B 类 slow 测试：

- **`test_pal_stagnation.py`**：3 方法（`reaches_fold`/`no_stagnation_oscillation`/`extends_x_past_fold`）共享 module 级 parametrized family fixture——每组合只跑一次 80 步延拓（原 3 方法各独立跑一次相同延拓）；组合 8 → 代表性 2（L1 北正、L2 北正，覆盖 z≈0.085 与 z≈0.30 两条折叠点分支）。**24 slow → 6 slow，延拓 24 次 → 2 次**。三方面物理判据（z_amp 阈值 / `direction_changes ≤ 2` / x 阈值）逐字未动。
- **`test_lissajous.py::TestLissajousBoundedTrajectory`**：契约（三元组结构 / 形状 / times 单调 / period>0）下沉 1 个非 slow 单元测试（实测 3.3s，与现有非 slow 最慢测试相当，故不标 slow）；有界性物理（面内偏移 < 3× 振幅）保留 2 组合（L1 小振幅 + L2 大振幅）。**4 slow → 1 非 slow 契约 + 2 slow 有界性**。

## 测试（checker 独立验证 ALL GREEN）

- 改动两文件：默认（`-m "not slow"`）**24 passed, 8 deselected**；含 slow（`-m ""`）**32 passed, 0 failed**。
- `ruff check` / `ruff format --check` / `mypy`（206 源文件）**全绿**。
- **fixture 共享证实**：`--durations` 显示 pal 模块仅 2 次 setup（延拓只在 fixture setup，3 断言方法 call 耗时 <0.005s）。
- **断言未弱化证实**：`git diff master` 逐行核对，所有数值阈值逐字未动。

默认套件的既存失败与本 PR 无关（#365/#366/#367 已开）。本 PR 未碰 `e2m2e/` 源码。