### PR TITLE
feat(forces): 接通 FiniteBurn 恒质量 Rust 传播 (#407)

### DIFF
--- a/crates/e2m2e-forces/src/forces/compiled.rs
+++ b/crates/e2m2e-forces/src/forces/compiled.rs
@@ -68,20 +68,24 @@ pub enum CompiledForce {
         body_radius_override: Option<f64>,
         gamma: f64,
     },
-    /// 小推力（电推进）模型。
+    /// 恒质量连续推力模型。
     ///
-    /// 推力加速度 = (T_max / m) * u * α
-    /// 其中 T_max 为最大推力（N），m 为航天器质量（kg），u ∈ [0, 1] 为推力幅值，
-    /// α 为单位推力方向向量。
+    /// 推力加速度 = (T / m) * α。推力可常开，也可仅在时段
+    /// ``(t_start, t_end)`` 内开启；端点处关机以避免 RK stage 把单点开关
+    /// 误算成有限冲量。方向在惯性、VNB 或 LVLH 系中给出。
     LowThrust {
-        /// 最大推力（N）
-        t_max: f64,
-        /// 比冲（s）
-        isp: f64,
-        /// 推力幅值 u ∈ [0, 1]（同伦参数）
-        throttle: f64,
-        /// 推力方向单位向量（惯性系）
+        /// 航天器恒定质量（kg）
+        mass: f64,
+        /// 推力幅值（N）
+        thrust: f64,
+        /// 开机时刻（SPICE et 秒）；None 表示常开
+        t_start: Option<f64>,
+        /// 关机时刻（SPICE et 秒）；None 表示常开
+        t_end: Option<f64>,
+        /// 推力方向（由 direction_frame 解释）
         direction: [f64; 3],
+        /// None / "VNB" / "LVLH"
+        direction_frame: Option<String>,
     },
     /// 大气阻力力模型。
     ///
@@ -97,6 +101,90 @@ pub enum CompiledForce {
         /// 传播系 frame（通常 "J2000"）
         propagation_frame: String,
     },
+}
+
+fn resolve_thrust_direction(
+    direction: &[f64; 3],
+    direction_frame: Option<&str>,
+    state: &[f64; 6],
+) -> Result<[f64; 3], String> {
+    let norm = |v: [f64; 3]| -> f64 { (v[0] * v[0] + v[1] * v[1] + v[2] * v[2]).sqrt() };
+    let scale =
+        |v: [f64; 3], factor: f64| -> [f64; 3] { [v[0] * factor, v[1] * factor, v[2] * factor] };
+    let cross = |a: [f64; 3], b: [f64; 3]| -> [f64; 3] {
+        [
+            a[1] * b[2] - a[2] * b[1],
+            a[2] * b[0] - a[0] * b[2],
+            a[0] * b[1] - a[1] * b[0],
+        ]
+    };
+    let r = [state[0], state[1], state[2]];
+    let v = [state[3], state[4], state[5]];
+    let local_to_inertial = match direction_frame {
+        None => *direction,
+        Some("VNB") => {
+            let v_norm = norm(v);
+            let h = cross(r, v);
+            let h_norm = norm(h);
+            if v_norm < 1e-12 {
+                return Err("VNB frame requires non-zero velocity".to_string());
+            }
+            if h_norm < 1e-12 {
+                return Err("VNB frame requires non-zero angular momentum".to_string());
+            }
+            let v_hat = scale(v, 1.0 / v_norm);
+            let n_hat = scale(h, 1.0 / h_norm);
+            let b_hat = cross(v_hat, n_hat);
+            [
+                direction[0] * v_hat[0] + direction[1] * n_hat[0] + direction[2] * b_hat[0],
+                direction[0] * v_hat[1] + direction[1] * n_hat[1] + direction[2] * b_hat[1],
+                direction[0] * v_hat[2] + direction[1] * n_hat[2] + direction[2] * b_hat[2],
+            ]
+        }
+        Some("LVLH") => {
+            let r_norm = norm(r);
+            let v_norm = norm(v);
+            let h = cross(r, v);
+            let h_norm = norm(h);
+            if r_norm < 1e-12 {
+                return Err("LVLH frame requires non-zero position".to_string());
+            }
+            if v_norm < 1e-12 {
+                return Err("LVLH frame requires non-zero velocity".to_string());
+            }
+            let r_hat = scale(r, 1.0 / r_norm);
+            let v_hat = scale(v, 1.0 / v_norm);
+            if h_norm < 1e-12 {
+                [
+                    direction[0] * r_hat[0] + direction[1] * v_hat[0],
+                    direction[0] * r_hat[1] + direction[1] * v_hat[1],
+                    direction[0] * r_hat[2] + direction[1] * v_hat[2],
+                ]
+            } else {
+                let n_hat = scale(h, 1.0 / h_norm);
+                // 与 LVLHAxes 对齐：沿迹轴垂直于径向轴，而非一般椭圆轨道
+                // 中含径向分量的速度单位向量。
+                let along_track = cross(n_hat, r_hat);
+                [
+                    direction[0] * r_hat[0]
+                        + direction[1] * along_track[0]
+                        + direction[2] * n_hat[0],
+                    direction[0] * r_hat[1]
+                        + direction[1] * along_track[1]
+                        + direction[2] * n_hat[1],
+                    direction[0] * r_hat[2]
+                        + direction[1] * along_track[2]
+                        + direction[2] * n_hat[2],
+                ]
+            }
+        }
+        Some(frame) => return Err(format!("unsupported thrust direction frame {frame:?}")),
+    };
+    let direction_norm = norm(local_to_inertial);
+    if direction_norm < 1e-15 {
+        return Err("thrust direction must be non-zero".to_string());
+    }
+    Ok(scale(local_to_inertial, 1.0 / direction_norm))
 }
 
 impl CompiledForce {
@@ -214,18 +302,25 @@ impl CompiledForce {
                 .map_err(|e| format!("{:?}", e))
             }
             Self::LowThrust {
-                t_max,
-                isp: _,
-                throttle,
+                mass,
+                thrust,
+                t_start,
+                t_end,
                 direction,
+                direction_frame,
             } => {
-                // 小推力加速度 = (T_max / m) * u * α
-                // 注意：当前实现假设质量恒定，实际应用中需要扩展状态向量包含质量
-                let mass = 1000.0; // kg，默认质量，实际应从状态或参数获取
-                                   // T_max 单位为 N (kg·m/s²)，质量单位为 kg，加速度单位为 m/s²
-                                   // 需要转换为 km/s²（除以 1000）
-                let accel_mag_m_s2 = (*t_max / mass) * throttle;
-                let accel_mag_km_s2 = accel_mag_m_s2 / 1000.0;
+                if *thrust == 0.0 {
+                    return Ok([0.0; 3]);
+                }
+                if let (Some(start), Some(end)) = (t_start, t_end) {
+                    if et <= *start || et >= *end {
+                        return Ok([0.0; 3]);
+                    }
+                }
+                let direction =
+                    resolve_thrust_direction(direction, direction_frame.as_deref(), state)?;
+                // N / kg = m/s²，传播状态使用 km/s，故除以 1000。
+                let accel_mag_km_s2 = thrust / mass / 1000.0;
                 Ok([
                     accel_mag_km_s2 * direction[0],
                     accel_mag_km_s2 * direction[1],
@@ -243,6 +338,26 @@ impl CompiledForce {
                 .map_err(|e| format!("{:?}", e)),
         }
     }
+}
+
+/// 返回 `(t, tf]` 内最早的编译力不连续时刻。
+///
+/// 恒质量 pulse 推力在开机/关机边界处不连续。积分器必须将其作为步长终点，
+/// 否则一个 RK 步跨越边界会使累计冲量依赖输出网格。
+pub fn next_force_discontinuity(forces: &[CompiledForce], t: f64, tf: f64) -> Option<f64> {
+    forces
+        .iter()
+        .filter_map(|force| match force {
+            CompiledForce::LowThrust {
+                t_start: Some(start),
+                t_end: Some(end),
+                ..
+            } => Some([*start, *end]),
+            _ => None,
+        })
+        .flatten()
+        .filter(|boundary| *boundary > t && *boundary <= tf)
+        .min_by(|left, right| left.total_cmp(right))
 }
 
 /// 计算所有 force 的总加速度。
@@ -272,6 +387,7 @@ pub fn supports_jacobian(force: &CompiledForce) -> bool {
             | CompiledForce::IndirectTerm { .. }
             | CompiledForce::SRP { .. }
             | CompiledForce::EcomSrp { .. }
+            | CompiledForce::LowThrust { .. }
             | CompiledForce::Drag { .. }
     )
 }
@@ -410,6 +526,38 @@ pub fn acceleration_and_jacobian(
                 }
             }
             let dadv = [[0.0_f64; 3]; 3];
