### PR TITLE
fix(tests): #365 GMAT fixture 路径 + #372 迁移引用存量清理（ADR 0013 合规）

### DIFF
--- a/e2m2e/data/frames/gmat_fixture.py
+++ b/e2m2e/data/frames/gmat_fixture.py
@@ -1,7 +1,8 @@
 """GMAT 裁剪 fixture 发现工具（开发期测试辅助）。
 
 ADR 0011 迁移：自 ``core/coordinate/gmat_data.py`` 迁入数据层。GMAT
-数据文件（EOP/闰秒）是开发期对照数据（ADR 0013），路径发现工具归数据层，
+数据文件（EOP/闰秒）作解析器测试**输入**（IERS 公布的物理事实），
+非对照标准（ADR 0013 禁其他软件输出做判据）。路径发现工具归数据层，
 供 ``algorithm/coordinate/`` 的 GMAT-compatible 坐标轴与测试使用。
 """
 
@@ -13,7 +14,7 @@ from pathlib import Path
 from .eop import CoordinateDataError
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
-_COMMITTED_GMAT_FIXTURE_DIR = _REPO_ROOT / "tests" / "core" / "coordinate" / "fixtures" / "gmat"
+_COMMITTED_GMAT_FIXTURE_DIR = _REPO_ROOT / "tests" / "data" / "frames" / "fixtures" / "gmat"
 
 
 def committed_gmat_fixture_dir() -> Path:

