### PR TITLE
fix(api): 删除 DesignOrbitRequest 死参数 correction_velocity_tolerance (#410)

### DIFF
--- a/e2m2e/api/models.py
+++ b/e2m2e/api/models.py
@@ -199,7 +199,6 @@ class DesignOrbitRequest(_ApiModel):
         "对不稳定轨道必发散），传入值会被覆盖",
     )
     correction_revolutions: int = Field(default=1, ge=1)
-    correction_velocity_tolerance: float = Field(default=0.1, gt=0.0)
 
     @classmethod
     def valid_ranges(

--- a/tests/api/test_facade.py
+++ b/tests/api/test_facade.py
@@ -78,6 +78,13 @@ class TestDesignOrbitRequest:
         with pytest.raises(ValidationError):
             DesignOrbitRequest(orbit_type="NRHO", perilune_height=50.0)
 
+    def test_dead_correction_velocity_tolerance_rejected(self):
+        """correction_velocity_tolerance 无消费方（#410），删除后按 extra=forbid 拒绝。"""
+        with pytest.raises(ValidationError, match="correction_velocity_tolerance"):
+            DesignOrbitRequest(orbit_type="DRO", correction_velocity_tolerance=0.5)
+        with pytest.raises(ValidationError, match="correction_velocity_tolerance"):
+            DesignOrbitRequest(orbit_type="NRHO", correction_velocity_tolerance=0.5)
+
     def test_global_amplitude_out_bound_survives_lissajous_l3_extension(self):
         with pytest.raises(ValidationError, match="amplitude_out"):
             DesignOrbitRequest(orbit_type="DRO", amplitude_out=80000.0)


### PR DESCRIPTION
## 关联 issue

Closes #410

## 改动摘要

`DesignOrbitRequest.correction_velocity_tolerance`（default=0.1, gt=0.0）在 5.6.8 中声明但算法层不消费：Rust 多重打靶的收敛策略由 `CORRECTION_TOL_KM` / `VELOCITY_TOL_KMS` 固定配置，GUI/CLI/MCP 参数面板暴露该字段只会让用户调一个无效旋钮。按 issue 建议删除该字段，删除后按模型的 `extra="forbid"` 规则拒绝传入。

- `e2m2e/api/models.py`：删除 `DesignOrbitRequest.correction_velocity_tolerance` 字段。
- `tests/api/test_facade.py`：新增回归测试——DRO/NRHO 传入该字段均抛含字段名的 `ValidationError`。

Rust 打靶收敛常量（`CORRECTION_TOL_KM` / `VELOCITY_TOL_KMS` / `CORRECTION_VEL_WEIGHT`）与算法行为保持不变，未把速度收敛改造成可调参数。

## 测试

```bash
uv run pytest tests/api/test_facade.py -q     # 87 passed
uv run ruff check .
uv run ruff format --check .
uv run mypy e2m2e/ --ignore-missing-imports   # Success: no issues found
```
