### PR TITLE
refactor(constants): #377 收尾公共 loader 与生成查找表

### DIFF
--- a/crates/e2m2e-propagation/build.rs
+++ b/crates/e2m2e-propagation/build.rs
@@ -192,7 +192,11 @@ fn write_header(out: &mut String) {
     );
 }
 
-fn write_universal(out: &mut String, root: &HashMap<String, TomlValue>) {
+fn write_universal(
+    out: &mut String,
+    root: &HashMap<String, TomlValue>,
+    lookup: &mut Vec<(String, String)>,
+) {
     let uni = match table_path(root, &["universal"]) {
         Some(t) => t,
         None => return,
@@ -226,6 +230,7 @@ fn write_universal(out: &mut String, root: &HashMap<String, TomlValue>) {
         out.push_str(&format!(
             "/// {rust_name} (source: {src})\npub const {rust_name}: f64 = {val:e};\n\n"
         ));
+        lookup.push((format!("universal.{toml_key}"), rust_name.to_string()));
     }
 
     // 派生量：1 AU 光压（N/m²）
@@ -235,9 +240,17 @@ fn write_universal(out: &mut String, root: &HashMap<String, TomlValue>) {
     out.push_str(
         "pub const SOLAR_PRESSURE_1AU: f64 = SOLAR_FLUX_W_M2 / (SPEED_OF_LIGHT_KMS * KM_TO_M);\n\n",
     );
+    lookup.push((
+        "universal.solar_pressure_1au".to_string(),
+        "SOLAR_PRESSURE_1AU".to_string(),
+    ));
 }
 
-fn write_datum(out: &mut String, root: &HashMap<String, TomlValue>) {
+fn write_datum(
+    out: &mut String,
+    root: &HashMap<String, TomlValue>,
+    lookup: &mut Vec<(String, String)>,
+) {
     let datums = match table_path(root, &["datum"]) {
         Some(t) => t,
         None => return,
@@ -267,11 +280,16 @@ fn write_datum(out: &mut String, root: &HashMap<String, TomlValue>) {
             out.push_str(&format!(
                 "/// {rust_name} (datum {datum_name}, key {key})\npub const {rust_name}: f64 = {val:e};\n\n"
             ));
+            lookup.push((format!("datum.{datum_name}.{key}"), rust_name));
         }
     }
 }
 
-fn write_body(out: &mut String, root: &HashMap<String, TomlValue>) {
+fn write_body(
+    out: &mut String,
+    root: &HashMap<String, TomlValue>,
+    lookup: &mut Vec<(String, String)>,
+) {
     let bodies = match table_path(root, &["body"]) {
         Some(t) => t,
         None => return,
@@ -297,29 +315,53 @@ fn write_body(out: &mut String, root: &HashMap<String, TomlValue>) {
             out.push_str(&format!(
                 "pub const {prefix}_MEAN_RADIUS_KM: f64 = {v:e};\n\n"
             ));
+            lookup.push((
+                format!("body.{body_name}.mean_radius_km"),
+                format!("{prefix}_MEAN_RADIUS_KM"),
+            ));
         }
         if let Some(v) = value_or_inline(bt, "gravity_ref_radius_km") {
             out.push_str(&format!(
                 "pub const {prefix}_GRAVITY_REF_RADIUS_KM: f64 = {v:e};\n\n"
             ));
+            lookup.push((
+                format!("body.{body_name}.gravity_ref_radius_km"),
+                format!("{prefix}_GRAVITY_REF_RADIUS_KM"),
+            ));
         }
         if let Some(v) = value_or_inline(bt, "flattening") {
             out.push_str(&format!("pub const {prefix}_FLATTENING: f64 = {v:e};\n\n"));
+            lookup.push((
+                format!("body.{body_name}.flattening"),
+                format!("{prefix}_FLATTENING"),
+            ));
         }
         if let Some(v) = value_or_inline(bt, "rotation_rate_iers_rad_s") {
             out.push_str(&format!(
                 "pub const {prefix}_ROTATION_RATE_IERS_RAD_S: f64 = {v:e};\n\n"
+            ));
+            lookup.push((
+                format!("body.{body_name}.rotation_rate_iers_rad_s"),
+                format!("{prefix}_ROTATION_RATE_IERS_RAD_S"),
             ));
         }
         if let Some(v) = value_or_inline(bt, "rotation_rate_gmat_rad_s") {
             out.push_str(&format!(
                 "pub const {prefix}_ROTATION_RATE_GMAT_RAD_S: f64 = {v:e};\n\n"
             ));
+            lookup.push((
+                format!("body.{body_name}.rotation_rate_gmat_rad_s"),
+                format!("{prefix}_ROTATION_RATE_GMAT_RAD_S"),
+            ));
         }
         if let Some(v) = value_or_inline(bt, "naif_id") {
             // naif_id 通常作为 i32 常量
             let i = v as i32;
             out.push_str(&format!("pub const {prefix}_NAIF_ID: i32 = {i};\n\n"));
+            lookup.push((
+                format!("body.{body_name}.naif_id"),
+                format!("{prefix}_NAIF_ID as f64"),
+            ));
         }
 
         // GM 按 datum
@@ -332,9 +374,25 @@ fn write_body(out: &mut String, root: &HashMap<String, TomlValue>) {
                 let Some(val) = val else { continue };
                 let rust_name = format!("{prefix}_GM_{}", datum.to_uppercase());
                 out.push_str(&format!("pub const {rust_name}: f64 = {val:e};\n\n"));
+                lookup.push((format!("body.{body_name}.gm.{datum}"), rust_name));
             }
         }
     }
+}
+
+fn write_lookup(out: &mut String, lookup: &[(String, String)]) {
+    out.push_str(
+        "// ----------------------------------------------------------------------------\n",
+    );
+    out.push_str("// Constant lookup table (key -> const)\n");
+    out.push_str(
+        "// ----------------------------------------------------------------------------\n",
+    );
+    out.push_str("pub const CONSTANT_LOOKUP: &[(&str, f64)] = &[\n");
+    for (key, rust_name) in lookup {
+        out.push_str(&format!("    (\"{key}\", {rust_name}),\n"));
+    }
+    out.push_str("];\n\n");
 }
 
 fn main() {
@@ -353,9 +411,11 @@ fn main() {
 
     let mut generated = String::new();
     write_header(&mut generated);
-    write_universal(&mut generated, &root);
-    write_datum(&mut generated, &root);
-    write_body(&mut generated, &root);
+    let mut lookup: Vec<(String, String)> = Vec::new();
+    write_universal(&mut generated, &root, &mut lookup);
+    write_datum(&mut generated, &root, &mut lookup);
+    write_body(&mut generated, &root, &mut lookup);
+    write_lookup(&mut generated, &lookup);
 
     let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
     let out_file = out_dir.join("generated_constants.rs");

--- a/crates/e2m2e-propagation/src/lib.rs
+++ b/crates/e2m2e-propagation/src/lib.rs
@@ -32,91 +32,14 @@ pub mod constants {
 #[cfg(feature = "pyo3")]
 #[pyo3::pyfunction]
 fn constant_value_py(key: &str) -> pyo3::PyResult<f64> {
-    use crate::constants::*;
-    use pyo3::exceptions::PyKeyError;
-
-    match key {
-        "universal.speed_of_light_kms" => Ok(SPEED_OF_LIGHT_KMS),
-        "universal.gravitational_constant" => Ok(GRAVITATIONAL_CONSTANT),
-        "universal.au_km" => Ok(AU_KM),
-        "universal.seconds_per_day" => Ok(SECONDS_PER_DAY),
-        "universal.days_per_julian_year" => Ok(DAYS_PER_JULIAN_YEAR),
-        "universal.days_per_julian_century" => Ok(DAYS_PER_JULIAN_CENTURY),
-        "universal.km_to_m" => Ok(KM_TO_M),
-        "universal.solar_flux_w_m2" => Ok(SOLAR_FLUX_W_M2),
-        "universal.solar_flux_tsi_w_m2" => Ok(SOLAR_FLUX_TSI_W_M2),
-        "universal.rad_per_deg" => Ok(RAD_PER_DEG),
-        "universal.solar_pressure_1au" => Ok(SOLAR_PRESSURE_1AU),
-
-        "datum.DE421.mu" => Ok(DATUM_DE421_MU),
-        "datum.DE421.char_length_km" => Ok(DATUM_DE421_CHAR_LENGTH_KM),
-        "datum.DE421.char_time_s" => Ok(DATUM_DE421_CHAR_TIME_S),
-        "datum.DE421.earth_gm" => Ok(DATUM_DE421_EARTH_GM),
-        "datum.DE421.moon_gm" => Ok(DATUM_DE421_MOON_GM),
-        "datum.DE421.sun_gm" => Ok(DATUM_DE421_SUN_GM),
-        "datum.DE421.emb_gm" => Ok(DATUM_DE421_EMB_GM),
-
-        "datum.DE440.mu" => Ok(DATUM_DE440_MU),
-        "datum.DE440.earth_gm" => Ok(DATUM_DE440_EARTH_GM),
-        "datum.DE440.moon_gm" => Ok(DATUM_DE440_MOON_GM),
-        "datum.DE440.sun_gm" => Ok(DATUM_DE440_SUN_GM),
-        "datum.DE440.emb_gm" => Ok(DATUM_DE440_EMB_GM),
-
-        "datum.WGS84.earth_gm" => Ok(DATUM_WGS84_EARTH_GM),
-        "datum.WGS84.earth_radius_km" => Ok(DATUM_WGS84_EARTH_RADIUS_KM),
-        "datum.WGS84.earth_flattening" => Ok(DATUM_WGS84_EARTH_FLATTENING),
-
-        "body.SUN.mean_radius_km" => Ok(SUN_MEAN_RADIUS_KM),
-        "body.SUN.naif_id" => Ok(SUN_NAIF_ID as f64),
-        "body.SUN.gm.DE440" => Ok(SUN_GM_DE440),
-
-        "body.EARTH.mean_radius_km" => Ok(EARTH_MEAN_RADIUS_KM),
-        "body.EARTH.gravity_ref_radius_km" => Ok(EARTH_GRAVITY_REF_RADIUS_KM),
-        "body.EARTH.flattening" => Ok(EARTH_FLATTENING),
-        "body.EARTH.naif_id" => Ok(EARTH_NAIF_ID as f64),
-        "body.EARTH.rotation_rate_iers_rad_s" => Ok(EARTH_ROTATION_RATE_IERS_RAD_S),
-        "body.EARTH.rotation_rate_gmat_rad_s" => Ok(EARTH_ROTATION_RATE_GMAT_RAD_S),
-        "body.EARTH.gm.DE421" => Ok(EARTH_GM_DE421),
-        "body.EARTH.gm.DE440" => Ok(EARTH_GM_DE440),
-        "body.EARTH.gm.WGS84" => Ok(EARTH_GM_WGS84),
-
-        "body.MOON.mean_radius_km" => Ok(MOON_MEAN_RADIUS_KM),
-        "body.MOON.gravity_ref_radius_km" => Ok(MOON_GRAVITY_REF_RADIUS_KM),
-        "body.MOON.naif_id" => Ok(MOON_NAIF_ID as f64),
-        "body.MOON.gm.DE421" => Ok(MOON_GM_DE421),
-        "body.MOON.gm.DE440" => Ok(MOON_GM_DE440),
-
-        "body.EMB.naif_id" => Ok(EMB_NAIF_ID as f64),
-        "body.EMB.gm.DE421" => Ok(EMB_GM_DE421),
-        "body.EMB.gm.DE440" => Ok(EMB_GM_DE440),
-
-        "body.MERCURY.mean_radius_km" => Ok(MERCURY_MEAN_RADIUS_KM),
-        "body.MERCURY.naif_id" => Ok(MERCURY_NAIF_ID as f64),
-        "body.MERCURY.gm.DE440" => Ok(MERCURY_GM_DE440),
-        "body.VENUS.mean_radius_km" => Ok(VENUS_MEAN_RADIUS_KM),
-        "body.VENUS.naif_id" => Ok(VENUS_NAIF_ID as f64),
-        "body.VENUS.gm.DE440" => Ok(VENUS_GM_DE440),
-        "body.MARS.mean_radius_km" => Ok(MARS_MEAN_RADIUS_KM),
-        "body.MARS.naif_id" => Ok(MARS_NAIF_ID as f64),
-        "body.MARS.gm.DE440" => Ok(MARS_GM_DE440),
-        "body.JUPITER.mean_radius_km" => Ok(JUPITER_MEAN_RADIUS_KM),
-        "body.JUPITER.naif_id" => Ok(JUPITER_NAIF_ID as f64),
-        "body.JUPITER.gm.DE440" => Ok(JUPITER_GM_DE440),
-        "body.SATURN.mean_radius_km" => Ok(SATURN_MEAN_RADIUS_KM),
-        "body.SATURN.naif_id" => Ok(SATURN_NAIF_ID as f64),
-        "body.SATURN.gm.DE440" => Ok(SATURN_GM_DE440),
-        "body.URANUS.mean_radius_km" => Ok(URANUS_MEAN_RADIUS_KM),
-        "body.URANUS.naif_id" => Ok(URANUS_NAIF_ID as f64),
-        "body.URANUS.gm.DE440" => Ok(URANUS_GM_DE440),
-        "body.NEPTUNE.mean_radius_km" => Ok(NEPTUNE_MEAN_RADIUS_KM),
-        "body.NEPTUNE.naif_id" => Ok(NEPTUNE_NAIF_ID as f64),
-        "body.NEPTUNE.gm.DE440" => Ok(NEPTUNE_GM_DE440),
-        "body.PLUTO.mean_radius_km" => Ok(PLUTO_MEAN_RADIUS_KM),
-        "body.PLUTO.naif_id" => Ok(PLUTO_NAIF_ID as f64),
-        "body.PLUTO.gm.DE440" => Ok(PLUTO_GM_DE440),
-
-        _ => Err(PyKeyError::new_err(format!("unknown constant key: {key}"))),
+    for (k, v) in constants::CONSTANT_LOOKUP {
+        if *k == key {
+            return Ok(*v);
+        }
     }
+    Err(pyo3::exceptions::PyKeyError::new_err(format!(
+        "unknown constant key: {key}"
+    )))
 }
 
 /// 返回一个已初始化的 `_propagation_constants` 子模块（供 `e2m2e-integrators`

--- a/e2m2e/data/constants/_loader.py
+++ b/e2m2e/data/constants/_loader.py
@@ -1,0 +1,17 @@
+"""constants.toml 加载器（单一来源文件路径只维护一处）。"""
+
+from pathlib import Path
+
+import tomllib
+
+_CONSTANTS_TOML = Path(__file__).resolve().parents[3] / "constants.toml"
+
+
+def _load_section(section: str) -> dict[str, object]:
+    if not _CONSTANTS_TOML.is_file():
+        raise FileNotFoundError(
+            f"物理常数单一来源文件缺失：{_CONSTANTS_TOML}\n"
+            f"请确认仓库根存在 constants.toml，它是 Python/Rust 物理常数的唯一来源。"
+        )
+    with _CONSTANTS_TOML.open("rb") as f:
+        return tomllib.load(f)[section]

--- a/e2m2e/data/constants/bodies.py
+++ b/e2m2e/data/constants/bodies.py
@@ -12,27 +12,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from pathlib import Path
+from typing import cast
 
-import tomllib
-
+from ._loader import _load_section
 from .sources import ConstantSource
 
-
-def _load_bodies() -> dict[str, dict[str, object]]:
-    """从仓库根 constants.toml 加载 [body.*] 段。"""
-    path = Path(__file__).resolve().parents[3] / "constants.toml"
-    if not path.is_file():
-        raise FileNotFoundError(
-            f"物理常数单一来源文件缺失：{path}\n"
-            f"请确认仓库根存在 constants.toml，它是 Python/Rust 物理常数的唯一来源。"
-        )
-    with path.open("rb") as f:
-        data = tomllib.load(f)
-    return data["body"]
-
-
-_BODIES = _load_bodies()
+_BODIES: dict[str, dict[str, object]] = cast(dict[str, dict[str, object]], _load_section("body"))
 
 
 def _scalar(section: dict[str, object], key: str) -> float | None:

--- a/e2m2e/data/constants/datums.py
+++ b/e2m2e/data/constants/datums.py
@@ -16,28 +16,15 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from pathlib import Path
+from typing import cast
 
-import tomllib
-
+from ._loader import _load_section
 from .sources import ConstantSource
 from .universal import SECONDS_PER_DAY
 
-
-def _load_datums() -> dict[str, dict[str, dict[str, object]]]:
-    """从仓库根 constants.toml 加载 [datum.*] 段。"""
-    path = Path(__file__).resolve().parents[3] / "constants.toml"
-    if not path.is_file():
-        raise FileNotFoundError(
-            f"物理常数单一来源文件缺失：{path}\n"
-            f"请确认仓库根存在 constants.toml，它是 Python/Rust 物理常数的唯一来源。"
-        )
-    with path.open("rb") as f:
-        data = tomllib.load(f)
-    return data["datum"]
-
-
-_DATUMS = _load_datums()
+_DATUMS: dict[str, dict[str, dict[str, object]]] = cast(
+    dict[str, dict[str, dict[str, object]]], _load_section("datum")
+)
 
 
 def _datum_value(datum: str, key: str) -> float | None:

--- a/e2m2e/data/constants/universal.py
+++ b/e2m2e/data/constants/universal.py
@@ -6,29 +6,14 @@
 
 from __future__ import annotations
 
-from pathlib import Path
+from typing import cast
 
-import tomllib
-
+from ._loader import _load_section
 from .sources import ConstantSource
 
-
-def _load_universal() -> dict[str, dict[str, object]]:
-    """从仓库根 constants.toml 加载 [universal] 段。"""
-    # 包文件 -> e2m2e/data/constants/universal.py
-    # 向上四级到仓库根（constants.toml 所在）
-    path = Path(__file__).resolve().parents[3] / "constants.toml"
-    if not path.is_file():
-        raise FileNotFoundError(
-            f"物理常数单一来源文件缺失：{path}\n"
-            f"请确认仓库根存在 constants.toml，它是 Python/Rust 物理常数的唯一来源。"
-        )
-    with path.open("rb") as f:
-        data = tomllib.load(f)
-    return data["universal"]
-
-
-_UNIVERSAL = _load_universal()
+_UNIVERSAL: dict[str, dict[str, object]] = cast(
+    dict[str, dict[str, object]], _load_section("universal")
+)
 
 
 def _value(key: str) -> float:


### PR DESCRIPTION
## 关联

Closes #377（PR #380 合并后的 code review 收尾）。

## 改动

- 新建 `e2m2e/data/constants/_loader.py`，集中维护 `constants.toml` 路径与加载逻辑，消除 `universal`、`datums`、`bodies` 三份重复 loader。
- `build.rs` 生成 70 条 `CONSTANT_LOOKUP` 查找表，`constant_value_py` 改为线性查找；新增常量只需修改 `constants.toml`，不再同步维护 Rust 手写 match。
- 保持旧 key 集合、常量值和公开 Python API 不变。

## 测试

- `uv run ruff check e2m2e/ tests/`
- `uv run ruff format --check e2m2e/ tests/`
- `uv run mypy e2m2e/ --ignore-missing-imports`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace -- -D warnings`
- `pytest tests/data/constants`：20 passed
- `pytest tests/data`：183 passed, 5 skipped
- `cargo test -p e2m2e-propagation -- --test-threads=1`：48 passed