### PR TITLE
feat(ci): 支持 aarch64 Linux 构建与发布——CSPICE arm64 静态库、构建矩阵、calcephpy arm64 wheel

### DIFF
--- a/.github/workflows/calcephpy-wheel.yml
+++ b/.github/workflows/calcephpy-wheel.yml
@@ -114,8 +114,61 @@ jobs:
           name: wheel-linux-${{ matrix.python }}
           path: /tmp/repaired/*.whl
 
+  # Linux aarch64 wheel：与 build-linux 同逻辑，但跑在 GitHub 原生 arm64
+  # runner + manylinux_2_28_aarch64 容器（quay.io/pypa 官方镜像，自带
+  # cmake+gcc+uv）。e2m2e 支持 aarch64 后，arm 用户经 [tool.uv.sources]
+  # 直接拉预编译 wheel，免现场编译。
+  build-linux-aarch64:
+    runs-on: ubuntu-24.04-arm
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.10", "3.11", "3.12", "3.13"]
+    container:
+      image: quay.io/pypa/manylinux_2_28_aarch64
+    env:
+      # uv python install 装的完整 CPython 的 bin 目录（安装后取真实路径）
+      PY_VER: ${{ matrix.python }}
+    steps:
+      - name: Show toolchain
+        run: |
+          cmake --version
+          uv --version
+      - name: 安装完整版 CPython（含 libpython 开发文件）
+        run: |
+          set -eux
+          uv python install ${PY_VER}
+          # uv python find 返回的是 python 可执行文件完整路径（.../bin/python3.x）
+          echo "PY=$(uv python find ${PY_VER})" >> "$GITHUB_ENV"
+          echo "PYROOT=$(dirname "$(dirname "$(uv python find ${PY_VER})")")" >> "$GITHUB_ENV"
+      - name: Build wheel
+        run: |
+          set -eux
+          ${PY} -m venv /tmp/v
+          /tmp/v/bin/pip install --no-cache-dir setuptools cython wheel
+          # Python_EXECUTABLE + Python_ROOT_DIR：让 cmake 找到完整 CPython 的
+          # include/libpython（stripped 的 /opt/python 找不到）。
+          export Python_EXECUTABLE=$PY
+          export Python_ROOT_DIR=$PYROOT
+          /tmp/v/bin/pip wheel calcephpy==5.0.0 --no-deps --no-build-isolation -w /tmp/wheelhouse/
+      - name: auditwheel repair（打 manylinux 标签并校验合规性）
+        run: |
+          set -eux
+          auditwheel repair -w /tmp/repaired /tmp/wheelhouse/*.whl
+          ls -la /tmp/repaired/
+      - name: Smoke test（安装并 import）
+        run: |
+          set -eux
+          /tmp/v/bin/pip install numpy
+          /tmp/v/bin/pip install --no-deps --no-index --find-links /tmp/repaired/ calcephpy
+          /tmp/v/bin/python -c "import calcephpy; print('calcephpy import OK')"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: wheel-linux-aarch64-${{ matrix.python }}
+          path: /tmp/repaired/*.whl
+
   release:
-    needs: [build, build-linux]
+    needs: [build, build-linux, build-linux-aarch64]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v8
@@ -133,8 +186,8 @@ jobs:
           gh release create calcephpy-v1 \
             --repo "$GITHUB_REPOSITORY" \
             --target master \
-            --title "calcephpy 预编译 wheel（Windows + Linux）" \
-            --notes "calcephpy 5.0.0 的预编译 wheel：Windows（cp310–cp313，win_amd64）+ Linux（cp310–cp313，manylinux_2_28_x86_64）。PyPI 仅有 sdist，Windows 需 MSVC、Linux 需 gcc 现场编译；此处提供预编译产物，供 e2m2e / transfer-orbit-design 的 uv sync 经 find-links 直接拉取。calcephpy 归 IMCCE/CNRS，CeCILL-C/B 或 CeCILL v2.1 许可。" \
+            --title "calcephpy 预编译 wheel（Windows + Linux x86_64 + Linux aarch64）" \
+            --notes "calcephpy 5.0.0 的预编译 wheel：Windows（cp310–cp313，win_amd64）+ Linux x86_64（cp310–cp313，manylinux_2_28_x86_64）+ Linux aarch64（cp310–cp313，manylinux_2_28_aarch64）。PyPI 仅有 sdist，Windows 需 MSVC、Linux 需 gcc 现场编译；此处提供预编译产物，供 e2m2e / transfer-orbit-design 的 uv sync 经 find-links 直接拉取。calcephpy 归 IMCCE/CNRS，CeCILL-C/B 或 CeCILL v2.1 许可。" \
             || true
           gh release upload calcephpy-v1 dist/*.whl --repo "$GITHUB_REPOSITORY" --clobber
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,31 @@ jobs:
       - run: uv run python scripts/check_deleted_dir_refs.py
 
 
+  # aarch64 回归：跑在 GitHub 原生 arm64 runner 上，验证 Rust 扩展在 aarch64
+  # 上编译/链接/运行（CSPICE_DIR 由 download_cspice.py 按 runner 架构自动选
+  # aarch64 资产；该资产由 cspice-aarch64-build.yml 维护）。
+  test-arm64:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: astral-sh/setup-uv@v7
+      # spice 为默认 feature：cargo test --workspace 编译并跑 spice-gated 代码，
+      # 须先下 CSPICE 编译包（CSPICE_DIR）与 SPICE 内核（kernels/）。
+      - name: 下载 SPICE 编译包（cspice-v1 release，aarch64 资产）
+        # --no-sync：脚本只用标准库；uv run 默认先 sync 构建扩展，此时
+        # CSPICE_DIR 未设、cspice-sys 直接报错（鸡生蛋，同 release.yml test）。
+        run: uv run --no-sync python scripts/download_cspice.py >> "$GITHUB_ENV"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: 下载 SPICE 内核（kernels-v1 release）
+        run: uv run --no-sync python scripts/download_kernels.py
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # --test-threads=1：CSPICE 全局线程锁，spice-gated 测试串行避免竞争。
+      - run: cargo test --workspace -- --test-threads=1
+
+
   typecheck:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/cspice-aarch64-build.yml
+++ b/.github/workflows/cspice-aarch64-build.yml
@@ -1,0 +1,83 @@
+# 在 GitHub arm64 runner 上从 NAIF 源码包编译 aarch64 的 CSPICE 静态库，
+# 打包 cspice-linux-aarch64.zip 发布到 cspice-v1 release，供 download_cspice.py
+# 在 aarch64 Linux 上构建 e2m2e 时下载。
+#
+# 背景：NAIF 官方只发布 x86_64 的 Linux 工具包（PC_Linux_GCC_64bit），conda-forge
+# 亦无 linux-aarch64 的 cspice。aarch64 库只能拿 NAIF 源码发行包（与 cspice-sys
+# 1.0.4 的 downloadcspice feature 同 URL）在 arm64 上 make。GitHub 原生 arm64
+# runner（ubuntu-24.04-arm）native 编译，产物 lib/cspice.a 重命名为 libcspice.a
+# （cspice-sys 用 rustc-link-lib=static=cspice 链接，cargo 找 libcspice.a），
+# 与现有 cspice-linux.zip 同样的 include/ + lib/ 目录结构，解压子目录名
+# mice_linux_aarch64（与 x86_64 的 mice_linux 区分，避免缓存目录互相覆盖）。
+#
+# 触发：手动（Actions → Run workflow），或修改本 workflow 时自动。
+
+name: Build CSPICE aarch64 static lib
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [master]
+    paths:
+      - .github/workflows/cspice-aarch64-build.yml
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 30
+    steps:
+      - name: 安装编译工具（make/gcc/csh；csh 供 NAIF 个别构建脚本用）
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y make gcc csh zip
+      - name: 下载 CSPICE 源码包（NAIF 官网，runner 在海外可达）
+        run: |
+          curl -fL --retry 3 -o cspice.tar.Z \
+            "https://naif.jpl.nasa.gov/pub/naif/toolkit//C/PC_Linux_GCC_64bit/packages/cspice.tar.Z"
+          ls -la cspice.tar.Z
+      - name: 解压
+        run: |
+          gzip -d cspice.tar.Z
+          tar xf cspice.tar
+          ls cspice/
+      - name: 编译（aarch64 native）
+        run: |
+          cd cspice
+          make 2>&1 | tail -30
+          ls -la lib/
+      - name: 校验产物并整理目录结构
+        run: |
+          set -eux
+          # make 产物是 lib/cspice.a（NAIF makefile），cspice-sys 需要 libcspice.a
+          cp cspice/lib/cspice.a cspice/lib/libcspice.a
+          file cspice/lib/libcspice.a
+          # 必须为 aarch64 ELF 静态库，否则后续 wheel 构建链接必炸
+          file cspice/lib/libcspice.a | grep -q aarch64
+          mkdir -p mice_linux_aarch64/include mice_linux_aarch64/lib
+          cp -r cspice/include/* mice_linux_aarch64/include/
+          cp cspice/lib/libcspice.a mice_linux_aarch64/lib/
+          # 冒烟：编译并链接一个最小 C 程序（furnsh_c 来自 libcspice.a）
+          printf '#include "SpiceUsr.h"\nint main(void){ furnsh_c(""); return 0; }\n' > smoke.c
+          gcc smoke.c -I mice_linux_aarch64/include mice_linux_aarch64/lib/libcspice.a -lm -o smoke
+          ./smoke && echo "SMOKE OK"
+      - name: 打包 cspice-linux-aarch64.zip
+        run: |
+          zip -r cspice-linux-aarch64.zip mice_linux_aarch64
+          ls -la cspice-linux-aarch64.zip
+      - name: 上传 cspice-v1 release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # release 不存在则创建（tag 指向 master HEAD）；已存在则跳过创建。
+          # upload --clobber 覆盖同名 asset，保证重跑幂等。
+          gh release create cspice-v1 \
+            --repo "$GITHUB_REPOSITORY" \
+            --target master \
+            --title "CSPICE 预编译包（x86_64 Linux / x86_64 Windows / aarch64 Linux）" \
+            --notes "e2m2e 构建用 CSPICE 预编译静态库：cspice-linux.zip（x86_64，NAIF MICE 包转存）、cspice-windows.zip（x86_64，NAIF MICE 包转存）、cspice-linux-aarch64.zip（本工作流在 arm64 runner 上从 NAIF 源码包编译）。cspice-sys 经 CSPICE_DIR 使用，无 CSPICE_DIR 时构建直接报错。" \
+            || true
+          gh release upload cspice-v1 cspice-linux-aarch64.zip \
+            --repo "$GITHUB_REPOSITORY" --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,8 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
           - os: windows-latest
             target: x86_64-pc-windows-msvc
     runs-on: ${{ matrix.os }}
@@ -91,8 +93,11 @@ jobs:
       # cspice-sys 1.0.4 的 downloadcspice 走 reqwest→native-tls→openssl-sys，
       # 找不到 pkg-config 文件而失败。manylinux_2_28 镜像自带 openssl 1.1.1
       # 与 openssl-devel（含 openssl.pc），加上 before-script 兜底安装。
-      # SPICE 编译包来自 cspice-v1 release（scripts/download_cspice.py），
-      # 设好 CSPICE_DIR 后 cspice-sys 跳过 NAIF 下载（国内网络常不可达）。
+      # SPICE 编译包来自 cspice-v1 release（scripts/download_cspice.py 按
+      # runner 架构自动选 x86_64/aarch64 资产），设好 CSPICE_DIR 后 cspice-sys
+      # 跳过 NAIF 下载（国内网络常不可达）。aarch64 条目跑在原生 arm64 runner
+      # （ubuntu-24.04-arm），maturin-action 自动用 manylinux_2_28_aarch64 容器，
+      # 无交叉工具链问题；CSPICE aarch64 库由 cspice-aarch64-build.yml 维护。
       - name: 下载 SPICE 编译包（cspice-v1 release）
         shell: bash
         run: python scripts/download_cspice.py >> "$GITHUB_ENV"

--- a/.gitignore
+++ b/.gitignore
@@ -99,7 +99,8 @@ examples/main_*.png
 # 下载方式：https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/
 kernels/*.bsp
 # 本地 CSPICE 库与下载缓存（scripts/download_cspice.py 生成）
-cspice/
+# 只忽略仓库根目录的 cspice/（手动解压的 CSPICE 源码包），不动 crates/cspice/
+/cspice/
 .cspice/
 # cspice 运行产生的 Fortran 临时输出
 fort.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # 变更日志
 
+## [Unreleased]
+
+### Added
+- **aarch64 Linux（arm64）构建与发布支持**：CSPICE 无官方 Linux ARM64 预编译包（NAIF 仅 x86_64，conda-forge 亦无），新增 `cspice-aarch64-build.yml` 在 GitHub 原生 arm64 runner 上从 NAIF 源码包（cspice-sys 同源 URL）编译静态库并发布到 `cspice-v1` release；`scripts/download_cspice.py` 按机器架构选择 x86_64/aarch64 资产（解压目录按架构隔离，避免缓存串用）；release 工作流构建矩阵增加 `ubuntu-24.04-arm`（maturin-action 自动用 manylinux_2_28_aarch64 容器）；calcephpy 增加 aarch64 预编译 wheel（calcephpy-wheel.yml 的 build-linux-aarch64 job）与 `[tool.uv.sources]` 条目，arm 用户免现场编译；CI 新增 arm64 回归 job（cargo test 全量跑在原生 arm64 runner）。
+
 ## [5.6.8] - 2026-08-13
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,9 @@ rayon = "1.10"
 # drainer reacquire GIL 调 Python callable（Sender 为 Send+Sync，可被 rayon
 # 多 worker 共享引用；std::sync::mpsc::Sender 是 !Sync，做不到）。
 crossbeam-channel = "0.5"
+
+# cspice 0.1.0 上游在 aarch64 上编译失败（E0606，string.rs 的 &[u8] as *const [i8]
+# 非法 cast，aarch64 的 C char 是 unsigned）；上游至今未修，仓库内 vendor 并修复，
+# 见 crates/cspice/（LGPL-3.0，LICENSE 与署名随目录分发）。
+[patch.crates-io]
+cspice = { path = "crates/cspice" }

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ e2m2e 是面向地月空间任务规划的**算法工具集基础设施**。在�
 uv pip install e2m2e
 ```
 
+发布物覆盖 Windows x86_64、Linux x86_64 与 Linux aarch64（arm64，如鲲鹏/飞腾/树莓派）的 wheel；其余平台从源码构建。
+
 在自己的项目中使用：
 
 ```bash

--- a/crates/cspice/Cargo.toml
+++ b/crates/cspice/Cargo.toml
@@ -1,0 +1,28 @@
+# cspice 0.1.0 的仓库内 vendor（上游 jacob-pro/cspice-rs，LGPL-3.0）。
+#
+# 背景：上游 cspice 0.1.0 的 string.rs 在 aarch64 上编译失败（E0606）——
+# aarch64 的 C char 是 unsigned，cspice-sys bindgen 生成的 SpiceChar = u8，
+# `&[u8] as *const [i8]` 非法 cast；上游 master 至今未修（2026-08 确认）。
+# 经 [patch.crates-io]（根 Cargo.toml）以本目录替代 crates.io 的 cspice 0.1.0，
+# 修复见 src/string.rs 的 from_buffer（from_raw_parts 写法，架构无关）。
+# 其余代码与上游 0.1.0 逐字节一致；升级上游前先核对上游是否已修复该 cast。
+# LGPL-3.0 文本见 LICENSE；本目录不是 workspace member，不进 clippy/fmt 检查。
+
+[package]
+name = "cspice"
+version = "0.1.0"
+edition = "2021"
+description = "Safe wrapper around the NAIF CSPICE toolkit"
+license = "LGPL-3.0"
+authors = ["Jacob Halsey <jacob@jhalsey.com>", "Contributors"]
+homepage = "https://github.com/jacob-pro/cspice-rs/tree/master/cspice"
+repository = "https://github.com/jacob-pro/cspice-rs"
+
+[dependencies]
+chrono = { version = "0.4.19", optional = true }
+cspice-sys = "1.0"
+derive_more = "0.99.17"
+parking_lot = "0.12.1"
+serde = { version = "1.0.137", features = ["derive"] }
+serde_plain = "1.0.0"
+thiserror = "1.0.31"

--- a/crates/cspice/LICENSE
+++ b/crates/cspice/LICENSE
@@ -1,0 +1,165 @@
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/crates/cspice/README.md
+++ b/crates/cspice/README.md
@@ -1,0 +1,12 @@
+# CSPICE
+
+[![Build](https://github.com/jacob-pro/cspice-rs/actions/workflows/rust.yml/badge.svg)](https://github.com/jacob-pro/cspice-rs/actions)
+[![crates.io](https://img.shields.io/crates/v/cspice.svg)](https://crates.io/crates/cspice)
+[![docs.rs](https://docs.rs/cspice/badge.svg)](https://docs.rs/cspice/latest/cspice/)
+![maintenance-status](https://img.shields.io/badge/maintenance-experimental-blue.svg)
+
+Rust wrapper around the NAIF [SPICE Toolkit](https://naif.jpl.nasa.gov/naif/index.html).
+
+Note: Please see [cspice-sys](../cspice-sys) for how to set up the toolkit.
+
+This is very much a work in progress - not many functions are implemented yet.

--- a/crates/cspice/src/cell.rs
+++ b/crates/cspice/src/cell.rs
@@ -1,0 +1,435 @@
+//! Functions for working with SPICE Cells.
+use crate::common::{ComparisonOperator, Side};
+use crate::error::get_last_error;
+use crate::string::StringParam;
+use crate::{with_spice_lock_or_panic, Error};
+use cspice_sys::{
+    _SpiceDataType_SPICE_CHR, _SpiceDataType_SPICE_DP, _SpiceDataType_SPICE_INT, appndc_c,
+    appndd_c, appndi_c, card_c, copy_c, scard_c, wncard_c, wncomd_c, wncond_c, wndifd_c, wnelmd_c,
+    wnexpd_c, wnextd_c, wnfetd_c, wnfild_c, wnfltd_c, wnincd_c, wninsd_c, wnintd_c, wnreld_c,
+    wnsumd_c, wnunid_c, wnvald_c, SpiceBoolean, SpiceChar, SpiceDouble, SpiceInt, SPICEFALSE,
+    SPICETRUE, SPICE_CELL_CTRLSZ,
+};
+use std::ffi::c_void;
+
+/// A type that can be used in a SPICE Cell.
+pub trait CellType {}
+
+impl CellType for SpiceDouble {}
+impl CellType for SpiceInt {}
+impl CellType for SpiceChar {}
+
+/// A Rust wrapper around a SpiceCell and its data.
+pub struct Cell<T: CellType> {
+    cell: cspice_sys::SpiceCell,
+    #[allow(dead_code)]
+    data: Vec<T>,
+}
+
+impl<T: CellType> Cell<T> {
+    /// Access the internal CSPICE Cell structure.
+    pub fn as_mut_cell(&mut self) -> *mut cspice_sys::SpiceCell {
+        &mut self.cell
+    }
+
+    /// Set the cardinality of a cell.
+    ///
+    /// See [scard_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/scard_c.html).
+    pub fn set_cardinality(&mut self, cardinality: usize) -> Result<(), Error> {
+        with_spice_lock_or_panic(|| {
+            unsafe { scard_c(cardinality as SpiceInt, self.as_mut_cell()) };
+            get_last_error()
+        })
+    }
+
+    /// Return the size (maximum cardinality) of a SPICE cell.
+    ///
+    /// See [size_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/size_c.html)
+    pub fn get_size(&mut self) -> Result<usize, Error> {
+        with_spice_lock_or_panic(|| {
+            let out = unsafe { card_c(self.as_mut_cell()) };
+            get_last_error()?;
+            Ok(out as usize)
+        })
+    }
+
+    /// Return the cardinality (current number of elements) in a cell.
+    ///
+    /// See [card_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/card_c.html).
+    pub fn get_cardinality(&mut self) -> Result<usize, Error> {
+        with_spice_lock_or_panic(|| {
+            let out = unsafe { card_c(self.as_mut_cell()) };
+            get_last_error()?;
+            Ok(out as usize)
+        })
+    }
+
+    /// Copy the contents of a SpiceCell of any data type to another cell of the same type.
+    ///
+    /// See [copy_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/copy_c.html).
+    pub fn copy(&mut self, dest: &mut Cell<T>) -> Result<(), Error> {
+        with_spice_lock_or_panic(|| {
+            unsafe { copy_c(self.as_mut_cell(), dest.as_mut_cell()) };
+            get_last_error()
+        })
+    }
+}
+
+impl Cell<SpiceDouble> {
+    /// Creates a SPICEDOUBLE_CELL
+    ///
+    /// See [Declaring and Initializing Cells](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/cells.html#Declaring%20and%20Initializing%20Cells)
+    pub fn new_double(size: usize) -> Self {
+        let mut data = vec![0.0; SPICE_CELL_CTRLSZ as usize + size];
+        let cell = cspice_sys::SpiceCell {
+            dtype: _SpiceDataType_SPICE_DP,
+            length: 0,
+            size: size as SpiceInt,
+            card: 0,
+            isSet: SPICETRUE as SpiceBoolean,
+            adjust: SPICEFALSE as SpiceBoolean,
+            init: SPICEFALSE as SpiceBoolean,
+            base: data.as_mut_ptr() as *mut c_void,
+            data: data[SPICE_CELL_CTRLSZ as usize..].as_mut_ptr() as *mut c_void,
+        };
+        Self { cell, data }
+    }
+
+    /// Append an item to a double precision cell
+    ///
+    /// See [appndd_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/appndd_c.html)
+    pub fn append(&mut self, item: SpiceDouble) -> Result<(), Error> {
+        with_spice_lock_or_panic(|| {
+            unsafe { appndd_c(item, self.as_mut_cell()) };
+            get_last_error()
+        })
+    }
+}
+
+impl Cell<SpiceInt> {
+    /// Creates a SPICEINT_CELL
+    ///
+    /// See [Declaring and Initializing Cells](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/cells.html#Declaring%20and%20Initializing%20Cells)
+    pub fn new_int(size: usize) -> Self {
+        let mut data = vec![0; SPICE_CELL_CTRLSZ as usize + size];
+        let cell = cspice_sys::SpiceCell {
+            dtype: _SpiceDataType_SPICE_INT,
+            length: 0,
+            size: size as SpiceInt,
+            card: 0,
+            isSet: SPICETRUE as SpiceBoolean,
+            adjust: SPICEFALSE as SpiceBoolean,
+            init: SPICEFALSE as SpiceBoolean,
+            base: data.as_mut_ptr() as *mut c_void,
+            data: data[SPICE_CELL_CTRLSZ as usize..].as_mut_ptr() as *mut c_void,
+        };
+        Self { cell, data }
+    }
+
+    /// Append an item to an integer cell
+    ///
+    /// See [appndi_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/appndi_c.html)
+    pub fn append(&mut self, item: SpiceInt) -> Result<(), Error> {
+        with_spice_lock_or_panic(|| {
+            unsafe { appndi_c(item, self.as_mut_cell()) };
+            get_last_error()
+        })
+    }
+}
+
+impl Cell<SpiceChar> {
+    /// Creates a SPICECHAR_CELL
+    ///
+    /// See [Character Cells](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/cells.html#Character%20Cells)
+    pub fn new_char(size: usize, length: usize) -> Self {
+        let data_len = (SPICE_CELL_CTRLSZ as usize + size) * length;
+        let start_index = SPICE_CELL_CTRLSZ as usize * length;
+        let mut data = vec![0; data_len];
+        let cell = cspice_sys::SpiceCell {
+            dtype: _SpiceDataType_SPICE_CHR,
+            length: length as SpiceInt,
+            size: size as SpiceInt,
+            card: 0,
+            isSet: SPICETRUE as SpiceBoolean,
+            adjust: SPICEFALSE as SpiceBoolean,
+            init: SPICEFALSE as SpiceBoolean,
+            base: data.as_mut_ptr() as *mut c_void,
+            data: data[start_index..].as_mut_ptr() as *mut c_void,
+        };
+        Self { cell, data }
+    }
+
+    /// Append an item to a character cell
+    ///
+    /// See [appndc_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/appndc_c.html)
+    pub fn append<'s, S: Into<StringParam<'s>>>(&mut self, item: S) -> Result<(), Error> {
+        with_spice_lock_or_panic(|| {
+            unsafe { appndc_c(item.into().as_mut_ptr(), self.as_mut_cell()) };
+            get_last_error()
+        })
+    }
+}
+
+/// Summary of a double precision window.
+///
+/// Returned from [Cell::window_summarize()]
+#[derive(Debug, Clone, PartialEq)]
+pub struct WindowSummary {
+    pub total_measure_of_intervals: SpiceDouble,
+    pub average_measure: SpiceDouble,
+    pub standard_deviation: SpiceDouble,
+    pub shortest_interval_index: usize,
+    pub longest_interval_index: usize,
+}
+
+pub type Window = Cell<SpiceDouble>;
+
+/// Window specific functions
+impl Cell<SpiceDouble> {
+    /// Return the cardinality (number of intervals) of a double precision window.
+    ///
+    /// See [wncard_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/wncard_c.html).
+    pub fn window_cardinality(&mut self) -> Result<SpiceInt, Error> {
+        with_spice_lock_or_panic(|| {
+            let out = unsafe { wncard_c(self.as_mut_cell()) };
+            get_last_error()?;
+            Ok(out)
+        })
+    }
+
+    /// Determine the complement of a double precision window with respect to a specified interval.
+    ///
+    /// See [wncomd_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/wncomd_c.html).
+    pub fn window_compliment(
+        &mut self,
+        left: SpiceDouble,
+        right: SpiceDouble,
+        output: &mut Window,
+    ) -> Result<(), Error> {
+        with_spice_lock_or_panic(|| {
+            unsafe { wncomd_c(left, right, self.as_mut_cell(), output.as_mut_cell()) };
+            get_last_error()
+        })
+    }
+
+    /// Contract each of the intervals of a double precision window.
+    ///
+    /// See [wncond_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/wncond_c.html).
+    pub fn window_contract(&mut self, left: SpiceDouble, right: SpiceDouble) -> Result<(), Error> {
+        with_spice_lock_or_panic(|| {
+            unsafe { wncond_c(left, right, self.as_mut_cell()) };
+            get_last_error()
+        })
+    }
+
+    /// Place the difference of two double precision windows into a third window.
+    ///
+    /// See [wndifd_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/wndifd_c.html).
+    pub fn window_difference(
+        &mut self,
+        other: &mut Window,
+        output: &mut Window,
+    ) -> Result<(), Error> {
+        with_spice_lock_or_panic(|| {
+            unsafe {
+                wndifd_c(
+                    self.as_mut_cell(),
+                    other.as_mut_cell(),
+                    output.as_mut_cell(),
+                );
+            };
+            get_last_error()
+        })
+    }
+
+    /// Determine whether a point is an element of a double precision window
+    ///
+    /// See [wnelmd_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/wnelmd_c.html).
+    pub fn window_contains_element(&mut self, point: SpiceDouble) -> Result<bool, Error> {
+        with_spice_lock_or_panic(|| {
+            let out = unsafe { wnelmd_c(point, self.as_mut_cell()) };
+            get_last_error()?;
+            Ok(out == SPICETRUE as SpiceBoolean)
+        })
+    }
+
+    /// Expand each of the intervals of a double precision window
+    ///
+    /// See [wnexpd_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/wnexpd_c.html).
+    pub fn window_expand(&mut self, left: SpiceDouble, right: SpiceDouble) -> Result<(), Error> {
+        with_spice_lock_or_panic(|| {
+            unsafe { wnexpd_c(left, right, self.as_mut_cell()) };
+            get_last_error()
+        })
+    }
+
+    /// Extract the left or right endpoints from a double precision window.
+    ///
+    /// See [wnextd_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/wnextd_c.html).
+    pub fn window_extract(&mut self, side: Side) -> Result<(), Error> {
+        with_spice_lock_or_panic(|| {
+            unsafe { wnextd_c(side.as_spice_char(), self.as_mut_cell()) };
+            get_last_error()
+        })
+    }
+
+    /// Fetch a particular interval from a double precision window.
+    ///
+    /// See [wnfetd_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/wnfetd_c.html).
+    pub fn window_interval(&mut self, n: usize) -> Result<(SpiceDouble, SpiceDouble), Error> {
+        with_spice_lock_or_panic(|| {
+            let (mut left, mut right) = (0.0, 0.0);
+            unsafe {
+                wnfetd_c(self.as_mut_cell(), n as SpiceInt, &mut left, &mut right);
+            };
+            get_last_error()?;
+            Ok((left, right))
+        })
+    }
+
+    /// Fill small gaps between adjacent intervals of a double precision window.
+    ///
+    /// See [wnfild_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/wnfild_c.html).
+    pub fn window_fill(&mut self, small_gap: SpiceDouble) -> Result<(), Error> {
+        with_spice_lock_or_panic(|| {
+            unsafe { wnfild_c(small_gap, self.as_mut_cell()) };
+            get_last_error()
+        })
+    }
+
+    /// Filter (remove) small intervals from a double precision window.
+    ///
+    /// See [wnfltd_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/wnfltd_c.html).
+    pub fn window_filter(&mut self, small_interval: SpiceDouble) -> Result<(), Error> {
+        with_spice_lock_or_panic(|| {
+            unsafe {
+                wnfltd_c(small_interval, self.as_mut_cell());
+            };
+            get_last_error()
+        })
+    }
+
+    /// Determine whether an interval is included in a double precision window.
+    ///
+    /// See [wnincd_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/wnincd_c.html).
+    pub fn window_contains_interval(
+        &mut self,
+        left: SpiceDouble,
+        right: SpiceDouble,
+    ) -> Result<bool, Error> {
+        with_spice_lock_or_panic(|| {
+            let out = unsafe { wnincd_c(left, right, self.as_mut_cell()) };
+            get_last_error()?;
+            Ok(out == SPICETRUE as SpiceBoolean)
+        })
+    }
+
+    /// Insert an interval into a double precision window.
+    ///
+    /// See [wninsd_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/wninsd_c.html).
+    pub fn window_insert_interval(
+        &mut self,
+        left: SpiceDouble,
+        right: SpiceDouble,
+    ) -> Result<(), Error> {
+        with_spice_lock_or_panic(|| {
+            unsafe { wninsd_c(left, right, self.as_mut_cell()) };
+            get_last_error()
+        })
+    }
+
+    /// Place the intersection of two double precision windows into a third window.
+    ///
+    /// See [wnintd_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/wnintd_c.html).
+    pub fn window_intersect(
+        &mut self,
+        other: &mut Window,
+        output: &mut Window,
+    ) -> Result<(), Error> {
+        with_spice_lock_or_panic(|| {
+            unsafe {
+                wnintd_c(
+                    self.as_mut_cell(),
+                    other.as_mut_cell(),
+                    output.as_mut_cell(),
+                )
+            };
+            get_last_error()
+        })
+    }
+
+    /// Compare two double precision windows.
+    ///
+    /// See [wnreld_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/wnreld_c.html).
+    pub fn window_compare(
+        &mut self,
+        comparison_op: ComparisonOperator,
+        other: &mut Window,
+    ) -> Result<bool, Error> {
+        with_spice_lock_or_panic(|| {
+            let out = unsafe {
+                wnreld_c(
+                    self.as_mut_cell(),
+                    comparison_op.as_spice_char(),
+                    other.as_mut_cell(),
+                )
+            };
+            get_last_error()?;
+            Ok(out == SPICETRUE as SpiceBoolean)
+        })
+    }
+
+    /// Summarize the contents of a double precision window.
+    ///
+    /// See [wnsumd_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/wnsumd_c.html).
+    pub fn window_summarize(&mut self) -> Result<WindowSummary, Error> {
+        with_spice_lock_or_panic(|| {
+            let (mut meas, mut avg, mut stddev) = (0.0, 0.0, 0.0);
+            let (mut idxsml, mut idxlon) = (0, 0);
+            unsafe {
+                wnsumd_c(
+                    self.as_mut_cell(),
+                    &mut meas,
+                    &mut avg,
+                    &mut stddev,
+                    &mut idxsml,
+                    &mut idxlon,
+                )
+            };
+            get_last_error()?;
+            Ok(WindowSummary {
+                total_measure_of_intervals: meas,
+                average_measure: avg,
+                standard_deviation: stddev,
+                shortest_interval_index: idxsml as usize,
+                longest_interval_index: idxlon as usize,
+            })
+        })
+    }
+
+    /// Place the union of two double precision windows into a third window.
+    ///
+    /// See [wnunid_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/wnunid_c.html).
+    pub fn window_union(&mut self, other: &mut Window, output: &mut Window) -> Result<(), Error> {
+        with_spice_lock_or_panic(|| {
+            unsafe {
+                wnunid_c(
+                    self.as_mut_cell(),
+                    other.as_mut_cell(),
+                    output.as_mut_cell(),
+                )
+            };
+            get_last_error()
+        })
+    }
+
+    /// Form a valid double precision window from the contents of a window array.
+    ///
+    /// See [wnvald_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/wnvald_c.html).
+    pub fn window_validate(&mut self, size: usize, n: usize) -> Result<(), Error> {
+        with_spice_lock_or_panic(|| {
+            unsafe { wnvald_c(size as SpiceInt, n as SpiceInt, self.as_mut_cell()) };
+            get_last_error()
+        })
+    }
+}

--- a/crates/cspice/src/common.rs
+++ b/crates/cspice/src/common.rs
@@ -1,0 +1,77 @@
+//! Miscellaneous enums and structures.
+use crate::string::{static_spice_str, StaticSpiceStr};
+use cspice_sys::SpiceChar;
+
+pub(crate) static SET: StaticSpiceStr = static_spice_str!("SET");
+pub(crate) static GET: StaticSpiceStr = static_spice_str!("GET");
+pub(crate) static CALENDAR: StaticSpiceStr = static_spice_str!("CALENDAR");
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum ComparisonOperator {
+    EQ,
+    NE,
+    LEQ,
+    LT,
+    GEQ,
+    GT,
+}
+
+impl ComparisonOperator {
+    pub(crate) unsafe fn as_spice_char(&self) -> *mut SpiceChar {
+        match &self {
+            ComparisonOperator::EQ => static_spice_str!("="),
+            ComparisonOperator::NE => static_spice_str!("<>"),
+            ComparisonOperator::LEQ => static_spice_str!("<="),
+            ComparisonOperator::LT => static_spice_str!("<"),
+            ComparisonOperator::GEQ => static_spice_str!(">="),
+            ComparisonOperator::GT => static_spice_str!(">"),
+        }
+        .as_mut_ptr()
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Side {
+    Left,
+    Right,
+}
+
+impl Side {
+    pub fn as_spice_char(&self) -> SpiceChar {
+        (match &self {
+            Side::Left => 'L',
+            Side::Right => 'R',
+        }) as SpiceChar
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[allow(non_camel_case_types)]
+pub enum AberrationCorrection {
+    NONE,
+    LT,
+    LT_S,
+    CN,
+    CN_S,
+    XLT,
+    XLT_S,
+    XCN,
+    XCN_S,
+}
+
+impl AberrationCorrection {
+    pub(crate) unsafe fn as_spice_char(&self) -> *mut SpiceChar {
+        match &self {
+            AberrationCorrection::NONE => static_spice_str!("NONE"),
+            AberrationCorrection::LT => static_spice_str!("LT"),
+            AberrationCorrection::LT_S => static_spice_str!("LT+S"),
+            AberrationCorrection::CN => static_spice_str!("CN"),
+            AberrationCorrection::CN_S => static_spice_str!("CN+S"),
+            AberrationCorrection::XLT => static_spice_str!("XLT"),
+            AberrationCorrection::XLT_S => static_spice_str!("XLT+S"),
+            AberrationCorrection::XCN => static_spice_str!("XCN"),
+            AberrationCorrection::XCN_S => static_spice_str!("XCN+S"),
+        }
+        .as_mut_ptr()
+    }
+}

--- a/crates/cspice/src/coordinates.rs
+++ b/crates/cspice/src/coordinates.rs
@@ -1,0 +1,219 @@
+//! Functions for converting between different types of coordinates.
+use crate::with_spice_lock_or_panic;
+use cspice_sys::{azlrec_c, recazl_c, reclat_c, recrad_c, SpiceBoolean, SpiceDouble};
+use derive_more::Into;
+
+/// Rectangular coordinates
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Into)]
+pub struct Rectangular {
+    pub x: SpiceDouble,
+    pub y: SpiceDouble,
+    pub z: SpiceDouble,
+}
+
+impl From<[SpiceDouble; 3]> for Rectangular {
+    fn from(rect: [SpiceDouble; 3]) -> Self {
+        Rectangular {
+            x: rect[0],
+            y: rect[1],
+            z: rect[2],
+        }
+    }
+}
+
+impl From<Rectangular> for [SpiceDouble; 3] {
+    fn from(rect: Rectangular) -> Self {
+        [rect.x, rect.y, rect.z]
+    }
+}
+
+/// Range, azimuth, and elevation
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+pub struct AzEl {
+    pub range: SpiceDouble,
+    pub az: SpiceDouble,
+    pub el: SpiceDouble,
+}
+
+impl AzEl {
+    /// See [recazl_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/recazl_c.html)
+    pub fn from_rect(mut rect: Rectangular, azccw: bool, elplsz: bool) -> Self {
+        with_spice_lock_or_panic(|| {
+            let mut az_el = AzEl::default();
+            unsafe {
+                recazl_c(
+                    &mut rect.x as *mut SpiceDouble,
+                    azccw as SpiceBoolean,
+                    elplsz as SpiceBoolean,
+                    &mut az_el.range,
+                    &mut az_el.az,
+                    &mut az_el.el,
+                )
+            };
+            az_el
+        })
+    }
+}
+
+impl Rectangular {
+    /// See [azlrec_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/azlrec_c.html)
+    pub fn from_azel(azel: AzEl, azccw: bool, elplsz: bool) -> Self {
+        with_spice_lock_or_panic(|| {
+            let mut rect = [0.0f64; 3];
+            unsafe {
+                azlrec_c(
+                    azel.range,
+                    azel.az,
+                    azel.el,
+                    azccw as SpiceBoolean,
+                    elplsz as SpiceBoolean,
+                    rect.as_mut_ptr(),
+                )
+            };
+            rect.into()
+        })
+    }
+}
+
+/// Range, right ascension, and declination.
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+pub struct RaDec {
+    pub range: SpiceDouble,
+    pub ra: SpiceDouble,
+    pub dec: SpiceDouble,
+}
+
+impl From<Rectangular> for RaDec {
+    /// See [recrad_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/recrad_c.html).
+    fn from(mut rect: Rectangular) -> Self {
+        with_spice_lock_or_panic(|| {
+            let mut ra_dec = RaDec::default();
+            unsafe {
+                recrad_c(
+                    &mut rect.x as *mut SpiceDouble,
+                    &mut ra_dec.range,
+                    &mut ra_dec.ra,
+                    &mut ra_dec.dec,
+                )
+            };
+            ra_dec
+        })
+    }
+}
+
+/// Latitudinal coordinates.
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+pub struct Latitudinal {
+    pub radius: SpiceDouble,
+    pub longitude: SpiceDouble,
+    pub latitude: SpiceDouble,
+}
+
+impl From<Rectangular> for Latitudinal {
+    /// See [reclat_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/reclat_c.html).
+    fn from(mut rect: Rectangular) -> Self {
+        with_spice_lock_or_panic(|| {
+            let mut lat = Latitudinal::default();
+            unsafe {
+                reclat_c(
+                    &mut rect.x as *mut SpiceDouble,
+                    &mut lat.radius,
+                    &mut lat.longitude,
+                    &mut lat.latitude,
+                )
+            };
+            lat
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const EPSILON: f64 = 1e-3;
+
+    // Test data comes from NAIF website https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/recazl_c.html
+    const TEST_DATA_F_F: [[SpiceDouble; 6]; 11] = [
+        [0.000, 0.000, 0.000, 0.000, 0.000, 0.000],
+        [1.000, 0.000, 0.000, 1.000, 0.000, 0.000],
+        [0.000, 1.000, 0.000, 1.000, 270.000, 0.000],
+        [0.000, 0.000, 1.000, 1.000, 0.000, -90.000],
+        [-1.000, 0.000, 0.000, 1.000, 180.000, 0.000],
+        [0.000, -1.000, 0.000, 1.000, 90.000, 0.000],
+        [0.000, 0.000, -1.000, 1.000, 0.000, 90.000],
+        [1.000, 1.000, 0.000, 1.414, 315.000, 0.000],
+        [1.000, 0.000, 1.000, 1.414, 0.000, -45.000],
+        [0.000, 1.000, 1.000, 1.414, 270.000, -45.000],
+        [1.000, 1.000, 1.000, 1.732, 315.000, -35.264],
+    ];
+
+    const TEST_DATA_F_T: [[SpiceDouble; 6]; 11] = [
+        [0.000, 0.000, 0.000, 0.000, 0.000, 0.000],
+        [1.000, 0.000, 0.000, 1.000, 0.000, 0.000],
+        [0.000, 1.000, 0.000, 1.000, 270.000, 0.000],
+        [0.000, 0.000, 1.000, 1.000, 0.000, 90.000],
+        [-1.000, 0.000, 0.000, 1.000, 180.000, 0.000],
+        [0.000, -1.000, 0.000, 1.000, 90.000, 0.000],
+        [0.000, 0.000, -1.000, 1.000, 0.000, -90.000],
+        [1.000, 1.000, 0.000, 1.414, 315.000, 0.000],
+        [1.000, 0.000, 1.000, 1.414, 0.000, 45.000],
+        [0.000, 1.000, 1.000, 1.414, 270.000, 45.000],
+        [1.000, 1.000, 1.000, 1.732, 315.000, 35.264],
+    ];
+
+    const TEST_DATA_T_F: [[SpiceDouble; 6]; 11] = [
+        [0.000, 0.000, 0.000, 0.000, 0.000, 0.000],
+        [1.000, 0.000, 0.000, 1.000, 0.000, 0.000],
+        [0.000, 1.000, 0.000, 1.000, 90.000, 0.000],
+        [0.000, 0.000, 1.000, 1.000, 0.000, -90.000],
+        [-1.000, 0.000, 0.000, 1.000, 180.000, 0.000],
+        [0.000, -1.000, 0.000, 1.000, 270.000, 0.000],
+        [0.000, 0.000, -1.000, 1.000, 0.000, 90.000],
+        [1.000, 1.000, 0.000, 1.414, 45.000, 0.000],
+        [1.000, 0.000, 1.000, 1.414, 0.000, -45.000],
+        [0.000, 1.000, 1.000, 1.414, 90.000, -45.000],
+        [1.000, 1.000, 1.000, 1.732, 45.000, -35.264],
+    ];
+
+    const TEST_DATA_T_T: [[SpiceDouble; 6]; 11] = [
+        [0.000, 0.000, 0.000, 0.000, 0.000, 0.000],
+        [1.000, 0.000, 0.000, 1.000, 0.000, 0.000],
+        [0.000, 1.000, 0.000, 1.000, 90.000, 0.000],
+        [0.000, 0.000, 1.000, 1.000, 0.000, 90.000],
+        [-1.000, 0.000, 0.000, 1.000, 180.000, 0.000],
+        [0.000, -1.000, 0.000, 1.000, 270.000, 0.000],
+        [0.000, 0.000, -1.000, 1.000, 0.000, -90.000],
+        [1.000, 1.000, 0.000, 1.414, 45.000, 0.000],
+        [1.000, 0.000, 1.000, 1.414, 0.000, 45.000],
+        [0.000, 1.000, 1.000, 1.414, 90.000, 45.000],
+        [1.000, 1.000, 1.000, 1.732, 45.000, 35.264],
+    ];
+
+    #[test]
+    fn test_azel_rect_conversion() {
+        azel_rect_conversion(&TEST_DATA_F_F, false, false);
+        azel_rect_conversion(&TEST_DATA_F_T, false, true);
+        azel_rect_conversion(&TEST_DATA_T_F, true, false);
+        azel_rect_conversion(&TEST_DATA_T_T, true, true);
+    }
+
+    fn azel_rect_conversion(test_data: &[[f64; 6]; 11], azccw: bool, elplsz: bool) {
+        for test in test_data.iter() {
+            let azel = AzEl {
+                range: test[3],
+                az: test[4].to_radians(),
+                el: test[5].to_radians(),
+            };
+            let rect = Rectangular::from_azel(azel, azccw, elplsz);
+            assert!((rect.x - test[0]).abs() < EPSILON);
+            assert!((rect.y - test[1]).abs() < EPSILON);
+            assert!((rect.z - test[2]).abs() < EPSILON);
+            let azel_ = AzEl::from_rect(rect, azccw, elplsz);
+            assert!((azel_.range - test[3]).abs() < EPSILON);
+            assert!((azel_.az - test[4].to_radians()).abs() < EPSILON);
+            assert!((azel_.el - test[5].to_radians()).abs() < EPSILON);
+        }
+    }
+}

--- a/crates/cspice/src/data.rs
+++ b/crates/cspice/src/data.rs
@@ -1,0 +1,40 @@
+//! Functions for loading and unloading SPICE Kernels.
+use crate::error::get_last_error;
+use crate::string::StringParam;
+use crate::{with_spice_lock_or_panic, Error};
+use cspice_sys::{furnsh_c, unload_c};
+
+/// Load one or more SPICE kernels into a program.
+///
+/// See [furnsh_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/furnsh_c.html).
+pub fn furnish<'f, F: Into<StringParam<'f>>>(file: F) -> Result<(), Error> {
+    with_spice_lock_or_panic(|| {
+        unsafe {
+            furnsh_c(file.into().as_mut_ptr());
+        };
+        get_last_error()
+    })
+}
+
+/// Unload a SPICE kernel.
+///
+/// See [unload_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/unload_c.html).
+pub fn unload<'f, F: Into<StringParam<'f>>>(file: F) -> Result<(), Error> {
+    with_spice_lock_or_panic(|| {
+        unsafe {
+            unload_c(file.into().as_mut_ptr());
+        };
+        get_last_error()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_furnish() {
+        let error = furnish("NON_EXISTENT_FILE").err().unwrap();
+        assert_eq!(error.short_message, "SPICE(NOSUCHFILE)");
+    }
+}

--- a/crates/cspice/src/error.rs
+++ b/crates/cspice/src/error.rs
@@ -1,0 +1,195 @@
+//! Functions relating to error handling.
+use crate::common::{GET, SET};
+use crate::string::{SpiceStr, SpiceString};
+use crate::with_spice_lock_or_panic;
+use cspice_sys::{
+    erract_c, errdev_c, failed_c, getmsg_c, qcktrc_c, reset_c, SpiceInt, SPICE_ERROR_LMSGLN,
+    SPICE_ERROR_SMSGLN, SPICE_ERROR_TRCLEN, SPICE_ERROR_XMSGLN,
+};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+const FILEN: SpiceInt = 255;
+
+/// An error that occurred in SPICE.
+#[derive(Debug, Clone, Error)]
+#[error("{short_message}\n\n{explanation}\n\n{long_message}\n\nTraceback:\n{traceback}")]
+pub struct Error {
+    pub short_message: String,
+    pub explanation: String,
+    pub long_message: String,
+    pub traceback: String,
+}
+
+/// See [Choosing the Error Response Action](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/error.html#Choosing%20the%20Error%20Response%20Action).
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum ErrorAction {
+    Abort,
+    Ignore,
+    Report,
+    Return,
+    Default,
+}
+
+/// See [Choosing Where the Error Messages Are Sent](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/error.html#Choosing%20Where%20the%20Error%20Messages%20Are%20Sent).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ErrorDevice {
+    Screen,
+    Null,
+    Filename(String),
+}
+
+/// Tests, retrieves, and resets the last error if it is present. Otherwise returns Ok.
+///
+/// For context see [CSPICE Error Handling](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/error.html#Testing%20the%20Error%20Status).
+#[inline]
+pub fn get_last_error() -> Result<(), Error> {
+    with_spice_lock_or_panic(|| {
+        unsafe {
+            if failed_c() == 0 {
+                return Ok(());
+            }
+
+            // Gather error info
+            let option = SpiceString::from("SHORT");
+            let mut short_message = [0; SPICE_ERROR_SMSGLN as usize];
+            getmsg_c(
+                option.as_mut_ptr(),
+                short_message.len() as SpiceInt,
+                short_message.as_mut_ptr(),
+            );
+            let option = SpiceString::from("EXPLAIN");
+            let mut explanation = [0; SPICE_ERROR_XMSGLN as usize];
+            getmsg_c(
+                option.as_mut_ptr(),
+                explanation.len() as SpiceInt,
+                explanation.as_mut_ptr(),
+            );
+            let option = SpiceString::from("LONG");
+            let mut long_message = [0; SPICE_ERROR_LMSGLN as usize];
+            getmsg_c(
+                option.as_mut_ptr(),
+                long_message.len() as SpiceInt,
+                long_message.as_mut_ptr(),
+            );
+            let mut traceback = [0; SPICE_ERROR_TRCLEN as usize];
+            qcktrc_c(traceback.len() as SpiceInt, traceback.as_mut_ptr());
+
+            // Reset last error
+            reset_c();
+
+            Err(Error {
+                short_message: SpiceStr::from_buffer(&short_message).to_string(),
+                explanation: SpiceStr::from_buffer(&explanation).to_string(),
+                long_message: SpiceStr::from_buffer(&long_message).to_string(),
+                traceback: SpiceStr::from_buffer(&traceback).to_string(),
+            })
+        }
+    })
+}
+
+/// Set the action when an error occurs in a SPICE function.
+///
+/// See [erract_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/erract_c.html).
+pub fn set_error_action(action: ErrorAction) -> Result<(), Error> {
+    let action = SpiceString::from(serde_plain::to_string(&action).unwrap());
+    with_spice_lock_or_panic(|| {
+        unsafe { erract_c(SET.as_mut_ptr(), 0, action.as_mut_ptr()) };
+        get_last_error()
+    })
+}
+
+/// Get the action when an error occurs in a SPICE function.
+///
+/// See [erract_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/erract_c.html).
+pub fn get_error_action() -> Result<ErrorAction, Error> {
+    let mut buffer = [0; 20];
+    with_spice_lock_or_panic(|| {
+        unsafe {
+            erract_c(
+                GET.as_mut_ptr(),
+                buffer.len() as SpiceInt,
+                buffer.as_mut_ptr(),
+            )
+        };
+        get_last_error()
+    })?;
+    let action = SpiceStr::from_buffer(&buffer);
+    Ok(serde_plain::from_str(&action.as_str()).unwrap())
+}
+
+/// Set Error Output Device.
+///
+/// See [errdev_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/errdev_c.html).
+pub fn set_error_output_device(device: ErrorDevice) -> Result<(), Error> {
+    let device = match device {
+        ErrorDevice::Screen => SpiceString::from("SCREEN"),
+        ErrorDevice::Null => SpiceString::from("NULL"),
+        ErrorDevice::Filename(filename) => SpiceString::from(filename),
+    };
+    with_spice_lock_or_panic(|| {
+        unsafe { errdev_c(SET.as_mut_ptr(), 0, device.as_mut_ptr()) };
+        get_last_error()
+    })
+}
+
+/// Get Error Output Device.
+///
+/// See [errdev_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/errdev_c.html).
+pub fn get_error_output_device() -> Result<ErrorDevice, Error> {
+    let mut buffer = [0; FILEN as usize];
+    with_spice_lock_or_panic(|| {
+        unsafe {
+            errdev_c(
+                GET.as_mut_ptr(),
+                buffer.len() as SpiceInt,
+                buffer.as_mut_ptr(),
+            );
+        };
+        get_last_error()
+    })?;
+    let action = SpiceStr::from_buffer(&buffer);
+    Ok(match action.as_str() {
+        s if s == "SCREEN" => ErrorDevice::Screen,
+        s if s == "NULL" => ErrorDevice::Null,
+        s => ErrorDevice::Filename(s.into_owned()),
+    })
+}
+
+pub(crate) fn set_error_defaults() {
+    set_error_action(ErrorAction::Return).unwrap();
+    set_error_output_device(ErrorDevice::Null).unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_set_error_action() {
+        set_error_action(ErrorAction::Default).unwrap();
+        assert_eq!(get_error_action().unwrap(), ErrorAction::Default);
+        set_error_action(ErrorAction::Ignore).unwrap();
+        assert_eq!(get_error_action().unwrap(), ErrorAction::Ignore);
+        set_error_action(ErrorAction::Abort).unwrap();
+        assert_eq!(get_error_action().unwrap(), ErrorAction::Abort);
+
+        // Reset so we don't interfere with other tests
+        set_error_defaults();
+    }
+
+    #[test]
+    fn test_get_set_error_output_device() {
+        set_error_output_device(ErrorDevice::Null).unwrap();
+        assert_eq!(get_error_output_device().unwrap(), ErrorDevice::Null);
+        set_error_output_device(ErrorDevice::Screen).unwrap();
+        assert_eq!(get_error_output_device().unwrap(), ErrorDevice::Screen);
+        let filename = ErrorDevice::Filename(String::from("errors.txt"));
+        set_error_output_device(filename.clone()).unwrap();
+        assert_eq!(get_error_output_device().unwrap(), filename);
+
+        // Reset so we don't interfere with other tests
+        set_error_defaults();
+    }
+}

--- a/crates/cspice/src/gf.rs
+++ b/crates/cspice/src/gf.rs
@@ -1,0 +1,104 @@
+//! Geometry Finder functions.
+
+use crate::cell::Window;
+use crate::common::AberrationCorrection;
+use crate::error::get_last_error;
+use crate::string::StaticSpiceStr;
+use crate::string::{static_spice_str, StringParam};
+use crate::{with_spice_lock_or_panic, Error};
+use cspice_sys::{gfsep_c, SpiceChar, SpiceDouble, SpiceInt};
+
+#[derive(Copy, Clone, Debug)]
+pub enum Shape {
+    Sphere,
+    Point,
+}
+
+impl Shape {
+    pub(crate) unsafe fn as_spice_char(&self) -> *mut SpiceChar {
+        match &self {
+            Shape::Sphere => static_spice_str!("SPHERE"),
+            Shape::Point => static_spice_str!("POINT"),
+        }
+        .as_mut_ptr()
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum RelationalOperator {
+    GT,
+    EQ,
+    LT,
+    AbsMax,
+    AbsMin,
+    LocalMax,
+    LocalMin,
+}
+
+impl RelationalOperator {
+    pub(crate) unsafe fn as_spice_char(&self) -> *mut SpiceChar {
+        match &self {
+            RelationalOperator::GT => static_spice_str!(">"),
+            RelationalOperator::EQ => static_spice_str!("="),
+            RelationalOperator::LT => static_spice_str!("<"),
+            RelationalOperator::AbsMax => static_spice_str!("ABSMAX"),
+            RelationalOperator::AbsMin => static_spice_str!("ABSMIN"),
+            RelationalOperator::LocalMax => static_spice_str!("LOCMAX"),
+            RelationalOperator::LocalMin => static_spice_str!("LOCMIN"),
+        }
+        .as_mut_ptr()
+    }
+}
+
+/// Determine time intervals when the angular separation between the position vectors of two target
+/// bodies relative to an observer satisfies a numerical relationship.
+///
+/// See [gfsep_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/gfsep_c.html)
+#[allow(clippy::too_many_arguments)]
+pub fn separation_search<'b1, 'f1, 'b2, 'f2, 'o, B1, F1, B2, F2, O>(
+    body1: B1,
+    shape1: Shape,
+    frame1: F1,
+    body2: B2,
+    shape2: Shape,
+    frame2: F2,
+    aberration_correction: AberrationCorrection,
+    observing_body: O,
+    relational_operator: RelationalOperator,
+    refval: SpiceDouble,
+    adjust: SpiceDouble,
+    step_size: SpiceDouble,
+    intervals: usize,
+    confine: &mut Window,
+    output: &mut Window,
+) -> Result<(), Error>
+where
+    B1: Into<StringParam<'b1>>,
+    F1: Into<StringParam<'f1>>,
+    B2: Into<StringParam<'b2>>,
+    F2: Into<StringParam<'f2>>,
+    O: Into<StringParam<'o>>,
+{
+    with_spice_lock_or_panic(|| {
+        unsafe {
+            gfsep_c(
+                body1.into().as_mut_ptr(),
+                shape1.as_spice_char(),
+                frame1.into().as_mut_ptr(),
+                body2.into().as_mut_ptr(),
+                shape2.as_spice_char(),
+                frame2.into().as_mut_ptr(),
+                aberration_correction.as_spice_char(),
+                observing_body.into().as_mut_ptr(),
+                relational_operator.as_spice_char(),
+                refval,
+                adjust,
+                step_size,
+                intervals as SpiceInt,
+                confine.as_mut_cell(),
+                output.as_mut_cell(),
+            );
+        };
+        get_last_error()
+    })
+}

--- a/crates/cspice/src/lib.rs
+++ b/crates/cspice/src/lib.rs
@@ -1,0 +1,91 @@
+pub mod cell;
+pub mod common;
+pub mod coordinates;
+pub mod data;
+pub mod error;
+pub mod gf;
+pub mod spk;
+pub mod string;
+pub mod time;
+pub mod vector;
+
+use crate::error::set_error_defaults;
+pub use crate::error::Error;
+use crate::string::SpiceString;
+use parking_lot::{ReentrantMutex, ReentrantMutexGuard};
+use std::cell::RefCell;
+use std::fmt::Debug;
+use std::ops::Deref;
+use thiserror::Error;
+
+// Boolean indicates if library has been initialised
+static SPICE_LOCK: ReentrantMutex<RefCell<bool>> = ReentrantMutex::new(RefCell::new(false));
+
+pub(crate) fn with_spice_lock_or_panic<R, F>(f: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    match try_with_spice_lock(f) {
+        Ok(k) => k,
+        Err(e) => {
+            panic!("{e}")
+        }
+    }
+}
+
+/// The SPICE library [is not thread safe](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/problems.html#Problem:%20SPICE%20code%20is%20not%20thread%20safe.).
+/// This function can be used to synchronise calls to SPICE functions.
+/// All safe functions in this library use this lock internally.
+pub fn try_with_spice_lock<R, F>(f: F) -> Result<R, SpiceLockError>
+where
+    F: FnOnce() -> R,
+{
+    let guard = SPICE_LOCK.try_lock().ok_or(SpiceLockError)?;
+    initialise_library(&guard);
+    Ok(f())
+}
+
+/// The SPICE library [is not thread safe](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/problems.html#Problem:%20SPICE%20code%20is%20not%20thread%20safe.).
+/// This function can be used to synchronise calls to SPICE functions.
+/// All safe functions in this library use this lock internally.
+/// The lock is reentrant.
+pub fn with_spice_lock<R, F>(f: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    let guard = SPICE_LOCK.lock();
+    initialise_library(&guard);
+    f()
+}
+
+fn initialise_library(guard: &ReentrantMutexGuard<'static, RefCell<bool>>) {
+    if !guard.borrow().deref() {
+        *guard.borrow_mut() = true;
+        set_error_defaults();
+    }
+}
+
+#[derive(Debug)]
+pub struct SpiceLock(ReentrantMutexGuard<'static, RefCell<bool>>);
+
+/// Error returned from [try_with_spice_lock()].
+#[derive(Debug, Clone, Error)]
+#[cfg_attr(not(test), error("SPICE is already in use by another thread. If multi-threaded use is intentional wrap the call using `with_spice_lock()`."))]
+#[cfg_attr(test, error("SPICE is already in use by another thread. When running unit tests you will likely need to use the `--test-threads=1` argument."))]
+pub struct SpiceLockError;
+
+#[cfg(test)]
+mod tests {
+    use crate::data::furnish;
+    use std::path::PathBuf;
+    use std::sync::Once;
+
+    /// Load test data (once)
+    pub fn load_test_data() {
+        static SPICE_INIT: Once = Once::new();
+        SPICE_INIT.call_once(|| {
+            let data_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test_data");
+            furnish(data_dir.join("testkernel.txt").to_string_lossy()).unwrap();
+        });
+    }
+}

--- a/crates/cspice/src/spk.rs
+++ b/crates/cspice/src/spk.rs
@@ -1,0 +1,274 @@
+//! Functions relating to the Spacecraft and Planet Ephemeris (SPK) subsystem of SPICE.
+use crate::common::AberrationCorrection;
+use crate::coordinates::Rectangular;
+use crate::error::get_last_error;
+use crate::string::StringParam;
+use crate::time::Et;
+use crate::vector::Vector3D;
+use crate::{with_spice_lock_or_panic, Error};
+use cspice_sys::{spkez_c, spkezp_c, spkezr_c, spkpos_c, SpiceDouble};
+use derive_more::Into;
+
+/// A Cartesian state vector representing the position and velocity of the target body
+/// relative to the specified observer
+#[derive(Copy, Clone, Debug, Default, PartialEq, Into)]
+pub struct State {
+    pub position: Rectangular,
+    pub velocity: Vector3D,
+}
+
+impl From<[SpiceDouble; 6]> for State {
+    fn from(state: [SpiceDouble; 6]) -> Self {
+        Self {
+            position: Rectangular::from([state[0], state[1], state[2]]),
+            velocity: Vector3D([state[3], state[4], state[5]]),
+        }
+    }
+}
+
+/// Return the position of a target body relative to an observing body, optionally corrected for
+/// light time (planetary aberration) and stellar aberration.
+///
+/// See [spkpos_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/spkpos_c.html).
+pub fn position<'t, 'r, 'o, T, R, O>(
+    target: T,
+    et: Et,
+    reference_frame: R,
+    aberration_correction: AberrationCorrection,
+    observing_body: O,
+) -> Result<(Rectangular, SpiceDouble), Error>
+where
+    T: Into<StringParam<'t>>,
+    R: Into<StringParam<'r>>,
+    O: Into<StringParam<'o>>,
+{
+    with_spice_lock_or_panic(|| {
+        let mut position = [0.0f64; 3];
+        let mut light_time = 0.0;
+        unsafe {
+            spkpos_c(
+                target.into().as_mut_ptr(),
+                et.0,
+                reference_frame.into().as_mut_ptr(),
+                aberration_correction.as_spice_char(),
+                observing_body.into().as_mut_ptr(),
+                position.as_mut_ptr(),
+                &mut light_time,
+            )
+        };
+        get_last_error()?;
+        Ok((position.into(), light_time))
+    })
+}
+
+/// Return the state (position and velocity) of a target body
+/// relative to an observing body, optionally corrected for light
+/// time (planetary aberration) and stellar aberration.
+///
+/// See [spkez_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/spkez_c.html).
+pub fn easy_reader<'r, R>(
+    target: i32,
+    et: Et,
+    reference_frame: R,
+    aberration_correction: AberrationCorrection,
+    observing_body: i32,
+) -> Result<(State, SpiceDouble), Error>
+where
+    R: Into<StringParam<'r>>,
+{
+    with_spice_lock_or_panic(|| {
+        let mut pos_vel: [SpiceDouble; 6] = [0.0; 6];
+        let mut light_time = 0.0;
+        unsafe {
+            spkez_c(
+                target,
+                et.0,
+                reference_frame.into().as_mut_ptr(),
+                aberration_correction.as_spice_char(),
+                observing_body,
+                pos_vel.as_mut_ptr(),
+                &mut light_time,
+            )
+        };
+        get_last_error()?;
+        Ok((State::from(pos_vel), light_time))
+    })
+}
+
+/// Return the position of a target body relative to an observing
+/// body, optionally corrected for light time (planetary aberration)
+/// and stellar aberration.
+///
+/// See [spkezp_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/spkezp_c.html).
+pub fn easy_position<'r, R>(
+    target: i32,
+    et: Et,
+    reference_frame: R,
+    aberration_correction: AberrationCorrection,
+    observing_body: i32,
+) -> Result<(Rectangular, SpiceDouble), Error>
+where
+    R: Into<StringParam<'r>>,
+{
+    with_spice_lock_or_panic(|| {
+        let mut position = [0.0f64; 3];
+        let mut light_time = 0.0;
+        unsafe {
+            spkezp_c(
+                target,
+                et.0,
+                reference_frame.into().as_mut_ptr(),
+                aberration_correction.as_spice_char(),
+                observing_body,
+                position.as_mut_ptr(),
+                &mut light_time,
+            )
+        };
+        get_last_error()?;
+        Ok((position.into(), light_time))
+    })
+}
+
+/// Return the state (position and velocity) of a target body
+/// relative to an observing body, optionally corrected for light
+/// time (planetary aberration) and stellar aberration.
+///
+/// See [spkezr_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/spkezr_c.html)
+pub fn easier_reader<'t, 'r, 'o, T, R, O>(
+    target: T,
+    et: Et,
+    reference_frame: R,
+    aberration_correction: AberrationCorrection,
+    observing_body: O,
+) -> Result<(State, SpiceDouble), Error>
+where
+    T: Into<StringParam<'t>>,
+    R: Into<StringParam<'r>>,
+    O: Into<StringParam<'o>>,
+{
+    with_spice_lock_or_panic(|| {
+        let mut pos_vel = [0.0f64; 6];
+        let mut light_time = 0.0;
+        unsafe {
+            spkezr_c(
+                target.into().as_mut_ptr(),
+                et.0,
+                reference_frame.into().as_mut_ptr(),
+                aberration_correction.as_spice_char(),
+                observing_body.into().as_mut_ptr(),
+                pos_vel.as_mut_ptr(),
+                &mut light_time,
+            )
+        };
+        get_last_error()?;
+        Ok((State::from(pos_vel), light_time))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests::load_test_data;
+    const EPSILON: f64 = 1e-10;
+    const ETS: [Et; 3] = [Et(0.0), Et(3600.0), Et(120000.0)];
+    const LTS: [SpiceDouble; 3] = [
+        1.3423106094958182f64,
+        1.342693954033622f64,
+        1.3519329044685606f64,
+    ];
+
+    // Test data generated via spiceypy using the above ephemeris times
+    fn gen_test_data() -> [State; 3] {
+        [
+            [
+                -291569.26474221050739f64,
+                -266709.18712562322617f64,
+                -76099.15410456061363f64,
+                0.64353061379157f64,
+                -0.66608181544709f64,
+                -0.30132283179347f64,
+            ]
+            .into(),
+            [
+                -289240.78060919046402f64,
+                -269096.44152130186558f64,
+                -77180.89871158450842f64,
+                0.65006211575479f64,
+                -0.66016273764220f64,
+                -0.29964267392589f64,
+            ]
+            .into(),
+            [
+                -202558.33919326588511f64,
+                -333880.37279736995697f64,
+                -108450.58380541205406f64,
+                0.82840534359059f64,
+                -0.44612163419131f64,
+                -0.23419745913028f64,
+            ]
+            .into(),
+        ]
+    }
+
+    #[test]
+    fn moon_earth_spkpos_test() {
+        load_test_data();
+        let test_data = gen_test_data();
+        for i in 0..3 {
+            let (pos, lt) =
+                position("moon", ETS[i], "J2000", AberrationCorrection::LT, "earth").unwrap();
+            assert!((pos.x - test_data[i].position.x).abs() < EPSILON);
+            assert!((pos.y - test_data[i].position.y).abs() < EPSILON);
+            assert!((pos.z - test_data[i].position.z).abs() < EPSILON);
+            assert!((lt - LTS[i]).abs() < EPSILON);
+        }
+    }
+
+    #[test]
+    fn moon_earth_spkez_test() {
+        load_test_data();
+        let test_data = gen_test_data();
+        for i in 0..3 {
+            let (state, lt) =
+                easy_reader(301, ETS[i], "J2000", AberrationCorrection::LT, 399).unwrap();
+            assert!((state.position.x - test_data[i].position.x).abs() < EPSILON);
+            assert!((state.position.y - test_data[i].position.y).abs() < EPSILON);
+            assert!((state.position.z - test_data[i].position.z).abs() < EPSILON);
+            for j in 0..3 {
+                assert!((state.velocity[j] - test_data[i].velocity[j]).abs() < EPSILON);
+            }
+            assert!((lt - LTS[i]).abs() < EPSILON);
+        }
+    }
+
+    #[test]
+    fn moon_earth_spkezp_test() {
+        load_test_data();
+        let test_data = gen_test_data();
+        for i in 0..3 {
+            let (pos, lt) =
+                easy_position(301, ETS[i], "J2000", AberrationCorrection::LT, 399).unwrap();
+            assert!((pos.x - test_data[i].position.x).abs() < EPSILON);
+            assert!((pos.y - test_data[i].position.y).abs() < EPSILON);
+            assert!((pos.z - test_data[i].position.z).abs() < EPSILON);
+            assert!((lt - LTS[i]).abs() < EPSILON);
+        }
+    }
+
+    #[test]
+    fn moon_earth_spkezr_test() {
+        load_test_data();
+        let test_data = gen_test_data();
+        for i in 0..3 {
+            let (state, lt) =
+                easier_reader("moon", ETS[i], "J2000", AberrationCorrection::LT, "earth").unwrap();
+            assert!((state.position.x - test_data[i].position.x).abs() < EPSILON);
+            assert!((state.position.y - test_data[i].position.y).abs() < EPSILON);
+            assert!((state.position.z - test_data[i].position.z).abs() < EPSILON);
+            for j in 0..3 {
+                assert!((state.velocity[j] - test_data[i].velocity[j]).abs() < EPSILON);
+            }
+            assert!((lt - LTS[i]).abs() < EPSILON);
+        }
+    }
+}

--- a/crates/cspice/src/string.rs
+++ b/crates/cspice/src/string.rs
@@ -1,0 +1,204 @@
+//! Functions for converting between Rust strings and SPICE (C) strings.
+use cspice_sys::SpiceChar;
+use std::borrow::Cow;
+use std::ffi::{CStr, CString};
+use std::fmt::{Debug, Display, Formatter};
+use std::ops::Deref;
+
+/// An owned nul terminated C string that can be used as input to SPICE functions.
+///
+/// A SpiceString can be created from a Rust &str type using [SpiceString::from].
+///
+/// An existing dynamically sized buffer can be converted in-place into a SpiceString using
+/// [SpiceString::from_buffer].
+#[derive(Clone, Eq, PartialEq, Hash)]
+pub struct SpiceString(pub CString);
+
+impl Debug for SpiceString {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SpiceString({})", self.as_str())
+    }
+}
+
+impl Display for SpiceString {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.as_str())
+    }
+}
+
+/// A SpiceString can be created from a Rust string.
+impl<T: AsRef<str>> From<T> for SpiceString {
+    #[inline]
+    fn from(s: T) -> Self {
+        Self(CString::new(s.as_ref()).unwrap())
+    }
+}
+
+impl SpiceString {
+    /// Get the pointer to the SpiceString's data. Intended for use passing string input to SPICE.
+    ///
+    /// # Safety
+    ///
+    /// This is a mut pointer for compatibility with the SPICE APIs, however it must not actually
+    /// be mutated.
+    #[inline]
+    pub unsafe fn as_mut_ptr(&self) -> *mut SpiceChar {
+        self.0.as_ptr() as *mut SpiceChar
+    }
+
+    /// Convert a buffer of SpiceChar into a SpiceString.
+    ///
+    /// This will panic if the buffer is not nul terminated.
+    #[inline]
+    pub fn from_buffer(mut s: Vec<SpiceChar>) -> Self {
+        // Truncate from nul terminator
+        let nul_pos = s
+            .iter()
+            .position(|&x| x == 0)
+            .expect("missing nul terminator");
+        s.resize(nul_pos, 0);
+
+        // Convert from Vec<i8> to Vec<u8>
+        // https://doc.rust-lang.org/src/alloc/vec/mod.rs.html#725
+        // https://stackoverflow.com/a/59707887/7547647
+        let mut s = std::mem::ManuallyDrop::new(s);
+        let (ptr, len, cap) = (s.as_mut_ptr(), s.len(), s.capacity());
+
+        unsafe {
+            let s = Vec::from_raw_parts(ptr as *mut u8, len, cap);
+            Self(CString::from_vec_unchecked(s))
+        }
+    }
+
+    #[inline]
+    pub fn as_str(&self) -> Cow<'_, str> {
+        self.0.to_string_lossy()
+    }
+}
+
+/// A reference to a nul-terminated C string.
+///
+/// A SpiceStr can be created from a reference to a byte buffer using [SpiceStr::from_buffer].
+#[derive(Clone, Eq, PartialEq, Hash)]
+pub struct SpiceStr<'a>(pub &'a CStr);
+
+impl SpiceStr<'_> {
+    /// Get a SpiceStr (CStr) from a buffer. Intended for reading a buffer containing a string
+    /// output from SPICE.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the buffer is not nul terminated.
+    #[inline]
+    pub fn from_buffer(buffer: &[SpiceChar]) -> Self {
+        // https://doc.rust-lang.org/src/std/ffi/c_str.rs.html#1295-1306
+        let nul_pos = buffer
+            .iter()
+            .position(|&x| x == 0)
+            .expect("missing nul terminator");
+        let subslice = &buffer[..nul_pos + 1];
+        unsafe {
+            // 上游原写法 `subslice as *const [i8] as *const [u8]` 在 aarch64 上
+            // 编译失败（E0606）：aarch64 的 C char 是 unsigned，SpiceChar = u8，
+            // &[u8] 直接 cast 成 *const [i8] 非法。from_raw_parts 写法架构无关。
+            let u8slice =
+                std::slice::from_raw_parts(subslice.as_ptr() as *const u8, subslice.len());
+            Self(CStr::from_bytes_with_nul_unchecked(u8slice))
+        }
+    }
+
+    #[inline]
+    pub fn as_str(&self) -> Cow<'_, str> {
+        self.0.to_string_lossy()
+    }
+}
+
+impl Debug for SpiceStr<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SpiceStr({})", self.as_str())
+    }
+}
+
+impl Display for SpiceStr<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.as_str())
+    }
+}
+
+/// Internal static C strings used when calling SPICE APIs.
+///
+/// Should be created using the [static_spice_str!] macro to ensure nul termination.
+#[derive(Copy, Clone)]
+pub(crate) struct StaticSpiceStr(pub &'static str);
+
+impl StaticSpiceStr {
+    pub(crate) unsafe fn as_mut_ptr(&self) -> *mut SpiceChar {
+        self.0.as_ptr() as *mut SpiceChar
+    }
+}
+
+macro_rules! static_spice_str {
+    ($input:literal) => {
+        StaticSpiceStr(concat!($input, "\0"))
+    };
+}
+pub(crate) use static_spice_str;
+
+/// Allows you to pass a Rust string that will automatically be converted into a nul terminated C
+/// string. Alternatively you can pass an existing &SpiceString as an argument so that the string
+/// does not need to be converted on each call.
+pub enum StringParam<'a> {
+    Ref(&'a SpiceString),
+    Owned(SpiceString),
+}
+
+impl<S: AsRef<str>> From<S> for StringParam<'_> {
+    fn from(s: S) -> Self {
+        StringParam::Owned(SpiceString::from(s))
+    }
+}
+
+impl<'a> From<&'a SpiceString> for StringParam<'a> {
+    fn from(s: &'a SpiceString) -> Self {
+        StringParam::Ref(s)
+    }
+}
+
+impl From<SpiceString> for StringParam<'_> {
+    fn from(s: SpiceString) -> Self {
+        StringParam::Owned(s)
+    }
+}
+
+impl Deref for StringParam<'_> {
+    type Target = SpiceString;
+
+    fn deref(&self) -> &Self::Target {
+        match &self {
+            StringParam::Ref(r) => r,
+            StringParam::Owned(o) => o,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_buffer() {
+        let buffer = vec!['a' as SpiceChar, 'b' as SpiceChar, 0, 0, 0];
+        let spice_str = SpiceString::from_buffer(buffer);
+        assert_eq!(spice_str.as_str(), "ab");
+    }
+
+    #[test]
+    fn test_from_bad_buffer() {
+        std::panic::catch_unwind(|| {
+            let buffer = vec!['a' as SpiceChar, 'b' as SpiceChar];
+            SpiceString::from_buffer(buffer);
+        })
+        .err()
+        .expect("Expected to panic");
+    }
+}

--- a/crates/cspice/src/time/calendar.rs
+++ b/crates/cspice/src/time/calendar.rs
@@ -1,0 +1,51 @@
+//! The calendars supported by SPICE.
+
+/// See [Calendars in timout_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/timout_c.html).
+pub trait Calendar {
+    fn short_name() -> &'static str;
+    fn name() -> &'static str;
+}
+
+/// Uses the Julian calendar for dates prior to Oct 5, 1582, and the Gregorian calendar for dates
+/// after Oct 15, 1582.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct Mixed;
+
+/// The Gregorian calendar. Dates before the Gregorian calendar's inception in 1582 are defined via
+/// extrapolation.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct Gregorian;
+
+/// The Julian calendar.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct Julian;
+
+impl Calendar for Mixed {
+    fn short_name() -> &'static str {
+        "MCAL"
+    }
+
+    fn name() -> &'static str {
+        "MIXED"
+    }
+}
+
+impl Calendar for Gregorian {
+    fn short_name() -> &'static str {
+        "GCAL"
+    }
+
+    fn name() -> &'static str {
+        "GREGORIAN"
+    }
+}
+
+impl Calendar for Julian {
+    fn short_name() -> &'static str {
+        "JCAL"
+    }
+
+    fn name() -> &'static str {
+        "JULIAN"
+    }
+}

--- a/crates/cspice/src/time/date_time.rs
+++ b/crates/cspice/src/time/date_time.rs
@@ -1,0 +1,202 @@
+use crate::common::{CALENDAR, GET, SET};
+use crate::error::get_last_error;
+use crate::string::SpiceStr;
+use crate::time::calendar::Calendar;
+use crate::time::julian_date::JulianDate;
+use crate::time::system::System;
+use crate::time::{set_default_calendar, Et};
+use crate::{with_spice_lock_or_panic, SpiceString};
+use cspice_sys::{timdef_c, timout_c, SpiceInt};
+use std::fmt::{Display, Formatter};
+use std::marker::PhantomData;
+
+/// An instant in time, typically expressed as a date and time of day.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct DateTime<T: Calendar, S: System> {
+    pub year: i16,
+    pub month: u8,
+    pub day: u8,
+    pub hour: u8,
+    pub minute: u8,
+    pub second: f32,
+    pub system: S,
+    calendar: PhantomData<T>,
+}
+
+impl<C: Calendar, S: System> DateTime<C, S> {
+    #[inline]
+    pub fn new(
+        year: i16,
+        month: u8,
+        day: u8,
+        hour: u8,
+        minute: u8,
+        second: f32,
+        system: S,
+    ) -> Self {
+        Self {
+            year,
+            month,
+            day,
+            hour,
+            minute,
+            second,
+            system,
+            calendar: Default::default(),
+        }
+    }
+
+    /// Convert an Ephemeris Time (TDB) to a DateTime.
+    #[inline]
+    pub fn from_et(et: Et, system: S) -> Self {
+        let pictur = SpiceString::from(format!(
+            "ERA:YYYY:MM:DD:HR:MN:SC.##### ::{} ::{}",
+            system.meta_marker(),
+            C::short_name()
+        ));
+        let mut buffer = [0; 100];
+        with_spice_lock_or_panic(|| {
+            unsafe {
+                timout_c(
+                    et.0,
+                    pictur.as_mut_ptr(),
+                    buffer.len() as SpiceInt,
+                    buffer.as_mut_ptr(),
+                );
+            };
+            get_last_error().unwrap();
+        });
+        let output = SpiceStr::from_buffer(&buffer);
+        let cow = output.as_str();
+        let split: Vec<&str> = cow.split(':').collect();
+        let year: i16 = if split[0] == "B.C." {
+            1 - split[1].trim().parse::<i16>().unwrap()
+        } else {
+            split[1].trim().parse().unwrap()
+        };
+        DateTime::new(
+            year,
+            split[2].parse().unwrap(),
+            split[3].parse().unwrap(),
+            split[4].parse().unwrap(),
+            split[5].parse().unwrap(),
+            split[6].parse().unwrap(),
+            system,
+        )
+    }
+}
+
+impl<C: Calendar, S: System> From<Et> for DateTime<C, S> {
+    #[inline]
+    fn from(et: Et) -> Self {
+        DateTime::from_et(et, S::default())
+    }
+}
+
+impl<C: Calendar, S: System> From<DateTime<C, S>> for Et {
+    /// Convert a DateTime to Ephemeris Time (TDB)
+    #[inline]
+    fn from(dt: DateTime<C, S>) -> Self {
+        with_spice_lock_or_panic(|| {
+            // Get default calendar setting
+            let mut original_cal = [0; 12];
+            unsafe {
+                timdef_c(
+                    GET.as_mut_ptr(),
+                    CALENDAR.as_mut_ptr(),
+                    original_cal.len() as SpiceInt,
+                    original_cal.as_mut_ptr(),
+                );
+            };
+            get_last_error().unwrap();
+            let year = if dt.year > 0 {
+                dt.year.to_string()
+            } else {
+                format!("{} BC", dt.year.abs() + 1)
+            };
+            let date = format!(
+                "{year}-{}-{} {}:{}:{} {}",
+                dt.month,
+                dt.day,
+                dt.hour,
+                dt.minute,
+                dt.second,
+                dt.system.meta_marker(),
+            );
+            set_default_calendar::<C>();
+            let et = Et::from_string(date).unwrap();
+            // Restore default calendar
+            unsafe {
+                timdef_c(
+                    SET.as_mut_ptr(),
+                    CALENDAR.as_mut_ptr(),
+                    0,
+                    original_cal.as_mut_ptr(),
+                );
+            };
+            get_last_error().unwrap();
+            et
+        })
+    }
+}
+
+impl<C: Calendar, S: System> From<JulianDate<S>> for DateTime<C, S> {
+    #[inline]
+    fn from(jd: JulianDate<S>) -> Self {
+        DateTime::from(Et::from(jd))
+    }
+}
+
+impl<C: Calendar, S: System> Display for DateTime<C, S> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}-{}-{} {}:{}:{} {} {}",
+            self.year,
+            self.month,
+            self.day,
+            self.hour,
+            self.minute,
+            self.second,
+            self.system.meta_marker(),
+            C::short_name()
+        )
+    }
+}
+
+#[cfg(feature = "chrono")]
+impl From<chrono::DateTime<chrono::FixedOffset>>
+    for DateTime<super::calendar::Gregorian, super::system::Utc>
+{
+    fn from(c: chrono::DateTime<chrono::FixedOffset>) -> Self {
+        use chrono::{Datelike, Timelike};
+        let seconds = c.second() as f32 + c.nanosecond() as f32 / 1_000_000.0;
+        DateTime::new(
+            c.year() as i16,
+            c.month() as u8,
+            c.day() as u8,
+            c.hour() as u8,
+            c.minute() as u8,
+            seconds,
+            super::system::Utc::from_zone_seconds(c.timezone().local_minus_utc()),
+        )
+    }
+}
+
+#[cfg(feature = "chrono")]
+impl From<DateTime<super::calendar::Gregorian, super::system::Utc>>
+    for chrono::DateTime<chrono::FixedOffset>
+{
+    fn from(t: DateTime<super::calendar::Gregorian, super::system::Utc>) -> Self {
+        use chrono::TimeZone;
+        let ns = t.second.fract() * 1_000_000_f32;
+        chrono::FixedOffset::east(t.system.to_zone_seconds())
+            .ymd(t.year as i32, t.month as u32, t.day as u32)
+            .and_hms_nano(
+                t.hour as u32,
+                t.minute as u32,
+                t.second.floor() as u32,
+                ns as u32,
+            )
+    }
+}

--- a/crates/cspice/src/time/julian_date.rs
+++ b/crates/cspice/src/time/julian_date.rs
@@ -1,0 +1,75 @@
+use crate::error::get_last_error;
+use crate::string::{SpiceStr, SpiceString};
+use crate::time::calendar::Calendar;
+use crate::time::date_time::DateTime;
+use crate::time::system::System;
+use crate::time::Et;
+use crate::with_spice_lock_or_panic;
+use cspice_sys::{timout_c, SpiceDouble};
+use std::fmt::{Display, Formatter};
+use std::marker::PhantomData;
+
+/// See [Julian Date](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/time.html#Julian%20Date).
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct JulianDate<S: System> {
+    pub value: SpiceDouble,
+    scale: PhantomData<S>,
+}
+
+impl<S: System> From<SpiceDouble> for JulianDate<S> {
+    fn from(s: SpiceDouble) -> Self {
+        JulianDate::new(s)
+    }
+}
+
+impl<S: System> JulianDate<S> {
+    #[inline]
+    pub fn new(jd: SpiceDouble) -> Self {
+        Self {
+            value: jd,
+            scale: Default::default(),
+        }
+    }
+}
+
+impl<S: System> From<JulianDate<S>> for Et {
+    /// Convert a Julian Date to Ephemeris Time (TDB).
+    #[inline]
+    fn from(jd: JulianDate<S>) -> Self {
+        Et::from_string(format!("JD {} {}", S::system_name(), jd.value)).unwrap()
+    }
+}
+
+impl<S: System> From<Et> for JulianDate<S> {
+    /// Convert Ephemeris Time (TDB) to a Julian Date.
+    #[inline]
+    fn from(et: Et) -> Self {
+        let pictur = SpiceString::from(format!("JULIAND.############# ::{}", S::system_name()));
+        let mut buffer = [0; 40];
+        with_spice_lock_or_panic(|| {
+            unsafe {
+                timout_c(
+                    et.0,
+                    pictur.as_mut_ptr(),
+                    buffer.len() as i32,
+                    buffer.as_mut_ptr(),
+                )
+            };
+            get_last_error().unwrap();
+        });
+        Self::new(SpiceStr::from_buffer(&buffer).as_str().parse().unwrap())
+    }
+}
+
+impl<C: Calendar, S: System> From<DateTime<C, S>> for JulianDate<S> {
+    #[inline]
+    fn from(dt: DateTime<C, S>) -> Self {
+        JulianDate::from(Et::from(dt))
+    }
+}
+
+impl<S: System> Display for JulianDate<S> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "JD {} {}", S::system_name(), self.value)
+    }
+}

--- a/crates/cspice/src/time/mod.rs
+++ b/crates/cspice/src/time/mod.rs
@@ -1,0 +1,160 @@
+//! Structures and functions for the various SPICE time subsystems.
+mod date_time;
+mod julian_date;
+
+pub mod calendar;
+pub mod system;
+
+pub use date_time::DateTime;
+pub use julian_date::JulianDate;
+
+use crate::common::{CALENDAR, SET};
+use crate::error::get_last_error;
+use crate::string::{SpiceString, StringParam};
+use crate::{with_spice_lock_or_panic, Error};
+use calendar::Calendar;
+use cspice_sys::{str2et_c, timdef_c, timout_c, SpiceDouble, SpiceInt};
+use derive_more::{From, Into};
+use std::fmt::{Debug, Display, Formatter};
+
+/// Ephemeris Time (time in seconds past the ephemeris epoch J2000) (TDB).
+///
+/// See [ET Means TDB](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/FORTRAN/req/time.html#In%20the%20Toolkit%20ET%20Means%20TDB).
+#[derive(Copy, Clone, Debug, PartialEq, From, Into)]
+pub struct Et(pub SpiceDouble);
+
+impl Display for Et {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ET {}", self.0)
+    }
+}
+
+impl Et {
+    /// Convert Ephemeris Time to a different time format.
+    ///
+    /// `out_length` must be large enough to store the output string or otherwise this function
+    /// will return Err.
+    ///
+    /// See [timout_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/timout_c.html).
+    #[inline]
+    pub fn time_out<'p, P: Into<StringParam<'p>>>(
+        &self,
+        pictur: P,
+        out_length: usize,
+    ) -> Result<String, Error> {
+        let mut buffer = vec![0; out_length];
+        with_spice_lock_or_panic(|| {
+            unsafe {
+                timout_c(
+                    self.0,
+                    pictur.into().as_mut_ptr(),
+                    buffer.len() as SpiceInt,
+                    buffer.as_mut_ptr(),
+                );
+            };
+            get_last_error()
+        })?;
+        Ok(SpiceString::from_buffer(buffer).to_string())
+    }
+
+    /// Convert a time string to Ephemeris Time (TDB)
+    ///
+    /// See [str2et_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/str2et_c.html)
+    #[inline]
+    pub fn from_string<'p, P: Into<StringParam<'p>>>(string: P) -> Result<Self, Error> {
+        with_spice_lock_or_panic(|| {
+            let mut output = 0f64;
+            unsafe {
+                str2et_c(string.into().as_mut_ptr(), &mut output);
+            };
+            get_last_error()?;
+            Ok(Self(output))
+        })
+    }
+}
+
+/// Sets the default calendar to use with input strings.
+///
+/// See [timdef_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/timdef_c.html).
+#[inline]
+pub fn set_default_calendar<C: Calendar>() {
+    let name = SpiceString::from(C::name());
+    with_spice_lock_or_panic(|| {
+        unsafe {
+            timdef_c(
+                SET.as_mut_ptr(),
+                CALENDAR.as_mut_ptr(),
+                0,
+                name.as_mut_ptr(),
+            );
+        };
+        get_last_error().unwrap();
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests::load_test_data;
+    use crate::time::calendar::{Gregorian, Mixed};
+    use crate::time::system::{Tdb, Utc};
+
+    #[test]
+    fn test_et_to_jd() {
+        load_test_data();
+        assert_eq!(
+            JulianDate::from(Et(0f64)),
+            JulianDate::<Tdb>::new(2451545.0)
+        );
+    }
+
+    #[test]
+    fn test_jd_to_date_time() {
+        load_test_data();
+        let et = Et::from(JulianDate::<Tdb>::new(1502273.5));
+        let dt = DateTime::<Mixed, _>::from_et(et, Tdb);
+        assert_eq!(dt, DateTime::new(-599, 1, 1, 0, 0, 0.0, Tdb));
+    }
+
+    #[test]
+    fn test_date_time_to_jd() {
+        load_test_data();
+        let jd = JulianDate::<Utc>::new(1502273.5);
+        assert_eq!(
+            JulianDate::from(DateTime::<Mixed, _>::new(
+                -599,
+                1,
+                1,
+                0,
+                0,
+                0.0,
+                Utc::default()
+            ),),
+            jd
+        );
+        assert_eq!(
+            JulianDate::from(DateTime::<Mixed, _>::new(
+                -599,
+                1,
+                1,
+                3,
+                0,
+                0.0,
+                Utc::new(3, 0)
+            ),),
+            jd
+        );
+        assert_eq!(
+            JulianDate::from(DateTime::<Gregorian, _>::new(
+                -600,
+                12,
+                26,
+                0,
+                0,
+                0.0,
+                Utc::default()
+            ),),
+            jd
+        );
+    }
+}

--- a/crates/cspice/src/time/system.rs
+++ b/crates/cspice/src/time/system.rs
@@ -1,0 +1,118 @@
+//! The time systems supported by SPICE.
+use std::borrow::Cow;
+
+/// See [SPICE Time Subsystem](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/time.html).
+pub trait System: Default {
+    fn system_name() -> &'static str;
+    fn meta_marker(&self) -> Cow<'static, str>;
+}
+
+/// Terrestrial Dynamical Time (TDT).
+///
+/// Note: TDT and TT represent the same time system
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
+pub struct Tdt;
+
+/// Barycentric Dynamical Time (TDB).
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
+pub struct Tdb;
+
+/// Coordinated Universal Time (UTC).
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
+pub struct Utc {
+    pub zone_hours: i8,
+    pub zone_minutes: u8,
+}
+
+impl System for Tdt {
+    fn system_name() -> &'static str {
+        "TDT"
+    }
+
+    fn meta_marker(&self) -> Cow<'static, str> {
+        "TDT".into()
+    }
+}
+
+impl System for Tdb {
+    fn system_name() -> &'static str {
+        "TDB"
+    }
+
+    fn meta_marker(&self) -> Cow<'static, str> {
+        "TDB".into()
+    }
+}
+
+impl System for Utc {
+    fn system_name() -> &'static str {
+        "UTC"
+    }
+
+    fn meta_marker(&self) -> Cow<'static, str> {
+        format!("UTC{:+}:{}", self.zone_hours, self.zone_minutes).into()
+    }
+}
+
+impl Utc {
+    #[inline]
+    pub fn new(zone_hours: i8, zone_minutes: u8) -> Self {
+        Self {
+            zone_hours,
+            zone_minutes,
+        }
+    }
+
+    #[inline]
+    pub fn to_zone_seconds(&self) -> i32 {
+        let hour_component = self.zone_hours.abs() as i32 * 60 * 60;
+        let minute_component = self.zone_minutes as i32 * 60;
+        let sum = hour_component + minute_component;
+        if self.zone_hours.is_negative() {
+            return -sum;
+        }
+        sum
+    }
+
+    /// This will round to the nearest minute.
+    #[inline]
+    pub fn from_zone_seconds(seconds: i32) -> Self {
+        let abs = seconds.abs();
+        let hours = abs / 3600;
+        let minutes = ((abs % 3600) as f32 / 60.0).round();
+        let hours = if seconds.is_negative() { -hours } else { hours };
+        Self {
+            zone_hours: hours as i8,
+            zone_minutes: minutes as u8,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::time::system::Utc;
+
+    #[test]
+    fn test_utc_from_seconds() {
+        let utc = Utc::from_zone_seconds(9000);
+        assert_eq!(utc, Utc::new(2, 30));
+
+        let utc = Utc::from_zone_seconds(-9000);
+        assert_eq!(utc, Utc::new(-2, 30));
+
+        let utc = Utc::from_zone_seconds(-9001);
+        assert_eq!(utc, Utc::new(-2, 30));
+
+        let utc = Utc::from_zone_seconds(-9050);
+        assert_eq!(utc, Utc::new(-2, 31));
+    }
+
+    #[test]
+    fn test_utc_to_seconds() {
+        let utc = Utc::new(2, 30);
+        assert_eq!(utc.to_zone_seconds(), 9000);
+
+        let utc = Utc::new(-2, 30);
+        assert_eq!(utc.to_zone_seconds(), -9000);
+    }
+}

--- a/crates/cspice/src/vector.rs
+++ b/crates/cspice/src/vector.rs
@@ -1,0 +1,32 @@
+//! Functions for working with 3D Vectors.
+//!
+//! See [Performing simple operations on 3D vectors](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/info/mostused.html#U)
+use crate::coordinates::Rectangular;
+use crate::with_spice_lock_or_panic;
+use cspice_sys::{vsep_c, SpiceDouble};
+use derive_more::{Deref, DerefMut, From, Into};
+
+/// A 3D vector
+#[derive(Copy, Clone, Debug, Default, PartialEq, From, Into, Deref, DerefMut)]
+pub struct Vector3D(pub [SpiceDouble; 3]);
+
+impl Vector3D {
+    /// Find the separation angle in radians between two double precision, 3-dimensional vectors.
+    /// This angle is defined as zero if either vector is zero.
+    ///
+    /// See [vsep_c](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/vsep_c.html)
+    pub fn separation_angle(&self, other: &Vector3D) -> SpiceDouble {
+        with_spice_lock_or_panic(|| unsafe {
+            vsep_c(
+                self.as_ptr() as *mut SpiceDouble,
+                other.as_ptr() as *mut SpiceDouble,
+            )
+        })
+    }
+}
+
+impl From<Rectangular> for Vector3D {
+    fn from(rect: Rectangular) -> Self {
+        Self([rect.x, rect.y, rect.z])
+    }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,16 +122,24 @@ docs = [
 
 [tool.uv.sources]
 # calcephpy（r2s2 的传递依赖）PyPI 仅有 sdist，Windows 需 cmake+MSVC、Linux 需
-# cmake+gcc 现场编译。在 Windows/Linux 上按 Python 版本指向本仓库 calcephpy-v1
-# release 的预编译 wheel；其他平台不匹配 marker，回落到 PyPI sdist 现场编译。
+# cmake+gcc 现场编译。在 Windows/Linux（x86_64 与 aarch64）上按 Python 版本指向本
+# 仓库 calcephpy-v1 release 的预编译 wheel；其他平台不匹配 marker，回落到 PyPI
+# sdist 现场编译。aarch64 wheel 由 calcephpy-wheel.yml 在 arm64 runner 上构建
+# （auditwheel 对 aarch64 只打 manylinux_2_28 标签，无 manylinux2014 前缀）。
 # 重新生成 uv.lock 需 uv lock --upgrade-package calcephpy。
 calcephpy = [
   { url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp310-cp310-win_amd64.whl", marker = "sys_platform == 'win32' and python_version == '3.10'" },
   { url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp311-cp311-win_amd64.whl", marker = "sys_platform == 'win32' and python_version == '3.11'" },
   { url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp312-cp312-win_amd64.whl", marker = "sys_platform == 'win32' and python_version == '3.12'" },
   { url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp313-cp313-win_amd64.whl", marker = "sys_platform == 'win32' and python_version == '3.13'" },
-  { url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", marker = "sys_platform == 'linux' and python_version == '3.10'" },
-  { url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", marker = "sys_platform == 'linux' and python_version == '3.11'" },
-  { url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", marker = "sys_platform == 'linux' and python_version == '3.12'" },
-  { url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", marker = "sys_platform == 'linux' and python_version == '3.13'" },
+  { url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", marker = "sys_platform == 'linux' and python_version == '3.10' and platform_machine == 'x86_64'" },
+  { url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", marker = "sys_platform == 'linux' and python_version == '3.11' and platform_machine == 'x86_64'" },
+  { url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", marker = "sys_platform == 'linux' and python_version == '3.12' and platform_machine == 'x86_64'" },
+  { url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", marker = "sys_platform == 'linux' and python_version == '3.13' and platform_machine == 'x86_64'" },
+  # aarch64 wheel 尚未发布（calcephpy-wheel.yml 的 build-linux-aarch64 job 跑完
+  # 并上传 calcephpy-v1 后取消以下 4 条注释，再 uv lock --upgrade-package calcephpy）。
+  # { url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp310-cp310-manylinux_2_28_aarch64.whl", marker = "sys_platform == 'linux' and python_version == '3.10' and platform_machine == 'aarch64'" },
+  # { url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp311-cp311-manylinux_2_28_aarch64.whl", marker = "sys_platform == 'linux' and python_version == '3.11' and platform_machine == 'aarch64'" },
+  # { url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", marker = "sys_platform == 'linux' and python_version == '3.12' and platform_machine == 'aarch64'" },
+  # { url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", marker = "sys_platform == 'linux' and python_version == '3.13' and platform_machine == 'aarch64'" },
 ]

--- a/scripts/colab_download_cspice.py
+++ b/scripts/colab_download_cspice.py
@@ -1,0 +1,57 @@
+# 在 Google Colab 中运行的下载脚本：从 NAIF 官网下载 CSPICE 源码包。
+#
+# 用途：e2m2e 支持 aarch64 Linux 需要 aarch64 的 libcspice.a（NAIF 官方没有
+# Linux ARM64 预编译包，必须拿源码在 arm64 上 make）。NAIF 官网国内网络不可达，
+# 但 Colab 可访问（用户已实测成功下载 Voyager 内核）。本脚本把源码包存到
+# Google Drive，再从 Drive 取回本地（.cspice/ 或任意目录）。
+#
+# 下载源与 cspice-sys 1.0.4 的 downloadcspice feature 同 URL：
+#   https://naif.jpl.nasa.gov/pub/naif/toolkit//C/PC_Linux_GCC_64bit/packages/cspice.tar.Z
+# 该包是平台源码发行包（含 makefile），架构无关，在 aarch64 上 make 即得
+# lib/cspice.a（重命名 libcspice.a 后即 cspice-sys 需要的静态库）。
+#
+# 用法：全部复制到 Colab 单元格运行。产物：<Drive>/e2m2e_CSPICE/cspice.tar.Z（约 60MB）。
+
+import os
+
+import requests
+from google.colab import drive
+
+# 1. 挂载 Google Drive
+drive.mount('/content/drive')
+
+
+def download_file(url, filename, save_dir):
+    """下载到临时文件再改名落盘：中断的下载不残留半截文件。"""
+    save_path = os.path.join(save_dir, filename)
+    tmp_path = save_path + '.part'
+    if os.path.exists(save_path):
+        size_mb = os.path.getsize(save_path) / 1024 / 1024
+        print(f"文件已存在，跳过下载: {filename} ({size_mb:.1f} MB)")
+        return
+    print(f"🚀 正在下载: {filename}...")
+    try:
+        response = requests.get(url, stream=True, timeout=60)
+        response.raise_for_status()
+        with open(tmp_path, 'wb') as f:
+            for chunk in response.iter_content(chunk_size=1024 * 1024):
+                f.write(chunk)
+        os.replace(tmp_path, save_path)
+        size_mb = os.path.getsize(save_path) / 1024 / 1024
+        print(f"✅ 下载完成: {filename} ({size_mb:.1f} MB)")
+    except Exception as e:
+        print(f"❌ 下载失败 {filename}: {e}")
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
+
+
+# 2. Google Drive 存储目录
+spice_dir = "/content/drive/MyDrive/e2m2e_CSPICE"
+os.makedirs(spice_dir, exist_ok=True)
+
+# 3. CSPICE 源码包（PC_Linux_GCC_64bit：与 cspice-sys downloadcspice 同源，
+#    编译目标架构由编译机器的 makefile 决定，aarch64 上 make 即得 arm64 库）
+url = "https://naif.jpl.nasa.gov/pub/naif/toolkit//C/PC_Linux_GCC_64bit/packages/cspice.tar.Z"
+download_file(url, "cspice.tar.Z", spice_dir)
+
+print(f"\n🎉 已保存: {spice_dir}/cspice.tar.Z")

--- a/scripts/colab_download_cspice.py
+++ b/scripts/colab_download_cspice.py
@@ -18,13 +18,13 @@ import requests
 from google.colab import drive
 
 # 1. 挂载 Google Drive
-drive.mount('/content/drive')
+drive.mount("/content/drive")
 
 
 def download_file(url, filename, save_dir):
     """下载到临时文件再改名落盘：中断的下载不残留半截文件。"""
     save_path = os.path.join(save_dir, filename)
-    tmp_path = save_path + '.part'
+    tmp_path = save_path + ".part"
     if os.path.exists(save_path):
         size_mb = os.path.getsize(save_path) / 1024 / 1024
         print(f"文件已存在，跳过下载: {filename} ({size_mb:.1f} MB)")
@@ -33,7 +33,7 @@ def download_file(url, filename, save_dir):
     try:
         response = requests.get(url, stream=True, timeout=60)
         response.raise_for_status()
-        with open(tmp_path, 'wb') as f:
+        with open(tmp_path, "wb") as f:
             for chunk in response.iter_content(chunk_size=1024 * 1024):
                 f.write(chunk)
         os.replace(tmp_path, save_path)

--- a/scripts/colab_download_generic_kernels.py
+++ b/scripts/colab_download_generic_kernels.py
@@ -1,0 +1,113 @@
+# 在 Google Colab 中运行的下载脚本：按「方案 B」口径下载 NAIF 通用内核全集。
+#
+# 方案 B：当前版本全集，除卫星星历（spk/satellites 是大头 29.7GB，多为外行星卫星）
+#         与历史版本（a_old_versions）。预期 220 文件、9.80 GB，塞进 15GB Drive。
+#
+# 输入：Drive 上 naif_inventory/naif_files_sized.csv（colab_list_naif.py +
+#       colab_head_sizes.py 的产物，含路径与真实字节数）。
+# 输出：<Drive>/naif_download/generic_kernels/...（按 NAIF 相对路径建目录）。
+#
+# 幂等：已存在且字节数匹配的文件跳过；中断后重跑续传。速度与 ETA 每 10 个文件打印。
+# 用法：全部复制到 Colab 单元格运行。
+
+import csv
+import os
+import time
+from urllib.parse import quote
+
+import requests
+from google.colab import drive
+
+drive.mount("/content/drive")
+
+IN_DIR = "/content/drive/MyDrive/naif_inventory"
+IN_CSV = os.path.join(IN_DIR, "naif_files_sized.csv")
+OUT_DIR = "/content/drive/MyDrive/naif_download"
+ROOT_URL = "https://naif.jpl.nasa.gov/pub/naif/"
+
+session = requests.Session()
+session.headers["User-Agent"] = "Mozilla/5.0 (kernel downloader)"
+
+
+def include(path):
+    """方案 B 过滤：跳过历史版本与卫星星历。"""
+    parts = [x for x in path.split("/") if x]
+    return not (
+        "a_old_versions" in parts
+        or (
+            len(parts) >= 3
+            and parts[0] == "generic_kernels"
+            and parts[1] == "spk"
+            and parts[2] == "satellites"
+        )
+    )
+
+
+def download(url, dest, expect_size):
+    """下载到 .part 再改名；返回 (ok, 错误信息)。"""
+    tmp = dest + ".part"
+    try:
+        with session.get(url, stream=True, timeout=60) as r:
+            r.raise_for_status()
+            with open(tmp, "wb") as f:
+                for chunk in r.iter_content(chunk_size=1024 * 1024):
+                    f.write(chunk)
+        size = os.path.getsize(tmp)
+        if expect_size > 0 and size != expect_size:
+            os.remove(tmp)
+            return False, f"大小不符（得 {size}，期望 {expect_size}）"
+        os.replace(tmp, dest)
+        return True, ""
+    except Exception as e:
+        if os.path.exists(tmp):
+            os.remove(tmp)
+        return False, str(e)
+
+
+rows = []
+with open(IN_CSV) as f:
+    rows = list(csv.reader(f))
+body = [r for r in rows[1:] if include(r[0])]
+expect_total = sum(int(r[2]) for r in body if r[2].isdigit() and int(r[2]) > 0)
+print(f"方案 B：{len(body)} 个文件，预期 {expect_total / 1073741824:.2f} GB")
+print(f"输出目录: {OUT_DIR}\n")
+
+done_bytes = 0
+skipped = 0
+ok = 0
+failed = []
+start = time.time()
+for i, row in enumerate(body):
+    path, name, size_s = row
+    size = int(size_s) if size_s.isdigit() else -1
+    clean = "/".join(x for x in path.split("/") if x)
+    dest = os.path.join(OUT_DIR, *clean.split("/"))
+    # 幂等：字节数匹配则跳过
+    if os.path.exists(dest):
+        got = os.path.getsize(dest)
+        if size <= 0 or got == size:
+            skipped += 1
+            continue
+        os.remove(dest)  # 大小不符，重下
+    os.makedirs(os.path.dirname(dest), exist_ok=True)
+    url = ROOT_URL + "/".join(quote(x, safe="._-") for x in clean.split("/"))
+    o, err = download(url, dest, size)
+    if o:
+        ok += 1
+        done_bytes += os.path.getsize(dest)
+    else:
+        failed.append((path, err))
+    if (i + 1) % 10 == 0:
+        el = time.time() - start
+        speed = done_bytes / el / 1048576 if el > 0 else 0
+        eta = (expect_total - done_bytes) / (speed * 1048576) if speed > 0 else -1
+        print(
+            f"  {i + 1}/{len(body)}  已下 {done_bytes / 1073741824:.2f} GB  "
+            f"速度 {speed:.1f} MB/s  ETA {eta / 60:.0f} 分钟  失败 {len(failed)}"
+        )
+    time.sleep(0.05)
+
+print(f"\n完成：下载 {ok}，跳过 {skipped}，失败 {len(failed)}")
+for p, e in failed:
+    print(f"  ❌ {p}: {e}")
+print("（失败的文件重跑本脚本即可续传）")

--- a/scripts/colab_download_jpl.py
+++ b/scripts/colab_download_jpl.py
@@ -1,0 +1,72 @@
+# 在 Google Colab 中运行的下载脚本：从 NAIF（JPL）官网下载 SPICE 内核全集。
+#
+# 用途：e2m2e 运行期依赖的 SPICE 内核（星历/闰秒/常数/方向/帧）在项目
+# kernels-v1 release 里有一份（GitHub 可达），本脚本提供 NAIF 官方源的一份
+# 原始数据（国内网络不可达，Colab 可达），供离线部署/对比/更新使用。
+# 文件存到 Google Drive，再从 Drive 取回本地。
+#
+# 映射关系（NAIF 源 → 项目 kernels/ 用名）：
+#   de440s.bsp / de430.bsp             → 同名（行星星历，DE 系列）
+#   naif0011.tls / naif0012.tls        → 同名（闰秒）
+#   pck00010.tpc                       → 同名（行星常数）
+#   earth_latest_high_prec.bpc         → 同名（地球高精度方向）
+#   earth_070425_370426_predict.bpc    → SPICEEarthPredictedKernel.bpc（待验证）
+#   moon_pa_de421_1900-2050.bpc        → SPICELunaCurrentKernel.bpc（待验证）
+#   luna_iau2000.tf                    → SPICELunaFrameKernel.tf（待验证）
+#
+# 用法：全部复制到 Colab 单元格运行。产物：<Drive>/e2m2e_JPL/（约 170MB）。
+
+import os
+
+import requests
+from google.colab import drive
+
+# 1. 挂载 Google Drive
+drive.mount("/content/drive")
+
+
+def download_file(url, filename, save_dir):
+    """下载到临时文件再改名落盘：中断的下载不残留半截文件；已存在则跳过。"""
+    save_path = os.path.join(save_dir, filename)
+    tmp_path = save_path + ".part"
+    if os.path.exists(save_path) and os.path.getsize(save_path) > 0:
+        print(f"已存在，跳过: {filename}")
+        return
+    print(f"🚀 下载: {filename} ({url})")
+    try:
+        response = requests.get(url, stream=True, timeout=60)
+        response.raise_for_status()
+        with open(tmp_path, "wb") as f:
+            for chunk in response.iter_content(chunk_size=1024 * 1024):
+                f.write(chunk)
+        os.replace(tmp_path, save_path)
+        size_mb = os.path.getsize(save_path) / 1024 / 1024
+        print(f"✅ {filename} ({size_mb:.1f} MB)")
+    except Exception as e:
+        print(f"❌ {filename}: {e}")
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
+
+
+# 2. Google Drive 存储目录
+spice_dir = "/content/drive/MyDrive/e2m2e_JPL"
+os.makedirs(spice_dir, exist_ok=True)
+
+# 3. NAIF generic_kernels 下的内核清单：(相对路径, 保存文件名)
+NAIF = "https://naif.jpl.nasa.gov/pub/naif/generic_kernels"
+KERNELS = [
+    ("spk/planets/de440s.bsp", "de440s.bsp"),
+    ("spk/planets/de430.bsp", "de430.bsp"),
+    ("lsk/naif0012.tls", "naif0012.tls"),
+    ("lsk/naif0011.tls", "naif0011.tls"),
+    ("pck/pck00010.tpc", "pck00010.tpc"),
+    ("pck/earth_latest_high_prec.bpc", "earth_latest_high_prec.bpc"),
+    ("pck/earth_070425_370426_predict.bpc", "SPICEEarthPredictedKernel.bpc"),
+    ("pck/moon_pa_de421_1900-2050.bpc", "SPICELunaCurrentKernel.bpc"),
+    ("fk/satellites/luna_iau2000.tf", "SPICELunaFrameKernel.tf"),
+]
+
+for rel_path, filename in KERNELS:
+    download_file(f"{NAIF}/{rel_path}", filename, spice_dir)
+
+print(f"\n完成。目录: {spice_dir}（失败的文件见上方 ❌ 行，可重跑，已下载的会跳过）")

--- a/scripts/colab_download_satellites.py
+++ b/scripts/colab_download_satellites.py
@@ -1,0 +1,162 @@
+# 在 Google Colab 中运行的下载脚本：补齐「当前版本全集」的卫星星历部分。
+#
+# 方案 A = 方案 B（已下载）+ 本脚本的 spk/satellites 当前版（107 文件，约 29.7GB）。
+# 29.7GB 超过免费 Drive 15GB，故按 10GB 贪心分箱；每跑一箱 → 搬到本地 → 删 Drive
+# 上的该箱数据 → 改 BATCH 数字跑下一箱，直到全部搬完。
+#
+# 自包含：不依赖 Drive 上任何旧清单文件——本脚本自行枚举 satellites 目录、
+# HEAD 取真实大小、分箱。不会重复下载方案 B 的文件（那些不在 satellites 目录）。
+#
+# 用法：把 BATCH 改成当前要跑的箱号（1 起），整个文件复制到 Colab 单元格运行。
+#       产物：<Drive>/naif_download/generic_kernels/spk/satellites/*.bsp
+
+import os
+import re
+import time
+from urllib.parse import quote
+
+import requests
+from bs4 import BeautifulSoup
+from google.colab import drive
+
+# ====== 参数：每跑一箱改这里 ======
+BATCH = 1  # 箱号，从 1 开始
+BATCH_LIMIT_MB = 10000  # 每箱上限 10GB（Drive 免费额度 15GB 留余量）
+# ==================================
+
+drive.mount("/content/drive")
+
+DIR_URL = "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/satellites/"
+OUT_DIR = "/content/drive/MyDrive/naif_download/generic_kernels/spk/satellites"
+SIZE_RE = re.compile(r"^(\d+(?:\.\d+)?)([KMG])?$")
+_UNIT = {"K": 1024, "M": 1024**2, "G": 1024**3}
+
+session = requests.Session()
+session.headers["User-Agent"] = "Mozilla/5.0 (kernel downloader)"
+
+
+def fetch_sizes():
+    """枚举 satellites 目录文件（跳过 a_old_versions/）并 HEAD 取真实大小。"""
+    r = session.get(DIR_URL, timeout=60)
+    r.raise_for_status()
+    soup = BeautifulSoup(r.text, "html.parser")
+    names = []
+    for a in soup.find_all("a", href=True):
+        href = a["href"]
+        name = a.get_text(strip=True)
+        if href.startswith(("/", "?", "http", "mailto:")) or href in ("../",):
+            continue
+        if href.endswith("/") or not name:
+            continue
+        names.append(name)
+    print(f"satellites 目录：{len(names)} 个文件，HEAD 取大小中……")
+    entries = []
+    for i, name in enumerate(sorted(names)):
+        url = DIR_URL + quote(name)
+        size = -1
+        try:
+            h = session.head(url, timeout=30, allow_redirects=True)
+            if h.status_code == 405:
+                g = session.get(url, stream=True, timeout=30)
+                cl = g.headers.get("Content-Length")
+                g.close()
+                size = int(cl) if cl and cl.isdigit() else -1
+            else:
+                h.raise_for_status()
+                cl = h.headers.get("Content-Length")
+                size = int(cl) if cl and cl.isdigit() else -1
+        except Exception:
+            size = -1
+        entries.append((name, size))
+        if (i + 1) % 20 == 0:
+            print(f"  {i + 1}/{len(names)}")
+        time.sleep(0.05)
+    return entries
+
+
+def make_bins(entries, limit_mb):
+    """按大小降序贪心装箱，每箱 ≤ limit_mb。"""
+    limit = limit_mb * 1048576
+    entries = sorted(entries, key=lambda x: -(x[1] if x[1] > 0 else 0))
+    bins, cur, cur_sz = [], [], 0
+    for e in entries:
+        s = e[1] if e[1] > 0 else 0
+        if cur_sz + s > limit and cur:
+            bins.append(cur)
+            cur, cur_sz = [], 0
+        cur.append(e)
+        cur_sz += s
+    if cur:
+        bins.append(cur)
+    return bins
+
+
+def download(url, dest, expect_size):
+    tmp = dest + ".part"
+    try:
+        with session.get(url, stream=True, timeout=60) as r:
+            r.raise_for_status()
+            with open(tmp, "wb") as f:
+                for chunk in r.iter_content(chunk_size=1024 * 1024):
+                    f.write(chunk)
+        size = os.path.getsize(tmp)
+        if expect_size > 0 and size != expect_size:
+            os.remove(tmp)
+            return False, f"大小不符（得 {size}，期望 {expect_size}）"
+        os.replace(tmp, dest)
+        return True, ""
+    except Exception as e:
+        if os.path.exists(tmp):
+            os.remove(tmp)
+        return False, str(e)
+
+
+entries = fetch_sizes()
+bins = make_bins(entries, BATCH_LIMIT_MB)
+total = sum(s for _, s in entries if s > 0)
+print(
+    f"\n全部 {len(entries)} 文件，{total / 1073741824:.2f} GB，"
+    f"分 {len(bins)} 箱（每箱 ≤{BATCH_LIMIT_MB / 1000:.0f}GB）："
+)
+for i, b in enumerate(bins):
+    sz = sum(s for _, s in b if s > 0) / 1073741824
+    print(f"  箱 {i + 1}: {len(b)} 文件  {sz:.2f} GB" + ("  ← 本批" if i + 1 == BATCH else ""))
+
+if not (1 <= BATCH <= len(bins)):
+    raise SystemExit(f"BATCH={BATCH} 超出范围 1..{len(bins)}")
+
+batch = bins[BATCH - 1]
+batch_sz = sum(s for _, s in batch if s > 0)
+print(f"\n开始下载箱 {BATCH}（{batch_sz / 1073741824:.2f} GB）→ {OUT_DIR}")
+
+os.makedirs(OUT_DIR, exist_ok=True)
+ok = skipped = 0
+failed = []
+done_bytes = 0
+start = time.time()
+for i, (name, size) in enumerate(batch):
+    dest = os.path.join(OUT_DIR, name)
+    if os.path.exists(dest):
+        got = os.path.getsize(dest)
+        if size <= 0 or got == size:
+            skipped += 1
+            continue
+        os.remove(dest)
+    o, err = download(DIR_URL + quote(name), dest, size)
+    if o:
+        ok += 1
+        done_bytes += os.path.getsize(dest)
+    else:
+        failed.append((name, err))
+    # 每完成一个文件打印一次（箱内文件数少，实时反馈更重要）
+    el = time.time() - start
+    speed = done_bytes / el / 1048576 if el > 0 else 0
+    print(
+        f"  {i + 1}/{len(batch)} {name}  "
+        f"已下 {done_bytes / 1073741824:.2f} GB  速度 {speed:.1f} MB/s  失败 {len(failed)}"
+    )
+
+print(f"\n箱 {BATCH} 完成：下载 {ok}，跳过 {skipped}，失败 {len(failed)}")
+for n, e in failed:
+    print(f"  ❌ {n}: {e}")
+print("下一步：把本箱搬到本地 → 删 Drive 上 naif_download/ 的本箱数据 → BATCH 加 1 重跑")

--- a/scripts/colab_head_sizes.py
+++ b/scripts/colab_head_sizes.py
@@ -1,0 +1,76 @@
+# 在 Google Colab 中运行：对已枚举的 NAIF 文件清单逐个发请求取真实大小。
+#
+# 背景：NAIF 目录索引页的 HTML 非标准结构，文件大小解析两轮都失败；改用
+# 直接发 HTTP 请求拿 Content-Length（HEAD 优先，405 时回退 GET stream 只取头
+# 不读 body）。输入是 colab_list_naif.py 产出的 Drive 文件
+# naif_inventory/naif_files.csv（路径,文件名,字节），输出同目录
+# naif_files_sized.csv（补真实字节数）。
+#
+# 1145 个文件 × ~0.1s 延迟 + 网络往返，约 10-20 分钟，进度每 50 个打印一次。
+# 失败的文件 size 记 -1（下载阶段再处理）。
+#
+# 用法：全部复制到 Colab 单元格运行。
+
+import csv
+import os
+import time
+
+import requests
+from google.colab import drive
+
+drive.mount("/content/drive")
+
+IN_DIR = "/content/drive/MyDrive/naif_inventory"
+IN_CSV = os.path.join(IN_DIR, "naif_files.csv")
+OUT_CSV = os.path.join(IN_DIR, "naif_files_sized.csv")
+ROOT_URL = "https://naif.jpl.nasa.gov/pub/naif/"
+
+session = requests.Session()
+session.headers["User-Agent"] = "Mozilla/5.0 (inventory script)"
+
+
+def fetch_size(url):
+    """取文件大小：HEAD 优先，405/501 回退 GET stream 只读头。失败返回 -1。"""
+    try:
+        r = session.head(url, timeout=30, allow_redirects=True)
+        if r.status_code == 405:
+            r = session.get(url, stream=True, timeout=30)
+            cl = r.headers.get("Content-Length")
+            r.close()
+            return int(cl) if cl and cl.isdigit() else -1
+        r.raise_for_status()
+        cl = r.headers.get("Content-Length")
+        return int(cl) if cl and cl.isdigit() else -1
+    except Exception:
+        return -1
+
+
+rows = []
+with open(IN_CSV) as f:
+    rows = list(csv.reader(f))
+header, body = rows[0], rows[1:]
+print(f"共 {len(body)} 个文件，开始取大小……")
+
+ok, failed = 0, 0
+start = time.time()
+for i, row in enumerate(body):
+    path, name, _ = row
+    # 修双斜杠：枚举阶段目录名已含尾斜杠、拼接多了一个
+    clean = path.replace("//", "/")
+    size = fetch_size(ROOT_URL + clean)
+    row[2] = str(size)
+    if size < 0:
+        failed += 1
+    else:
+        ok += 1
+    if (i + 1) % 50 == 0:
+        el = time.time() - start
+        print(f"  {i + 1}/{len(body)}（成功 {ok}，失败 {failed}，用时 {el:.0f}s）")
+    time.sleep(0.05)
+
+with open(OUT_CSV, "w", newline="") as f:
+    csv.writer(f).writerows([header] + body)
+
+total = sum(int(r[2]) for r in body if r[2].isdigit() and int(r[2]) > 0)
+print(f"\n完成：成功 {ok}，失败 {failed}，总大小 {total / 1073741824:.2f} GB")
+print(f"输出: {OUT_CSV}")

--- a/scripts/colab_list_naif.py
+++ b/scripts/colab_list_naif.py
@@ -1,0 +1,161 @@
+# 在 Google Colab 中运行的枚举脚本：爬取 NAIF（JPL）官网目录结构，摸清可下载数据全貌。
+#
+# 背景：NAIF 全站（pub/naif/）含所有深空任务数据，总量数百 GB；通用内核
+# generic_kernels/ 才是日常可用的全集（闰秒/常数/星历/帧/数字形状/恒星等，
+# 仪器与姿态内核按任务放在各任务目录下，不在 generic_kernels）。
+# 本脚本先枚举、不下载：递归解析 Apache 索引页，输出
+#   - naif_tree.txt：目录树（每目录文件数/总大小）
+#   - naif_files.csv：文件级清单（相对路径,文件名,字节）
+# 存到 Google Drive，据此确定下载范围。
+#
+# 用法：全部复制到 Colab 单元格运行。
+
+import csv
+import os
+import re
+import time
+
+import requests
+from bs4 import BeautifulSoup
+from google.colab import drive
+
+drive.mount("/content/drive")
+
+ROOT_URL = "https://naif.jpl.nasa.gov/pub/naif/"
+OUT_DIR = "/content/drive/MyDrive/naif_inventory"
+os.makedirs(OUT_DIR, exist_ok=True)
+
+# Apache 索引 Size 列格式：纯字节数，或数字 + K/M/G 后缀；"-" 是目录
+SIZE_RE = re.compile(r"^(\d+(?:\.\d+)?)([KMG])?$")
+_UNIT = {"K": 1024, "M": 1024**2, "G": 1024**3}
+
+session = requests.Session()
+session.headers["User-Agent"] = "Mozilla/5.0 (inventory script)"
+
+
+def parse_size(td):
+    """从 td 文本解析字节数；不是大小格式（日期等）返回 None。"""
+    txt = td.get_text(strip=True)
+    m = SIZE_RE.match(txt)
+    if not m:
+        return None
+    num = float(m.group(1))
+    return int(num * _UNIT.get(m.group(2), 1))
+
+
+def extract_size(a):
+    """从 <a> 节点提取文件大小，兼容两种 Apache 索引格式：
+    - 表格（<tr><td>…大小列）：遍历 td 找 SIZE_RE 匹配项；
+    - 纯文本列表（<pre> 行）：收集 <a> 之后到行尾的文本，取最后一个 K/M/G token。
+    取不到返回 0。"""
+    tr = a.find_parent("tr")
+    if tr is not None:
+        for td in tr.find_all("td"):
+            s = parse_size(td)
+            if s is not None:
+                return s
+        return 0
+    tail = []
+    node = a
+    while True:
+        nxt = node.next_sibling
+        if nxt is None:
+            break
+        text = str(nxt)
+        tail.append(text)
+        if "\n" in text:
+            break
+        node = nxt
+    m = re.findall(r"(\d+(?:\.\d+)?)([KMG])(?![\d.])", "".join(tail))
+    if m:
+        num, unit = m[-1]
+        return int(float(num) * _UNIT[unit])
+    return 0
+
+
+def fetch_listing(url):
+    """抓取 Apache 索引页，返回 (子目录名列表, 文件[(名, 字节)]列表)。"""
+    r = session.get(url, timeout=60)
+    r.raise_for_status()
+    soup = BeautifulSoup(r.text, "html.parser")
+    dirs, files = [], []
+    for a in soup.find_all("a", href=True):
+        href = a["href"]
+        name = a.get_text(strip=True)
+        # 只收纯相对路径：跳过站点根/绝对 URL/mailto（坏链接或站外链接）
+        if href.startswith(("/", "?", "http", "mailto:")) or href in ("../",):
+            continue
+        if href.endswith("/") and name:
+            dirs.append(name)
+        elif name:
+            files.append((name, extract_size(a)))
+    return sorted(dirs), sorted(files)
+
+
+lines = []
+csv_rows = []
+total_files = 0
+total_bytes = 0
+req_count = 0
+
+
+def walk(url, depth, max_depth, prefix=""):
+    """递归枚举目录树。max_depth 限制深度；404/403 容错不中断。"""
+    global total_files, total_bytes, req_count
+    req_count += 1
+    try:
+        dirs, files = fetch_listing(url)
+    except requests.HTTPError as e:
+        lines.append(f"{prefix}!! HTTP {e.response.status_code}: {url}（跳过）")
+        print(f"跳过 {url}: HTTP {e.response.status_code}")
+        return
+    dir_bytes = sum(s for _, s in files)
+    dir_count = len(files)
+    total_files += dir_count
+    total_bytes += dir_bytes
+    rel = url[len(ROOT_URL) :].rstrip("/")
+    for fname, fsize in files:
+        csv_rows.append((rel + "/" + fname, fname, fsize))
+    lines.append(
+        f"{prefix}{os.path.basename(url.rstrip('/')) or '/'}/  "
+        f"({dir_count} 文件, {dir_bytes / 1048576:.1f} MB, 子目录 {len(dirs)})"
+    )
+    if depth >= max_depth:
+        return
+    for d in dirs:
+        walk(url + d + "/", depth + 1, max_depth, prefix + "  ")
+    time.sleep(0.1)
+
+
+# 1) 顶层：只列目录名与文件概况，不深入（任务数据太大）
+lines.append("=== pub/naif/ 顶层 ===")
+top_dirs, top_files = fetch_listing(ROOT_URL)
+for d in top_dirs:
+    lines.append(f"  {d}/")
+for name, size in top_files[:50]:
+    lines.append(f"  {name} ({size / 1048576:.1f} MB)")
+
+# 2) generic_kernels/：完整递归（含文件数/大小统计）
+print("爬取 generic_kernels/ 目录树中……")
+lines.append("")
+lines.append("=== generic_kernels/ 完整树（目录: 文件数, 大小, 子目录数）===")
+walk(ROOT_URL + "generic_kernels/", 0, 4)
+
+lines.append("")
+lines.append(
+    f"=== 统计：generic_kernels 共 {total_files} 文件，"
+    f"{total_bytes / 1048576 / 1024:.1f} GB，请求 {req_count} 次 ==="
+)
+
+out_tree = os.path.join(OUT_DIR, "naif_tree.txt")
+with open(out_tree, "w") as f:
+    f.write("\n".join(lines) + "\n")
+out_csv = os.path.join(OUT_DIR, "naif_files.csv")
+with open(out_csv, "w", newline="") as f:
+    csv.writer(f).writerows([("path", "name", "bytes")] + csv_rows)
+print(f"清单已保存: {out_tree}")
+print(f"文件级清单: {out_csv}")
+
+# 控制台打印概况（完整树在文件里）
+print("\n".join(lines[:40]))
+print("……（完整清单见 Drive 文件）")

--- a/scripts/download_cspice.py
+++ b/scripts/download_cspice.py
@@ -2,10 +2,10 @@
 
 背景：仓库不启用 ``cspice-sys`` 的 ``downloadcspice`` feature（其从 naif.jpl.nasa.gov 下载
 CSPICE 源码就地编译，国内网络常不可达，构建时 TCP 超时），CSPICE 一律经本脚本从
-e2m2e 的 GitHub Release 下载预编译的 MICE 工具包（``cspice-windows-v1`` /
-``cspice-linux-v1`` / ``cspice-linux-aarch64-v1``），解压后把 ``mice_{platform}`` 目录作为
-``CSPICE_DIR`` 输出。``cspice-sys`` 的 build.rs 检测到 ``CSPICE_DIR`` 即使用之；缺
-``CSPICE_DIR`` 时构建直接报错（见 cspice-sys build.rs 第 21-33 行）。
+e2m2e 的 GitHub Release 下载预编译的 MICE 工具包（release ``cspice-v1`` 的资产
+``cspice-windows.zip`` / ``cspice-linux.zip`` / ``cspice-linux-aarch64.zip``），解压后把
+``mice_{platform}`` 目录作为 ``CSPICE_DIR`` 输出。``cspice-sys`` 的 build.rs 检测到
+``CSPICE_DIR`` 即使用之；缺 ``CSPICE_DIR`` 时构建直接报错（见 cspice-sys build.rs 第 21-33 行）。
 
 资产按「操作系统 × 架构」选择：x86_64 Linux 与 aarch64 Linux 各自独立的 zip
 （``cspice-linux.zip`` / ``cspice-linux-aarch64.zip``），aarch64 库由
@@ -68,14 +68,8 @@ def _asset(platform_key: tuple[str, str]) -> tuple[str, str]:
         return ASSET_BY_PLATFORM[platform_key]
     except KeyError:
         os_name, machine = platform_key
-        hint = ""
-        if (os_name, machine) == ("linux", "aarch64"):
-            hint = (
-                "（aarch64 库需先运行 .github/workflows/cspice-aarch64-build.yml"
-                " 编译并上传 cspice-v1 release）"
-            )
         raise SystemExit(
-            f"暂无 {os_name}/{machine} 的 CSPICE 编译包{hint}：资产表 {sorted(ASSET_BY_PLATFORM)}"
+            f"暂无 {os_name}/{machine} 的 CSPICE 编译包：资产表 {sorted(ASSET_BY_PLATFORM)}"
         ) from None
 
 

--- a/scripts/download_cspice.py
+++ b/scripts/download_cspice.py
@@ -3,9 +3,16 @@
 背景：仓库不启用 ``cspice-sys`` 的 ``downloadcspice`` feature（其从 naif.jpl.nasa.gov 下载
 CSPICE 源码就地编译，国内网络常不可达，构建时 TCP 超时），CSPICE 一律经本脚本从
 e2m2e 的 GitHub Release 下载预编译的 MICE 工具包（``cspice-windows-v1`` /
-``cspice-linux-v1``），解压后把 ``mice_{platform}`` 目录作为 ``CSPICE_DIR`` 输出。
-``cspice-sys`` 的 build.rs 检测到 ``CSPICE_DIR`` 即使用之；缺 ``CSPICE_DIR`` 时构建直接报错
-（见 cspice-sys build.rs 第 21-33 行）。
+``cspice-linux-v1`` / ``cspice-linux-aarch64-v1``），解压后把 ``mice_{platform}`` 目录作为
+``CSPICE_DIR`` 输出。``cspice-sys`` 的 build.rs 检测到 ``CSPICE_DIR`` 即使用之；缺
+``CSPICE_DIR`` 时构建直接报错（见 cspice-sys build.rs 第 21-33 行）。
+
+资产按「操作系统 × 架构」选择：x86_64 Linux 与 aarch64 Linux 各自独立的 zip
+（``cspice-linux.zip`` / ``cspice-linux-aarch64.zip``），aarch64 库由
+``.github/workflows/cspice-aarch64-build.yml`` 在 GitHub arm64 runner 上从 NAIF 源码包
+编译后发到 ``cspice-v1`` release（NAIF 官方无 Linux ARM64 预编译包）。解压子目录
+按资产区分（x86_64 沿用 MICE 包的 ``mice_linux``，aarch64 为 ``mice_linux_aarch64``），
+避免同一缓存目录下两架构产物互相覆盖。Windows 仅 x86_64，维持原 ``mice_windows``。
 
 用法：
     python scripts/download_cspice.py [--cache-dir DIR]
@@ -23,6 +30,7 @@ from __future__ import annotations
 
 import argparse
 import pathlib
+import platform
 import shutil
 import sys
 import urllib.request
@@ -30,43 +38,62 @@ import zipfile
 
 REPO = "cislunarspace/e2m2e"
 RELEASE = "cspice-v1"
+# (操作系统, 架构) → (release 资产名, 解压后 CSPICE 子目录名)
 ASSET_BY_PLATFORM = {
-    "windows": "cspice-windows.zip",
-    "linux": "cspice-linux.zip",
+    ("windows", "x86_64"): ("cspice-windows.zip", "mice_windows"),
+    ("linux", "x86_64"): ("cspice-linux.zip", "mice_linux"),
+    ("linux", "aarch64"): ("cspice-linux-aarch64.zip", "mice_linux_aarch64"),
 }
-# MICE 包内，include/ 与 lib/ 位于 mice_{platform}/ 子目录
-CSPICE_SUBDIR = {"windows": "mice_windows", "linux": "mice_linux"}
+# 架构归一化：各平台对同一 ISA 的 machine 字符串不尽相同
+_MACHINE_ALIASES = {"amd64": "x86_64", "arm64": "aarch64"}
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 
 
-def _platform() -> str:
+def _platform() -> tuple[str, str]:
+    """返回 (操作系统, 架构)，二者都归一化到 ASSET_BY_PLATFORM 的键。"""
     sys_platform = sys.platform
     if sys_platform.startswith("win"):
-        return "windows"
-    if sys_platform.startswith("linux"):
-        return "linux"
-    raise SystemExit(f"不支持平台：{sys_platform}（当前仅支持 windows/linux）")
+        os_name = "windows"
+    elif sys_platform.startswith("linux"):
+        os_name = "linux"
+    else:
+        raise SystemExit(f"不支持平台：{sys_platform}（当前仅支持 windows/linux）")
+    machine = _MACHINE_ALIASES.get(platform.machine().lower(), platform.machine().lower())
+    return os_name, machine
 
 
-def _asset_url(platform_name: str) -> str:
-    asset = ASSET_BY_PLATFORM[platform_name]
+def _asset(platform_key: tuple[str, str]) -> tuple[str, str]:
+    try:
+        return ASSET_BY_PLATFORM[platform_key]
+    except KeyError:
+        os_name, machine = platform_key
+        hint = ""
+        if (os_name, machine) == ("linux", "aarch64"):
+            hint = (
+                "（aarch64 库需先运行 .github/workflows/cspice-aarch64-build.yml"
+                " 编译并上传 cspice-v1 release）"
+            )
+        raise SystemExit(
+            f"暂无 {os_name}/{machine} 的 CSPICE 编译包{hint}：资产表 {sorted(ASSET_BY_PLATFORM)}"
+        ) from None
+
+
+def _asset_url(asset: str) -> str:
     return f"https://github.com/{REPO}/releases/download/{RELEASE}/{asset}"
 
 
 def _ensure_extracted(cache_dir: pathlib.Path) -> pathlib.Path:
     """下载（若未缓存）并解压 MICE 包，返回指向 ``mice_{platform}`` 的目录。"""
-    platform_name = _platform()
-    subdir = CSPICE_SUBDIR[platform_name]
+    asset, subdir = _asset(_platform())
     target = cache_dir / subdir
     if target.is_dir() and (target / "include" / "SpiceUsr.h").is_file():
         return target
 
     cache_dir.mkdir(parents=True, exist_ok=True)
-    asset = ASSET_BY_PLATFORM[platform_name]
     zip_path = cache_dir / asset
     if not zip_path.is_file():
-        url = _asset_url(platform_name)
+        url = _asset_url(asset)
         print(f"下载 {url} → {zip_path}", file=sys.stderr)
         urllib.request.urlretrieve(url, zip_path)  # noqa: S310 — 固定 https URL
     print(f"解压 {zip_path} → {cache_dir}", file=sys.stderr)
@@ -77,7 +104,7 @@ def _ensure_extracted(cache_dir: pathlib.Path) -> pathlib.Path:
     # 平台修补：cspice-sys 用 ``rustc-link-lib=static=cspice`` 链接，
     # Linux 下 cargo 找 ``libcspice.a``，但 MICE 包 lib/ 只带 ``cspice.a``
     # （官方 downloadcspice 分支会重命名，CSPICE_DIR 路径不会）。
-    if platform_name == "linux":
+    if _platform()[0] == "linux":
         src = target / "lib" / "cspice.a"
         dst = target / "lib" / "libcspice.a"
         if src.is_file() and not dst.is_file():

--- a/uv.lock
+++ b/uv.lock
@@ -5,15 +5,19 @@ resolution-markers = [
     "python_full_version >= '3.15'",
     "python_full_version == '3.14.*'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and platform_machine != 'x86_64' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and platform_machine != 'x86_64' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "python_full_version == '3.12.*' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and platform_machine != 'x86_64' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "python_full_version == '3.11.*' and sys_platform == 'win32'",
     "python_full_version < '3.11' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version < '3.11' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and platform_machine != 'x86_64' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "python_full_version < '3.11' and sys_platform == 'win32'",
 ]
 
@@ -112,14 +116,18 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15'",
     "python_full_version == '3.14.*'",
+    "python_full_version == '3.13.*' and platform_machine != 'x86_64' and sys_platform == 'linux'",
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and platform_machine != 'x86_64' and sys_platform == 'linux'",
     "python_full_version == '3.11.*' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and platform_machine != 'x86_64' and sys_platform == 'linux'",
     "python_full_version < '3.11' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version < '3.11' and platform_machine != 'x86_64' and sys_platform == 'linux'",
 ]
 dependencies = [
     { name = "cython" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'linux' and sys_platform != 'win32')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine != 'x86_64') or (python_full_version >= '3.11' and sys_platform != 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'win32'" },
     { name = "setuptools" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c0/83/a3e830fd0ea6e1427fd172b5a4d4f0704cfae5e86471920581ca8e22c0c9/calcephpy-5.0.0.tar.gz", hash = "sha256:abf52b8d2898299ff837f90ed9824cc40d70745700b440374d6f375a86a5e831", size = 8633564, upload-time = "2026-07-06T11:48:01.49Z" }
@@ -129,7 +137,7 @@ name = "calcephpy"
 version = "5.0.0"
 source = { url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl" }
 resolution-markers = [
-    "python_full_version < '3.11' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'",
 ]
 dependencies = [
     { name = "cython" },
@@ -175,7 +183,7 @@ name = "calcephpy"
 version = "5.0.0"
 source = { url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl" }
 resolution-markers = [
-    "python_full_version == '3.11.*' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
 ]
 dependencies = [
     { name = "cython" },
@@ -221,7 +229,7 @@ name = "calcephpy"
 version = "5.0.0"
 source = { url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl" }
 resolution-markers = [
-    "python_full_version == '3.12.*' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
 ]
 dependencies = [
     { name = "cython" },
@@ -267,7 +275,7 @@ name = "calcephpy"
 version = "5.0.0"
 source = { url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl" }
 resolution-markers = [
-    "python_full_version == '3.13.*' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
 ]
 dependencies = [
     { name = "cython" },
@@ -754,7 +762,8 @@ version = "0.21.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version < '3.11' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and platform_machine != 'x86_64' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "python_full_version < '3.11' and sys_platform == 'win32'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ae/ed/aefcc8cd0ba62a0560c3c18c33925362d46c6075480bfa4df87b28e169a9/docutils-0.21.2.tar.gz", hash = "sha256:3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f", size = 2204444, upload-time = "2024-04-23T18:57:18.24Z" }
@@ -770,12 +779,15 @@ resolution-markers = [
     "python_full_version >= '3.15'",
     "python_full_version == '3.14.*'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and platform_machine != 'x86_64' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and platform_machine != 'x86_64' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "python_full_version == '3.12.*' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and platform_machine != 'x86_64' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "python_full_version == '3.11.*' and sys_platform == 'win32'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
@@ -788,14 +800,14 @@ name = "e2m2e"
 version = "5.6.8"
 source = { editable = "." }
 dependencies = [
-    { name = "calcephpy", version = "5.0.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and sys_platform == 'linux') or (python_full_version >= '3.14' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32')" },
-    { name = "calcephpy", version = "5.0.0", source = { url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl" }, marker = "python_full_version < '3.11' and sys_platform == 'linux'" },
+    { name = "calcephpy", version = "5.0.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and sys_platform == 'linux') or (python_full_version >= '3.14' and sys_platform == 'win32') or (platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and sys_platform != 'win32')" },
+    { name = "calcephpy", version = "5.0.0", source = { url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl" }, marker = "python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "calcephpy", version = "5.0.0", source = { url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp310-cp310-win_amd64.whl" }, marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "calcephpy", version = "5.0.0", source = { url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl" }, marker = "python_full_version == '3.11.*' and sys_platform == 'linux'" },
+    { name = "calcephpy", version = "5.0.0", source = { url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl" }, marker = "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "calcephpy", version = "5.0.0", source = { url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp311-cp311-win_amd64.whl" }, marker = "python_full_version == '3.11.*' and sys_platform == 'win32'" },
-    { name = "calcephpy", version = "5.0.0", source = { url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl" }, marker = "python_full_version == '3.12.*' and sys_platform == 'linux'" },
+    { name = "calcephpy", version = "5.0.0", source = { url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl" }, marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "calcephpy", version = "5.0.0", source = { url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp312-cp312-win_amd64.whl" }, marker = "python_full_version == '3.12.*' and sys_platform == 'win32'" },
-    { name = "calcephpy", version = "5.0.0", source = { url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl" }, marker = "python_full_version == '3.13.*' and sys_platform == 'linux'" },
+    { name = "calcephpy", version = "5.0.0", source = { url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl" }, marker = "python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "calcephpy", version = "5.0.0", source = { url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp313-cp313-win_amd64.whl" }, marker = "python_full_version == '3.13.*' and sys_platform == 'win32'" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -838,11 +850,11 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "calcephpy", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version >= '3.14' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32') or (python_full_version >= '3.14' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32')", specifier = "==5.0.0" },
-    { name = "calcephpy", marker = "python_full_version == '3.10.*' and sys_platform == 'linux'", url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl" },
-    { name = "calcephpy", marker = "python_full_version == '3.11.*' and sys_platform == 'linux'", url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl" },
-    { name = "calcephpy", marker = "python_full_version == '3.12.*' and sys_platform == 'linux'", url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl" },
-    { name = "calcephpy", marker = "python_full_version == '3.13.*' and sys_platform == 'linux'", url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl" },
+    { name = "calcephpy", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version >= '3.14' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32') or (python_full_version >= '3.14' and sys_platform == 'win32') or (platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and sys_platform != 'win32')", specifier = "==5.0.0" },
+    { name = "calcephpy", marker = "python_full_version == '3.10.*' and platform_machine == 'x86_64' and sys_platform == 'linux'", url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl" },
+    { name = "calcephpy", marker = "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'", url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl" },
+    { name = "calcephpy", marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'", url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl" },
+    { name = "calcephpy", marker = "python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'linux'", url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl" },
     { name = "calcephpy", marker = "python_full_version == '3.10.*' and sys_platform == 'win32'", url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp310-cp310-win_amd64.whl" },
     { name = "calcephpy", marker = "python_full_version == '3.11.*' and sys_platform == 'win32'", url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp311-cp311-win_amd64.whl" },
     { name = "calcephpy", marker = "python_full_version == '3.12.*' and sys_platform == 'win32'", url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp312-cp312-win_amd64.whl" },
@@ -1093,7 +1105,8 @@ version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version < '3.11' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and platform_machine != 'x86_64' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "python_full_version < '3.11' and sys_platform == 'win32'",
 ]
 dependencies = [
@@ -1112,12 +1125,15 @@ resolution-markers = [
     "python_full_version >= '3.15'",
     "python_full_version == '3.14.*'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and platform_machine != 'x86_64' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and platform_machine != 'x86_64' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "python_full_version == '3.12.*' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and platform_machine != 'x86_64' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "python_full_version == '3.11.*' and sys_platform == 'win32'",
 ]
 dependencies = [
@@ -1380,7 +1396,8 @@ version = "4.0.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version < '3.11' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and platform_machine != 'x86_64' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "python_full_version < '3.11' and sys_platform == 'win32'",
 ]
 dependencies = [
@@ -1404,12 +1421,15 @@ resolution-markers = [
     "python_full_version >= '3.15'",
     "python_full_version == '3.14.*'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and platform_machine != 'x86_64' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and platform_machine != 'x86_64' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "python_full_version == '3.12.*' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and platform_machine != 'x86_64' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "python_full_version == '3.11.*' and sys_platform == 'win32'",
 ]
 dependencies = [
@@ -1432,7 +1452,8 @@ version = "2.2.6"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version < '3.11' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and platform_machine != 'x86_64' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "python_full_version < '3.11' and sys_platform == 'win32'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/21/7d2a95e4bba9dc13d043ee156a356c0a8f0c6309dff6b21b4d71a073b8a8/numpy-2.2.6.tar.gz", hash = "sha256:e29554e2bef54a90aa5cc07da6ce955accb83f21ab5de01a62c8478897b264fd", size = 20276440, upload-time = "2025-05-17T22:38:04.611Z" }
@@ -1501,12 +1522,15 @@ resolution-markers = [
     "python_full_version >= '3.15'",
     "python_full_version == '3.14.*'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and platform_machine != 'x86_64' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and platform_machine != 'x86_64' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "python_full_version == '3.12.*' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and platform_machine != 'x86_64' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "python_full_version == '3.11.*' and sys_platform == 'win32'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d7/9f/b8cef5bffa569759033adda9481211426f12f53299629b410340795c2514/numpy-2.4.4.tar.gz", hash = "sha256:2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0", size = 20731587, upload-time = "2026-03-29T13:22:01.298Z" }
@@ -1956,14 +1980,14 @@ name = "r2s2"
 version = "0.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "calcephpy", version = "5.0.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and sys_platform == 'linux') or (python_full_version >= '3.14' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32')" },
-    { name = "calcephpy", version = "5.0.0", source = { url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl" }, marker = "python_full_version < '3.11' and sys_platform == 'linux'" },
+    { name = "calcephpy", version = "5.0.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and sys_platform == 'linux') or (python_full_version >= '3.14' and sys_platform == 'win32') or (platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and sys_platform != 'win32')" },
+    { name = "calcephpy", version = "5.0.0", source = { url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl" }, marker = "python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "calcephpy", version = "5.0.0", source = { url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp310-cp310-win_amd64.whl" }, marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "calcephpy", version = "5.0.0", source = { url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl" }, marker = "python_full_version == '3.11.*' and sys_platform == 'linux'" },
+    { name = "calcephpy", version = "5.0.0", source = { url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl" }, marker = "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "calcephpy", version = "5.0.0", source = { url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp311-cp311-win_amd64.whl" }, marker = "python_full_version == '3.11.*' and sys_platform == 'win32'" },
-    { name = "calcephpy", version = "5.0.0", source = { url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl" }, marker = "python_full_version == '3.12.*' and sys_platform == 'linux'" },
+    { name = "calcephpy", version = "5.0.0", source = { url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl" }, marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "calcephpy", version = "5.0.0", source = { url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp312-cp312-win_amd64.whl" }, marker = "python_full_version == '3.12.*' and sys_platform == 'win32'" },
-    { name = "calcephpy", version = "5.0.0", source = { url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl" }, marker = "python_full_version == '3.13.*' and sys_platform == 'linux'" },
+    { name = "calcephpy", version = "5.0.0", source = { url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl" }, marker = "python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "calcephpy", version = "5.0.0", source = { url = "https://github.com/cislunarspace/e2m2e/releases/download/calcephpy-v1/calcephpy-5.0.0-cp313-cp313-win_amd64.whl" }, marker = "python_full_version == '3.13.*' and sys_platform == 'win32'" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -2018,7 +2042,8 @@ version = "0.30.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version < '3.11' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and platform_machine != 'x86_64' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "python_full_version < '3.11' and sys_platform == 'win32'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
@@ -2147,12 +2172,15 @@ resolution-markers = [
     "python_full_version >= '3.15'",
     "python_full_version == '3.14.*'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and platform_machine != 'x86_64' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and platform_machine != 'x86_64' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "python_full_version == '3.12.*' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and platform_machine != 'x86_64' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "python_full_version == '3.11.*' and sys_platform == 'win32'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/aa/2a/9618a122aeb2a169a28b03889a2995fe297588964333d4a7d67bdf46e147/rpds_py-2026.6.3.tar.gz", hash = "sha256:1cebd1337c242e4ec2293e541f712b2da849b29f48f0c293684b71c0632625d4", size = 64051, upload-time = "2026-06-30T07:17:53.009Z" }
@@ -2305,7 +2333,8 @@ version = "1.15.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version < '3.11' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and platform_machine != 'x86_64' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "python_full_version < '3.11' and sys_platform == 'win32'",
 ]
 dependencies = [
@@ -2368,12 +2397,15 @@ resolution-markers = [
     "python_full_version >= '3.15'",
     "python_full_version == '3.14.*'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and platform_machine != 'x86_64' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and platform_machine != 'x86_64' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "python_full_version == '3.12.*' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and platform_machine != 'x86_64' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "python_full_version == '3.11.*' and sys_platform == 'win32'",
 ]
 dependencies = [
@@ -2467,7 +2499,8 @@ version = "8.1.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version < '3.11' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and platform_machine != 'x86_64' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "python_full_version < '3.11' and sys_platform == 'win32'",
 ]
 dependencies = [
@@ -2500,7 +2533,8 @@ version = "9.0.4"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and platform_machine != 'x86_64' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "python_full_version == '3.11.*' and sys_platform == 'win32'",
 ]
 dependencies = [
@@ -2535,9 +2569,11 @@ resolution-markers = [
     "python_full_version >= '3.15'",
     "python_full_version == '3.14.*'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and platform_machine != 'x86_64' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and platform_machine != 'x86_64' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "python_full_version == '3.12.*' and sys_platform == 'win32'",
 ]
 dependencies = [


### PR DESCRIPTION
支持 aarch64 Linux（arm64）的构建与发布：CSPICE arm64 静态库、release 构建矩阵、calcephpy arm64 wheel。

## 改动

- **CSPICE aarch64 静态库**：NAIF 官方无 Linux ARM64 预编译包（conda-forge 亦无），新增 `cspice-aarch64-build.yml` 在 GitHub 原生 arm64 runner 上从 NAIF 源码包（cspice-sys 同源 URL）编译并发布到 `cspice-v1` release；`scripts/download_cspice.py` 按机器架构选择 x86_64/aarch64 资产（解压目录按架构隔离，避免缓存串用）。
- **release 构建矩阵**：增加 `ubuntu-24.04-arm` / `aarch64-unknown-linux-gnu`（maturin-action 自动用 manylinux_2_28_aarch64 原生容器，无交叉工具链问题）。
- **calcephpy arm64 wheel**：`calcephpy-wheel.yml` 增加 build-linux-aarch64 job（manylinux_2_28_aarch64）；`[tool.uv.sources]` 按 `platform_machine` 区分架构，arm 用户免现场编译（aarch64 条目暂注释，wheel 发布后启用）。
- **CI 回归**：新增 test-arm64 job，cargo test 全量跑在原生 arm64 runner。
- 文档：CHANGELOG [Unreleased]、README 平台说明、`scripts/colab_download_cspice.py`（NAIF 源码包下载辅助，国内网络不可达时的获取途径）。

## 测试

- 本地：ruff 通过、YAML 合法、download_cspice.py 架构选择模拟验证、x86_64 路径不回归。
- 交叉编译冒烟：`aarch64-linux-gnu-gcc` 编译 `libcspice.a` 验证为 ARM aarch64 ELF，C 程序链接 `furnsh_c` 成功。
- `cspice-linux-aarch64.zip` 已上传 `cspice-v1` release，CI 的 test-arm64 可直接运行。

无关联 issue。
