### PR TITLE
build(ci): #372 已删目录引用 CI 断言 + ADR 0021 迁移 checklist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,8 @@ jobs:
       - run: uv run ruff format --check .
       # 五层依赖方向检查（ADR 0012）：data/algorithm/api 无越层 import
       - run: uv run python scripts/check_layer_imports.py
+      # 已删目录无引用检查（ADR 0021 迁移防漏，#372）
+      - run: uv run python scripts/check_deleted_dir_refs.py
 
 
   typecheck:

--- a/docs/adr/0021-test-suite-functional-categories.md
+++ b/docs/adr/0021-test-suite-functional-categories.md
@@ -33,3 +33,12 @@ ADR 0013 定下"正确性由物理定义裁决"，并附一句"测试分层：Ru
 
 - `pyproject.toml` markers 换 7 类 + `slow`/`spice`；`architecture.md §验证策略` 删 L1–L4 段；本 ADR 取代 ADR 0013 中"测试分层"那句（0013 其余不变）。
 - 迁移分三 PR：①`git mv` 纯移动（保历史、不改逻辑、不换标记）；②逐文件打功能类标记、去 l1–l4/e2e；③清理结构债（私有符号测试、golden/gmat/dfh 术语、#358 归类）。
+
+## 迁移 checklist（防引用遗留）
+
+`tests/` 下目录一旦删除，源码与测试代码里指向它的字符串就成了死引用——`linked_tests` 追踪、注释、docstring 都可能藏着。CI 由 `scripts/check_deleted_dir_refs.py` 把关（已删目录清单在该脚本顶 `DELETED_DIRS` 维护）。删目录前/后都应：
+
+- 把目录加入 `DELETED_DIRS`，跑 `uv run python scripts/check_deleted_dir_refs.py`，并 `grep -rn "tests/<旧目录>" e2m2e/ tests/` 复核（脚本只拦代码，文档由人审）。
+- 源码字符串/注释/docstring 里的旧路径全部清理或重映射——迁移完成的标志是无任何旧路径引用。
+- `linked_tests` 一类的需求↔测试追踪最易漏（#373 漏了 `tests/core`、#372 漏了 `tests/algorithms`），按迁移表逐条重映射到新路径。
+- 历史标注（"ported from …"）改写为不引用旧路径的表述（如"迁移前位于旧 core 包"），或删除。