--- a/e2m2e/mbse/requirements/core_requirements.py
+++ b/e2m2e/mbse/requirements/core_requirements.py
@@ -18,7 +18,10 @@ CORE_REQUIREMENTS = [
         priority=RequirementPriority.SHALL,
         verification_method="test",
         linked_code=["e2m2e.core.orbit", "e2m2e.core.dynamics"],
-        linked_tests=["tests/core/test_orbit.py", "tests/core/test_dynamics.py"],
+        linked_tests=[
+            "tests/data/types/test_orbit.py",
+            "tests/numerical/dynamics/test_dynamics.py",
+        ],
     ),
     Requirement(
         id="REQ-002",
@@ -31,8 +34,8 @@ CORE_REQUIREMENTS = [
         verification_method="test",
         linked_code=["e2m2e.core.dynamics", "e2m2e.core.ephemeris_dynamics"],
         linked_tests=[
-            "tests/core/test_dynamics.py",
-            "tests/core/dynamics/test_ephemeris_dynamics.py",
+            "tests/numerical/dynamics/test_dynamics.py",
+            "tests/numerical/dynamics/test_ephemeris_dynamics.py",
         ],
     ),
     Requirement(
@@ -43,7 +46,7 @@ CORE_REQUIREMENTS = [
         priority=RequirementPriority.SHALL,
         verification_method="test",
         linked_code=["e2m2e.core.dynamics"],
-        linked_tests=["tests/core/test_dynamics.py"],
+        linked_tests=["tests/numerical/dynamics/test_dynamics.py"],
     ),
     Requirement(
         id="REQ-004",
@@ -55,7 +58,7 @@ CORE_REQUIREMENTS = [
         priority=RequirementPriority.SHALL,
         verification_method="analysis",
         linked_code=["e2m2e.core.dynamics"],
-        linked_tests=["tests/core/test_dynamics.py"],
+        linked_tests=["tests/numerical/dynamics/test_dynamics.py"],
     ),
     # ---- 继承与接口 ----
     Requirement(
@@ -66,7 +69,7 @@ CORE_REQUIREMENTS = [
         priority=RequirementPriority.SHALL,
         verification_method="inspection",
         linked_code=["e2m2e.core.dynamics", "e2m2e.core.ephemeris_dynamics"],
-        linked_tests=["tests/core/dynamics/test_ephemeris_dynamics.py"],
+        linked_tests=["tests/numerical/dynamics/test_ephemeris_dynamics.py"],
     ),
     Requirement(
         id="REQ-006",
@@ -76,7 +79,7 @@ CORE_REQUIREMENTS = [
         priority=RequirementPriority.SHALL,
         verification_method="test",
         linked_code=["e2m2e.core.coordinate_system", "e2m2e.core.synodic_j2000"],
-        linked_tests=["tests/core/coordinate/test_synodic_j2000.py"],
+        linked_tests=["tests/algorithm/coordinate/test_synodic_j2000.py"],
     ),
     # ---- 物理模型精度 ----
     Requirement(
@@ -87,7 +90,7 @@ CORE_REQUIREMENTS = [
         priority=RequirementPriority.SHALL,
         verification_method="test",
         linked_code=["e2m2e.core.system"],
-        linked_tests=["tests/core/test_system.py"],
+        linked_tests=["tests/numerical/dynamics/test_system.py"],
     ),
     Requirement(
         id="REQ-011",
@@ -97,7 +100,7 @@ CORE_REQUIREMENTS = [
         priority=RequirementPriority.SHOULD,
         verification_method="test",
         linked_code=["e2m2e.core.system"],
-        linked_tests=["tests/core/test_system.py"],
+        linked_tests=["tests/numerical/dynamics/test_system.py"],
     ),
     Requirement(
         id="REQ-012",
@@ -107,7 +110,7 @@ CORE_REQUIREMENTS = [
         priority=RequirementPriority.SHALL,
         verification_method="inspection",
         linked_code=["e2m2e.core.dynamics"],
-        linked_tests=["tests/core/test_dynamics.py"],
+        linked_tests=["tests/numerical/dynamics/test_dynamics.py"],
     ),
     # ---- 轨道数据 ----
     Requirement(
@@ -118,7 +121,7 @@ CORE_REQUIREMENTS = [
         priority=RequirementPriority.SHALL,
         verification_method="test",
         linked_code=["e2m2e.core.orbit"],
-        linked_tests=["tests/core/orbit/test_orbit_io.py"],
+        linked_tests=["tests/data/types/test_orbit_io.py"],
     ),
     Requirement(
         id="REQ-021",
@@ -128,7 +131,7 @@ CORE_REQUIREMENTS = [
         priority=RequirementPriority.SHOULD,
         verification_method="test",
         linked_code=["e2m2e.core.orbit"],
-        linked_tests=["tests/core/test_orbit.py"],
+        linked_tests=["tests/data/types/test_orbit.py"],
     ),
     Requirement(
         id="REQ-022",
@@ -140,7 +143,7 @@ CORE_REQUIREMENTS = [
         priority=RequirementPriority.SHALL,
         verification_method="test",
         linked_code=["e2m2e.core.orbit"],
-        linked_tests=["tests/core/orbit/test_orbit_family.py"],
+        linked_tests=["tests/data/types/test_orbit_family.py"],
     ),
     # ---- 星历动力学 ----
     # 注：EphemerisDynamics 已降级为遗留内部实现（仅供 multiple_shooting/homotopy
@@ -156,7 +159,7 @@ CORE_REQUIREMENTS = [
         priority=RequirementPriority.SHALL,
         verification_method="test",
         linked_code=["e2m2e.core.ephemeris_dynamics"],
-        linked_tests=["tests/core/dynamics/test_ephemeris_dynamics.py"],
+        linked_tests=["tests/numerical/dynamics/test_ephemeris_dynamics.py"],
     ),
     Requirement(
         id="REQ-026",
@@ -169,6 +172,6 @@ CORE_REQUIREMENTS = [
         priority=RequirementPriority.SHOULD,
         verification_method="test",
         linked_code=["e2m2e.core.ephemeris_dynamics"],
-        linked_tests=["tests/core/dynamics/test_ephemeris_dynamics.py"],
+        linked_tests=["tests/numerical/dynamics/test_ephemeris_dynamics.py"],
     ),
 ]

--- a/tests/algorithm/transfer/test_lowthrust_shooting.py
+++ b/tests/algorithm/transfer/test_lowthrust_shooting.py
@@ -2,7 +2,7 @@
 
 对照 ``docs/plans/lowthrust-shooting-prd.md``：min-fuel 轨道提升闭环、零推力
 退化、段间连续性、决策变量规模。复用与
-``tests/core/forces/test_low_thrust_variable_mass.py`` 相同的 Earth 星历 fixture。
+``tests/numerical/forces/test_low_thrust_variable_mass.py`` 相同的 Earth 星历 fixture。
 """
 
 import numpy as np

--- a/tests/data/frames/test_gmat_fixtures.py
+++ b/tests/data/frames/test_gmat_fixtures.py
@@ -1,13 +1,16 @@
 """GMAT fixture 解析器、时间转换与约化测试。
 
-覆盖 TAI-UTC 表、EOP 文件、时间转换器与 ITRF 矩阵黄金值。
+覆盖 TAI-UTC 表、EOP 文件、时间转换器与 ITRF 矩阵（动态对照 SPICE ITRF93）。
 """
+
+import os
 
 import numpy as np
 import pytest
 
 from e2m2e.algorithm.coordinate.gmat_itrf import GmatItrfReduction
 from e2m2e.algorithm.coordinate.gmat_time import TimeSystemConverter
+from e2m2e.algorithm.coordinate.standard_axes import ITRFSpiceAxes
 from e2m2e.algorithm.coordinate.xys import ErfaXysProvider
 from e2m2e.data.frames.eop import ARCSEC_TO_RAD, EopFile
 from e2m2e.data.frames.gmat_fixture import CoordinateDataError, gmat_fixture_path
@@ -104,6 +107,13 @@ def test_time_converter_keeps_et_public_and_exposes_low_level_a1():
 
 
 def test_erfa_xys_provider_matches_reference_epoch_values():
+    """参考值取自 SOFA ``iauXys06a``（``erfa.xys06a``，IAU 2006 岁差 + 2000A 章动模型）。
+
+    三个历元分别对应 J2000（TT MJD 51544.5）、2017-01-01、2026-06-12
+    （2026 年 EOP fixture 采样窗口）。SOFA IAU 2006/2000A 模型是物理定义
+    （ADR 0013 决策 2 允许的文献值），非 golden 对照。实测与
+    ``erfa.xys06a(jd, 0.0)`` 逐位一致。
+    """
     provider = ErfaXysProvider()
 
     assert provider.xys(51544.5) == pytest.approx(
@@ -127,7 +137,23 @@ def test_erfa_xys_provider_rejects_invalid_time_input():
         provider.xys(np.inf)
 
 
-def test_gmat_itrf_reduction_returns_expected_rotation_matrix():
+def test_gmat_itrf_reduction_matches_spice_itrf93():
+    """GMAT 原生约化的 ITRF 旋转矩阵动态对照 SPICE ITRF93（ADR 0003 决策 5）。
+
+    硬编码矩阵已删除：golden 对照违反 ADR 0013（只证回归不证正确），
+    正确性由动态对照 SPICE ITRF93 在 1e-7 量级裁决（原生链采用约化的 IAU
+    岁差章动 + 线性插值 EOP，精度预期在 1e-7，非 SPICE 的 1e-12 量级）。
+    保留物理定义断言 R @ R.T == I（正交性）。
+    """
+    from kernel_helpers import load_body_fixed_kernels, unload_kernels
+
+    from e2m2e.data.kernels.manager import SPICEManager
+
+    manager = SPICEManager()
+    loaded = load_body_fixed_kernels(manager)
+    if "earth_latest_high_prec.bpc" not in [os.path.basename(p) for p in loaded]:
+        pytest.skip("需 ITRF93 BPC 内核做 SPICE 动态对照（ADR 0003 决策 5）")
+
     table = TaiUtcTable.from_file(gmat_fixture_path("tai-utc.dat"))
     eop = EopFile.from_file(gmat_fixture_path("eopc04_08.62-now.trimmed"))
     reduction = GmatItrfReduction(
@@ -135,22 +161,12 @@ def test_gmat_itrf_reduction_returns_expected_rotation_matrix():
     )
 
     rotation, rate = reduction.rotation_and_rate(0.0)
+    expected_rotation, expected_rate = ITRFSpiceAxes(frame="ITRF93").rotation_and_rate(0.0)
 
-    expected_rotation = np.array(
-        [
-            [1.7698059086970885e-01, 9.8421434140198782e-01, -2.5180552539875151e-05],
-            [-9.8421434146500908e-01, 1.7698059017814771e-01, -2.7473499692626049e-05],
-            [-2.2583343356466699e-05, 2.9645337144618008e-05, 9.9999999930557326e-01],
-        ]
-    )
-    expected_rate = np.array(
-        [
-            [7.1770042281617740e-05, -1.2905628333586957e-05, -3.8737281106045770e-11],
-            [1.2905628279101173e-05, 7.1770042289155805e-05, 1.2876618117528296e-10],
-            [2.2953613657794217e-09, 1.6621400564072720e-09, 2.5622314985763502e-15],
-        ]
-    )
-
-    np.testing.assert_allclose(rotation, expected_rotation, atol=1e-14)
-    np.testing.assert_allclose(rate, expected_rate, atol=1e-14)
-    np.testing.assert_allclose(rotation @ rotation.T, np.eye(3), atol=1e-14)
+    try:
+        np.testing.assert_allclose(rotation, expected_rotation, atol=1e-7)
+        np.testing.assert_allclose(rate, expected_rate, atol=1e-7)
+        # 物理定义：旋转矩阵正交
+        np.testing.assert_allclose(rotation @ rotation.T, np.eye(3), atol=1e-14)
+    finally:
+        unload_kernels(manager, loaded)

--- a/tests/data/kernels/test_no_furnsh_bypass.py
+++ b/tests/data/kernels/test_no_furnsh_bypass.py
@@ -23,7 +23,7 @@ import pytest
 
 pytestmark = pytest.mark.data
 
-# 仓库根：tests/core/spice/ → 上溯四级
+# 仓库根：tests/data/kernels/ → 上溯四级
 _REPO_ROOT = os.path.dirname(
     os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 )


### PR DESCRIPTION
## 关联

- **Closes #365**：GMAT fixture 路径常量补修 + 测试 ADR 0013 合规整改
- **关联 #372**：本 PR 完成「存量清理」部分；「流程保护」（ADR 0021 附录 checklist + CI 断言）后续单独 PR

## 改了什么

### #365（Closes）
- `gmat_fixture.py:16` 路径常量指向迁移后实际位置 `tests/data/frames/fixtures/gmat`（恢复 13 个 GMAT 测试）
- golden 矩阵测试改**动态对照 SPICE ITRF93**（atol=1e-7，落实 ADR 0003 决策 5），删除硬编码 golden 矩阵（违反 ADR 0013）；保留正交性断言；ITRF93 BPC 内核缺失时 skip
- module docstring 删「ADR 0013 对照数据」误引，改为「GMAT 裁剪 EOP/闰秒作解析器测试输入」
- xys 参考值 docstring 标注来源：SOFA `iauXys06a`（IAU 2006 岁差 + 2000A 章动，文献值，ADR 0013 决策 2 允许）

### #372（存量部分）
- `core_requirements.py`：16 处 `linked_tests` 旧 `tests/core/*` 全部映射到迁移后真实测试路径（`find` 确认存在，零 TODO）
- `test_no_furnsh_bypass.py` / `test_lowthrust_shooting.py`：注释中真引用更新为迁移后路径
- `conftest.py` / `test_system.py` 的历史迁移标注（ported from）保留不动

## 测试

```bash
# 相关测试（#365）
.venv/bin/python -m pytest tests/data/frames/test_gmat_fixtures.py tests/algorithm/coordinate/test_itrf.py tests/algorithm/coordinate/test_coordinate_public_api.py
# → 35 passed, 1 skipped（golden 对照 SPICE 真跑通过，未被 skip 掩盖）

# #372 文件
.venv/bin/python -m pytest tests/algorithm/transfer/test_lowthrust_shooting.py tests/data/kernels/test_no_furnsh_bypass.py
# → 6 passed

# 静态
ruff check . → All checks passed
ruff format --check . → 通过
mypy e2m2e/ --ignore-missing-imports → Success
```