### PR TITLE
fix(ci): 修 aarch64 架构校验——file 对 ar 归档不报架构，改取归档成员检查

### DIFF
--- a/.github/workflows/cspice-aarch64-build.yml
+++ b/.github/workflows/cspice-aarch64-build.yml
@@ -62,9 +62,10 @@ jobs:
           set -eux
           # make 产物是 lib/cspice.a（NAIF makefile），cspice-sys 需要 libcspice.a
           cp cspice/lib/cspice.a cspice/lib/libcspice.a
-          file cspice/lib/libcspice.a
-          # 必须为 aarch64 ELF 静态库，否则后续 wheel 构建链接必炸
-          file cspice/lib/libcspice.a | grep -q aarch64
+          # 必须为 aarch64 ELF 静态库，否则后续 wheel 构建链接必炸。file 对 ar
+          # 归档只报 "current ar archive" 不带架构，须取归档第一个成员检查。
+          ar p cspice/lib/libcspice.a $(ar t cspice/lib/libcspice.a | head -1) \
+            | file - | grep -q aarch64
           mkdir -p mice_linux_aarch64/include mice_linux_aarch64/lib
           cp -r cspice/include/* mice_linux_aarch64/include/
           cp cspice/lib/libcspice.a mice_linux_aarch64/lib/


### PR DESCRIPTION
修复 cspice-aarch64-build workflow 的架构校验步骤。此前两次运行都失败在 `file libcspice.a | grep -q aarch64`：file 对 ar 归档只报 "current ar archive" 不带架构，该校验从未通过过（编译本身其实已成功——2229 个 .o、ar 打包、ranlib 均正常完成）。

修复：取归档第一个成员文件检查架构（本地已验证：x86_64 库报 x86-64 被正确拒绝，aarch64 库报 ARM aarch64 通过）。冒烟链接检查（file smoke）不变——smoke 是 ELF 可执行文件，file 正常报架构。

合并后 push 到 master 会再次触发该 workflow 做端到端验证（编译 → 架构校验 → 冒烟 → 打包 → 覆盖上传 cspice-v1）。

无关联 issue。
