### PR TITLE
为轨道设计模型公开条件参数范围

### DIFF
--- a/docs/adr/0014-api-facade-mcp-cli.md
+++ b/docs/adr/0014-api-facade-mcp-cli.md
@@ -17,6 +17,7 @@ e2m2e 现有对外形态是散装 API（用户拼 `CR3BP_System → Dynamics →
 5. **CLI 子命令 = Facade 方法**（mcp_exposed=True 的），参数从同一份 Pydantic 模型生成。CLI 与 MCP 完全对称。
 6. **MCP 部署形态 = 进程内库为主体 + CLI 薄包装 mcp-serve**：`create_server(facade)` 函数 + `e2m2e mcp-serve` 子命令。一个 Facade 实例 = 一个 server。
 7. **config.py 构造注入**：`Facade(config=Config(...))`，只管运行环境（内核路径/精度阈值/日志）；物理常量归 data/templates/。SPICEManager 全局句柄、r2s2 进程单例作为已知限制用 Config 显式管理。
+8. **条件取值域公开且同源**：输入模型中依赖其他字段的取值域，必须通过机器可读的公开接口提供；校验器与该接口共用一份规则定义。GUI、CLI、MCP 不得解析错误文本、阅读校验器源码或维护本地范围副本。
 
 ### MCP 工具清单
 
@@ -27,10 +28,10 @@ e2m2e 现有对外形态是散装 API（用户拼 `CR3BP_System → Dynamics →
 ## 理由
 
 1. **纯派生**：Facade 方法单一来源，加能力 = 加 Facade 方法 + 手写模型 = MCP 工具 + CLI 子命令自动都有，清单不漂移。
-2. **手写模型**：一档是 Agent 最常用的，schema 要精心（单位/默认值/取值域在 Pydantic 里写清），为后续维护质量。
+2. **手写模型**：一档是 Agent 最常用的，schema 要精心（单位/默认值/取值域在 Pydantic 里写清）；条件取值域不能由静态 schema 完整表达时，以模型公开接口补充，为后续维护质量。
 3. **CLI 与 MCP 对称**：同一个 Facade 方法，MCP 给 Agent、CLI 给人类，参数校验同一套模型。
 
 ## 结果
 
 - api/ 层提供 Facade/config/models/mcp/cli。
-- transfer-orbit-design 保留独立仓库只留 GUI（废弃 tod/generates 算法脚本层，被 e2m2e CLI 覆盖），GUI 参数表单从 e2m2e Pydantic 模型生成。
+- transfer-orbit-design 保留独立仓库只留 GUI（废弃 tod/generates 算法脚本层，被 e2m2e CLI 覆盖），GUI 参数表单从 e2m2e Pydantic 模型及其条件取值域公开接口生成。

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -49,6 +49,8 @@
 
 任务级 Facade（MCP/CLI 同源派生）、任务轨道设计的算法链（族初猜 → Rust 修正 → 高精度预报三段）、子问题构造（族策略、控制律、流形种子）三层编排。
 
+任务级 API 模型除执行输入校验外，还公开当前任务上下文下的参数元数据，供 GUI、CLI、MCP 生成控件及范围提示；条件取值域与校验器共用同一份规则定义，外部消费者不维护本地参数规则副本。
+
 ## 4. CI 模块
 
 支持 Linux x64 AMD（Ubuntu、麒麟等操作系统）、Linux ARM（aarch64，鲲鹏/飞腾）、Windows 平台的软件编译。三平台 wheel 矩阵 + sdist + GitHub Release + PyPI；CSPICE 编译包（x86_64 转存 NAIF 官方包，aarch64 自建）走 GitHub Release；麒麟等国产系统靠 manylinux 2_28 的 glibc 基线覆盖。

--- a/e2m2e/api/__init__.py
+++ b/e2m2e/api/__init__.py
@@ -20,6 +20,7 @@ from .models import (
     ControlOrbitResponse,
     DesignOrbitRequest,
     DesignOrbitResponse,
+    NumericRange,
     OrbitError,
 )
 
