### PR TITLE
fix(design): 修 segmented 星历位置与时间网格错位——GUI 中 Halo 轨道一圈一圈偏离

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,7 @@ fort.*
 # agent/工具会话产物（本地工作文件，不入库）
 .mimocode/
 .zcode/
+.pi/
 *.pdb
 AGENTS.md
 CONTEXT.md

--- a/e2m2e/algorithm/design/design_orbit.py
+++ b/e2m2e/algorithm/design/design_orbit.py
@@ -885,10 +885,15 @@ def _design_elfo(
     # ForceModel._prepare_t_eval 会在 t_eval 末尾自动追加 t_span 终点
     # （duration 非整小时时 et_end 不在 et_grid 上，输出多 1 点）；截断到
     # et_grid 长度，保证状态与时间网格逐点对齐（否则位置数组比时间字段
-    # 多 1 点，_build_ephemeris_table 的长度一致性断言会拒绝）。
-    n_pts = min(len(states), len(et_grid))
-    states = states[:n_pts]
-    times = et_grid[:n_pts]
+    # 多 1 点，_build_ephemeris_table 的长度一致性断言会拒绝）。输出短于
+    # et_grid 说明积分提前终止（max_steps 撞上），显式报错而非静默出短星历。
+    if len(states) < len(et_grid):
+        raise DesignNotConvergedError(
+            "ELFO 传播输出点数少于时间网格（积分提前终止）",
+            cause=FailureCause.INTEGRATION_FAILED,
+        )
+    states = states[: len(et_grid)]
+    times = et_grid[: len(states)]
 
     # 月心根数提取与漂移统计
     moon_oe = _extract_moon_centric_elements(times, states, spice)
@@ -897,7 +902,7 @@ def _design_elfo(
     # 星历表（ELFO 仍输出地心惯性系 + 会合系，格式与 CR3BP 一致）
     system = earth_moon_system()
     syn_j2000 = SynodicJ2000System(cr3bp_system=system, spice=spice)
-    ephemeris = _build_ephemeris_table(spice, syn_j2000, et0, et_grid[:n_pts], states)
+    ephemeris = _build_ephemeris_table(spice, syn_j2000, et0, et_grid, states)
 
     return OrbitDesignResult(
         orbit_type="ELFO",
@@ -1186,17 +1191,26 @@ def design_orbit(
             )
 
             # 逐段积分填满 et_grid：每段从修正后节点初值积分到下一节点。
-            # mask 用右开区间（seam 整点只归后段），相邻段 t_eval 无重叠。
+            # 中间段 mask 用右开区间（seam 整点只归后段），相邻段 t_eval 无
+            # 重叠；最后一段闭区间、t_span 终点延伸到 et_grid 尾部——打靶节点
+            # 采样不含圈终点（endpoint=False），et_grid 尾部可能超出最后节点，
+            # 右开会把尾部点排除在段外，星历缺尾段数据（长度断言报错）。
             states_list: list[np.ndarray] = []
             for i in range(len(t_patch_long) - 1):
                 seg_t0, seg_t1 = t_patch_long[i], t_patch_long[i + 1]
-                mask = (et_grid >= seg_t0 - 1e-6) & (et_grid < seg_t1 - 1e-6)
+                is_last = i == len(t_patch_long) - 2
+                if is_last:
+                    mask = et_grid >= seg_t0 - 1e-6
+                    seg_end = et_grid[-1]
+                else:
+                    mask = (et_grid >= seg_t0 - 1e-6) & (et_grid < seg_t1 - 1e-6)
+                    seg_end = seg_t1
                 t_eval_seg = et_grid[mask]
                 if len(t_eval_seg) == 0:
                     continue
                 out_seg = fm.propagate(
                     s_patch_long[i],
-                    (float(seg_t0), float(seg_t1)),
+                    (float(seg_t0), float(seg_end)),
                     t_eval=t_eval_seg,
                     max_steps=500_000,
                 )
@@ -1212,12 +1226,8 @@ def design_orbit(
                     cause=FailureCause.INTEGRATION_FAILED,
                 )
             states_dense = np.concatenate(states_list, axis=0)
-            # 去重（段间共享端点）
-            if len(states_dense) > 1:
-                keep = np.concatenate(
-                    ([True], np.linalg.norm(np.diff(states_dense[:, :3], axis=0), axis=1) > 1e-9)
-                )
-                states_dense = states_dense[keep]
+            # 右开区间下段间无重叠，无需去重；去重反而会掩蔽 mask 回归（若改回
+            # 闭区间，seam 重复点被删、长度恢复一致，长度断言失效）。
         finally:
             spice.disable_ephem_cache()
 

--- a/e2m2e/algorithm/design/design_orbit.py
+++ b/e2m2e/algorithm/design/design_orbit.py
@@ -591,6 +591,14 @@ def _build_ephemeris_table(
     """
     t_c = syn_j2000.cr3bp_system.characteristic_time
     assert t_c is not None
+    # 位置/速度与时间网格必须逐点对齐：segmented 逐段积分曾把 propagate
+    # 自动追加的段终点 tf 拼进 states（位置数组比时间网格多出段数个点），
+    # batch_j2000_to_synodic 按索引配对位置与旋转时刻，错位逐段累积导致
+    # 会合系曲线一圈一圈偏离周期轨道。此断言防未来回归。
+    if len(states) != len(et_grid):
+        raise ValueError(
+            f"星历状态点数 {len(states)} 与时间网格点数 {len(et_grid)} 不一致，位置与时间将错位"
+        )
     t_syn = (et_grid - et0) / t_c
     synodic = syn_j2000.batch_j2000_to_synodic(states, t_syn, et0)[:, :3]
     synodic[:, 0] += syn_j2000.cr3bp_system.mu
@@ -874,7 +882,12 @@ def _design_elfo(
     et_grid = et0 + np.arange(0.0, duration_sec + 0.5 * output_step, output_step)
     out = fm.propagate(state0, (et0, et_end), t_eval=et_grid, max_steps=5_000_000)
     states = np.asarray(out["states"], dtype=float)
-    n_pts = len(states)
+    # ForceModel._prepare_t_eval 会在 t_eval 末尾自动追加 t_span 终点
+    # （duration 非整小时时 et_end 不在 et_grid 上，输出多 1 点）；截断到
+    # et_grid 长度，保证状态与时间网格逐点对齐（否则位置数组比时间字段
+    # 多 1 点，_build_ephemeris_table 的长度一致性断言会拒绝）。
+    n_pts = min(len(states), len(et_grid))
+    states = states[:n_pts]
     times = et_grid[:n_pts]
 
     # 月心根数提取与漂移统计
@@ -1172,11 +1185,12 @@ def design_orbit(
                 verbose=verbose,
             )
 
-            # 逐段积分填满 et_grid：每段从修正后节点初值积分到下一节点
+            # 逐段积分填满 et_grid：每段从修正后节点初值积分到下一节点。
+            # mask 用右开区间（seam 整点只归后段），相邻段 t_eval 无重叠。
             states_list: list[np.ndarray] = []
             for i in range(len(t_patch_long) - 1):
                 seg_t0, seg_t1 = t_patch_long[i], t_patch_long[i + 1]
-                mask = (et_grid >= seg_t0 - 1e-6) & (et_grid <= seg_t1 + 1e-6)
+                mask = (et_grid >= seg_t0 - 1e-6) & (et_grid < seg_t1 - 1e-6)
                 t_eval_seg = et_grid[mask]
                 if len(t_eval_seg) == 0:
                     continue
@@ -1186,7 +1200,12 @@ def design_orbit(
                     t_eval=t_eval_seg,
                     max_steps=500_000,
                 )
-                states_list.append(np.asarray(out_seg["states"], dtype=float))
+                # ForceModel._prepare_t_eval 会在 t_eval 末尾自动追加段终点 tf，
+                # 输出比 t_eval 多 1 点（段终点状态，不在 et_grid 上）。截断丢掉，
+                # 保证 states_dense 与 et_grid 严格对齐——否则星历位置数组比时间
+                # 网格多出段数个点，batch_j2000_to_synodic 按索引配对位置与旋转
+                # 时刻，错位逐段累积，会合系曲线一圈一圈偏离 Halo 轨道。
+                states_list.append(np.asarray(out_seg["states"], dtype=float)[: len(t_eval_seg)])
             if not states_list:
                 raise DesignNotConvergedError(
                     "segmented 拼接未生成任何星历点",

--- a/tests/algorithm/design/test_segmented_ephemeris_alignment.py
+++ b/tests/algorithm/design/test_segmented_ephemeris_alignment.py
@@ -1,0 +1,74 @@
+"""segmented 星历时间轴对齐回归测试。
+
+回归 bug：``ForceModel._prepare_t_eval`` 在 t_eval 末尾自动追加段终点 tf，
+``design_orbit`` 的 segmented 逐段积分把每段的 tf 端点状态一并拼进
+``states_dense``，位置数组（756 点）比时间网格 ``et_grid``（731 点）多出
+段数个点；``batch_j2000_to_synodic`` 按索引把位置与旋转时刻配对，错位逐段
+累积，星历会合系曲线一圈一圈偏离 Halo 轨道（GUI 观感"慢慢发散"）。
+
+用 GUI 默认参数的 30 天 Halo（L2、30000 km、phase 0）端到端回归：
+长度一致判据直接对应根因（位置-时间错位），y 对称判据直接对应症状
+（错位把 y 拉到单侧 -0.266，正常 ±0.107）。
+"""
+
+from __future__ import annotations
+
+import os
+
+import numpy as np
+import pytest
+
+from e2m2e.algorithm.design import design_orbit
+from e2m2e.api.models import DesignOrbitRequest
+
+_SPICE_KERNEL_DIR = os.environ.get(
+    "SPICE_KERNEL_DIR",
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "..", "kernels"),
+)
+_SPICE_AVAILABLE = os.path.isdir(_SPICE_KERNEL_DIR) and any(
+    f.endswith(".bsp") for f in os.listdir(_SPICE_KERNEL_DIR)
+)
+
+pytestmark = [
+    pytest.mark.orchestration,
+    pytest.mark.spice,
+    pytest.mark.skipif(not _SPICE_AVAILABLE, reason="SPICE kernels not available"),
+]
+
+DURATION_SEC = 30 * 86400.0
+OUTPUT_STEP_SEC = 3600.0
+# et_grid = et0 + arange(0, duration + 0.5·step, step)，含首末点
+N_EXPECTED = int(DURATION_SEC / OUTPUT_STEP_SEC) + 1
+
+
+@pytest.fixture(scope="module")
+def halo_result():
+    """GUI 默认参数的 30 天 Halo segmented 设计，模块内复用一次。"""
+    return design_orbit(
+        DesignOrbitRequest(
+            orbit_type="HALO",
+            collinear_point=2,
+            amplitude=30000.0,
+            phase=0.0,
+            duration=DURATION_SEC,
+            output_step=OUTPUT_STEP_SEC,
+        )
+    )
+
+
+def test_ephemeris_fields_aligned_with_time_grid(halo_result):
+    """星历位置/速度/会合系点数必须与时间字段一致（位置-时间错位回归）。"""
+    eph = halo_result.ephemeris
+    assert len(eph) == N_EXPECTED
+    assert len(eph.position_km) == N_EXPECTED
+    assert len(eph.velocity_mps) == N_EXPECTED
+    assert len(eph.synodic_position) == N_EXPECTED
+
+
+def test_synodic_y_symmetric(halo_result):
+    """会合系 y 振幅对称（错位回归：逐段累积的时间错位把 y 拉到单侧）。"""
+    syn = np.asarray(halo_result.ephemeris.synodic_position)
+    y = syn[:, 1]
+    # 正常 Halo y ∈ ±0.107，|max+min| ≈ 0；错位时 y ∈ [-0.266, 0.010]，
+    # |max+min| ≈ 0.256。阈值 0.05 远小于错位特征、远大于正常残差。
+    assert abs(y.max() + y.min()) < 0.05, f"会合系 y 不对称: max={y.max():.4f} min={y.min():.4f}"

--- a/tests/algorithm/design/test_segmented_ephemeris_alignment.py
+++ b/tests/algorithm/design/test_segmented_ephemeris_alignment.py
@@ -2,13 +2,19 @@
 
 回归 bug：``ForceModel._prepare_t_eval`` 在 t_eval 末尾自动追加段终点 tf，
 ``design_orbit`` 的 segmented 逐段积分把每段的 tf 端点状态一并拼进
-``states_dense``，位置数组（756 点）比时间网格 ``et_grid``（731 点）多出
-段数个点；``batch_j2000_to_synodic`` 按索引把位置与旋转时刻配对，错位逐段
-累积，星历会合系曲线一圈一圈偏离 Halo 轨道（GUI 观感"慢慢发散"）。
+``states_dense``，位置数组比时间网格 ``et_grid`` 多出段数个点（30 天 1
+小时步长实测 746 点 vs 721 点，每段多 1 点）；``batch_j2000_to_synodic``
+按索引把位置与旋转时刻配对，错位逐段累积，星历会合系曲线一圈一圈偏离
+Halo 轨道（GUI 观感"慢慢发散"）。
 
 用 GUI 默认参数的 30 天 Halo（L2、30000 km、phase 0）端到端回归：
 长度一致判据直接对应根因（位置-时间错位），y 对称判据直接对应症状
-（错位把 y 拉到单侧 -0.266，正常 ±0.107）。
+（修复前实测错位把 y 拉到单侧 [-0.266, 0.010]，正常 ±0.107）。
+
+另覆盖右开 mask 的尾部覆盖回归（duration 落入最后打靶节点与 n_rev 圈
+终点之间的窗口时，et_grid 尾部点曾无段覆盖、长度断言报错）：
+43 天与 30 天同为 3 圈（n_rev=3），但 43 天超出最后节点，修复前直接
+ValueError。
 """
 
 from __future__ import annotations
@@ -72,3 +78,35 @@ def test_synodic_y_symmetric(halo_result):
     # 正常 Halo y ∈ ±0.107，|max+min| ≈ 0；错位时 y ∈ [-0.266, 0.010]，
     # |max+min| ≈ 0.256。阈值 0.05 远小于错位特征、远大于正常残差。
     assert abs(y.max() + y.min()) < 0.05, f"会合系 y 不对称: max={y.max():.4f} min={y.min():.4f}"
+
+
+LONG_DURATION_SEC = 43 * 86400.0  # 3 圈（n_rev=3），但超出最后打靶节点
+
+
+@pytest.fixture(scope="module")
+def halo_result_long():
+    """43 天 Halo segmented 设计：et_grid 尾部落入无节点覆盖窗口。"""
+    return design_orbit(
+        DesignOrbitRequest(
+            orbit_type="HALO",
+            collinear_point=2,
+            amplitude=30000.0,
+            phase=0.0,
+            duration=LONG_DURATION_SEC,
+            output_step=OUTPUT_STEP_SEC,
+        )
+    )
+
+
+def test_ephemeris_tail_beyond_last_patch_point(halo_result_long):
+    """尾部窗口回归：et_grid 超出最后打靶节点时星历仍完整逐点对齐。
+
+    修复前右开 mask 把尾部点排除在段外，此处曾报 ValueError（星历状态
+    1022 点 vs 时间网格 1033 点，差 11 点）。
+    """
+    eph = halo_result_long.ephemeris
+    n_expected = int(LONG_DURATION_SEC / OUTPUT_STEP_SEC) + 1
+    assert len(eph) == n_expected
+    assert len(eph.position_km) == n_expected
+    assert len(eph.velocity_mps) == n_expected
+    assert len(eph.synodic_position) == n_expected


### PR DESCRIPTION
## 关联 issue

无关联 issue。

## 改动摘要

修复 segmented 逐段积分星历与时间网格错位的问题（GUI 中 Halo 轨道一圈一圈偏离周期轨道）。

- 根因：`ForceModel._prepare_t_eval` 会在 t_eval 末尾自动追加段终点 tf，segmented 逐段积分把每段多出的 tf 端点状态拼进 states_dense，位置数组比时间网格多出段数个点；`batch_j2000_to_synodic` 按索引配对位置与旋转时刻，错位逐段累积，星历会合系曲线一圈一圈偏离周期轨道。
- segmented 逐段积分：mask 改右开区间（seam 整点只归后段），每段输出截断丢 tf 端点，states_dense 与 et_grid 严格逐点对齐。
- ELFO 路径同类问题：duration 非整小时时输出多 1 点，按 min 截断对齐。
- `_build_ephemeris_table` 加长度一致性断言防回归。
- 新增 30 天 Halo 端到端回归测试：星历各字段与时间网格点数一致、会合系 y 振幅对称。
- chore: 将 .pi/ 加入 .gitignore（pi 编码代理的会话产物目录，与 .mimocode/、.zcode/ 同类，不入库）。

## 测试

```bash
export CSPICE_DIR=$(python3 scripts/download_cspice.py --print-cspice-dir)
uv run maturin develop
uv run pytest tests/algorithm/design/test_segmented_ephemeris_alignment.py -q
```

结果：2 passed in 46.22s