### PR TITLE
fix: #393 退化态阈值可观测 + #394 crates 元数据 + #395 Windows CRT 链接修复

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,9 @@
+# Windows MSVC 链接修复（issue #395）：cspice-v1 release 的预编译 cspice.lib
+# 以静态 CRT（/MT）编译——其 COFF .drectve 段含 /DEFAULTLIB:"LIBCMT"（已用
+# objdump/strings 验证），而 PyO3 扩展按动态 CRT（/MD）链接，两者混链触发
+# LINK LNK4098，且跨边界分配/释放内存有堆崩溃风险。CSPICE 为纯 C 库，FFI
+# 边界只传调用方分配的缓冲区，无跨界 free，故禁止自动链接 LIBCMT、让其中
+# CRT 符号统一解析到 MSVCRT 是安全的，消除双 CRT 共存。
+# 根治办法是 cspice 编译包改 /MD 重出 release；此处为仓库侧修复。
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "link-arg=/NODEFAULTLIB:LIBCMT"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ members = [
 version = "5.6.6"
 edition = "2021"
 license = "Apache-2.0"
+homepage = "https://github.com/cislunarspace/e2m2e"
+repository = "https://github.com/cislunarspace/e2m2e"
 
 [workspace.dependencies]
 pyo3 = { version = "0.24", features = ["extension-module", "abi3-py310"] }

--- a/crates/e2m2e-forces/Cargo.toml
+++ b/crates/e2m2e-forces/Cargo.toml
@@ -2,6 +2,9 @@
 name = "e2m2e-forces"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
 description = "Force models for e2m2e (N-body, gravity field, STM)"
 
 [lib]

--- a/crates/e2m2e-integrators/Cargo.toml
+++ b/crates/e2m2e-integrators/Cargo.toml
@@ -3,6 +3,8 @@ name = "e2m2e-integrators"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+homepage.workspace = true
+repository.workspace = true
 description = "PyO3 bindings for e2m2e (propagation, forces, spice)"
 
 [lib]

--- a/crates/e2m2e-propagation/Cargo.toml
+++ b/crates/e2m2e-propagation/Cargo.toml
@@ -2,6 +2,9 @@
 name = "e2m2e-propagation"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
 description = "ODE integrators for e2m2e (RK, ABM, Cowell)"
 
 [lib]

--- a/crates/e2m2e-spice/Cargo.toml
+++ b/crates/e2m2e-spice/Cargo.toml
@@ -2,6 +2,9 @@
 name = "e2m2e-spice"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
 description = "SPICE FFI bindings for e2m2e"
 
 [lib]

--- a/e2m2e/algorithm/coordinate/standard_dynamic_axes.py
+++ b/e2m2e/algorithm/coordinate/standard_dynamic_axes.py
@@ -11,6 +11,14 @@ import numpy.typing as npt
 
 from .dynamic_axes import DynamicAxes
 
+# 退化态阈值（ADR 0020 决策 5：机器精度正则化保留）。三个阈值均为机器精度
+# 量级，仅防除零 NaN 与产出无意义方向；低于阈值抛 ValueError，实测量与阈值
+# 写入异常信息（阈值可观测）。状态单位由调用方定（星历传播为 km/km·s⁻¹，
+# CR3BP 为无量纲），故阈值取绝对机器量级而非物理量纲值。
+VELOCITY_NORM_MIN = 1e-12
+ANGULAR_MOMENTUM_NORM_MIN = 1e-12
+POSITION_NORM_MIN = 1e-12
+
 
 class VNBAxes(DynamicAxes):
     """速度-法向-副法向（VNB）坐标轴。
@@ -20,20 +28,30 @@ class VNBAxes(DynamicAxes):
     即 R 的第 0 列为 v_hat，第 1 列为 n_hat，第 2 列为 b_hat。
 
     Raises:
-        ValueError: 零速度（|v|=0）或零角动量（|r×v|=0，即 r ∥ v 或 r=0）
-            时轴向奇异（ADR 0007 补白：退化态显式失败，不静默）。
+        ValueError: 零速度（|v| < ``VELOCITY_NORM_MIN``）或零角动量
+            （|r×v| < ``ANGULAR_MOMENTUM_NORM_MIN``，即 r ∥ v 或 r=0）时
+            轴向奇异（ADR 0007 补白 / ADR 0020 决策 5：退化态显式失败，
+            不静默）；异常信息含实测范数与阈值。
     """
 
     def update(self, t: float, state: npt.NDArray[np.floating]) -> None:
         r = state[:3]
         v = state[3:]
         h = np.cross(r, v)
-        if np.linalg.norm(v) < 1e-12:
-            raise ValueError("VNB 轴向退化：速度为零，无法定义速度方向")
-        if np.linalg.norm(h) < 1e-12:
-            raise ValueError("VNB 轴向退化：角动量为零（r ∥ v 或 r = 0），无法定义法向")
-        v_hat = v / np.linalg.norm(v)
-        h_hat = h / np.linalg.norm(h)
+        v_norm = np.linalg.norm(v)
+        h_norm = np.linalg.norm(h)
+        if v_norm < VELOCITY_NORM_MIN:
+            raise ValueError(
+                f"VNB 轴向退化：速度为零（|v|={v_norm:.3e}，阈值 "
+                f"{VELOCITY_NORM_MIN:.1e}），无法定义速度方向"
+            )
+        if h_norm < ANGULAR_MOMENTUM_NORM_MIN:
+            raise ValueError(
+                f"VNB 轴向退化：角动量为零（|r×v|={h_norm:.3e}，阈值 "
+                f"{ANGULAR_MOMENTUM_NORM_MIN:.1e}，r ∥ v 或 r = 0），无法定义法向"
+            )
+        v_hat = v / v_norm
+        h_hat = h / h_norm
         b_hat = np.cross(v_hat, h_hat)
         self._rotation = np.column_stack([v_hat, h_hat, b_hat])
         self._updated = True
@@ -50,20 +68,30 @@ class LVLHAxes(DynamicAxes):
     即 R 的第 0 列为 r_hat，第 1 列为 v_hat，第 2 列为 h_hat。
 
     Raises:
-        ValueError: 零位置（|r|=0）或零角动量（|r×v|=0，即 r ∥ v）时
-            轴向奇异（ADR 0007 补白：退化态显式失败，不静默）。
+        ValueError: 零位置（|r| < ``POSITION_NORM_MIN``）或零角动量
+            （|r×v| < ``ANGULAR_MOMENTUM_NORM_MIN``，即 r ∥ v）时
+            轴向奇异（ADR 0007 补白 / ADR 0020 决策 5：退化态显式失败，
+            不静默）；异常信息含实测范数与阈值。
     """
 
     def update(self, t: float, state: npt.NDArray[np.floating]) -> None:
         r = state[:3]
         v = state[3:]
         h = np.cross(r, v)
-        if np.linalg.norm(r) < 1e-12:
-            raise ValueError("LVLH 轴向退化：位置为零，无法定义径向")
-        if np.linalg.norm(h) < 1e-12:
-            raise ValueError("LVLH 轴向退化：角动量为零（r ∥ v），无法定义法向")
-        r_hat = r / np.linalg.norm(r)
-        h_hat = h / np.linalg.norm(h)
+        r_norm = np.linalg.norm(r)
+        h_norm = np.linalg.norm(h)
+        if r_norm < POSITION_NORM_MIN:
+            raise ValueError(
+                f"LVLH 轴向退化：位置为零（|r|={r_norm:.3e}，阈值 "
+                f"{POSITION_NORM_MIN:.1e}），无法定义径向"
+            )
+        if h_norm < ANGULAR_MOMENTUM_NORM_MIN:
+            raise ValueError(
+                f"LVLH 轴向退化：角动量为零（|r×v|={h_norm:.3e}，阈值 "
+                f"{ANGULAR_MOMENTUM_NORM_MIN:.1e}，r ∥ v），无法定义法向"
+            )
+        r_hat = r / r_norm
+        h_hat = h / h_norm
         v_hat = np.cross(h_hat, r_hat)
         self._rotation = np.column_stack([r_hat, v_hat, h_hat])
         self._updated = True

--- a/tests/algorithm/coordinate/test_dynamic_axes.py
+++ b/tests/algorithm/coordinate/test_dynamic_axes.py
@@ -6,7 +6,13 @@
 import numpy as np
 import pytest
 
-from e2m2e.algorithm.coordinate.standard_dynamic_axes import LVLHAxes, VNBAxes
+from e2m2e.algorithm.coordinate.standard_dynamic_axes import (
+    ANGULAR_MOMENTUM_NORM_MIN,
+    POSITION_NORM_MIN,
+    VELOCITY_NORM_MIN,
+    LVLHAxes,
+    VNBAxes,
+)
 
 pytestmark = pytest.mark.data
 
@@ -214,3 +220,44 @@ class TestDegenerateStates:
         axes = LVLHAxes()
         with pytest.raises(ValueError, match="角动量为零"):
             axes.update(0.0, self.STATE_ZERO_ANGULAR_MOMENTUM)
+
+    # --- 阈值可观测（ADR 0020 决策 5）：异常信息含实测范数与阈值 ---
+
+    def test_vnb_zero_velocity_message_reports_measured_and_threshold(self):
+        """VNB 零速度异常信息含实测 |v| 与阈值。"""
+        axes = VNBAxes()
+        with pytest.raises(ValueError) as exc_info:
+            axes.update(0.0, self.STATE_ZERO_VELOCITY)
+        msg = str(exc_info.value)
+        assert "0.000e+00" in msg  # 实测 |v| = 0
+        assert f"{VELOCITY_NORM_MIN:.1e}" in msg
+
+    def test_vnb_small_angular_momentum_message_reports_measured(self):
+        """VNB 近零角动量异常信息含实测 |r×v|（非恰零，验证实测量确实写入）。"""
+        # r=[1,0,0], v=[1,1e-13,0] → r×v = [0,0,1e-13]，|h| = 1e-13 < 阈值
+        state = np.array([1.0, 0.0, 0.0, 1.0, 1e-13, 0.0])
+        axes = VNBAxes()
+        with pytest.raises(ValueError) as exc_info:
+            axes.update(0.0, state)
+        msg = str(exc_info.value)
+        assert "1.000e-13" in msg
+        assert f"{ANGULAR_MOMENTUM_NORM_MIN:.1e}" in msg
+
+    def test_lvlh_zero_position_message_reports_measured_and_threshold(self):
+        """LVLH 零位置异常信息含实测 |r| 与阈值。"""
+        axes = LVLHAxes()
+        with pytest.raises(ValueError) as exc_info:
+            axes.update(0.0, self.STATE_ZERO_POSITION)
+        msg = str(exc_info.value)
+        assert "0.000e+00" in msg  # 实测 |r| = 0
+        assert f"{POSITION_NORM_MIN:.1e}" in msg
+
+    def test_lvlh_small_angular_momentum_message_reports_measured(self):
+        """LVLH 近零角动量异常信息含实测 |r×v| 与阈值。"""
+        state = np.array([1.0, 0.0, 0.0, 1.0, 1e-13, 0.0])
+        axes = LVLHAxes()
+        with pytest.raises(ValueError) as exc_info:
+            axes.update(0.0, state)
+        msg = str(exc_info.value)
+        assert "1.000e-13" in msg
+        assert f"{ANGULAR_MOMENTUM_NORM_MIN:.1e}" in msg


### PR DESCRIPTION
## 关联 issue

- Closes #393（VNB/LVLH 动态坐标轴退化态处置）
- Closes #394（cargo package 警告：crates 缺 license/homepage/repository 元数据）
- 关联 #395（Windows LNK4098；代码修复已落地，Windows wheel 运行时验证待下次 release 构建，issue 保持开放）

## 改动摘要

1. **#393**（`standard_dynamic_axes.py`）：退化态阈值提为 `VELOCITY_NORM_MIN` / `ANGULAR_MOMENTUM_NORM_MIN` / `POSITION_NORM_MIN` 命名常量（值 1e-12 不变，ADR 0020 决策 5 的机器精度正则化保留）；异常信息写入实测范数与阈值，阈值可观测。取舍说明：阈值取绝对机器量级而非物理量纲值——`state` 单位由调用方定（星历传播 km/km·s⁻¹，CR3BP 无量纲），无普适物理阈值，理由见模块注释。
2. **#394**（根 + 四 crate 的 `Cargo.toml`）：`[workspace.package]` 追加 `homepage`/`repository`，四个 crate 以 `.workspace = true` 继承 license/homepage/repository；`documentation` 按 issue 决定不设。
3. **#395**（新增 `.cargo/config.toml`）：根因已确认——cspice-v1 的 `cspice.lib` 以 /MT 编译（COFF `.drectve` 段含 `/DEFAULTLIB:"LIBCMT"`），与 PyO3 扩展 /MD 混链触发 LNK4098。对 `x86_64-pc-windows-msvc` 加 `-C link-arg=/NODEFAULTLIB:LIBCMT`；CSPICE 为纯 C、FFI 边界无跨界分配/释放，统一解析到 MSVCRT 安全。Linux 下该 target 段不生效。

## 测试

- `uv run pytest tests/algorithm/coordinate/test_dynamic_axes.py`：20 passed（含 4 个新增的阈值可观测性测试，先红后绿）
- `cargo package -p <四 crate> --list`：警告全消（修复前逐 crate 复现了 issue 所述警告）
- `cargo metadata`：`.cargo/config.toml` 在 Linux 下正确解析且不生效
- `make check`（cargo fmt/clippy + ruff check/format）与 `mypy e2m2e/`：全绿
- `make test`：Rust 工作区测试 + Python 1967 passed / 52 skipped