@@ -27,6 +28,7 @@ __all__ = [
     "Facade",
     "mcp_tools",
     "OrbitError",
+    "NumericRange",
     "DesignOrbitRequest",
     "DesignOrbitResponse",
     "ControlOrbitRequest",

--- a/e2m2e/api/models.py
+++ b/e2m2e/api/models.py
@@ -7,6 +7,9 @@ api/ 边界，算法层用 numpy/dataclass。每个 Facade 方法一个 Request/
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -18,6 +21,7 @@ from e2m2e.data.templates.perturbations import DEFAULT_PERTURBATION
 
 __all__ = [
     "OrbitError",
+    "NumericRange",
     "ResultResponse",
     "DesignOrbitRequest",
     "DesignOrbitResponse",
@@ -67,6 +71,86 @@ class _ApiModel(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+@dataclass(frozen=True)
+class NumericRange:
+    """数值参数的上下界及开闭区间语义。"""
+
+    minimum: float | None = None
+    maximum: float | None = None
+    minimum_inclusive: bool = True
+    maximum_inclusive: bool = True
+
+    def contains(self, value: float) -> bool:
+        """判断值是否落在此区间内。"""
+        if self.minimum is not None and (
+            value < self.minimum or (value == self.minimum and not self.minimum_inclusive)
+        ):
+            return False
+        return not (
+            self.maximum is not None
+            and (value > self.maximum or (value == self.maximum and not self.maximum_inclusive))
+        )
+
+    def format_interval(self) -> str:
+        """返回用于校验错误的紧凑区间表示。"""
+        left = "[" if self.minimum_inclusive else "("
+        right = "]" if self.maximum_inclusive else ")"
+        return f"{left}{self.minimum}, {self.maximum}{right}"
+
+
+def _range_map(**ranges: NumericRange) -> Mapping[str, NumericRange]:
+    """构造不可变的按字段索引范围表。"""
+    return MappingProxyType(ranges)
+
+
+_GLOBAL_AMPLITUDE_OUT_RANGE = NumericRange(0.0, 76000.0, minimum_inclusive=False)
+
+
+def _with_global_amplitude_out(
+    ranges: Mapping[str, NumericRange],
+) -> Mapping[str, NumericRange]:
+    """为各类型范围补上共享字段 amplitude_out 的 API 上限。"""
+    return MappingProxyType({"amplitude_out": _GLOBAL_AMPLITUDE_OUT_RANGE, **ranges})
+
+
+_GLOBAL_AMPLITUDE_OUT_RANGES = _with_global_amplitude_out(_range_map())
+_DRO_DPO_RANGES = _with_global_amplitude_out(_range_map(amplitude=NumericRange(1737.0, 110000.0)))
+_SPO_RANGES = _with_global_amplitude_out(_range_map(amplitude=NumericRange(1737.0, 200000.0)))
+_LPO_RANGES = _with_global_amplitude_out(_range_map(amplitude=NumericRange(1000.0, 200000.0)))
+_HORSESHOE_RANGES = _with_global_amplitude_out(
+    _range_map(amplitude=NumericRange(50000.0, 200000.0))
+)
+
+_ORBIT_TYPE_RANGES: Mapping[str, Mapping[str, NumericRange]] = MappingProxyType(
+    {
+        "DRO": _DRO_DPO_RANGES,
+        "DPO": _DRO_DPO_RANGES,
+        "HALO": _with_global_amplitude_out(_range_map(amplitude=NumericRange(-73000.0, 73000.0))),
+        "NRHO": _with_global_amplitude_out(
+            _range_map(perilune_height=NumericRange(100.0, 10000.0))
+        ),
+        "L4": _GLOBAL_AMPLITUDE_OUT_RANGES,
+        "L5": _GLOBAL_AMPLITUDE_OUT_RANGES,
+        "AXIAL": _with_global_amplitude_out(_range_map(amplitude=NumericRange(-60000.0, 60000.0))),
+        "L4_SPO": _SPO_RANGES,
+        "L5_SPO": _SPO_RANGES,
+        "L4_LPO": _LPO_RANGES,
+        "L5_LPO": _LPO_RANGES,
+        "L4_HORSESHOE": _HORSESHOE_RANGES,
+        "L5_HORSESHOE": _HORSESHOE_RANGES,
+        "ELFO": _GLOBAL_AMPLITUDE_OUT_RANGES,
+    }
+)
+_LISSAJOUS_L1_L2_RANGES = _range_map(
+    amplitude_in=NumericRange(0.0, 7600.0, minimum_inclusive=False),
+    amplitude_out=NumericRange(0.0, 7600.0, minimum_inclusive=False),
+)
+_LISSAJOUS_L3_RANGES = _range_map(
+    amplitude_in=NumericRange(0.0, 100000.0, minimum_inclusive=False),
+    amplitude_out=NumericRange(0.0, 100000.0, minimum_inclusive=False),
+)
+
+
 class DesignOrbitRequest(_ApiModel):
     """任务轨道设计输入。
 
@@ -82,7 +166,7 @@ class DesignOrbitRequest(_ApiModel):
     collinear_point: int | None = Field(default=None, ge=1, le=3)
     north_south: int | None = Field(default=None, ge=1, le=2)
     amplitude_in: float | None = Field(default=None, gt=0.0, le=100000.0)
-    amplitude_out: float | None = Field(default=None, gt=0.0, le=76000.0)
+    amplitude_out: float | None = Field(default=None, gt=0.0, le=100000.0)
     phase_in: float | None = Field(default=None, ge=0.0, le=1.0)
     phase_out: float | None = Field(default=None, ge=0.0, le=1.0)
     # 共享参数
@@ -117,6 +201,39 @@ class DesignOrbitRequest(_ApiModel):
     correction_revolutions: int = Field(default=1, ge=1)
     correction_velocity_tolerance: float = Field(default=0.1, gt=0.0)
 
+    @classmethod
+    def valid_ranges(
+        cls, orbit_type: str, *, collinear_point: int | None = None
+    ) -> dict[str, NumericRange]:
+        """返回指定轨道类型和上下文下适用的条件数值范围。"""
+        if not isinstance(orbit_type, str):
+            raise ValueError(f"orbit_type 必须为字符串，当前 {orbit_type!r}")
+        selection = orbit_type.upper()
+        if selection == "LISSAJOUS":
+            point = 2 if collinear_point is None else collinear_point
+            if point not in (1, 2, 3):
+                raise ValueError(
+                    f"LISSAJOUS collinear_point 必须为 1、2 或 3，当前 {collinear_point!r}"
+                )
+            ranges = _LISSAJOUS_L3_RANGES if point == 3 else _LISSAJOUS_L1_L2_RANGES
+        else:
+            try:
+                ranges = _ORBIT_TYPE_RANGES[selection]
+            except KeyError as exc:
+                raise ValueError(f"不支持的 orbit_type: {orbit_type!r}") from exc
+        return dict(ranges)
+
+    def _validate_conditional_ranges(self, selection: str) -> None:
+        """用公开范围接口校验已填充默认值的条件参数。"""
+        for field, numeric_range in self.valid_ranges(
+            selection, collinear_point=self.collinear_point
+        ).items():
+            value = getattr(self, field)
+            if value is not None and not numeric_range.contains(value):
+                raise ValueError(
+                    f"{selection} {field} 应在 {numeric_range.format_interval()} km，实际 {value}"
+                )
+
     @model_validator(mode="after")
     def _validate_orbit_type(self) -> DesignOrbitRequest:
         sel = self.orbit_type.upper()
@@ -133,6 +250,7 @@ class DesignOrbitRequest(_ApiModel):
                 self.arg_of_pericenter = 270.0
             if self.perilune_height is None:
                 self.perilune_height = 200.0
+            self._validate_conditional_ranges(sel)
             return self
 
         # CR3BP 类型：按类型填默认值
@@ -141,15 +259,11 @@ class DesignOrbitRequest(_ApiModel):
                 self.amplitude = 10000.0
             if self.phase is None:
                 self.phase = 0.5001
-            if not 1737.0 <= self.amplitude <= 110000.0:
-                raise ValueError(f"DRO amplitude 应在 1737~110000 km，实际 {self.amplitude}")
         elif sel == "DPO":
             if self.amplitude is None:
                 self.amplitude = 20000.0
             if self.phase is None:
                 self.phase = 0.5001
-            if not 1737.0 <= self.amplitude <= 110000.0:
-                raise ValueError(f"DPO amplitude 应在 1737~110000 km，实际 {self.amplitude}")
         elif sel == "HALO":
             if self.collinear_point is None:
                 self.collinear_point = 2
@@ -159,8 +273,6 @@ class DesignOrbitRequest(_ApiModel):
                 self.phase = 0.0
             if self.collinear_point not in (1, 2):
                 raise ValueError(f"HALO collinear_point 必须为 1 或 2，当前 {self.collinear_point}")
-            if abs(self.amplitude) > 73000.0:
-                raise ValueError(f"HALO amplitude 应在 ±73000 km，实际 {self.amplitude}")
         elif sel == "NRHO":
             if self.collinear_point is None:
                 self.collinear_point = 2
@@ -172,10 +284,6 @@ class DesignOrbitRequest(_ApiModel):
                 self.phase = 0.5
             if self.collinear_point not in (1, 2):
                 raise ValueError(f"NRHO collinear_point 必须为 1 或 2，当前 {self.collinear_point}")
-            if not 100.0 <= self.perilune_height <= 10000.0:
-                raise ValueError(
-                    f"NRHO perilune_height 应在 100~10000 km，实际 {self.perilune_height}"
-                )
         elif sel == "LISSAJOUS":
             if self.collinear_point is None:
                 self.collinear_point = 2
@@ -187,15 +295,6 @@ class DesignOrbitRequest(_ApiModel):
                 self.phase_in = 0.01
             if self.phase_out is None:
                 self.phase_out = 0.55
-            limit = 100000.0 if self.collinear_point == 3 else 7600.0
-            if not 0.0 < self.amplitude_in <= limit:
-                raise ValueError(
-                    f"LISSAJOUS amplitude_in 应在 (0, {limit}] km，实际 {self.amplitude_in}"
-                )
-            if not 0.0 < self.amplitude_out <= limit:
-                raise ValueError(
-                    f"LISSAJOUS amplitude_out 应在 (0, {limit}] km，实际 {self.amplitude_out}"
-                )
         elif sel in ("L4", "L5"):
             if self.amplitude_in is None:
                 self.amplitude_in = 8000.0
@@ -212,34 +311,27 @@ class DesignOrbitRequest(_ApiModel):
                 self.amplitude = 5000.0
             if self.phase is None:
                 self.phase = 0.0
-            if abs(self.amplitude) > 60000.0:
-                raise ValueError(f"AXIAL amplitude 应在 ±60000 km，实际 {self.amplitude}")
         elif sel in ("L4_SPO", "L5_SPO"):
             if self.amplitude is None:
                 self.amplitude = 10000.0
             if self.phase is None:
                 self.phase = 0.0
-            if not 1737.0 <= self.amplitude <= 200000.0:
-                raise ValueError(f"{sel} amplitude 应在 1737~200000 km，实际 {self.amplitude}")
         elif sel in ("L4_LPO", "L5_LPO"):
             if self.amplitude is None:
                 self.amplitude = 50000.0
             if self.phase is None:
                 self.phase = 0.0
-            if not 1000.0 <= self.amplitude <= 200000.0:
-                raise ValueError(f"{sel} amplitude 应在 1000~200000 km，实际 {self.amplitude}")
         elif sel in ("L4_HORSESHOE", "L5_HORSESHOE"):
             if self.amplitude is None:
                 self.amplitude = 150000.0
             if self.phase is None:
                 self.phase = 0.0
-            if not 50000.0 <= self.amplitude <= 200000.0:
-                raise ValueError(f"{sel} amplitude 应在 50000~200000 km，实际 {self.amplitude}")
         else:
             raise ValueError(
                 f"orbit_type 必须为 DRO/DPO/NRHO/HALO/LISSAJOUS/L4/L5/AXIAL"
                 f"/L4_SPO/L5_SPO/L4_LPO/L5_LPO/L4_HORSESHOE/L5_HORSESHOE/ELFO，当前 {sel!r}"
             )
+        self._validate_conditional_ranges(sel)
         return self
 
 

--- a/tests/api/test_facade.py
+++ b/tests/api/test_facade.py
@@ -9,6 +9,7 @@ import numpy as np
 import pytest
 from pydantic import ValidationError
 
+from e2m2e.api import NumericRange
 from e2m2e.api.facade import Facade, mcp_tools
 from e2m2e.api.models import (
     ControlOrbitRequest,
@@ -27,6 +28,21 @@ from e2m2e.data.types.trajectory import EphemerisTable
 pytestmark = pytest.mark.interface
 
 _CONTROL_RUNTIME_PARAMS = {"spice", "kernel_dir", "n_workers", "seed"}
+_CONDITIONAL_RANGE_CASES = [
+    ("DRO", "amplitude", 1737.0, 110000.0, True),
+    ("DPO", "amplitude", 1737.0, 110000.0, True),
+    ("HALO", "amplitude", -73000.0, 73000.0, True),
+    ("NRHO", "perilune_height", 100.0, 10000.0, True),
+    ("L4", "amplitude_out", 0.0, 76000.0, False),
+    ("L5", "amplitude_out", 0.0, 76000.0, False),
+    ("AXIAL", "amplitude", -60000.0, 60000.0, True),
+    ("L4_SPO", "amplitude", 1737.0, 200000.0, True),
+    ("L5_SPO", "amplitude", 1737.0, 200000.0, True),
+    ("L4_LPO", "amplitude", 1000.0, 200000.0, True),
+    ("L5_LPO", "amplitude", 1000.0, 200000.0, True),
+    ("L4_HORSESHOE", "amplitude", 50000.0, 200000.0, True),
+    ("L5_HORSESHOE", "amplitude", 50000.0, 200000.0, True),
+]
 
 
 def _control_business_params() -> dict[str, inspect.Parameter]:
@@ -61,6 +77,94 @@ class TestDesignOrbitRequest:
     def test_perilune_height_bounds(self):
         with pytest.raises(ValidationError):
             DesignOrbitRequest(orbit_type="NRHO", perilune_height=50.0)
+
+    def test_global_amplitude_out_bound_survives_lissajous_l3_extension(self):
+        with pytest.raises(ValidationError, match="amplitude_out"):
+            DesignOrbitRequest(orbit_type="DRO", amplitude_out=80000.0)
+        with pytest.raises(ValidationError, match="amplitude_out"):
+            DesignOrbitRequest(orbit_type="ELFO", semi_major_axis=3000.0, amplitude_out=80000.0)
+
+    def test_valid_ranges_exposes_conditional_amplitude_limits(self):
+        dro = DesignOrbitRequest.valid_ranges("dro")
+        halo = DesignOrbitRequest.valid_ranges("HALO")
+        axial = DesignOrbitRequest.valid_ranges("AXIAL")
+
+        assert dro["amplitude"].minimum == 1737.0
+        assert dro["amplitude"].maximum == 110000.0
+        assert dro["amplitude"].minimum_inclusive
+        assert dro["amplitude"].maximum_inclusive
+        assert halo["amplitude"].minimum == -73000.0
+        assert halo["amplitude"].maximum == 73000.0
+        assert axial["amplitude"].minimum == -60000.0
+        assert axial["amplitude"].maximum == 60000.0
+
+    @pytest.mark.parametrize(
+        ("orbit_type", "field", "minimum", "maximum", "minimum_inclusive"),
+        _CONDITIONAL_RANGE_CASES,
+    )
+    def test_valid_ranges_exposes_all_conditional_numeric_limits(
+        self, orbit_type, field, minimum, maximum, minimum_inclusive
+    ):
+        numeric_range = DesignOrbitRequest.valid_ranges(orbit_type)[field]
+
+        assert numeric_range.minimum == minimum
+        assert numeric_range.maximum == maximum
+        assert numeric_range.minimum_inclusive is minimum_inclusive
+        assert numeric_range.maximum_inclusive
+
+    @pytest.mark.parametrize(
+        ("orbit_type", "field", "minimum", "maximum", "minimum_inclusive"),
+        _CONDITIONAL_RANGE_CASES,
+    )
+    def test_conditional_range_boundaries_match_request_validation(
+        self, orbit_type, field, minimum, maximum, minimum_inclusive
+    ):
+        accepted = DesignOrbitRequest(orbit_type=orbit_type, **{field: maximum})
+        assert getattr(accepted, field) == maximum
+
+        with pytest.raises(ValidationError, match=field):
+            DesignOrbitRequest(orbit_type=orbit_type, **{field: maximum + 1.0})
+
+        if minimum_inclusive:
+            accepted = DesignOrbitRequest(orbit_type=orbit_type, **{field: minimum})
+            assert getattr(accepted, field) == minimum
+            with pytest.raises(ValidationError, match=field):
+                DesignOrbitRequest(orbit_type=orbit_type, **{field: minimum - 1.0})
+        else:
+            with pytest.raises(ValidationError, match=field):
+                DesignOrbitRequest(orbit_type=orbit_type, **{field: minimum})
+            accepted = DesignOrbitRequest(orbit_type=orbit_type, **{field: minimum + 1.0})
+            assert getattr(accepted, field) == minimum + 1.0
+
+    def test_valid_ranges_exposes_lissajous_limit_by_collinear_point(self):
+        default = DesignOrbitRequest.valid_ranges("LISSAJOUS")
+        l1 = DesignOrbitRequest.valid_ranges("LISSAJOUS", collinear_point=1)
+        l3 = DesignOrbitRequest.valid_ranges("LISSAJOUS", collinear_point=3)
+
+        assert default["amplitude_out"].maximum == 7600.0
+        assert l1["amplitude_in"].minimum == 0.0
+        assert not l1["amplitude_in"].minimum_inclusive
+        assert l1["amplitude_out"].maximum == 7600.0
+        assert l3["amplitude_in"].maximum == 100000.0
+        assert l3["amplitude_out"].maximum == 100000.0
+        assert isinstance(l3["amplitude_out"], NumericRange)
+
+        with pytest.raises(ValueError, match="collinear_point"):
+            DesignOrbitRequest.valid_ranges("LISSAJOUS", collinear_point=4)
+        with pytest.raises(ValueError, match="字符串"):
+            DesignOrbitRequest.valid_ranges(None)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("field", ["amplitude_in", "amplitude_out"])
+    def test_lissajous_boundaries_match_ranges(self, field):
+        l1 = DesignOrbitRequest(orbit_type="LISSAJOUS", collinear_point=1, **{field: 7600.0})
+        l3 = DesignOrbitRequest(orbit_type="LISSAJOUS", collinear_point=3, **{field: 80000.0})
+        assert getattr(l1, field) == 7600.0
+        assert getattr(l3, field) == 80000.0
+
+        with pytest.raises(ValidationError, match=field):
+            DesignOrbitRequest(orbit_type="LISSAJOUS", collinear_point=1, **{field: 0.0})
+        with pytest.raises(ValidationError, match=field):
+            DesignOrbitRequest(orbit_type="LISSAJOUS", collinear_point=1, **{field: 80000.0})
 
 
 class TestControlOrbitRequest:


### PR DESCRIPTION
关联 issue：#409（DesignOrbitRequest 的分支范围只在 model_validator 代码里，GUI 无法机器读取每类型可填范围）。

## 改动摘要

- 新增公开的 `NumericRange` 值对象（上下界 + 开闭区间语义）与 `DesignOrbitRequest.valid_ranges(orbit_type, *, collinear_point=None)`，GUI/CLI/MCP 可直接读取各轨道类型当前上下文下的可填范围。
- 条件范围由不可变映射统一维护，`model_validator` 复用同一份规则校验，公开接口与实际校验不再漂移。
- 修复 Lissajous L3：`amplitude_in/out` 上限按 L3 为 100000 km、L1/L2 为 7600 km；L3 填 80000 km 现在可正常通过，L1/L2 仍拒绝。
- 保持其他轨道类型原有的 `amplitude_out` 全局上限，不改变既有 API 接受/拒绝行为。
- ADR 0014 新增决策 8（条件取值域公开且同源），架构文档补充任务级 API 参数元数据契约说明。

## 测试

- `uv run pytest tests/api/test_facade.py tests/algorithm/family/test_axial_family.py tests/algorithm/family/test_dpo_family.py tests/algorithm/family/test_spo_family.py tests/algorithm/family/test_lpo_family.py tests/algorithm/family/test_horseshoe_family.py` — 183 passed
- `make test-python` — 1741 passed, 264 skipped
- `make check` — 通过（cargo fmt、clippy、ruff check、ruff format）
- `uv run mypy e2m2e/api/ --ignore-missing-imports` — 通过

注：`make test-rust` 中的 SRP Jacobian 两项测试因缺少 `kernels/de430.bsp` 未运行，与本次改动无关。