+            Ok((acc0, jac, dadv))
+        }
+        CompiledForce::LowThrust { .. } => {
+            // VNB/LVLH 方向取决于状态，统一在 Rust 内中心差分，避免 Python
+            // 回调并使 STM 与普通 RHS 使用同一方向定义。
+            let r_norm = (state[0] * state[0] + state[1] * state[1] + state[2] * state[2]).sqrt();
+            let v_norm = (state[3] * state[3] + state[4] * state[4] + state[5] * state[5]).sqrt();
+            let h_r = (f64::EPSILON.sqrt() * r_norm).max(1e-6);
+            let h_v = (f64::EPSILON.sqrt() * v_norm).max(1e-9);
+            let acc0 = force.acceleration(et, state, observer)?;
+            let mut jac = [[0.0_f64; 3]; 3];
+            let mut dadv = [[0.0_f64; 3]; 3];
+            for dim in 0..3 {
+                let mut plus = *state;
+                let mut minus = *state;
+                plus[dim] += h_r;
+                minus[dim] -= h_r;
+                let a_plus = force.acceleration(et, &plus, observer)?;
+                let a_minus = force.acceleration(et, &minus, observer)?;
+                for row in 0..3 {
+                    jac[row][dim] = (a_plus[row] - a_minus[row]) / (2.0 * h_r);
+                }
+                let mut plus_v = *state;
+                let mut minus_v = *state;
+                plus_v[dim + 3] += h_v;
+                minus_v[dim + 3] -= h_v;
+                let a_plus_v = force.acceleration(et, &plus_v, observer)?;
+                let a_minus_v = force.acceleration(et, &minus_v, observer)?;
+                for row in 0..3 {
+                    dadv[row][dim] = (a_plus_v[row] - a_minus_v[row]) / (2.0 * h_v);
+                }
+            }
             Ok((acc0, jac, dadv))
         }
         CompiledForce::Drag {

--- a/crates/e2m2e-forces/src/forces/compiled_stm.rs
+++ b/crates/e2m2e-forces/src/forces/compiled_stm.rs
@@ -6,7 +6,9 @@
 //!
 //! 复用 `nbody_stm` 的 `stm_derivative`。
 
-use super::compiled::{compute_total_acceleration_and_jacobian, CompiledForce};
+use super::compiled::{
+    compute_total_acceleration_and_jacobian, next_force_discontinuity, CompiledForce,
+};
 use super::nbody_stm;
 use e2m2e_propagation::butcher::{explicit_rk_step, suggest_next_step};
 use e2m2e_propagation::rk_methods::RkMethod;
@@ -138,11 +140,16 @@ pub fn propagate_compiled_stm(
     while t < t_eval[t_eval.len() - 1] && n_steps < s_max {
         n_steps += 1;
 
-        if eval_idx < t_eval.len() {
-            let t_next_eval = t_eval[eval_idx];
-            if t + h > t_next_eval {
-                h = t_next_eval - t;
-            }
+        let mut t_next = if eval_idx < t_eval.len() {
+            t_eval[eval_idx]
+        } else {
+            t_span.1
+        };
+        if let Some(boundary) = next_force_discontinuity(forces, t, t_span.1) {
+            t_next = t_next.min(boundary);
+        }
+        if t + h > t_next {
+            h = t_next - t;
         }
         h = h.min(h_max);
         if h < MIN_STEP * (t_span.1 - t_span.0).abs() {

--- a/crates/e2m2e-integrators/src/lib.rs
+++ b/crates/e2m2e-integrators/src/lib.rs
@@ -1117,21 +1117,71 @@ pub(crate) fn parse_force_tuple(
             })
         }
         "low_thrust" => {
-            // 元组格式：("low_thrust", t_max, isp, throttle, direction)
-            let t_max: f64 = tuple.get_item(1)?.extract()?;
-            let isp: f64 = tuple.get_item(2)?.extract()?;
-            let throttle: f64 = tuple.get_item(3)?.extract()?;
-            let direction: Vec<f64> = tuple.get_item(4)?.extract()?;
+            // 元组格式：("low_thrust", mass, thrust, t_start, t_end, direction,
+            // direction_frame)。起止时间同时为 None 时表示常开。
+            let mass: f64 = tuple.get_item(1)?.extract()?;
+            let thrust: f64 = tuple.get_item(2)?.extract()?;
+            let start_obj = tuple.get_item(3)?;
+            let t_start: Option<f64> = if start_obj.is_none() {
+                None
+            } else {
+                Some(start_obj.extract()?)
+            };
+            let end_obj = tuple.get_item(4)?;
+            let t_end: Option<f64> = if end_obj.is_none() {
+                None
+            } else {
+                Some(end_obj.extract()?)
+            };
+            let direction: Vec<f64> = tuple.get_item(5)?.extract()?;
+            let frame_obj = tuple.get_item(6)?;
+            let direction_frame: Option<String> = if frame_obj.is_none() {
+                None
+            } else {
+                Some(frame_obj.extract()?)
+            };
+            if mass <= 0.0 {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "low_thrust mass must be positive",
+                ));
+            }
+            if thrust < 0.0 {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "low_thrust thrust must be non-negative",
+                ));
+            }
+            if t_start.is_some() != t_end.is_some() {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "low_thrust pulse requires both t_start and t_end",
+                ));
+            }
+            if let (Some(start), Some(end)) = (t_start, t_end) {
+                if end < start {
+                    return Err(pyo3::exceptions::PyValueError::new_err(
+                        "low_thrust t_end must be greater than or equal to t_start",
+                    ));
+                }
+            }
             if direction.len() != 3 {
                 return Err(pyo3::exceptions::PyValueError::new_err(
                     "low_thrust direction must have 3 elements",
                 ));
             }
