### PR TITLE
fix(algorithm): 修复 NRHO L1 PAL 路径 AttributeError 崩溃 (#434)

### DIFF
--- a/e2m2e/algorithm/family/halo_family.py
+++ b/e2m2e/algorithm/family/halo_family.py
@@ -344,7 +344,7 @@ def halo_pseudo_arclength_continuation(
             target_direction=td,
             progress_callback=progress_callback,
         )
-        for o in sub.orbits[1:]:
+        for o in sub.family.orbits[1:]:
             tag(o)
             orbit_family.add_orbit(o)
 

--- a/e2m2e/algorithm/solver/continuation.py
+++ b/e2m2e/algorithm/solver/continuation.py
@@ -210,7 +210,8 @@ class Continuation:
             verbose: 是否打印信息
 
         Returns:
-            OrbitFamily: 包含轨道族的OrbitFamily对象
+            ContinuationResult: 结果状态三元组（status/cause/message）+
+            轨道族与延拓统计（族在 ``.family``，含种子与新生成成员）。
         """
         # 验证并限制步长
         if step_size > self.max_step_size:
@@ -459,7 +460,8 @@ class Continuation:
                 （0=rx, 1=rz, 2=vy, 3=T/2）。
 
         Returns:
-            OrbitFamily: 仅含种子与本支新轨道（不重复添加种子）。
+            ContinuationResult: 结果状态三元组（status/cause/message）+
+            轨道族与延拓统计（族在 ``.family``，仅含种子与本支新轨道）。
         """
         dynamics = self.dynamics
 

--- a/tests/algorithm/design/continuation/test_halo_pal_continuation.py
+++ b/tests/algorithm/design/continuation/test_halo_pal_continuation.py
@@ -1,0 +1,58 @@
+"""Halo PAL 编排函数 halo_pseudo_arclength_continuation 冒烟测试。
+
+#434 回归测试：#351 结果契约迁移后，编排层曾读取延拓结果的旧属性名
+（``.orbits``，现契约下族在 ``ContinuationResult.family``），任何调用
+必然 AttributeError——而套件对此零覆盖。此处以 session 缓存的 L1 Halo
+种子直接驱动编排函数，小步数验证它返回带标签的 Halo 族。
+"""
+
+import pytest
+
+from e2m2e.algorithm.family import halo_pseudo_arclength_continuation
+from e2m2e.algorithm.solver.continuation import Continuation
+from e2m2e.algorithm.solver.differential_correction import DifferentialCorrection
+
+pytestmark = pytest.mark.orchestration
+
+#: 冒烟步数：足以检验编排层结果读取与标签逻辑，又控制 STM 传播开销
+N_NEW_ORBITS = 2
+
+
+def test_pal_wrapper_returns_tagged_family(corrected_halo_l1, earth_moon_dynamics):
+    """正向 PAL 编排返回 种子+N_NEW_ORBITS 条带 Halo 标签的族成员。"""
+    seed, _result = corrected_halo_l1
+    # 种子标签由调用方负责（生产调用方 _walk_pal_to_perilune 同样先打标签）
+    seed.family_type = "halo"
+    seed.parameters = {
+        "libration_point": 1,
+        "halo_class": 0,
+        "amplitude_z": abs(float(seed.states[0, 2])),
+    }
+    continuation = Continuation(corrector=DifferentialCorrection(earth_moon_dynamics))
+    family = halo_pseudo_arclength_continuation(
+        continuation,
+        seed_orbit=seed,
+        n_orbits=N_NEW_ORBITS,
+        direction="positive",
+        step_size=0.0045,
+        verbose=False,
+    )
+
+    # 统一族容器：种子 + N_NEW_ORBITS 条新成员
+    assert len(family) == 1 + N_NEW_ORBITS
+
+    # 成员带 Halo 族标签与参数
+    for orbit in family.orbits:
+        assert orbit.family_type == "halo"
+        assert orbit.parameters["libration_point"] == 1
+        assert orbit.parameters["halo_class"] == 0
+
+    # 正向延拓（北族）：面外振幅单调增大
+    amplitudes = [o.parameters["amplitude_z"] for o in family.orbits]
+    assert amplitudes[1] > amplitudes[0]
+    assert amplitudes[2] > amplitudes[1]
+
+    # 每条新成员都是修正收敛产物（闭合误差已记录且远低于轨道量级）
+    for orbit in family.orbits[1:]:
+        assert orbit.closure_error is not None
+        assert orbit.closure_error < 1e-3

--- a/tests/algorithm/family/test_nrho_family.py
+++ b/tests/algorithm/family/test_nrho_family.py
@@ -1,0 +1,157 @@
+"""NRHO 轨道族端到端 + 物理不变量测试。
+
+覆盖 design_nrho 的两条实现路径：L1 经伪弧长延拓（PAL）行走到目标
+近月距，L2 经固定 x0 族行走。检验收敛性、近月距命中、周期闭合、
+Jacobi 守恒、近直线特征与注册表。
+
+L1 用例是 #434 的回归测试：#351 结果契约迁移漏改 PAL 编排层的结果
+读取，L1 NRHO 必然 AttributeError 崩溃，而套件曾对此零覆盖。
+
+References:
+    Lee (2019). Lunar Destination Analysis for Human Exploration Missions.
+    NRHO 近直线特征：近月距远小于远月距。
+"""
+
+import numpy as np
+import pytest
+
+from e2m2e.algorithm.dynamics import CR3BP_Dynamics
+from e2m2e.algorithm.family import registry
+from e2m2e.algorithm.family.cr3bp_orbits import (
+    _moon_distance_minmax,
+    design_nrho,
+)
+
+pytestmark = pytest.mark.orchestration
+
+MOON_RADIUS_KM = 1737.4
+CHAR_LENGTH_KM = 384400.0
+
+# design_nrho 默认 tol_km=10：近月距命中容差。断言留少许裕度。
+PERILUNE_TOL_KM = 15.0
+
+
+@pytest.fixture(scope="module")
+def l1_north_orbit():
+    """共享一条 L1 北族 NRHO（近月高 6000 km，PAL 路径）。"""
+    return design_nrho(1, 1, 6000.0)
+
+
+@pytest.fixture(scope="module")
+def l2_south_orbit():
+    """共享一条 L2 南族 NRHO（近月高 2500 km，固定 x0 行走路径）。"""
+    return design_nrho(2, 2, 2500.0)
+
+
+@pytest.fixture(scope="module")
+def dynamics(l1_north_orbit):
+    return CR3BP_Dynamics(l1_north_orbit.system)
+
+
+def _perilune_height_km(dynamics: CR3BP_Dynamics, orbit) -> float:
+    """一个周期内距月心最小距离换算的近月点高度（km）。"""
+    d_min, _ = _moon_distance_minmax(dynamics, orbit)
+    return d_min * CHAR_LENGTH_KM - MOON_RADIUS_KM
+
+
+# =============================================================================
+# Registry
+# =============================================================================
+
+
+class TestRegistry:
+    """注册表应包含 NRHO 条目。"""
+
+    def test_nrho_in_registry(self):
+        assert "NRHO" in registry
+
+    def test_nrho_callable(self):
+        assert callable(registry["NRHO"])
+
+    def test_nrho_same_as_design_nrho(self):
+        assert registry["NRHO"] is design_nrho
+
+
+# =============================================================================
+# End-to-end convergence
+# =============================================================================
+
+
+class TestDesignNrhoConvergence:
+    """design_nrho 端到端收敛测试（L1 PAL 路径 + L2 固定 x0 路径）。"""
+
+    def test_design_nrho_l1_north_converges(self, l1_north_orbit):
+        assert l1_north_orbit is not None
+        assert l1_north_orbit.period is not None
+        assert l1_north_orbit.period > 0
+
+    def test_design_nrho_l2_south_converges(self, l2_south_orbit):
+        assert l2_south_orbit is not None
+        assert l2_south_orbit.period is not None
+        assert l2_south_orbit.period > 0
+
+    def test_perilune_matches_target_l1(self, l1_north_orbit, dynamics):
+        """L1 北族近月高应命中 6000 km（设计容差 10 km）。"""
+        height = _perilune_height_km(dynamics, l1_north_orbit)
+        assert abs(height - 6000.0) < PERILUNE_TOL_KM, f"近月高 {height:.1f} km 未命中 6000 km"
+
+    def test_perilune_matches_target_l2(self, l2_south_orbit, dynamics):
+        """L2 南族近月高应命中 2500 km（设计容差 10 km）。"""
+        height = _perilune_height_km(dynamics, l2_south_orbit)
+        assert abs(height - 2500.0) < PERILUNE_TOL_KM, f"近月高 {height:.1f} km 未命中 2500 km"
+
+    def test_north_south_orientation(self, l1_north_orbit, l2_south_orbit):
+        """北族初始状态 z>0，南族 z<0（北/南约定与 design_halo 一致）。"""
+        assert l1_north_orbit.states[0, 2] > 0
+        assert l2_south_orbit.states[0, 2] < 0
+
+    def test_period_in_nrho_range(self, l1_north_orbit, l2_south_orbit):
+        """NRHO 周期约 1-3 TU（约 4-13 天，覆盖 9:2 共振邻域）。"""
+        for orbit in (l1_north_orbit, l2_south_orbit):
+            assert 1.0 < orbit.period < 3.0, f"周期 {orbit.period:.3f} TU 不在 NRHO 典型范围"
+
+
+# =============================================================================
+# Physical invariants
+# =============================================================================
+
+
+class TestPhysicalInvariants:
+    """收敛轨道的物理不变量检验。"""
+
+    def test_jacobi_conservation(self, l1_north_orbit, dynamics):
+        """Jacobi 常数在一个周期内漂移 < 1e-10。"""
+        T = l1_north_orbit.period
+        result = dynamics.propagate(
+            l1_north_orbit.states[0],
+            (0, T),
+            t_eval=np.linspace(0, T, 2000),
+            with_jacobi=True,
+        )
+        jacobi = result["jacobi"]
+        drift = abs(jacobi[-1] - jacobi[0])
+        assert drift < 1e-10
+
+    def test_periodic_closure_l1(self, l1_north_orbit, dynamics):
+        """全周期闭合误差 < 1e-6（L1 PAL 路径）。"""
+        T = l1_north_orbit.period
+        result = dynamics.propagate(
+            l1_north_orbit.states[0], (0, T), t_eval=np.linspace(0, T, 2000)
+        )
+        closure = np.linalg.norm(result["states"][-1] - l1_north_orbit.states[0])
+        assert closure < 1e-6
+
+    def test_periodic_closure_l2(self, l2_south_orbit, dynamics):
+        """全周期闭合误差 < 1e-6（L2 固定 x0 路径）。"""
+        T = l2_south_orbit.period
+        result = dynamics.propagate(
+            l2_south_orbit.states[0], (0, T), t_eval=np.linspace(0, T, 2000)
+        )
+        closure = np.linalg.norm(result["states"][-1] - l2_south_orbit.states[0])
+        assert closure < 1e-6
+
+    def test_near_rectilinear(self, l1_north_orbit, l2_south_orbit, dynamics):
+        """近直线特征：远月距应数倍于近月距（NRHO 定义性几何）。"""
+        for orbit in (l1_north_orbit, l2_south_orbit):
+            d_min, d_max = _moon_distance_minmax(dynamics, orbit)
+            assert d_max > 3.0 * d_min, f"远月距/近月距 = {d_max / d_min:.2f}，不具备近直线特征"


### PR DESCRIPTION
## 关联

Closes #434

## 改动

- 修复 Halo PAL 编排层仍按旧契约读取 `.orbits` 的回归：内层延拓实际返回 `ContinuationResult`，轨道族位于 `.family`；L1 NRHO 因而恢复可用。
- 更正自然参数延拓与 PAL 延拓的返回值 docstring，使其与 `ContinuationResult` 契约一致。
- 新增 L1/L2 NRHO 端到端与物理不变量覆盖；L1 北族 6000 km 用例直接覆盖 PAL 回归路径。
- 新增 Halo PAL 编排冒烟测试，验证统一族容器、标签、正向振幅与闭合误差。

## 验证

- `uv run pytest tests/algorithm/family/ tests/algorithm/design/continuation/ -q -n auto --dist loadscope`：119 passed
- `uv run pytest -n auto --dist loadscope -q`：1666 passed, 248 skipped
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy e2m2e/ --ignore-missing-imports`

## 评审

已完成规范轴与规格轴审查，无阻塞项。保留与既有族测试一致的注册表、L2 对照及物理不变量覆盖；两处延拓 docstring 同属 #351 结果契约迁移遗留，已一并更正。