--- a/e2m2e/algorithm/family/lissajous_initial_guess.py
+++ b/e2m2e/algorithm/family/lissajous_initial_guess.py
@@ -250,7 +250,7 @@ def compute_lissajous_bounded_trajectory(
 
     rho0 = _rho_from_synodic(state0, mu, libration_position)
 
-    # fast 流水线参数（与 tests/algorithms/normal_form 一致）。CR3BP 模式由
+    # fast 流水线参数（与 tests/algorithm/normal_form 一致）。CR3BP 模式由
     # ctx.force_cr3bp 声明：整条约化路径（DS rhs、Bdot2A 的 C_pq、rho↔EM 旋转
     # 矩阵）一律直接用 CR3BP 常量、不探 SPICE 星历——design_orbit 会全局加载
     # SPICE 内核，否则星历几何进入约化会使 quasi-Floquet↔CM Lie ODE 失稳。

--- a/e2m2e/algorithm/solver/continuation.py
+++ b/e2m2e/algorithm/solver/continuation.py
@@ -499,7 +499,7 @@ class Continuation:
 
         # [FIX] directional_increment 的原始实现每步根据 Xdot 重新判定方向,在
         # 族流形折叠点(fold)处 Xdot 渐近过零变号,形成 2-周期环振荡(steps 65+
-        # 退回 z≈0.085,详见 tests/algorithms/test_pal_stagnation.py 回归测试)。
+        # 退回 z≈0.085,详见 tests/algorithm/correction/test_pal_stagnation.py 回归测试)。
         #
         # 修复方案:directional_increment 在 PAL 折叠点本质上不稳定。PAL 的
         # 核心优势就是能沿弧长穿过折叠,此时目标变量(tv)会自然反转。

--- a/e2m2e/mbse/requirements/algorithms_requirements.py
+++ b/e2m2e/mbse/requirements/algorithms_requirements.py
@@ -16,7 +16,7 @@ ALGORITHMS_REQUIREMENTS = [
         priority=RequirementPriority.SHALL,
         verification_method="test",
         linked_code=["e2m2e.algorithms.differential_correction"],
-        linked_tests=["tests/algorithms/test_differential_correction.py"],
+        linked_tests=["tests/algorithm/correction/test_differential_correction.py"],
     ),
     Requirement(
         id="REQ-101",
@@ -26,7 +26,7 @@ ALGORITHMS_REQUIREMENTS = [
         priority=RequirementPriority.SHALL,
         verification_method="inspection",
         linked_code=["e2m2e.algorithms.differential_correction"],
-        linked_tests=["tests/algorithms/test_differential_correction.py"],
+        linked_tests=["tests/algorithm/correction/test_differential_correction.py"],
     ),
     Requirement(
         id="REQ-102",
@@ -39,7 +39,7 @@ ALGORITHMS_REQUIREMENTS = [
         priority=RequirementPriority.SHOULD,
         verification_method="inspection",
         linked_code=["e2m2e.algorithms.strategies", "e2m2e.algorithms.differential_correction"],
-        linked_tests=["tests/algorithms/test_differential_correction.py"],
+        linked_tests=["tests/algorithm/correction/test_differential_correction.py"],
     ),
     Requirement(
         id="REQ-103",
@@ -53,7 +53,7 @@ ALGORITHMS_REQUIREMENTS = [
         priority=RequirementPriority.SHALL,
         verification_method="inspection",
         linked_code=["e2m2e.algorithms.continuation"],
-        linked_tests=["tests/algorithms/test_continuation.py"],
+        linked_tests=["tests/algorithm/correction/test_continuation.py"],
     ),
     Requirement(
         id="REQ-104",
@@ -66,7 +66,7 @@ ALGORITHMS_REQUIREMENTS = [
         priority=RequirementPriority.SHALL,
         verification_method="inspection",
         linked_code=["e2m2e.algorithms.differential_correction"],
-        linked_tests=["tests/algorithms/test_differential_correction.py"],
+        linked_tests=["tests/algorithm/correction/test_differential_correction.py"],
     ),
     Requirement(
         id="REQ-105",
@@ -78,7 +78,7 @@ ALGORITHMS_REQUIREMENTS = [
         priority=RequirementPriority.SHOULD,
         verification_method="test",
         linked_code=["e2m2e.algorithms.differential_correction"],
-        linked_tests=["tests/algorithms/test_differential_correction.py"],
+        linked_tests=["tests/algorithm/correction/test_differential_correction.py"],
     ),
     # ---- 稳定性分析 ----
     Requirement(
@@ -89,7 +89,7 @@ ALGORITHMS_REQUIREMENTS = [
         priority=RequirementPriority.SHOULD,
         verification_method="test",
         linked_code=["e2m2e.algorithms.stability"],
-        linked_tests=["tests/algorithms/test_stability.py"],
+        linked_tests=["tests/algorithm/stability/test_stability.py"],
     ),
     # ---- 多点射击 ----
     Requirement(
@@ -100,7 +100,7 @@ ALGORITHMS_REQUIREMENTS = [
         priority=RequirementPriority.SHOULD,
         verification_method="test",
         linked_code=["e2m2e.algorithms.multiple_shooting"],
-        linked_tests=["tests/algorithms/test_multiple_shooting.py"],
+        linked_tests=["tests/algorithm/correction/test_multiple_shooting.py"],
     ),
     # ---- 延拓 ----
     Requirement(
@@ -113,7 +113,7 @@ ALGORITHMS_REQUIREMENTS = [
         priority=RequirementPriority.SHOULD,
         verification_method="test",
         linked_code=["e2m2e.algorithms.continuation"],
-        linked_tests=["tests/algorithms/test_continuation.py"],
+        linked_tests=["tests/algorithm/correction/test_continuation.py"],
     ),
     Requirement(
         id="REQ-113",
@@ -123,6 +123,6 @@ ALGORITHMS_REQUIREMENTS = [
         priority=RequirementPriority.SHALL,
         verification_method="inspection",
         linked_code=["e2m2e.algorithms.continuation"],
-        linked_tests=["tests/algorithms/test_continuation.py"],
+        linked_tests=["tests/algorithm/correction/test_continuation.py"],
     ),
 ]

--- a/scripts/check_deleted_dir_refs.py
+++ b/scripts/check_deleted_dir_refs.py
@@ -1,0 +1,59 @@
+"""已删目录引用检查（ADR 0021 迁移防漏，#372）。
+
+ADR 0021 五层迁移删了 ``tests/core/``（单数）与 ``tests/algorithms/``（复数）。
+迁移完成的标志是源码与测试代码中无任何旧路径引用——``linked_tests``、注释、
+docstring 一律不得残留。本脚本扫描 ``e2m2e/`` 与 ``tests/`` 下所有 ``.py``，
+发现旧目录路径引用即失败，倒逼彻底清理。
+
+误报处理：ADR / 迁移计划等文档中描述迁移历史的"tests/core"是事实陈述，本脚本
+不扫 ``docs/``，自然排除；代码中确属必要的历史标注请改写为不引用旧路径的表述
+（如"迁移前位于旧 core 包"）。
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+# ADR 0021 删除的目录前缀（未来再删别的目录，只改此处）
+DELETED_DIRS: tuple[str, ...] = (
+    "tests/core",
+    "tests/algorithms",
+)
+
+# 匹配 "tests/<dir>" 后跟 /、引号、空白或行尾；不匹配 tests/core_xxx 之类的延续
+PATTERN = re.compile(r"\b(" + "|".join(re.escape(d) for d in DELETED_DIRS) + r')(?=[/\s\'"]|$)')
+
+
+def check_file(path: pathlib.Path) -> list[str]:
+    """返回该文件违规行列表（``相对路径:行号: 内容``）。"""
+    rel = path.relative_to(ROOT)
+    violations: list[str] = []
+    for lineno, line in enumerate(path.read_text(encoding="utf-8-sig").splitlines(), 1):
+        if PATTERN.search(line):
+            violations.append(f"{rel}:{lineno}: {line.strip()}")
+    return violations
+
+
+def main() -> int:
+    violations: list[str] = []
+    for sub in ("e2m2e", "tests"):
+        for path in sorted((ROOT / sub).rglob("*.py")):
+            violations.extend(check_file(path))
+    if violations:
+        names = "、".join(DELETED_DIRS)
+        print(f"已删目录引用残留（{names} 已被 ADR 0021 删除）：")
+        for v in violations:
+            print(f"  {v}")
+        print("迁移后不得再引用；改写为不引用旧路径的表述，或更新为新路径。")
+        return 1
+    names = "、".join(DELETED_DIRS)
+    print(f"已删目录引用检查通过（{names} 无残留）")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/algorithm/coordinate/test_spacetime_convert.py
+++ b/tests/algorithm/coordinate/test_spacetime_convert.py
@@ -13,7 +13,7 @@ pytestmark = pytest.mark.data
 
 
 # ---------------------------------------------------------------------------
-# SPICE 与 kernel 可用性检测（与 tests/algorithms/normal_form/test_hamiltonian.py 一致）
+# SPICE 与 kernel 可用性检测（与 tests/algorithm/normal_form/test_hamiltonian.py 一致）
 # ---------------------------------------------------------------------------
 
 _SPICE_KERNEL_DIR = os.environ.get(

--- a/tests/algorithm/correction/test_continuation.py
+++ b/tests/algorithm/correction/test_continuation.py
@@ -14,7 +14,7 @@ from e2m2e.data.types.orbit import OrbitFamily
 pytestmark = pytest.mark.orchestration
 
 
-# 公共 fixtures 从 tests/algorithms/conftest.py 导入：
+# 公共 fixtures 从 tests/algorithm/conftest.py 导入：
 #   dro_dynamics, dro_corrector, dro_seed_orbit, corrected_dro, dro_continuation
 # 种子 x0=0.79188556619742, vy0=0.573665890385585, period=6.307498 来自 conftest。
 

--- a/tests/algorithm/correction/test_continuation_step_tracking.py
+++ b/tests/algorithm/correction/test_continuation_step_tracking.py
@@ -10,7 +10,7 @@ from e2m2e.data.types.orbit import Orbit, OrbitFamily
 pytestmark = pytest.mark.orchestration
 
 
-# 公共 fixtures 从 tests/algorithms/conftest.py 导入：
+# 公共 fixtures 从 tests/algorithm/conftest.py 导入：
 #   dro_dynamics, dro_corrector, dro_seed_orbit, corrected_dro, dro_continuation
 
 

--- a/tests/algorithm/correction/test_differential_correction.py
+++ b/tests/algorithm/correction/test_differential_correction.py
@@ -13,7 +13,7 @@ from e2m2e.data.types.orbit import Orbit
 pytestmark = pytest.mark.orchestration
 
 
-# 公共 fixtures 从 tests/algorithms/conftest.py 导入：
+# 公共 fixtures 从 tests/algorithm/conftest.py 导入：
 #   dro_dynamics, dro_corrector, dro_seed_orbit, corrected_dro
 # 这里仅在需要测试 _非_标准配置时构造自己的 corrector。
 

--- a/tests/algorithm/correction/test_differential_correction_closure.py
+++ b/tests/algorithm/correction/test_differential_correction_closure.py
@@ -12,7 +12,7 @@ from e2m2e.data.types.orbit import Orbit
 pytestmark = pytest.mark.orchestration
 
 
-# 公共 fixtures 从 tests/algorithms/conftest.py 导入：
+# 公共 fixtures 从 tests/algorithm/conftest.py 导入：
 #   dro_dynamics, dro_corrector, dro_seed_orbit, corrected_dro
 # 种子 x0=0.79188556619742, vy0=0.573665890385585, period=6.307498 来自 conftest。
 # 注：corrected_dro 每次返回深拷贝，可安全 mutate。

--- a/tests/algorithm/correction/test_differential_correction_period_validation.py
+++ b/tests/algorithm/correction/test_differential_correction_period_validation.py
@@ -10,7 +10,7 @@ from e2m2e.data.types.orbit import Orbit
 pytestmark = pytest.mark.orchestration
 
 
-# 公共 fixtures 从 tests/algorithms/conftest.py 导入：
+# 公共 fixtures 从 tests/algorithm/conftest.py 导入：
 #   dro_dynamics, dro_corrector, dro_seed_orbit, corrected_dro
 # 种子 x0=0.79188556619742, vy0=0.573665890385585, period=6.307498 来自 conftest。
 

--- a/tests/algorithm/correction/test_differential_correction_via_propagate.py
+++ b/tests/algorithm/correction/test_differential_correction_via_propagate.py
@@ -15,7 +15,7 @@ from e2m2e.data.types.orbit import Orbit
 # 地月系统质量比
 MU = 1.21506683e-2
 
-# 公共 fixtures 从 tests/algorithms/conftest.py 导入：
+# 公共 fixtures 从 tests/algorithm/conftest.py 导入：
 #   dro_dynamics, dro_corrector, dro_seed_orbit, corrected_dro
 
 

--- a/tests/algorithm/correction/test_dro_ephemeris_correction.py
+++ b/tests/algorithm/correction/test_dro_ephemeris_correction.py
@@ -55,7 +55,7 @@ def dro_orbit(cr3bp_dynamics, cr3bp_system):
     corrector.setup_2D_symmetric_x_fixed_x0(DRO_31_X0)
     result = corrector.iterate_correction(seed_orbit, verbose=False)
 
-    # DRO 微分修正在此标准 seed 下应收敛（与 tests/algorithms/conftest.py 的
+    # DRO 微分修正在此标准 seed 下应收敛（与 tests/algorithm/conftest.py 的
     # corrected_dro fixture 一致）；不收敛是回归，直接失败而非 skip（issue #218）
     assert result is not None and corrector.success, "DRO 微分修正未收敛"
     return result

--- a/tests/algorithm/design/seeds.py
+++ b/tests/algorithm/design/seeds.py
@@ -40,7 +40,7 @@ TRIANGULAR: dict[int, dict[str, float]] = {
 
 # --- 阶段 2：修正/延拓标准种子（来源标注于各条）---
 
-# DRO 地月（Cui et al. 2025 单圈 DRO，与 tests/algorithms/conftest 一致）
+# DRO 地月（Cui et al. 2025 单圈 DRO，与 tests/algorithm/conftest 一致）
 DRO_X0 = 0.79188556619742
 DRO_VY0 = 0.573665890385585
 DRO_PERIOD = 6.307498

--- a/tests/algorithm/manifold/test_manifolds.py
+++ b/tests/algorithm/manifold/test_manifolds.py
@@ -19,7 +19,7 @@ from e2m2e.data.types.orbit import Orbit
 pytestmark = pytest.mark.orchestration
 
 
-# 地月系统质量参数（与 tests/algorithms/conftest.py 一致）
+# 地月系统质量参数（与 tests/algorithm/conftest.py 一致）
 MU = 1.21506683e-2
 DU = 384405.0  # km
 

--- a/tests/algorithm/normal_form/test_dynamical_substitution.py
+++ b/tests/algorithm/normal_form/test_dynamical_substitution.py
@@ -400,7 +400,7 @@ def test_W_poly_regression_against_qiao_L1DynSubs_npz():
     均不可得，故以 ``pytest.skip`` 守卫占位。
 
     解锁条件（任一）：
-    1. 将 qiao ``L1DynSubs.npz`` 放入 ``tests/algorithms/normal_form/data/``；
+    1. 将 qiao ``L1DynSubs.npz`` 放入 ``tests/algorithm/normal_form/data/``；
     2. 提供 SPICE 内核（``.tls`` + ``.bsp``）并在长窗口下跑 reduce。
 
     fixture 就绪后，本测试应加载 npz 中的 ``W_poly``，与

--- a/tests/algorithm/normal_form/test_pipeline.py
+++ b/tests/algorithm/normal_form/test_pipeline.py
@@ -275,7 +275,7 @@ def test_qiao_L1_Halo_Large_regression_is_skipped_without_fixture():
     该回归需要：
 
     1. qiao ``L1_rho2param_data.npz``（或等价 fixture）放入
-       ``tests/algorithms/normal_form/data/``；
+       ``tests/algorithm/normal_form/data/``；
     2. SPICE 内核（``.tls`` + ``.bsp``）+ 完整 ``T_total = 0.1·2^16`` 窗口，
        使动力学替代走星历模型而非纯 CR3BP 退路。
 

--- a/tests/algorithm/propagation/test_propagation.py
+++ b/tests/algorithm/propagation/test_propagation.py
@@ -13,7 +13,7 @@ pytestmark = pytest.mark.integrator
 
 
 # ---------------------------------------------------------------------------
-# SPICE 与 kernel 可用性检测（与 tests/algorithms/normal_form/test_hamiltonian.py 一致）
+# SPICE 与 kernel 可用性检测（与 tests/algorithm/normal_form/test_hamiltonian.py 一致）
 # ---------------------------------------------------------------------------
 
 _SPICE_KERNEL_DIR = os.environ.get(

--- a/tests/algorithm/transfer/test_low_energy.py
+++ b/tests/algorithm/transfer/test_low_energy.py
@@ -37,7 +37,7 @@ _EPS = 50.0 / DU
 
 
 def _make_l1_lyapunov_orbit(system, dynamics) -> tuple[Orbit, DifferentialCorrection]:
-    """生成地月 L1 小振幅 Lyapunov 轨道（与 tests/algorithms/test_manifolds.py 同法）。"""
+    """生成地月 L1 小振幅 Lyapunov 轨道（与 tests/algorithm/manifold/test_manifolds.py 同法）。"""
     gamma = _compute_gamma(MU, 1)
     x_l1 = 1 - MU - gamma
 

--- a/tests/algorithm/transfer/test_terminal.py
+++ b/tests/algorithm/transfer/test_terminal.py
@@ -43,7 +43,7 @@ def dynamics(earth_moon_system):
 
 @pytest.fixture
 def dummy_orbit(earth_moon_system):
-    # DRO 种子初值（Cui et al. 2025，同 tests/algorithms/conftest.py）：稳定周期
+    # DRO 种子初值（Cui et al. 2025，同 tests/algorithm/conftest.py）：稳定周期
     # 轨道，远离月球，CR3BP 积分到任意相位都不发散。测试只用首点与 period，
     # 故 50 点填同值即可。
     state0 = np.array([0.79188556619742, 0.0, 0.0, 0.0, 0.573665890385585, 0.0])

--- a/tests/algorithm/transfer/test_three_body_lambert.py
+++ b/tests/algorithm/transfer/test_three_body_lambert.py
@@ -21,7 +21,7 @@ from e2m2e.data.types.orbit import Orbit
 pytestmark = pytest.mark.orchestration
 
 
-# 地月系统质量参数（与 tests/algorithms/conftest.py 一致）
+# 地月系统质量参数（与 tests/algorithm/conftest.py 一致）
 MU = 1.21506683e-2
 DU = 384405.0  # km
 
@@ -36,7 +36,7 @@ def _make_system():
 
 
 def _make_l1_lyapunov_orbit(system) -> Orbit:
-    """生成地月 L1 小振幅 Lyapunov 轨道（与 tests/algorithms/test_manifolds.py 同法）。"""
+    """生成地月 L1 小振幅 Lyapunov 轨道（与 tests/algorithm/manifold/test_manifolds.py 同法）。"""
     dynamics = CR3BP_Dynamics(system)
     gamma = _compute_gamma(MU, 1)
     x_l1 = 1 - MU - gamma

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,12 +131,12 @@ def dro_31_period():
 # SPICE ephemeris fixtures
 #
 # Six test files previously rebuilt this chain locally:
-#   tests/algorithms/test_multiple_shooting.py
-#   tests/algorithms/test_dro_ephemeris_correction.py
-#   tests/algorithms/test_differential_correction_via_propagate.py
-#   tests/algorithms/test_patch_point_utils.py
-#   tests/core/coordinate/test_synodic_j2000.py
-#   tests/core/dynamics/test_ephemeris_dynamics.py
+#   tests/algorithm/correction/test_multiple_shooting.py
+#   tests/algorithm/correction/test_dro_ephemeris_correction.py
+#   tests/algorithm/correction/test_differential_correction_via_propagate.py
+#   tests/algorithm/correction/test_patch_point_utils.py
+#   tests/algorithm/coordinate/test_synodic_j2000.py
+#   tests/numerical/dynamics/test_ephemeris_dynamics.py
 #
 # The previous test_differential_correction_via_propagate._make_eph_dynamics helper had a kernel
 # leak (mgr.unload_kernel never called). These fixtures fix that by going

--- a/tests/numerical/dynamics/test_system.py
+++ b/tests/numerical/dynamics/test_system.py
@@ -365,8 +365,8 @@ class TestCR3BPSystemPhysicalConstants:
         assert expected == CR3BP_System.YEAR
 
 
-# --- Ported from tests/core/system/test_system_info.py ---
-# info() method tests — unique coverage not in the main system test suite
+# --- info() method tests（迁移前位于旧 core 包）---
+# unique coverage not in the main system test suite
 
 
 @pytest.fixture


### PR DESCRIPTION
## 关联

**Closes #372**：迁移流程补漏——堵"删目录不 grep 引用"漏洞（#365/#361 之后第三个同源的流程根因）。

**Stacked on #373**（base 设 #373 分支）：本分支 merge 了 #373 让脚本能绿（#373 修了 tests/core 存量），但两边改的文件完全不重叠。**先合 #373，再合本 PR**；#373 合并后本 PR 的 base 自动跟到 master。

## 改了什么

### 流程保护（#372 核心）
- **新 `scripts/check_deleted_dir_refs.py`**：CI 断言脚本。扫 `e2m2e/`+`tests/` 断言不含 `tests/core`/`tests/algorithms`（ADR 0021 已删目录）的路径引用。`DELETED_DIRS` 常量集中管理，正则 lookahead 排除 `tests/core_foo` 等误报，边界用例 12 条验证。
- **`ci.yml` lint job 接线**：紧跟现有 `check_layer_imports.py` 之后，作为 ADR 0021 迁移防漏门。
- **ADR 0021 加「迁移 checklist」附录**：删目录前跑脚本 + grep、`linked_tests` 类追踪最易漏（点名 #373 漏 tests/core、本 PR 漏 tests/algorithms）、历史标注改写不引用旧路径。

### 清剩余 tests/algorithms 存量（让脚本能绿的必要清理）
- `algorithms_requirements.py`：10 处 `linked_tests` 旧 `tests/algorithms/*` 映射到迁移后真实路径（`find` 确认存在，零 TODO）。
- `lissajous_initial_guess.py` / `continuation.py`：注释里 `tests/algorithms/*` 更新为新路径。
- `tests/` 17 文件历史注释：旧路径引用更新为新路径（有导航价值的，如 conftest 列 SPICE fixture 用户）或改写为不引用旧路径（纯 `ported from` 标注）。**迁移完成的标志是源码无任何旧路径引用。**

## 价值证明

本 PR 的脚本在本分支上能绿，**恰恰因为 merge 了 #373**——#373 只清了 `tests/core` 存量，本 PR 清理时发现 `tests/algorithms` 存量仍存在（`algorithms_requirements.py` 10 处 + 2 源码注释 + 17 测试注释）。这正是 #372 要防的漏：单点修不干净，下次迁移再生。

## 测试

```bash
.venv/bin/python scripts/check_deleted_dir_refs.py   # 通过（无残留）
ruff check .   # All checks passed
ruff format --check .   # 469 files already formatted
mypy e2m2e/ --ignore-missing-imports   # Success
# 正则边界用例 12 条全过；algorithms_requirements 10 路径全存在
```