+            if !matches!(
+                direction_frame.as_deref(),
+                None | Some("VNB") | Some("LVLH")
+            ) {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "low_thrust direction_frame must be None, 'VNB', or 'LVLH'",
+                ));
+            }
             Ok(CompiledForce::LowThrust {
-                t_max,
-                isp,
-                throttle,
+                mass,
+                thrust,
+                t_start,
+                t_end,
                 direction: [direction[0], direction[1], direction[2]],
+                direction_frame,
             })
         }
         "drag" => {
@@ -1186,7 +1236,7 @@ fn propagate_compiled_core(
     forces: &[e2m2e_forces::forces::compiled::CompiledForce],
     max_steps: usize,
 ) -> Result<CompiledPropResult, String> {
-    use e2m2e_forces::forces::compiled::compute_total_acceleration;
+    use e2m2e_forces::forces::compiled::{compute_total_acceleration, next_force_discontinuity};
     let table = method.table();
     let mut y = y0.to_vec();
     let mut t = t0;
@@ -1217,11 +1267,17 @@ fn propagate_compiled_core(
         // 限制步长不超过下一个评估点（提高 t_eval 命中率），且不超过
         // h_init（作为最大步长：稀疏 t_eval 下自适应步长失控，实测
         // 2 点 vs 31 点网格的 30 天结果差 22 万 km）
-        if eval_idx < t_eval.len() {
-            let t_next_eval = t_eval[eval_idx];
-            if t + h > t_next_eval {
-                h = t_next_eval - t;
-            }
+        let t_final = t_eval[t_eval.len() - 1];
+        let mut t_next = if eval_idx < t_eval.len() {
+            t_eval[eval_idx]
+        } else {
+            t_final
+        };
+        if let Some(boundary) = next_force_discontinuity(forces, t, t_final) {
+            t_next = t_next.min(boundary);
+        }
+        if t + h > t_next {
+            h = t_next - t;
         }
         if h > h_init {
             n_steps_capped += 1;

--- a/docs/core/forces.rst
+++ b/docs/core/forces.rst
@@ -117,7 +117,8 @@ Atmosphere 1976 分段指数模型），``C_d`` 为阻力系数（默认 2.2）�
    \mathbf{a}_{\text{thrust}} = \frac{T(t)}{m} \, \hat{\mathbf{d}}
 
 其中 ``T(t)`` 为标量推力函数，``d̂`` 为归一化方向向量。配置往返支持固定
-推力/脉冲剖面与固定方向的封闭 DSL；任意 Python callable 可传播但无法序列化。
+推力/脉冲剖面与固定方向的封闭 DSL；只有该 DSL 控制可在 Rust 编译传播中执行，
+任意 Python callable 会在传播入口显式拒绝。
 
 **VariableMassFiniteBurn** — 可变质量连续推力，是低推力转移与月面动力下降等
 最优控制问题的受控动力学基座。与 ``FiniteBurn`` 的唯一区别：质量不是常量，

--- a/e2m2e/algorithm/forces/__init__.py
+++ b/e2m2e/algorithm/forces/__init__.py
@@ -5,8 +5,8 @@ Python 类是"力模型定义"（参数验证 + to_rust_spec 序列化），与 
 配置 schema 在 ``data/templates/force_config.py`` （纯数据）；大气密度模型
 （``atmosphere.py``）一并迁入（源 ``core/atmosphere/``）。
 
-实现状态：``FiniteBurn``（恒质量低推力）为预留，未接入 Rust
-``CompiledForce::LowThrust`` 变体（issue #407）；其余力模型均已接入。
+``FiniteBurn``（恒质量 6D）与 ``VariableMassFiniteBurn``（变质量 7D）均通过
+Rust 编译传播执行；仅可序列化的固定控制可下沉，任意 Python callable 会显式拒绝。
 """
 
 from __future__ import annotations

--- a/e2m2e/algorithm/forces/thrust.py
+++ b/e2m2e/algorithm/forces/thrust.py
@@ -133,12 +133,12 @@ def _resolve_thrust_direction(
 
 
 class FiniteBurn(PhysicalModel):
-    """连续推力加速度力模型（实现状态：预留，见 issue #407）。
+    """恒质量连续推力加速度力模型。
 
-    恒质量低推力从未有效接入传播：``compute_acceleration`` 已按 #378 删除，
-    ``to_rust_spec`` 尚未接入 Rust 侧已实现的 ``CompiledForce::LowThrust``
-    变体。方向帧解析逻辑（``_resolve_thrust_direction``）代码已就绪但无消费者。
-    需要推力传播请改用 :class:`VariableMassFiniteBurn`（变质量，7D 状态）。
+    6D 状态传播由 Rust 编译路径执行。配置 DSL 构造的 ``constant`` / ``pulse``
+    profile 和固定方向可下沉；任意 Python callable 无法进入 Rust RK 内循环，
+    在传播入口会显式报能力错误。需要推进剂消耗时使用
+    :class:`VariableMassFiniteBurn`（变质量，7D 状态）。
 
     ``direction`` 给出方向向量（固定向量或随状态更新的可调用），
     内部归一化为单位向量。质量为常量（不支持推进剂消耗）。
@@ -224,19 +224,35 @@ class FiniteBurn(PhysicalModel):
         )
 
     def to_rust_spec(self, system: object) -> tuple | None:
-        """``FiniteBurn`` 尚未接入 Rust 编译路径，显式抛 ``NotImplementedError``。
+        """序列化为恒质量 6D 编译传播接受的推力规格。
 
-        Rust 侧 ``CompiledForce::LowThrust`` 变体已实现（恒质量小推力，元组格式
-        ``("low_thrust", t_max, isp, throttle, direction)``），但 Python 侧
-        ``FiniteBurn`` 尚未接入——时变 ``thrust_profile`` 到固定 t_max/throttle
-        的映射、isp 来源等接口设计待定（issue #407）。需要推力传播请改用
-        :class:`VariableMassFiniteBurn` （7D 状态，走
-        ``propagate_compiled_lowthrust``）。issue #378：不允许静默回退 Python。
+        只有配置 DSL 构造的 constant/pulse 推力 profile 和固定方向可以下沉
+        到 Rust；任意 Python callable 无法在 Rust RK 内安全求值，返回 ``None``。
+        返回规格为 ``("low_thrust", mass, thrust, t_start, t_end, direction,
+        direction_frame)``，其中 constant profile 的起止时间为 ``None``。
         """
-        raise NotImplementedError(
-            "FiniteBurn 恒质量低推力尚未接入 Rust 编译传播"
-            "（CompiledForce::LowThrust 变体已实现，Python 侧待接入，见 #407）；"
-            "如需推力传播请改用 VariableMassFiniteBurn。"
+        profile_info = getattr(self._thrust_profile, "_e2m2e_config_kind", None)
+        if profile_info is None or callable(self._direction):
+            return None
+        _kind, profile = profile_info
+        kind = profile["kind"]
+        if kind == "constant":
+            t_start = None
+            t_end = None
+        elif kind == "pulse":
+            t_start = float(profile["t_start"])
+            t_end = float(profile["t_end"])
+        else:
+            raise NotImplementedError(f"FiniteBurn 不支持编译推力 profile: {kind!r}")
+        direction = np.asarray(self._direction, dtype=float)
+        return (
+            "low_thrust",
+            self._mass,
+            float(profile["thrust"]),
+            t_start,
+            t_end,
+            direction.tolist(),
+            self._direction_frame,
         )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,10 +83,9 @@ select = ["E", "F", "W", "I", "UP", "B", "SIM"]
 testpaths = ["tests"]
 # 让 tests/kernel_helpers.py 在 xdist worker 中可导入
 pythonpath = ["tests"]
-# 默认测试门排除尚未完成的低推力功能；测试按功能类目组织，不按运行速度分层。
-addopts = ["-m", "not low_thrust"]
+# 测试按功能类目组织，不按运行速度分层。
 markers = [
-    "low_thrust: 低推力——VariableMassFiniteBurn（变质量）Rust 7D 路径已实现；FiniteBurn（恒质量）从未有效实现（#407，20 个预留测试标记 xfail）；Facade 任务入口占位；默认绿门排除",
+    "low_thrust: 低推力——FiniteBurn 恒质量 6D 与 VariableMassFiniteBurn 变质量 7D 的 Rust 传播、物理与配置验收",
     "spice: 依赖 SPICE 内核的测试，内核缺失时跳过（正交于功能类）",
     "theory: 数理/物理理论——解析对照、守恒律、闭式解",
     "integrator: 积分器——传播器算法、步长控制、dense output",

--- a/tests/numerical/forces/config/test_force_config.py
+++ b/tests/numerical/forces/config/test_force_config.py
@@ -139,29 +139,41 @@ def test_finite_burn_pulse_round_trip():
     assert ForceModel.to_config(fm) == config_dict
 
 
-def test_finite_burn_built_force_propagation_rejected():
-    """DSL 构造的 FiniteBurn 在传播入口明确拒绝未实现的 Rust 能力。"""
+def test_finite_burn_built_force_propagates_with_its_configured_mass():
+    """DSL 常量推力在 Rust 6D 路径传播，速度增量与质量成反比。"""
     system = FakeSystem()
-    config_dict = {
-        "version": 1,
-        "forces": [
+
+    def propagate_for_mass(mass: float) -> np.ndarray:
+        fm = ForceModel.from_config(
             {
-                "name": "engine",
-                "type": "FiniteBurn",
-                "enabled": True,
-                "params": {
-                    "mass": 1000.0,
-                    "thrust_profile": {"kind": "constant", "thrust": 10.0},
-                    "direction": {"kind": "fixed", "vector": [1.0, 0.0, 0.0]},
-                },
-            }
-        ],
-    }
+                "version": 1,
+                "forces": [
+                    {
+                        "name": "engine",
+                        "type": "FiniteBurn",
+                        "enabled": True,
+                        "params": {
+                            "mass": mass,
+                            "thrust_profile": {"kind": "constant", "thrust": 10.0},
+                            "direction": {"kind": "fixed", "vector": [1.0, 0.0, 0.0]},
+                        },
+                    }
+                ],
+            },
+            system,
+        )
+        result = fm.propagate(
+            np.array([7000.0, 0.0, 0.0, 0.0, 7.5, 0.0]),
+            (0.0, 1.0),
+            t_eval=np.array([0.0, 1.0]),
+        )
+        return result["states"][-1]
 
-    fm = ForceModel.from_config(config_dict, system)
+    light = propagate_for_mass(1000.0)
+    heavy = propagate_for_mass(2000.0)
 
-    with pytest.raises(NotImplementedError, match="FiniteBurn.*Rust"):
-        fm.propagate(np.array([7000.0, 0.0, 0.0, 0.0, 7.5, 0.0]), (0.0, 1.0))
+    np.testing.assert_allclose(light[3] - 0.0, 1e-5, rtol=1e-8)
+    np.testing.assert_allclose(heavy[3] - 0.0, 5e-6, rtol=1e-8)
 
 
 def test_finite_burn_unknown_callable_not_serializable():
@@ -297,11 +309,12 @@ def test_finite_burn_vnb_direction_frame_round_trip():
 
     assert ForceModel.to_config(fm) == config_dict
 
-    with pytest.raises(NotImplementedError, match="FiniteBurn.*Rust"):
-        fm.propagate(
-            np.array([7000.0, 0.0, 0.0, 0.0, 7.5, 0.0]),
-            (0.0, 1.0),
-        )
+    result = fm.propagate(
+        np.array([7000.0, 0.0, 0.0, 0.0, 7.5, 0.0]),
+        (0.0, 1.0),
+        t_eval=np.array([0.0, 1.0]),
+    )
+    np.testing.assert_allclose(result["states"][-1, 4] - 7.5, 1e-5, atol=1e-11)
 
 
 def test_finite_burn_lvlh_direction_frame_round_trip():
@@ -328,11 +341,12 @@ def test_finite_burn_lvlh_direction_frame_round_trip():
 
     assert ForceModel.to_config(fm) == config_dict
 
-    with pytest.raises(NotImplementedError, match="FiniteBurn.*Rust"):
-        fm.propagate(
-            np.array([7000.0, 0.0, 0.0, 0.0, 7.5, 0.0]),
-            (0.0, 1.0),
-        )
+    result = fm.propagate(
+        np.array([7000.0, 0.0, 0.0, 0.0, 7.5, 0.0]),
+        (0.0, 1.0),
+        t_eval=np.array([0.0, 1.0]),
+    )
+    np.testing.assert_allclose(result["states"][-1, 5], 1e-5, atol=1e-11)
 
 
 def test_finite_burn_invalid_direction_frame_from_config_raises():

--- a/tests/numerical/forces/config/test_low_thrust_config_propagation.py
+++ b/tests/numerical/forces/config/test_low_thrust_config_propagation.py
@@ -4,7 +4,7 @@
 轨道，末态一致（< 1e-12）。这是配置保真的物理检查，与
 ``test_leo_config_propagation.py``（LEO 场景）同类。
 
-低推力功能尚未开发完成，本文件标记 ``low_thrust``，本轮检查排除在绿门外。
+本文件标记 ``low_thrust``，纳入默认测试门。
 """
 
 import numpy as np
@@ -17,7 +17,6 @@ pytestmark = [pytest.mark.force, pytest.mark.low_thrust]
 
 
 @pytest.mark.spice
-@pytest.mark.xfail(reason="预留 #407：FiniteBurn 恒质量低推力从未实现")
 def test_low_thrust_config_round_trip(earth_icrf_system):
     """FiniteBurn 配置往返后，低推力传播结果一致。"""
     system = earth_icrf_system

--- a/tests/numerical/forces/contract/test_thrust.py
+++ b/tests/numerical/forces/contract/test_thrust.py
@@ -1,20 +1,16 @@
-"""ImpulsiveBurn / FiniteBurn 定义与 API 契约。
-
-覆盖冻结拷贝、零推力、常值推力、固定/可调用方向与归一化、构造校验。低推力
-传播物理见 ``physics/test_thrust.py``。
-
-低推力功能尚未开发完成（Facade 任务入口占位，Rust 传播路径已接入）；本文件标记
-``low_thrust``，本轮检查排除在绿门外。
-"""
+"""ImpulsiveBurn / FiniteBurn 定义与 API 契约。"""
 
 import dataclasses
 
 import numpy as np
 import pytest
 
+from e2m2e.algorithm.forces import ForceModel
+from e2m2e.algorithm.forces.force_config import build_force
 from e2m2e.algorithm.forces.thrust import FiniteBurn, ImpulsiveBurn
+from tests.numerical.forces.conftest import FakeSystem
 
-pytestmark = [pytest.mark.force, pytest.mark.low_thrust]
+pytestmark = pytest.mark.force
 
 
 def test_impulsive_burn_stores_copied_delta_v_and_is_frozen():
@@ -34,74 +30,107 @@ def test_impulsive_burn_stores_copied_delta_v_and_is_frozen():
         burn.epoch = 2.0
 
 
-@pytest.mark.xfail(reason="预留 #407：FiniteBurn 恒质量低推力从未实现")
-def test_finite_burn_zero_thrust_returns_zero_acceleration():
-    """thrust_profile 返回 0 → compute_acceleration 返回 zeros(3)。"""
-    burn = FiniteBurn(
-        thrust_profile=lambda t: 0.0,
-        direction=np.array([1.0, 0.0, 0.0]),
-        mass=1000.0,
+def _compiled_burn(
+    *,
+    mass: float = 1000.0,
+    thrust_profile: dict[str, float | str] | None = None,
+    direction: list[float] | None = None,
+    direction_frame: str | None = None,
+) -> FiniteBurn:
+    params: dict[str, object] = {
+        "mass": mass,
+        "thrust_profile": thrust_profile or {"kind": "constant", "thrust": 10.0},
+        "direction": {"kind": "fixed", "vector": direction or [1.0, 0.0, 0.0]},
+    }
+    if direction_frame is not None:
+        params["direction_frame"] = direction_frame
+    return build_force("FiniteBurn", params)
+
+
+def test_finite_burn_constant_and_zero_thrust_propagation():
+    """恒定/零 DSL 推力通过公开传播接口给出正确的速度变化。"""
+    y0 = np.array([7000.0, 0.0, 0.0, 0.0, 7.5, 0.0])
+    for thrust, expected_delta_v in ((10.0, 1e-5), (0.0, 0.0)):
+        burn = _compiled_burn(thrust_profile={"kind": "constant", "thrust": thrust})
+        result = ForceModel(FakeSystem(), [burn]).propagate(
+            y0, (0.0, 1.0), t_eval=np.array([0.0, 1.0])
+        )
+        np.testing.assert_allclose(result["states"][-1, 3] - y0[3], expected_delta_v, rtol=1e-8)
+
+
+def test_finite_burn_pulse_profile_switches_at_configured_epochs():
+    """pulse profile 只在闭区间内施加推力。"""
+    fm = ForceModel(
+        FakeSystem(),
+        [
+            _compiled_burn(
+                thrust_profile={
+                    "kind": "pulse",
+                    "t_start": 1.0,
+                    "t_end": 2.0,
+                    "thrust": 10.0,
+                }
+            )
+        ],
     )
-    state = np.array([7000.0, 0.0, 0.0, 0.0, 7.5, 0.0])
-    acc = burn.compute_acceleration(0.0, state, system=None)
-    np.testing.assert_allclose(acc, np.zeros(3), atol=1e-15)
+    y0 = np.array([7000.0, 0.0, 0.0, 0.0, 7.5, 0.0])
+    result = fm.propagate(y0, (0.0, 3.0), t_eval=np.array([0.0, 1.0, 2.0, 3.0]))
+    # 端点包含在内，积分器在两个端点间只会对约 1 秒的有效区间累计推力。
+    np.testing.assert_allclose(result["states"][-1, 3], 1e-5, rtol=1e-5, atol=1e-11)
 
 
-@pytest.mark.xfail(reason="预留 #407：FiniteBurn 恒质量低推力从未实现")
-def test_finite_burn_constant_thrust_fixed_direction():
-    """常值推力 + 固定方向 → a = thrust/mass/1000 · d̂（内部归一化方向）。"""
-    state = np.zeros(6)
-
-    # 轴对齐：方向 [3,0,0] 归一化为 [1,0,0]
-    burn = FiniteBurn(
-        thrust_profile=lambda t: 500.0,
-        direction=np.array([3.0, 0.0, 0.0]),
-        mass=1000.0,
+def test_finite_burn_pulse_profile_honors_boundaries_outside_t_eval():
+    """pulse 边界不是输出点时，累计冲量仍只覆盖开机区间。"""
+    burn = _compiled_burn(
+        thrust_profile={"kind": "pulse", "t_start": 0.75, "t_end": 1.25, "thrust": 10.0}
     )
-    acc = burn.compute_acceleration(0.0, state, system=None)
-    # 500 N / 1000 kg = 0.5 m/s² → 5e-4 km/s²
-    np.testing.assert_allclose(acc, [5e-4, 0.0, 0.0], rtol=1e-12)
-
-    # 非轴对齐：验证归一化
-    burn2 = FiniteBurn(
-        thrust_profile=lambda t: 500.0,
-        direction=np.array([1.0, 1.0, 0.0]),
-        mass=1000.0,
+    y0 = np.array([7000.0, 0.0, 0.0, 0.0, 7.5, 0.0])
+    sparse = ForceModel(FakeSystem(), [burn]).propagate(y0, (0.0, 3.0), t_eval=np.array([0.0, 3.0]))
+    dense = ForceModel(FakeSystem(), [burn]).propagate(
+        y0, (0.0, 3.0), t_eval=np.linspace(0.0, 3.0, 31)
     )
-    acc2 = burn2.compute_acceleration(0.0, state, system=None)
-    expected = 0.5 / 1000.0 * np.array([1.0, 1.0, 0.0]) / np.sqrt(2.0)
-    np.testing.assert_allclose(acc2, expected, rtol=1e-12)
+    np.testing.assert_allclose(sparse["states"][-1, 3], 5e-6, rtol=2e-5, atol=1e-11)
+    np.testing.assert_allclose(sparse["states"][-1], dense["states"][-1], atol=1e-11)
 
 
-@pytest.mark.xfail(reason="预留 #407：FiniteBurn 恒质量低推力从未实现")
-def test_finite_burn_callable_direction_normalized():
-    """可调用方向 (t, state) -> (3,) 被调用并归一化使用（如沿速度方向）。"""
-    velocity = np.array([0.0, 7.5, 0.0])
-    state = np.array([7000.0, 0.0, 0.0, 0.0, 7.5, 0.0])
-    burn = FiniteBurn(
-        thrust_profile=lambda t: 500.0,
-        direction=lambda t, s: s[3:6],  # 返回速度向量（未归一化）
-        mass=1000.0,
+def test_finite_burn_constant_force_supports_stm():
+    """恒质量固定方向推力可通过公开接口传播 STM。"""
+    y0 = np.array([7000.0, 0.0, 0.0, 0.0, 7.5, 0.0])
+    result = ForceModel(FakeSystem(), [_compiled_burn()]).propagate(
+        y0, (0.0, 1.0), t_eval=np.array([0.0, 1.0]), with_stm=True
     )
-    acc = burn.compute_acceleration(0.0, state, system=None)
-    expected = 0.5 / 1000.0 * velocity / np.linalg.norm(velocity)
-    np.testing.assert_allclose(acc, expected, rtol=1e-12)
+    assert result["stm"].shape == (2, 6, 6)
+    np.testing.assert_allclose(result["stm"][0], np.eye(6), atol=1e-12)
+    np.testing.assert_allclose(result["stm"][-1, 3:, 3:], np.eye(3), atol=1e-8)
 
 
-@pytest.mark.xfail(reason="预留 #407：FiniteBurn 恒质量低推力从未实现")
-def test_finite_burn_validation():
-    """mass≤0 / 固定方向零向量 → 构造时 ValueError；thrust<0 → 求值时 ValueError。"""
-    # mass ≤ 0
-    with pytest.raises(ValueError, match="mass"):
-        FiniteBurn(lambda t: 1.0, np.array([1.0, 0.0, 0.0]), 0.0)
-    with pytest.raises(ValueError, match="mass"):
-        FiniteBurn(lambda t: 1.0, np.array([1.0, 0.0, 0.0]), -1.0)
+def test_finite_burn_vnb_stm_matches_initial_velocity_finite_difference():
+    """VNB 推力的公开 STM 与独立初态速度有限差分一致。"""
+    y0 = np.array([7000.0, 0.0, 0.0, 0.0, 7.5, 0.0])
+    t_eval = np.array([0.0, 10.0])
+    fm = ForceModel(
+        FakeSystem(), [_compiled_burn(direction=[1.0, 0.0, 0.0], direction_frame="VNB")]
+    )
+    stm_result = fm.propagate(y0, (0.0, 10.0), t_eval=t_eval, with_stm=True)
+    perturbation = 1e-6
+    plus = y0.copy()
+    minus = y0.copy()
+    plus[3] += perturbation
+    minus[3] -= perturbation
+    final_plus = fm.propagate(plus, (0.0, 10.0), t_eval=t_eval)["states"][-1]
+    final_minus = fm.propagate(minus, (0.0, 10.0), t_eval=t_eval)["states"][-1]
+    finite_difference = (final_plus - final_minus) / (2.0 * perturbation)
 
-    # 固定方向零向量
-    with pytest.raises(ValueError, match="direction"):
-        FiniteBurn(lambda t: 1.0, np.zeros(3), 1000.0)
+    np.testing.assert_allclose(stm_result["stm"][-1, :, 3], finite_difference, rtol=1e-4, atol=1e-7)
 
-    # thrust < 0（求值时）
-    burn = FiniteBurn(lambda t: -5.0, np.array([1.0, 0.0, 0.0]), 1000.0)
-    with pytest.raises(ValueError, match="thrust"):
-        burn.compute_acceleration(0.0, np.zeros(6), system=None)
+
+def test_finite_burn_rejects_uncompiled_callables():
+    """任意 Python callable 不能在 Rust RK 内执行，传播必须明确拒绝。"""
+    y0 = np.array([7000.0, 0.0, 0.0, 0.0, 7.5, 0.0])
+    callable_profile = FiniteBurn(lambda t: 10.0, [1.0, 0.0, 0.0], 1000.0)
+    compiled_profile = _compiled_burn().thrust_profile
+    callable_direction = FiniteBurn(compiled_profile, lambda _t, _state: [1.0, 0.0, 0.0], 1000.0)
+
+    for burn in (callable_profile, callable_direction):
+        with pytest.raises(NotImplementedError, match="无 Rust 实现"):
+            ForceModel(FakeSystem(), [burn]).propagate(y0, (0.0, 1.0))

--- a/tests/numerical/forces/contract/test_thrust_direction_frame.py
+++ b/tests/numerical/forces/contract/test_thrust_direction_frame.py
@@ -1,329 +1,116 @@
-"""FiniteBurn direction_frame 测试（TDD）。
-
-验证 VNB/LVLH 坐标系转换、非法帧拒绝、
-callable 方向与零速度/零位置边界。
-
-低推力功能尚未开发完成，FiniteBurn 的 Rust 传播路径暂缺；本文件标记
-``low_thrust``，本轮检查排除在绿门外。
-"""
+"""FiniteBurn 编译传播的方向帧契约。"""
 
 import numpy as np
 import pytest
 
-from e2m2e.algorithm.forces import FiniteBurn
+from e2m2e.algorithm.forces import ForceModel
+from e2m2e.algorithm.forces.force_config import build_force
+from e2m2e.algorithm.forces.thrust import FiniteBurn
 from tests.numerical.forces.conftest import FakeSystem
 
-pytestmark = [pytest.mark.force, pytest.mark.low_thrust]
+pytestmark = pytest.mark.force
 
 
-# --- 构造辅助 ---
+def _propagate_delta_v(direction, direction_frame=None, *, thrust=10.0, state=None):
+    params = {
+        "mass": 1000.0,
+        "thrust_profile": {"kind": "constant", "thrust": thrust},
+        "direction": {"kind": "fixed", "vector": direction},
+    }
+    if direction_frame is not None:
+        params["direction_frame"] = direction_frame
+    burn = build_force("FiniteBurn", params)
+    y0 = (
+        np.asarray(state, dtype=float)
+        if state is not None
+        else np.array([7000.0, 0.0, 0.0, 0.0, 7.5, 0.0])
+    )
+    result = ForceModel(FakeSystem(), [burn]).propagate(y0, (0.0, 1.0), t_eval=[0.0, 1.0])
+    return result["states"][-1, 3:6] - y0[3:6]
 
 
-def _make_state(r, v):
-    """构造 6 维状态向量。"""
-    return np.array([*r, *v], dtype=float)
-
-
-# --- direction_frame 参数校验 ---
+@pytest.mark.parametrize("direction_frame", ["VNB", "LVLH"])
+def test_finite_burn_direction_frame_is_validated(direction_frame):
+    """VNB/LVLH 是允许的编译方向帧。"""
+    burn = FiniteBurn(lambda _t: 10.0, [1.0, 0.0, 0.0], 1000.0, direction_frame)
+    assert burn.direction_frame == direction_frame
 
 
 def test_finite_burn_invalid_direction_frame_raises():
-    """非法 direction_frame 在构造时抛 ValueError。"""
+    """非法方向帧在构造时拒绝。"""
     with pytest.raises(ValueError, match="direction_frame"):
-        FiniteBurn(
-            thrust_profile=lambda t: 10.0,
-            direction=[1.0, 0.0, 0.0],
-            mass=1000.0,
-            direction_frame="INVALID",
-        )
+        FiniteBurn(lambda _t: 10.0, [1.0, 0.0, 0.0], 1000.0, "INVALID")
 
 
-def test_finite_burn_vnb_direction_frame_accepted():
-    """direction_frame='VNB' 合法。"""
-    burn = FiniteBurn(
-        thrust_profile=lambda t: 10.0,
-        direction=[1.0, 0.0, 0.0],
-        mass=1000.0,
-        direction_frame="VNB",
+def test_finite_burn_lvlh_along_track_uses_orbital_axis():
+    """LVLH 沿迹轴垂直于径向，即使速度含径向分量也不随速度偏斜。"""
+    delta_v = _propagate_delta_v(
+        [0.0, 1.0, 0.0],
+        "LVLH",
+        state=[7000.0, 0.0, 0.0, 1.0, 7.5, 0.0],
     )
-    assert burn.direction_frame == "VNB"
+    assert abs(delta_v[0]) < 1e-8
+    assert delta_v[1] > 0.99e-5
 
 
-def test_finite_burn_lvlh_direction_frame_accepted():
-    """direction_frame='LVLH' 合法。"""
-    burn = FiniteBurn(
-        thrust_profile=lambda t: 10.0,
-        direction=[0.0, 1.0, 0.0],
-        mass=1000.0,
-        direction_frame="LVLH",
+@pytest.mark.parametrize(
+    ("direction_frame", "direction", "expected"),
+    [
+        (None, [2.0, 0.0, 0.0], [1e-5, 0.0, 0.0]),
+        ("VNB", [1.0, 0.0, 0.0], [0.0, 1e-5, 0.0]),
+        ("VNB", [0.0, 1.0, 0.0], [0.0, 0.0, 1e-5]),
+        ("VNB", [0.0, 0.0, 1.0], [1e-5, 0.0, 0.0]),
+        ("LVLH", [1.0, 0.0, 0.0], [1e-5, 0.0, 0.0]),
+        ("LVLH", [0.0, 1.0, 0.0], [0.0, 1e-5, 0.0]),
+        ("LVLH", [0.0, 0.0, 1.0], [0.0, 0.0, 1e-5]),
+    ],
+)
+def test_finite_burn_compiled_direction_frames(direction_frame, direction, expected):
+    """固定推力方向在 Rust RHS 中按惯性/VNB/LVLH 正确解析。"""
+    np.testing.assert_allclose(_propagate_delta_v(direction, direction_frame), expected, atol=1e-8)
+
+
+def test_finite_burn_lvlh_collinear_state_normalizes_direction():
+    """LVLH 共线退化时，径向/沿迹分量仍归一化为单位方向。"""
+    delta_v = _propagate_delta_v(
+        [2.0, 0.0, 0.0],
+        "LVLH",
+        state=[7000.0, 0.0, 0.0, 7.5, 0.0, 0.0],
     )
-    assert burn.direction_frame == "LVLH"
+    np.testing.assert_allclose(delta_v, [1e-5, 0.0, 0.0], atol=1e-11)
 
 
-def test_finite_burn_none_direction_frame_default():
-    """direction_frame=None 为默认值，保持原有行为。"""
-    burn = FiniteBurn(
-        thrust_profile=lambda t: 10.0,
-        direction=[1.0, 0.0, 0.0],
-        mass=1000.0,
+def test_finite_burn_zero_thrust_skips_degenerate_direction_frame():
+    """关机时不需要定义 VNB 方向。"""
+    delta_v = _propagate_delta_v(
+        [1.0, 0.0, 0.0], "VNB", thrust=0.0, state=[7000.0, 0.0, 0.0, 0.0, 0.0, 0.0]
     )
-    assert burn.direction_frame is None
+    np.testing.assert_array_equal(delta_v, np.zeros(3))
 
 
-# --- direction_frame=None 时保持原有行为 ---
+@pytest.mark.parametrize(
+    ("direction_frame", "state", "error"),
+    [
+        ("VNB", [7000.0, 0.0, 0.0, 0.0, 0.0, 0.0], "non-zero velocity"),
+        ("LVLH", [0.0, 0.0, 0.0, 0.0, 7.5, 0.0], "non-zero position"),
+    ],
+)
+def test_finite_burn_degenerate_direction_frame_raises(direction_frame, state, error):
+    """开机时动态方向帧的退化状态明确失败。"""
+    with pytest.raises(RuntimeError, match=error):
+        _propagate_delta_v([1.0, 0.0, 0.0], direction_frame, state=state)
 
 
-@pytest.mark.xfail(reason="预留 #407：FiniteBurn 恒质量低推力从未实现")
-def test_finite_burn_none_frame_fixed_direction():
-    """direction_frame=None 时，固定方向直接归一化使用。"""
-    burn = FiniteBurn(
-        thrust_profile=lambda t: 10.0,
-        direction=[2.0, 0.0, 0.0],  # 非单位向量
-        mass=1000.0,
-    )
-    state = _make_state([7000.0, 0.0, 0.0], [0.0, 7.5, 0.0])
-    acc = burn.compute_acceleration(0.0, state, FakeSystem())
-
-    # 10N / 1000kg = 0.01 m/s² = 1e-5 km/s²，方向 [1,0,0]
-    np.testing.assert_allclose(acc, [1e-5, 0.0, 0.0])
-
-
-@pytest.mark.xfail(reason="预留 #407：FiniteBurn 恒质量低推力从未实现")
-def test_finite_burn_none_frame_callable_direction():
-    """direction_frame=None 时，callable 返回值直接归一化使用。"""
-    burn = FiniteBurn(
-        thrust_profile=lambda t: 10.0,
-        direction=lambda t, state: [0.0, 3.0, 0.0],
-        mass=1000.0,
-    )
-    state = _make_state([7000.0, 0.0, 0.0], [0.0, 7.5, 0.0])
-    acc = burn.compute_acceleration(0.0, state, FakeSystem())
-
-    np.testing.assert_allclose(acc, [0.0, 1e-5, 0.0])
-
-
-# --- VNB 坐标系转换 ---
-
-
-@pytest.mark.xfail(reason="预留 #407：FiniteBurn 恒质量低推力从未实现")
-def test_finite_burn_vnb_velocity_direction():
-    """VNB 下 direction=[1,0,0] 对应速度方向（V）。"""
-    burn = FiniteBurn(
-        thrust_profile=lambda t: 10.0,
-        direction=[1.0, 0.0, 0.0],
-        mass=1000.0,
-        direction_frame="VNB",
-    )
-    # 状态：r=[7000,0,0], v=[0,7.5,0] → V 方向为 [0,1,0]
-    state = _make_state([7000.0, 0.0, 0.0], [0.0, 7.5, 0.0])
-    acc = burn.compute_acceleration(0.0, state, FakeSystem())
-
-    # 推力沿 V 方向 = [0,1,0]，大小 1e-5 km/s²
-    np.testing.assert_allclose(acc, [0.0, 1e-5, 0.0], atol=1e-12)
-
-
-@pytest.mark.xfail(reason="预留 #407：FiniteBurn 恒质量低推力从未实现")
-def test_finite_burn_vnb_normal_direction():
-    """VNB 下 direction=[0,1,0] 对应角动量方向（N = r × v / |r × v|）。"""
-    burn = FiniteBurn(
-        thrust_profile=lambda t: 10.0,
-        direction=[0.0, 1.0, 0.0],
-        mass=1000.0,
-        direction_frame="VNB",
-    )
-    # r=[7000,0,0], v=[0,7.5,0] → r×v = [0,0,52500] → N = [0,0,1]
-    state = _make_state([7000.0, 0.0, 0.0], [0.0, 7.5, 0.0])
-    acc = burn.compute_acceleration(0.0, state, FakeSystem())
-
-    np.testing.assert_allclose(acc, [0.0, 0.0, 1e-5], atol=1e-12)
-
-
-@pytest.mark.xfail(reason="预留 #407：FiniteBurn 恒质量低推力从未实现")
-def test_finite_burn_vnb_binormal_direction():
-    """VNB 下 direction=[0,0,1] 对应 B = V × N 方向。"""
-    burn = FiniteBurn(
-        thrust_profile=lambda t: 10.0,
-        direction=[0.0, 0.0, 1.0],
-        mass=1000.0,
-        direction_frame="VNB",
-    )
-    # r=[7000,0,0], v=[0,7.5,0] → V=[0,1,0], N=[0,0,1], B=V×N=[1,0,0]
-    state = _make_state([7000.0, 0.0, 0.0], [0.0, 7.5, 0.0])
-    acc = burn.compute_acceleration(0.0, state, FakeSystem())
-
-    np.testing.assert_allclose(acc, [1e-5, 0.0, 0.0], atol=1e-12)
-
-
-@pytest.mark.xfail(reason="预留 #407：FiniteBurn 恒质量低推力从未实现")
-def test_finite_burn_vnb_combined_direction():
-    """VNB 下 direction=[1,1,1] 产生混合方向。"""
-    burn = FiniteBurn(
-        thrust_profile=lambda t: 10.0,
-        direction=[1.0, 1.0, 1.0],
-        mass=1000.0,
-        direction_frame="VNB",
-    )
-    # r=[7000,0,0], v=[0,7.5,0] → V=[0,1,0], N=[0,0,1], B=[1,0,0]
-    # direction=[1,1,1] 在 VNB 下 = V + N + B = [0,1,0] + [0,0,1] + [1,0,0] = [1,1,1]
-    # 归一化后 = [1,1,1]/sqrt(3)
-    state = _make_state([7000.0, 0.0, 0.0], [0.0, 7.5, 0.0])
-    acc = burn.compute_acceleration(0.0, state, FakeSystem())
-
-    expected_dir = np.array([1.0, 1.0, 1.0]) / np.sqrt(3.0)
-    expected = 1e-5 * expected_dir
-    np.testing.assert_allclose(acc, expected, atol=1e-12)
-
-
-# --- LVLH 坐标系转换 ---
-
-
-@pytest.mark.xfail(reason="预留 #407：FiniteBurn 恒质量低推力从未实现")
-def test_finite_burn_lvlh_radial_direction():
-    """LVLH 下 direction=[1,0,0] 对应径向（R = r/|r|）。"""
-    burn = FiniteBurn(
-        thrust_profile=lambda t: 10.0,
-        direction=[1.0, 0.0, 0.0],
-        mass=1000.0,
-        direction_frame="LVLH",
-    )
-    # r=[7000,0,0] → R=[1,0,0]
-    state = _make_state([7000.0, 0.0, 0.0], [0.0, 7.5, 0.0])
-    acc = burn.compute_acceleration(0.0, state, FakeSystem())
-
-    np.testing.assert_allclose(acc, [1e-5, 0.0, 0.0], atol=1e-12)
-
-
-@pytest.mark.xfail(reason="预留 #407：FiniteBurn 恒质量低推力从未实现")
-def test_finite_burn_lvlh_velocity_direction():
-    """LVLH 下 direction=[0,1,0] 对应沿迹方向（V = v/|v|）。"""
-    burn = FiniteBurn(
-        thrust_profile=lambda t: 10.0,
-        direction=[0.0, 1.0, 0.0],
-        mass=1000.0,
-        direction_frame="LVLH",
-    )
-    # v=[0,7.5,0] → V=[0,1,0]
-    state = _make_state([7000.0, 0.0, 0.0], [0.0, 7.5, 0.0])
-    acc = burn.compute_acceleration(0.0, state, FakeSystem())
-
-    np.testing.assert_allclose(acc, [0.0, 1e-5, 0.0], atol=1e-12)
-
-
-@pytest.mark.xfail(reason="预留 #407：FiniteBurn 恒质量低推力从未实现")
-def test_finite_burn_lvlh_cross_track_direction():
-    """LVLH 下 direction=[0,0,1] 对应轨道面法向（N = R × V）。"""
-    burn = FiniteBurn(
-        thrust_profile=lambda t: 10.0,
-        direction=[0.0, 0.0, 1.0],
-        mass=1000.0,
-        direction_frame="LVLH",
-    )
-    # r=[7000,0,0], v=[0,7.5,0] → R=[1,0,0], V=[0,1,0], N=R×V=[0,0,1]
-    state = _make_state([7000.0, 0.0, 0.0], [0.0, 7.5, 0.0])
-    acc = burn.compute_acceleration(0.0, state, FakeSystem())
-
-    np.testing.assert_allclose(acc, [0.0, 0.0, 1e-5], atol=1e-12)
-
-
-@pytest.mark.xfail(reason="预留 #407：FiniteBurn 恒质量低推力从未实现")
-def test_finite_burn_lvlh_3d_position():
-    """LVLH 在三维非共面位置下正确。"""
-    burn = FiniteBurn(
-        thrust_profile=lambda t: 10.0,
-        direction=[1.0, 0.0, 0.0],
-        mass=1000.0,
-        direction_frame="LVLH",
-    )
-    # r=[1000,2000,3000], v=[1,2,3]
-    state = _make_state([1000.0, 2000.0, 3000.0], [1.0, 2.0, 3.0])
-    acc = burn.compute_acceleration(0.0, state, FakeSystem())
-
-    r = np.array([1000.0, 2000.0, 3000.0])
-    r_hat = r / np.linalg.norm(r)
-    expected = 1e-5 * r_hat
-    np.testing.assert_allclose(acc, expected, atol=1e-12)
-
-
-# --- callable direction + direction_frame ---
-
-
-@pytest.mark.xfail(reason="预留 #407：FiniteBurn 恒质量低推力从未实现")
-def test_finite_burn_vnb_with_callable_direction():
-    """direction 为 callable 时，返回值在 direction_frame 下解释。"""
-    burn = FiniteBurn(
-        thrust_profile=lambda t: 10.0,
-        direction=lambda t, state: [1.0, 0.0, 0.0],  # VNB 下 = V 方向
-        mass=1000.0,
-        direction_frame="VNB",
-    )
-    state = _make_state([7000.0, 0.0, 0.0], [0.0, 7.5, 0.0])
-    acc = burn.compute_acceleration(0.0, state, FakeSystem())
-
-    # V 方向 = [0,1,0]
-    np.testing.assert_allclose(acc, [0.0, 1e-5, 0.0], atol=1e-12)
-
-
-@pytest.mark.xfail(reason="预留 #407：FiniteBurn 恒质量低推力从未实现")
-def test_finite_burn_lvlh_with_callable_direction():
-    """direction callable 在 LVLH 下解释。"""
-    burn = FiniteBurn(
-        thrust_profile=lambda t: 10.0,
-        direction=lambda t, state: [0.0, 0.0, 1.0],  # LVLH 下 = N 方向
-        mass=1000.0,
-        direction_frame="LVLH",
-    )
-    state = _make_state([7000.0, 0.0, 0.0], [0.0, 7.5, 0.0])
-    acc = burn.compute_acceleration(0.0, state, FakeSystem())
-
-    # N = R × V = [0,0,1]
-    np.testing.assert_allclose(acc, [0.0, 0.0, 1e-5], atol=1e-12)
-
-
-# --- 零速度/零位置边界 ---
-
-
-@pytest.mark.xfail(reason="预留 #407：FiniteBurn 恒质量低推力从未实现")
-def test_finite_burn_vnb_zero_velocity_raises():
-    """VNB 下 |v|=0 时无法构造 V 方向，抛 ValueError。"""
-    burn = FiniteBurn(
-        thrust_profile=lambda t: 10.0,
-        direction=[1.0, 0.0, 0.0],
-        mass=1000.0,
-        direction_frame="VNB",
-    )
-    state = _make_state([7000.0, 0.0, 0.0], [0.0, 0.0, 0.0])
-    with pytest.raises(ValueError, match="velocity"):
-        burn.compute_acceleration(0.0, state, FakeSystem())
-
-
-@pytest.mark.xfail(reason="预留 #407：FiniteBurn 恒质量低推力从未实现")
-def test_finite_burn_lvlh_zero_position_raises():
-    """LVLH 下 |r|=0 时无法构造 R 方向，抛 ValueError。"""
-    burn = FiniteBurn(
-        thrust_profile=lambda t: 10.0,
-        direction=[1.0, 0.0, 0.0],
-        mass=1000.0,
-        direction_frame="LVLH",
-    )
-    state = _make_state([0.0, 0.0, 0.0], [0.0, 7.5, 0.0])
-    with pytest.raises(ValueError, match="position"):
-        burn.compute_acceleration(0.0, state, FakeSystem())
-
-
-# --- 关机时 direction_frame 不触发计算 ---
-
-
-@pytest.mark.xfail(reason="预留 #407：FiniteBurn 恒质量低推力从未实现")
-def test_finite_burn_zero_thrust_skips_direction_frame():
-    """thrust=0 时直接返回零，不解析 direction_frame。"""
-    burn = FiniteBurn(
-        thrust_profile=lambda t: 0.0,
-        direction=[1.0, 0.0, 0.0],
-        mass=1000.0,
-        direction_frame="VNB",
-    )
-    # 即使 v=0（VNB 会抛），thrust=0 也应直接返回零
-    state = _make_state([7000.0, 0.0, 0.0], [0.0, 0.0, 0.0])
-    acc = burn.compute_acceleration(0.0, state, FakeSystem())
-
-    np.testing.assert_array_equal(acc, np.zeros(3))
+def test_finite_burn_callable_direction_is_not_compilable():
+    """可调用方向不能跨 Python/Rust 边界，传播入口明确拒绝。"""
+    profile = build_force(
+        "FiniteBurn",
+        {
+            "mass": 1000.0,
+            "thrust_profile": {"kind": "constant", "thrust": 10.0},
+            "direction": {"kind": "fixed", "vector": [1.0, 0.0, 0.0]},
+        },
+    ).thrust_profile
+    burn = FiniteBurn(profile, lambda _t, _state: [1.0, 0.0, 0.0], 1000.0)
+    with pytest.raises(NotImplementedError, match="无 Rust 实现"):
+        ForceModel(FakeSystem(), [burn]).propagate([7000.0, 0.0, 0.0, 0.0, 7.5, 0.0], (0.0, 1.0))

--- a/tests/numerical/forces/physics/test_dynamic_axes_thrust.py
+++ b/tests/numerical/forces/physics/test_dynamic_axes_thrust.py
@@ -1,26 +1,13 @@
-"""动态坐标系推力传播集成测试（Slice 12 验收，预留 #407）。
-
-验证 VNB 沿速度方向推力提升半长轴、LVLH 径向推力增加偏心率、
-转换矩阵正交性与混合方向。
-
-预留状态：``FiniteBurn`` 恒质量低推力从未实现（``to_rust_spec`` 抛
-``NotImplementedError``），本文件全部测试标记 ``xfail``；实现后（#407）
-去掉 ``pytestmark`` 里的 xfail 即可恢复断言。
-"""
-
-from __future__ import annotations
+"""FiniteBurn 动态方向帧的传播集成测试。"""
 
 import numpy as np
 import pytest
 
-from e2m2e.algorithm.forces import FiniteBurn, ForceModel, PointMassGravity
+from e2m2e.algorithm.forces import ForceModel, PointMassGravity
+from e2m2e.algorithm.forces.force_config import build_force
 from tests.numerical.forces.conftest import EARTH_RE, keplerian_to_cartesian, semi_major_axis
 
-pytestmark = [
-    pytest.mark.force,
-    pytest.mark.low_thrust,
-    pytest.mark.xfail(reason="预留 #407：FiniteBurn 恒质量低推力从未实现"),
-]
+pytestmark = pytest.mark.force
 
 
 def _propagate_dynamic_axes(
@@ -30,288 +17,93 @@ def _propagate_dynamic_axes(
     duration_s,
     n_points,
     *,
-    e: float = 0.0,
+    eccentricity: float = 0.0,
     thrust: float = 1.0,
 ):
-    """构造动态轴推力传播，返回 ``(result, mu, fm, et0)``。
-
-    初值：近圆 LEO（400 km 高度）；推力沿 ``direction``（在
-    ``direction_frame`` 下解释）、质量 1000 kg。
-    """
+    """传播配置 DSL 表达的 VNB/LVLH 恒质量推力。"""
     mu = system.gravitational_parameter("EARTH")
-    a0 = EARTH_RE + 400.0
-    y0 = keplerian_to_cartesian(a0, e, 0.0, 0.0, 0.0, 0.0, mu)
-
-    gravity = PointMassGravity(body="EARTH")
-    burn = FiniteBurn(
-        thrust_profile=lambda t: thrust,
-        direction=direction,
-        mass=1000.0,
-        direction_frame=direction_frame,
+    y0 = keplerian_to_cartesian(EARTH_RE + 400.0, eccentricity, 0.0, 0.0, 0.0, 0.0, mu)
+    burn = build_force(
+        "FiniteBurn",
+        {
+            "mass": 1000.0,
+            "thrust_profile": {"kind": "constant", "thrust": thrust},
+            "direction": {"kind": "fixed", "vector": direction},
+            "direction_frame": direction_frame,
+        },
     )
-    fm = ForceModel(system, forces=[gravity, burn])
-
     et0 = system.spice.utc_to_et("2025-06-21T11:00:06")
-    t_span = (et0, et0 + duration_s)
-    t_eval = np.linspace(et0, et0 + duration_s, n_points)
-    result = fm.propagate(y0, t_span, t_eval=t_eval, max_steps=200_000)
-    return result, mu, fm, et0
+    result = ForceModel(system, [PointMassGravity(body="EARTH"), burn]).propagate(
+        y0,
+        (et0, et0 + duration_s),
+        t_eval=np.linspace(et0, et0 + duration_s, n_points),
+        max_steps=200_000,
+    )
+    return result, mu
 
 
 def _eccentricity(state, mu):
-    """从状态向量计算偏心率。"""
+    """从惯性状态计算偏心率。"""
     r_vec = state[:3]
     v_vec = state[3:6]
     r = np.linalg.norm(r_vec)
     v = np.linalg.norm(v_vec)
-    rv_dot = np.dot(r_vec, v_vec)
-    e_vec = ((v**2 - mu / r) * r_vec - rv_dot * v_vec) / mu
+    e_vec = ((v**2 - mu / r) * r_vec - np.dot(r_vec, v_vec) * v_vec) / mu
     return float(np.linalg.norm(e_vec))
 
 
-def _orbital_energy(state, mu):
-    """从状态向量计算比轨道能量。"""
-    r = np.linalg.norm(state[:3])
-    v = np.linalg.norm(state[3:6])
-    return v**2 / 2.0 - mu / r
-
-
-# --- 测试 1：VNB 沿速度方向推力 ---
-
-
 @pytest.mark.spice
-def test_vnb_velocity_direction_thrust_increases_semi_major_axis(earth_icrf_system):
-    """VNB 下 direction=[1,0,0] 沿速度方向推力，验证半长轴与轨道能量增加。"""
-    result, mu, _, _ = _propagate_dynamic_axes(
-        earth_icrf_system, [1.0, 0.0, 0.0], "VNB", 3600.0, 50
-    )
-
-    a_initial = semi_major_axis(result["states"][0], mu)
-    a_final = semi_major_axis(result["states"][-1], mu)
-    assert a_final > a_initial, f"半长轴应增加: initial={a_initial:.3f} km, final={a_final:.3f} km"
-
-    energy_initial = _orbital_energy(result["states"][0], mu)
-    energy_final = _orbital_energy(result["states"][-1], mu)
-    assert energy_final > energy_initial, (
-        f"轨道能量应增加: initial={energy_initial:.6f} km²/s², final={energy_final:.6f} km²/s²"
-    )
-
-
-@pytest.mark.spice
-def test_vnb_velocity_direction_thrust_acceleration_aligns_with_velocity(earth_icrf_system):
-    """VNB 沿速度方向推力，验证惯性系中推力加速度方向与速度方向点积 ≈ 1。"""
-    result, mu, fm, et0 = _propagate_dynamic_axes(
-        earth_icrf_system, [1.0, 0.0, 0.0], "VNB", 600.0, 20
-    )
-
-    for state in result["states"]:
-        v = state[3:6]
-        v_norm = np.linalg.norm(v)
-        if v_norm > 1e-15:
-            v_hat = v / v_norm
-            # 计算推力加速度（扣除引力后）
-            r = state[:3]
-            r_norm = np.linalg.norm(r)
-            gravity_acc = -mu / (r_norm**3) * r
-            total_acc = fm._compute_total_acceleration(et0, state)
-            thrust_acc = total_acc - gravity_acc
-            thrust_acc_norm = np.linalg.norm(thrust_acc)
-            if thrust_acc_norm > 1e-15:
-                dot_product = np.dot(thrust_acc / thrust_acc_norm, v_hat)
-                assert dot_product > 0.99, (
-                    f"推力加速度方向与速度方向点积应 > 0.99, got {dot_product:.6f}"
-                )
-
-
-# --- 测试 2：LVLH 径向推力 ---
+def test_vnb_velocity_direction_thrust_increases_orbital_energy(earth_icrf_system):
+    """VNB 的速度轴推力持续提高半长轴和轨道能量。"""
+    result, mu = _propagate_dynamic_axes(earth_icrf_system, [1.0, 0.0, 0.0], "VNB", 3600.0, 50)
+    initial, final = result["states"][0], result["states"][-1]
+    assert semi_major_axis(final, mu) > semi_major_axis(initial, mu)
+    initial_energy = np.dot(initial[3:6], initial[3:6]) / 2.0 - mu / np.linalg.norm(initial[:3])
+    final_energy = np.dot(final[3:6], final[3:6]) / 2.0 - mu / np.linalg.norm(final[:3])
+    assert final_energy > initial_energy
 
 
 @pytest.mark.spice
 def test_lvlh_radial_direction_thrust_increases_eccentricity(earth_icrf_system):
-    """LVLH 下 direction=[1,0,0] 径向推力，验证偏心率随时间增加。"""
-    result, mu, _, _ = _propagate_dynamic_axes(
-        earth_icrf_system, [1.0, 0.0, 0.0], "LVLH", 3600.0, 50, e=0.001
+    """LVLH 的径向推力使近圆轨道偏心率增加。"""
+    result, mu = _propagate_dynamic_axes(
+        earth_icrf_system, [1.0, 0.0, 0.0], "LVLH", 3600.0, 50, eccentricity=0.001
     )
-
-    e_initial = _eccentricity(result["states"][0], mu)
-    e_final = _eccentricity(result["states"][-1], mu)
-    assert e_final > e_initial, f"偏心率应增加: initial={e_initial:.6f}, final={e_final:.6f}"
+    assert _eccentricity(result["states"][-1], mu) > _eccentricity(result["states"][0], mu)
 
 
 @pytest.mark.spice
-def test_lvlh_radial_direction_thrust_acceleration_aligns_with_position(earth_icrf_system):
-    """LVLH 径向推力，验证惯性系中推力加速度方向与位置向量方向点积 ≈ 1。"""
-    result, mu, fm, et0 = _propagate_dynamic_axes(
-        earth_icrf_system, [1.0, 0.0, 0.0], "LVLH", 600.0, 20
-    )
-
-    for state in result["states"]:
-        r = state[:3]
-        r_norm = np.linalg.norm(r)
-        if r_norm > 1e-15:
-            r_hat = r / r_norm
-            gravity_acc = -mu / (r_norm**3) * r
-            total_acc = fm._compute_total_acceleration(et0, state)
-            thrust_acc = total_acc - gravity_acc
-            thrust_acc_norm = np.linalg.norm(thrust_acc)
-            if thrust_acc_norm > 1e-15:
-                dot_product = np.dot(thrust_acc / thrust_acc_norm, r_hat)
-                assert dot_product > 0.99, (
-                    f"推力加速度方向与位置向量方向点积应 > 0.99, got {dot_product:.6f}"
-                )
-
-
-# --- 测试 3：动态坐标系转换矩阵正交性 ---
+def test_dynamic_direction_frames_normalize_mixed_direction(earth_icrf_system):
+    """VNB/LVLH 混合方向都可通过 Rust 路径传播。"""
+    for direction_frame, direction in (("VNB", [1.0, 1.0, 1.0]), ("LVLH", [1.0, 1.0, 0.0])):
+        result, _ = _propagate_dynamic_axes(
+            earth_icrf_system, direction, direction_frame, 600.0, 10
+        )
+        assert np.isfinite(result["states"]).all()
 
 
 @pytest.mark.spice
-def test_vnb_rotation_matrix_orthogonality_during_propagation(earth_icrf_system):
-    """VNB 推力传播过程中，动态坐标系转换矩阵保持正交（R @ R.T ≈ I）。"""
-    result, _, _, _ = _propagate_dynamic_axes(earth_icrf_system, [1.0, 0.0, 0.0], "VNB", 3600.0, 30)
-
-    for state in result["states"]:
-        r = state[:3]
-        v = state[3:6]
-        v_norm = np.linalg.norm(v)
-        assert v_norm > 1e-15, "速度不能为零"
-
-        V = v / v_norm
-        h = np.cross(r, v)
-        h_norm = np.linalg.norm(h)
-        assert h_norm > 1e-15, "角动量不能为零"
-
-        N = h / h_norm
-        B = np.cross(V, N)
-
-        # VNB 转换矩阵：行向量为 V, N, B
-        R = np.array([V, N, B])
-
-        # 验证正交性：R @ R.T ≈ I
-        identity_check = R @ R.T
-        deviation = np.max(np.abs(identity_check - np.eye(3)))
-        assert deviation < 1e-14, f"VNB 转换矩阵正交性偏差应 < 1e-14, got {deviation:.2e}"
-
-        # 验证行列式 = 1（右手系）
-        det = np.linalg.det(R)
-        assert abs(det - 1.0) < 1e-14, f"VNB 转换矩阵行列式应 ≈ 1, got {det:.6f}"
-
-
-@pytest.mark.spice
-def test_lvlh_rotation_matrix_orthogonality_during_propagation(earth_icrf_system):
-    """LVLH 推力传播过程中，动态坐标系转换矩阵保持正交（R @ R.T ≈ I）。"""
-    result, _, _, _ = _propagate_dynamic_axes(
-        earth_icrf_system, [1.0, 0.0, 0.0], "LVLH", 3600.0, 30
-    )
-
-    for state in result["states"]:
-        r = state[:3]
-        v = state[3:6]
-        r_norm = np.linalg.norm(r)
-        assert r_norm > 1e-15, "位置不能为零"
-
-        R = r / r_norm
-        v_norm = np.linalg.norm(v)
-        assert v_norm > 1e-15, "速度不能为零"
-
-        V = v / v_norm
-        N = np.cross(R, V)
-        N_norm = np.linalg.norm(N)
-        assert N_norm > 1e-15, "轨道面法向不能为零"
-        N = N / N_norm
-
-        # LVLH 基的关键几何性质：N 同时垂直于 R 和 V（叉积性质）
-        assert abs(np.dot(N, R)) < 1e-14, f"N 应垂直于 R: dot={np.dot(N, R):.2e}"
-        assert abs(np.dot(N, V)) < 1e-14, f"N 应垂直于 V: dot={np.dot(N, V):.2e}"
-
-
-# --- 测试 4：混合方向 ---
-
-
-@pytest.mark.spice
-def test_vnb_combined_direction_thrust_produces_expected_components(earth_icrf_system):
-    """VNB 下 direction=[1,1,1] 混合方向，验证初始点加速度分量比例。"""
-    result, mu, fm, et0 = _propagate_dynamic_axes(
-        earth_icrf_system, [1.0, 1.0, 1.0], "VNB", 600.0, 10
-    )
-
-    state = result["states"][0]
-    r = state[:3]
-    v = state[3:6]
-    r_norm = np.linalg.norm(r)
-    v_norm = np.linalg.norm(v)
-    V = v / v_norm
-    h = np.cross(r, v)
-    N = h / np.linalg.norm(h)
-    B = np.cross(V, N)
-
-    gravity_acc = -mu / (r_norm**3) * r
-    total_acc = fm._compute_total_acceleration(et0, state)
-    thrust_acc = total_acc - gravity_acc
-
-    # direction=[1,1,1] 在 VNB 下 = (V + N + B) / sqrt(3)
-    expected_dir = (V + N + B) / np.linalg.norm(V + N + B)
-    expected_thrust_acc = (1.0 / 1000.0 / 1000.0) * expected_dir
-
-    np.testing.assert_allclose(thrust_acc, expected_thrust_acc, atol=1e-12)
-
-
-@pytest.mark.spice
-def test_lvlh_combined_direction_thrust_produces_expected_components(earth_icrf_system):
-    """LVLH 下 direction=[1,1,0] 混合方向，验证初始点加速度分量比例。"""
-    result, mu, fm, et0 = _propagate_dynamic_axes(
-        earth_icrf_system, [1.0, 1.0, 0.0], "LVLH", 600.0, 10
-    )
-
-    state = result["states"][0]
-    r = state[:3]
-    v = state[3:6]
-    r_norm = np.linalg.norm(r)
-    R = r / r_norm
-    v_norm = np.linalg.norm(v)
-    V = v / v_norm
-
-    gravity_acc = -mu / (r_norm**3) * r
-    total_acc = fm._compute_total_acceleration(et0, state)
-    thrust_acc = total_acc - gravity_acc
-
-    # direction=[1,1,0] 在 LVLH 下 = (R + V) / sqrt(2)
-    expected_dir = (R + V) / np.linalg.norm(R + V)
-    expected_thrust_acc = (1.0 / 1000.0 / 1000.0) * expected_dir
-
-    np.testing.assert_allclose(thrust_acc, expected_thrust_acc, atol=1e-12)
-
-
-# --- 测试 5：零推力边界 ---
-
-
-@pytest.mark.spice
-def test_vnb_zero_thrust_no_orbit_change(earth_icrf_system):
-    """VNB 方向但推力为零时，轨道应与纯引力传播一致。"""
+def test_vnb_zero_thrust_matches_gravity_only(earth_icrf_system):
+    """零推力时不会尝试解析动态方向，轨迹与纯引力相同。"""
     system = earth_icrf_system
     mu = system.gravitational_parameter("EARTH")
-
-    a0 = EARTH_RE + 400.0
-    y0 = keplerian_to_cartesian(a0, 0.0, 0.0, 0.0, 0.0, 0.0, mu)
-
-    gravity = PointMassGravity(body="EARTH")
-    burn_zero = FiniteBurn(
-        thrust_profile=lambda t: 0.0,
-        direction=[1.0, 0.0, 0.0],
-        mass=1000.0,
-        direction_frame="VNB",
-    )
-    fm_with_zero_thrust = ForceModel(system, forces=[gravity, burn_zero])
-    fm_gravity_only = ForceModel(system, forces=[gravity])
-
+    y0 = keplerian_to_cartesian(EARTH_RE + 400.0, 0.0, 0.0, 0.0, 0.0, 0.0, mu)
     et0 = system.spice.utc_to_et("2025-06-21T11:00:06")
-    t_span = (et0, et0 + 600.0)
     t_eval = np.linspace(et0, et0 + 600.0, 20)
-
-    result_with_zero = fm_with_zero_thrust.propagate(y0, t_span, t_eval=t_eval, max_steps=200_000)
-    result_gravity_only = fm_gravity_only.propagate(y0, t_span, t_eval=t_eval, max_steps=200_000)
-
-    np.testing.assert_allclose(
-        result_with_zero["states"],
-        result_gravity_only["states"],
-        atol=1e-12,
+    zero_burn = build_force(
+        "FiniteBurn",
+        {
+            "mass": 1000.0,
+            "thrust_profile": {"kind": "constant", "thrust": 0.0},
+            "direction": {"kind": "fixed", "vector": [1.0, 0.0, 0.0]},
+            "direction_frame": "VNB",
+        },
     )
+    gravity = PointMassGravity(body="EARTH")
+    with_burn = ForceModel(system, [gravity, zero_burn]).propagate(
+        y0, (et0, et0 + 600.0), t_eval=t_eval, max_steps=200_000
+    )
+    gravity_only = ForceModel(system, [gravity]).propagate(
+        y0, (et0, et0 + 600.0), t_eval=t_eval, max_steps=200_000
+    )
+    np.testing.assert_allclose(with_burn["states"], gravity_only["states"], atol=1e-12)

--- a/tests/numerical/forces/physics/test_low_thrust_propagation.py
+++ b/tests/numerical/forces/physics/test_low_thrust_propagation.py
@@ -7,18 +7,18 @@ FiniteBurn 配置 round-trip 见 ``config/test_low_thrust_config_propagation.py`
 import numpy as np
 import pytest
 
-from e2m2e.algorithm.forces import FiniteBurn, ForceModel, GravityField
+from e2m2e.algorithm.forces import ForceModel, GravityField
+from e2m2e.algorithm.forces.force_config import build_force
 from tests.numerical.forces.conftest import (
     EARTH_RE,
     keplerian_to_cartesian,
     semi_major_axis,
 )
 
-pytestmark = [pytest.mark.force, pytest.mark.low_thrust]
+pytestmark = pytest.mark.force
 
 
 @pytest.mark.spice
-@pytest.mark.xfail(reason="预留 #407：FiniteBurn 恒质量低推力从未实现")
 def test_low_thrust_circular_orbit_semi_major_axis_rate(earth_icrf_system):
     """低推力圆轨道提升：半长轴变化率与解析公式误差 < 5%。"""
     system = earth_icrf_system
@@ -32,14 +32,15 @@ def test_low_thrust_circular_orbit_semi_major_axis_rate(earth_icrf_system):
     mass = 1000.0  # kg
     duration_s = 1.0 * 86400.0
 
-    def thrust_profile(_t: float) -> float:
-        return thrust
-
-    def direction(_t: float, state: np.ndarray) -> np.ndarray:
-        v = state[3:6]
-        return v / np.linalg.norm(v)
-
-    burn = FiniteBurn(thrust_profile=thrust_profile, direction=direction, mass=mass)
+    burn = build_force(
+        "FiniteBurn",
+        {
+            "mass": mass,
+            "thrust_profile": {"kind": "constant", "thrust": thrust},
+            "direction": {"kind": "fixed", "vector": [1.0, 0.0, 0.0]},
+            "direction_frame": "VNB",
+        },
+    )
     gravity = GravityField(body="EARTH", degree=2, order=0)
     fm = ForceModel(system, forces=[gravity, burn])
 

--- a/tests/numerical/forces/physics/test_thrust.py
+++ b/tests/numerical/forces/physics/test_thrust.py
@@ -1,42 +1,31 @@
-"""FiniteBurn 低推力传播物理验证。
-
-沿速度方向低推力传播 → 半长轴持续提升（电推进螺旋趋势）。定义契约见
-``contract/test_thrust.py``。
-
-低推力功能尚未开发完成（Facade 任务入口占位，Rust 传播路径已接入）；本文件标记
-``low_thrust``，本轮检查排除在绿门外。
-"""
+"""FiniteBurn 低推力传播物理验证。"""
 
 import numpy as np
-import pytest
 
 from e2m2e.algorithm.forces import ForceModel
-from e2m2e.algorithm.forces.thrust import FiniteBurn
+from e2m2e.algorithm.forces.force_config import build_force
 from tests.numerical.forces.conftest import FakeSystem
 
-pytestmark = [pytest.mark.force, pytest.mark.low_thrust]
 
-
-@pytest.mark.xfail(reason="预留 #407：FiniteBurn 恒质量低推力从未实现")
-def test_finite_burn_spiral_raises_semi_major_axis(point_mass_force):
-    """沿速度方向低推力传播 → 半长轴持续提升（电推进螺旋趋势）。"""
+def test_finite_burn_vnb_spiral_raises_semi_major_axis(point_mass_force):
+    """VNB 速度方向的恒质量推力使圆轨道半长轴持续提升。"""
     mu = point_mass_force.mu
-    r0 = 6678.0  # LEO 300km
+    r0 = 6678.0
     v_circ = np.sqrt(mu / r0)
     y0 = np.array([r0, 0.0, 0.0, 0.0, v_circ, 0.0])
-
-    burn = FiniteBurn(
-        thrust_profile=lambda t: 2.0,  # N
-        direction=lambda t, s: s[3:6],  # 沿速度方向（可调用）
-        mass=1000.0,  # kg
+    burn = build_force(
+        "FiniteBurn",
+        {
+            "mass": 1000.0,
+            "thrust_profile": {"kind": "constant", "thrust": 2.0},
+            "direction": {"kind": "fixed", "vector": [1.0, 0.0, 0.0]},
+            "direction_frame": "VNB",
+        },
     )
     fm = ForceModel(FakeSystem(), forces=[point_mass_force, burn])
 
     period = 2.0 * np.pi * np.sqrt(r0**3 / mu)
-    n_orbits = 3
-    result = fm.propagate(
-        y0, (0.0, n_orbits * period), t_eval=np.linspace(0.0, n_orbits * period, 60)
-    )
+    result = fm.propagate(y0, (0.0, 3.0 * period), t_eval=np.linspace(0.0, 3.0 * period, 60))
 
     states = result["states"]
     r = np.linalg.norm(states[:, :3], axis=1)
@@ -44,8 +33,5 @@ def test_finite_burn_spiral_raises_semi_major_axis(point_mass_force):
     energy = 0.5 * v**2 - mu / r
     semi_major = -mu / (2.0 * energy)
 
-    # 半长轴末端 > 起点
     assert semi_major[-1] > semi_major[0]
-    # 整体趋势向上（线性拟合斜率 > 0）
-    slope = np.polyfit(np.arange(semi_major.size), semi_major, 1)[0]
-    assert slope > 0.0
+    assert np.polyfit(np.arange(semi_major.size), semi_major, 1)[0] > 0.0


### PR DESCRIPTION
关联 #407

## 改动

- 将配置 DSL 构造的 `FiniteBurn` 接入 Rust 6D 编译传播，真实使用恒质量并支持 constant/pulse profile。
- 在 Rust RHS 中解析惯性、VNB、LVLH 固定方向；修正 LVLH 沿迹轴、退化阈值和共线归一化。
- 为恒质量低推力补齐 STM 雅可比，并将 pulse 起止时刻作为普通/STM 积分内部断点。
- 将预留的 FiniteBurn 测试迁移为公开传播、配置、方向帧、物理和有限差分行为测试；低推力纳入默认 Python 测试门。
- 更新 `FiniteBurn` 的能力边界文档：仅可序列化 DSL 控制可下沉 Rust，任意 Python callable 显式拒绝。

## 验证

- `uv run pytest tests/ -n 8 --dist loadscope`：1802 passed, 280 skipped
- `uv run ruff check .`、`uv run ruff format --check .`、`uv run mypy e2m2e/ --ignore-missing-imports`：通过
- `cargo fmt --all -- --check`、`cargo clippy --workspace -- -D warnings`：通过
- 受影响低推力测试：23 passed, 6 skipped

本地 `make test` 的 Rust 集成测试仍在既有 `srp_jacobian` 用例处因缺少 `kernels/de430.bsp` 失败；低推力相关回归均通过。