### PR TITLE
feat(transfer): 将 porkchop 网格扫描下沉 Rust (#446)

### DIFF
--- a/crates/e2m2e-forces/src/lib.rs
+++ b/crates/e2m2e-forces/src/lib.rs
@@ -12,6 +12,7 @@ pub mod bcr4bp;
 pub mod cr3bp;
 pub mod low_energy_patch;
 pub mod pal_continuation;
+pub mod porkchop;
 pub mod qlaw;
 pub mod solid_tide;
 pub mod spherical_harmonic;

--- a/crates/e2m2e-forces/src/porkchop.rs
+++ b/crates/e2m2e-forces/src/porkchop.rs
@@ -1,0 +1,429 @@
+//! porkchop 网格扫描评估单元（Rust 实现，纯数学，不依赖 SPICE）。
+//!
+//! 从 Python `e2m2e/algorithm/transfer/porkchop.py` 的网格循环下沉（#446，
+//! ADR 0017 边界条目）：终端状态传播 + Lambert 求解 + ΔV 组装 + 网格分发
+//! 全部在 Rust 完成，Python 只做问题构造与结果解释（架构设计文档 §2/§3）。
+//!
+//! 两条入口对应 Python 侧的两种问题构造方式：
+//!
+//! - [`porkchop_grid_serial`] / [`porkchop_grid_parallel`]：内置终端
+//!   （[`TerminalSpec`]）规格直接传入，终端传播在 Rust 内逐点进行——
+//!   语义逐行对照 `CR3BP_Dynamics.propagate_orbit_state_at_time`
+//!   （周期取模 + 首点重积分，直接调纯 Rust [`propagate_cr3bp`]，
+//!   不绕道持 GIL 的 `propagate_cr3bp_py`）。
+//! - [`porkchop_grid_states_serial`] / [`porkchop_grid_states_parallel`]：
+//!   终端状态网格由 Python 按 `get_arrival_state` 协议预提取（自定义
+//!   `TerminalCondition` 子类场景），Rust 只做 Lambert + ΔV 组装。
+//!
+//! 并行照搬 `transfer_grid_search` 的 Rayon 范式：`par_iter` + `collect`
+//! 保序，串/并逐位一致（`E2M2E_PORKCHOP_PARALLEL=0` 强制串行对照，
+//! 对称 `E2M2E_SEARCH_PARALLEL`）。
+
+use e2m2e_propagation::lambert::{lambert_izzo, TransferDirection};
+use rayon::prelude::*;
+
+use crate::cr3bp::propagate_cr3bp;
+
+/// 终端条件规格（对照 Python `TerminalCondition` 的两个内置实现）。
+#[derive(Clone, Copy, Debug)]
+pub enum TerminalSpec {
+    /// `OrbitTerminal`：周期轨道首点状态 + 时间原点 + 周期。
+    Orbit {
+        state0: [f64; 6],
+        t0: f64,
+        period: f64,
+    },
+    /// `StateTerminal`：固定状态（与时刻无关）。
+    State { state: [f64; 6] },
+}
+
+/// 终端传播配置（CR3BP 纯数学路径）。
+#[derive(Clone, Copy, Debug)]
+pub struct PropagationParams {
+    /// CR3BP 质量参数。
+    pub mu: f64,
+    pub rtol: f64,
+    pub atol: f64,
+    pub max_step: f64,
+}
+
+/// Lambert 求解配置。
+#[derive(Clone, Copy, Debug)]
+pub struct LambertParams {
+    /// 中心天体 GM（km³/s²）。
+    pub mu_central: f64,
+    pub long_way: bool,
+    pub revs: u32,
+}
+
+/// 单终端在时刻 `t` 的状态（移植 `propagate_orbit_state_at_time` 语义）。
+///
+/// 周期轨道：目标时刻对周期取模（`np.mod` ↔ `rem_euclid`，周期为正时一致），
+/// `t_rel < 1e-14` 直接返回首点状态；否则从首点重积分到 `t0 + t_rel`。
+///
+/// `propagate_cr3bp` 会在每个 `t_eval` 点截断步长，采样点会影响之后的自适应
+/// 步序列。因此此处逐式复现 Python `propagate_orbit_state_at_time` 的
+/// `n_steps = max(ceil(t_rel / 0.01) + 1, 2)` 与 `np.linspace`，而不能只传
+/// 首末两点；由此保证规格路径与协议路径的终端末态逐位一致。
+pub fn terminal_state_at(
+    terminal: &TerminalSpec,
+    t: f64,
+    propagation: Option<&PropagationParams>,
+) -> Result<[f64; 6], String> {
+    match terminal {
+        TerminalSpec::State { state } => Ok(*state),
+        TerminalSpec::Orbit { state0, t0, period } => {
+            let params = propagation.ok_or_else(|| {
+                "orbit 终端需要传播配置（CR3BP mu/容差/步长），但未提供".to_string()
+            })?;
+            let t_rel = (t - t0).rem_euclid(*period);
+            if t_rel < 1e-14 {
+                return Ok(*state0);
+            }
+            // 逐式对应 np.linspace(t0, t0 + t_rel, n_steps)：numpy 对末点
+            // 单独赋 stop，避免浮点乘加误差，Rust 侧同样显式写入。
+            let n_steps = ((t_rel / 0.01).ceil() as usize + 1).max(2);
+            let step = t_rel / (n_steps - 1) as f64;
+            let mut t_eval = Vec::with_capacity(n_steps);
+            for i in 0..n_steps - 1 {
+                t_eval.push(*t0 + step * i as f64);
+            }
+            t_eval.push(*t0 + t_rel);
+            let result = propagate_cr3bp(
+                params.mu,
+                (*t0, t0 + t_rel),
+                &t_eval,
+                state0,
+                params.rtol,
+                params.atol,
+                Some(params.max_step),
+                None,
+            )
+            .map_err(|e| format!("porkchop 终端状态传播失败（t={t}）：{e}"))?;
+            result
+                .states
+                .last()
+                .copied()
+                .ok_or_else(|| format!("porkchop 终端状态传播未返回状态（t={t}）"))
+        }
+    }
+}
+
+/// 单网格点评估：Lambert 求解 + 双脉冲 ΔV。
+///
+/// 无解组合（Lambert Err）返回 `(NaN, NaN)`，与 Python 侧
+/// `solve_lambert_batch` 的 NaN 占位语义一致。
+fn evaluate_cell(
+    dep_state: &[f64; 6],
+    arr_state: &[f64; 6],
+    tof: f64,
+    lambert: &LambertParams,
+) -> (f64, f64) {
+    let r0 = [dep_state[0], dep_state[1], dep_state[2]];
+    let rf = [arr_state[0], arr_state[1], arr_state[2]];
+    let direction = if lambert.long_way {
+        TransferDirection::LongWay
+    } else {
+        TransferDirection::ShortWay
+    };
+    match lambert_izzo(&r0, &rf, tof, lambert.mu_central, direction, lambert.revs) {
+        Ok((v0, vf, _n_iter)) => {
+            let dv1 = ((v0[0] - dep_state[3]).powi(2)
+                + (v0[1] - dep_state[4]).powi(2)
+                + (v0[2] - dep_state[5]).powi(2))
+            .sqrt();
+            let dv2 = ((arr_state[3] - vf[0]).powi(2)
+                + (arr_state[4] - vf[1]).powi(2)
+                + (arr_state[5] - vf[2]).powi(2))
+            .sqrt();
+            (dv1, dv2)
+        }
+        Err(_) => (f64::NAN, f64::NAN),
+    }
+}
+
+/// 状态网格评估（串行）：`dep_states[i]` 为 `t_dep[i]` 时刻出发状态，
+/// `arr_states[i * m + j]` 为 `t_dep[i] + tof[j]` 时刻到达状态（行优先，
+/// i 主序）。返回展平的 `(dv1, dv2)`，长度 `n * m`，同行优先约定。
+pub fn porkchop_grid_states_serial(
+    dep_states: &[[f64; 6]],
+    arr_states: &[[f64; 6]],
+    n_tof: usize,
+    tofs: &[f64],
+    lambert: &LambertParams,
+) -> (Vec<f64>, Vec<f64>) {
+    let n = dep_states.len();
+    let mut dv1 = Vec::with_capacity(n * n_tof);
+    let mut dv2 = Vec::with_capacity(n * n_tof);
+    for i in 0..n {
+        for j in 0..n_tof {
+            let (d1, d2) =
+                evaluate_cell(&dep_states[i], &arr_states[i * n_tof + j], tofs[j], lambert);
+            dv1.push(d1);
+            dv2.push(d2);
+        }
+    }
+    (dv1, dv2)
+}
+
+/// 状态网格评估（Rayon 并行）：`par_iter` + `collect` 保序，与
+/// [`porkchop_grid_states_serial`] 逐位一致。
+pub fn porkchop_grid_states_parallel(
+    dep_states: &[[f64; 6]],
+    arr_states: &[[f64; 6]],
+    n_tof: usize,
+    tofs: &[f64],
+    lambert: &LambertParams,
+) -> (Vec<f64>, Vec<f64>) {
+    let n = dep_states.len();
+    let cells: Vec<(f64, f64)> = (0..n * n_tof)
+        .into_par_iter()
+        .map(|idx| {
+            let (i, j) = (idx / n_tof, idx % n_tof);
+            evaluate_cell(&dep_states[i], &arr_states[idx], tofs[j], lambert)
+        })
+        .collect();
+    cells.into_iter().unzip()
+}
+
+/// 出发/到达状态网格对（`(dep_states, arr_states)`，行优先约定见
+/// [`porkchop_grid_states_serial`]）。
+type StateGrids = (Vec<[f64; 6]>, Vec<[f64; 6]>);
+
+/// 从终端规格构造状态网格（串行）：出发状态按 `t_dep` 逐点、到达状态按
+/// `(t_dep[i], tof[j])` 行优先逐点传播。
+fn build_state_grids_serial(
+    t_dep: &[f64],
+    tofs: &[f64],
+    dep: &TerminalSpec,
+    arr: &TerminalSpec,
+    propagation: Option<&PropagationParams>,
+) -> Result<StateGrids, String> {
+    let (n, m) = (t_dep.len(), tofs.len());
+    let mut dep_states = Vec::with_capacity(n);
+    for &td in t_dep {
+        dep_states.push(terminal_state_at(dep, td, propagation)?);
+    }
+    let mut arr_states = Vec::with_capacity(n * m);
+    for &td in t_dep {
+        for &tf in tofs {
+            arr_states.push(terminal_state_at(arr, td + tf, propagation)?);
+        }
+    }
+    Ok((dep_states, arr_states))
+}
+
+/// 从终端规格构造状态网格（Rayon 并行，保序）。
+fn build_state_grids_parallel(
+    t_dep: &[f64],
+    tofs: &[f64],
+    dep: &TerminalSpec,
+    arr: &TerminalSpec,
+    propagation: Option<&PropagationParams>,
+) -> Result<StateGrids, String> {
+    let (n, m) = (t_dep.len(), tofs.len());
+    let dep_states: Result<Vec<[f64; 6]>, String> = t_dep
+        .par_iter()
+        .map(|&td| terminal_state_at(dep, td, propagation))
+        .collect();
+    let dep_states = dep_states?;
+    let arr_states: Result<Vec<[f64; 6]>, String> = (0..n * m)
+        .into_par_iter()
+        .map(|idx| {
+            let (i, j) = (idx / m, idx % m);
+            terminal_state_at(arr, t_dep[i] + tofs[j], propagation)
+        })
+        .collect();
+    Ok((dep_states, arr_states?))
+}
+
+/// 规格路径网格扫描（串行）：终端传播 + Lambert + ΔV 组装。
+///
+/// 返回展平的 `(dv1, dv2)`，长度 `n * m`，行优先（i 主序）。
+/// 传播失败（步长塌缩等）整调用报错——与 Python 协议路径中
+/// `propagate_orbit_state_at_time` 直接上抛的行为对齐。
+pub fn porkchop_grid_serial(
+    t_dep: &[f64],
+    tofs: &[f64],
+    dep: &TerminalSpec,
+    arr: &TerminalSpec,
+    propagation: Option<&PropagationParams>,
+    lambert: &LambertParams,
+) -> Result<(Vec<f64>, Vec<f64>), String> {
+    let (dep_states, arr_states) = build_state_grids_serial(t_dep, tofs, dep, arr, propagation)?;
+    Ok(porkchop_grid_states_serial(
+        &dep_states,
+        &arr_states,
+        tofs.len(),
+        tofs,
+        lambert,
+    ))
+}
+
+/// 规格路径网格扫描（Rayon 并行）：与 [`porkchop_grid_serial`] 逐位一致。
+pub fn porkchop_grid_parallel(
+    t_dep: &[f64],
+    tofs: &[f64],
+    dep: &TerminalSpec,
+    arr: &TerminalSpec,
+    propagation: Option<&PropagationParams>,
+    lambert: &LambertParams,
+) -> Result<(Vec<f64>, Vec<f64>), String> {
+    let (dep_states, arr_states) = build_state_grids_parallel(t_dep, tofs, dep, arr, propagation)?;
+    Ok(porkchop_grid_states_parallel(
+        &dep_states,
+        &arr_states,
+        tofs.len(),
+        tofs,
+        lambert,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// 地月质量参数（DE421，与 Python 测试套件一致）。
+    const MU_EM: f64 = 0.012150585609624;
+    /// DRO 种子状态（Cui et al. 2025，与 tests/algorithm/conftest.py 一致）。
+    const DRO_SEED: [f64; 6] = [0.79188556619742, 0.0, 0.0, 0.0, 0.573665890385585, 0.0];
+    const DRO_PERIOD: f64 = 6.307498;
+
+    fn prop_params() -> PropagationParams {
+        PropagationParams {
+            mu: MU_EM,
+            rtol: 1e-9,
+            atol: 1e-9,
+            max_step: 0.05,
+        }
+    }
+
+    #[test]
+    fn state_terminal_returns_fixed_state() {
+        let term = TerminalSpec::State {
+            state: [1.0, 2.0, 3.0, 0.1, 0.2, 0.3],
+        };
+        let s = terminal_state_at(&term, 123.0, None).unwrap();
+        assert_eq!(s, [1.0, 2.0, 3.0, 0.1, 0.2, 0.3]);
+    }
+
+    #[test]
+    fn orbit_terminal_zero_phase_returns_seed() {
+        let term = TerminalSpec::Orbit {
+            state0: DRO_SEED,
+            t0: 0.0,
+            period: DRO_PERIOD,
+        };
+        // t_rel < 1e-14：不触发积分，直接返回首点。
+        let s = terminal_state_at(&term, 1e-15, Some(&prop_params())).unwrap();
+        assert_eq!(s, DRO_SEED);
+    }
+
+    #[test]
+    fn orbit_terminal_period_wrap_is_deterministic() {
+        // t 与 t + period 取模后 t_rel 相同 → 同一积分调用 → 逐位一致。
+        let term = TerminalSpec::Orbit {
+            state0: DRO_SEED,
+            t0: 0.0,
+            period: DRO_PERIOD,
+        };
+        let params = prop_params();
+        let a = terminal_state_at(&term, 1.25, Some(&params)).unwrap();
+        let b = terminal_state_at(&term, 1.25 + DRO_PERIOD, Some(&params)).unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn orbit_terminal_requires_propagation_params() {
+        let term = TerminalSpec::Orbit {
+            state0: DRO_SEED,
+            t0: 0.0,
+            period: DRO_PERIOD,
+        };
+        assert!(terminal_state_at(&term, 1.0, None).is_err());
+    }
+
+    #[test]
+    fn grid_states_assembles_dv_and_nan() {
+        // 两个固定状态：Lambert 有解时 dv 为速度差范数，tof 过小无解时为 NaN。
+        let dep = [7000.0, 0.0, 0.0, 0.0, 7.5, 0.0];
+        let arr = [0.0, 42164.0, 0.0, -3.0, 0.0, 0.0];
+        let lambert = LambertParams {
+            mu_central: 398600.4418,
+            long_way: false,
+            revs: 0,
+        };
+        let (dv1, dv2) =
+            porkchop_grid_states_serial(&[dep], &[arr, arr], 2, &[3600.0, 1e-3], &lambert);
+        assert!(dv1[0].is_finite() && dv2[0].is_finite());
+
+        // 无解单元：revs=1 而 tof 远低于一圈最小转移时间 → NaN 占位。
+        let lambert_multi_rev = LambertParams { revs: 1, ..lambert };
+        let (dv1_bad, dv2_bad) =
+            porkchop_grid_states_serial(&[dep], &[arr], 1, &[10.0], &lambert_multi_rev);
+        assert!(dv1_bad[0].is_nan() && dv2_bad[0].is_nan());
+
+        // 有解单元：与直接调 lambert_izzo 手工组装一致。
+        let r0 = [dep[0], dep[1], dep[2]];
+        let rf = [arr[0], arr[1], arr[2]];
+        let (v0, vf, _) = lambert_izzo(
+            &r0,
+            &rf,
+            3600.0,
+            398600.4418,
+            TransferDirection::ShortWay,
+            0,
+        )
+        .unwrap();
+        let exp_dv1 =
+            ((v0[0] - dep[3]).powi(2) + (v0[1] - dep[4]).powi(2) + (v0[2] - dep[5]).powi(2)).sqrt();
+        let exp_dv2 =
+            ((arr[3] - vf[0]).powi(2) + (arr[4] - vf[1]).powi(2) + (arr[5] - vf[2]).powi(2)).sqrt();
+        assert_eq!(dv1[0], exp_dv1);
+        assert_eq!(dv2[0], exp_dv2);
+    }
+
+    #[test]
+    fn grid_states_serial_parallel_bit_identical() {
+        let dep = [7000.0, 0.0, 0.0, 0.0, 7.5, 0.0];
+        let arr = [0.0, 42164.0, 0.0, -3.0, 0.0, 0.0];
+        let lambert = LambertParams {
+            mu_central: 398600.4418,
+            long_way: false,
+            revs: 0,
+        };
+        let dep_states = vec![dep; 3];
+        let arr_states = vec![arr; 3 * 4];
+        let tofs = [1800.0, 3600.0, 5400.0, 1e-3];
+        let (s1, s2) = porkchop_grid_states_serial(&dep_states, &arr_states, 4, &tofs, &lambert);
+        let (p1, p2) = porkchop_grid_states_parallel(&dep_states, &arr_states, 4, &tofs, &lambert);
+        for (a, b) in s1.iter().zip(p1.iter()).chain(s2.iter().zip(p2.iter())) {
+            assert!(a == b || (a.is_nan() && b.is_nan()));
+        }
+    }
+
+    #[test]
+    fn grid_specs_serial_parallel_bit_identical() {
+        let dep = TerminalSpec::Orbit {
+            state0: DRO_SEED,
+            t0: 0.0,
+            period: DRO_PERIOD,
+        };
+        let arr = dep;
+        let params = prop_params();
+        let lambert = LambertParams {
+            mu_central: 1.0,
+            long_way: false,
+            revs: 0,
+        };
+        let t_dep = [0.0, 0.7, 1.4];
+        let tofs = [0.5, 1.5, 2.5];
+        let (s1, s2) =
+            porkchop_grid_serial(&t_dep, &tofs, &dep, &arr, Some(&params), &lambert).unwrap();
+        let (p1, p2) =
+            porkchop_grid_parallel(&t_dep, &tofs, &dep, &arr, Some(&params), &lambert).unwrap();
+        for (a, b) in s1.iter().zip(p1.iter()).chain(s2.iter().zip(p2.iter())) {
+            assert!(a == b || (a.is_nan() && b.is_nan()));
+        }
+    }
+}

--- a/crates/e2m2e-integrators/src/lib.rs
+++ b/crates/e2m2e-integrators/src/lib.rs
@@ -2520,6 +2520,196 @@ fn lambert_izzo_py(
     Ok(dict.into())
 }
 
+/// 解析 porkchop 串/并开关：显式参数优先，否则读取环境变量。
+fn porkchop_parallel_enabled(parallel: Option<bool>) -> bool {
+    parallel.unwrap_or_else(|| std::env::var("E2M2E_PORKCHOP_PARALLEL").map_or(true, |v| v != "0"))
+}
+
+/// porkchop 网格扫描 Rust 后端（规格路径，#446）：终端传播 + Lambert + ΔV 组装。
+///
+/// 照搬 ``transfer_grid_search_py`` 的 ``py.allow_threads`` + Rayon + 环境变量
+/// 开关范式（对称 ``E2M2E_SEARCH_PARALLEL``）：默认并行，``parallel=False`` 或
+/// ``E2M2E_PORKCHOP_PARALLEL=0`` 强制串行，两者逐位一致。
+///
+/// **参数**
+///
+/// - ``t_dep`` / ``tof``：出发时刻与飞行时间网格。
+/// - ``dep_kind`` / ``arr_kind``：``"orbit"``（周期轨道终端：``*_state`` 为首点
+///   状态、``*_t0`` 时间原点、``*_period`` 周期）或 ``"state"``（固定状态终端，
+///   仅 ``*_state`` 有意义）。
+/// - ``mu_cr3bp`` / ``rtol`` / ``atol`` / ``max_step``：CR3BP 质量参数与终端
+///   传播积分器配置；两端均为 ``"state"`` 时均传 ``None``（无需传播）。
+/// - ``mu_central`` / ``long_way`` / ``revs``：Lambert 求解配置。
+///
+/// **返回**
+///
+/// ``(dv1, dv2)`` 展平列表，长度 ``len(t_dep) * len(tof)``，行优先（t_dep 主序）；
+/// 无解组合为 NaN。
+#[pyfunction]
+#[pyo3(signature = (t_dep, tof, dep_kind, dep_state, dep_t0, dep_period, arr_kind, arr_state, arr_t0, arr_period, mu_cr3bp, rtol, atol, max_step, mu_central, long_way, revs, *, parallel=None))]
+#[allow(clippy::too_many_arguments)]
+fn porkchop_grid_py(
+    t_dep: Vec<f64>,
+    tof: Vec<f64>,
+    dep_kind: &str,
+    dep_state: Vec<f64>,
+    dep_t0: f64,
+    dep_period: f64,
+    arr_kind: &str,
+    arr_state: Vec<f64>,
+    arr_t0: f64,
+    arr_period: f64,
+    mu_cr3bp: Option<f64>,
+    rtol: Option<f64>,
+    atol: Option<f64>,
+    max_step: Option<f64>,
+    mu_central: f64,
+    long_way: bool,
+    revs: u32,
+    parallel: Option<bool>,
+    py: Python<'_>,
+) -> PyResult<(Vec<f64>, Vec<f64>)> {
+    use e2m2e_forces::porkchop::{
+        porkchop_grid_parallel, porkchop_grid_serial, LambertParams, PropagationParams,
+        TerminalSpec,
+    };
+
+    let parse_terminal = |kind: &str, state: &[f64], t0: f64, period: f64| {
+        if state.len() != 6 {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "终端状态长度必须为 6，得到 {}",
+                state.len()
+            )));
+        }
+        let mut s = [0.0_f64; 6];
+        s.copy_from_slice(state);
+        match kind {
+            "orbit" => Ok(TerminalSpec::Orbit {
+                state0: s,
+                t0,
+                period,
+            }),
+            "state" => Ok(TerminalSpec::State { state: s }),
+            other => Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "终端类型必须是 'orbit' 或 'state'，得到 {other:?}"
+            ))),
+        }
+    };
+    let dep = parse_terminal(dep_kind, &dep_state, dep_t0, dep_period)?;
+    let arr = parse_terminal(arr_kind, &arr_state, arr_t0, arr_period)?;
+
+    let needs_propagation =
+        matches!(dep, TerminalSpec::Orbit { .. }) || matches!(arr, TerminalSpec::Orbit { .. });
+    let propagation = match (needs_propagation, mu_cr3bp, rtol, atol, max_step) {
+        (true, Some(mu), Some(rtol), Some(atol), Some(max_step)) => Some(PropagationParams {
+            mu,
+            rtol,
+            atol,
+            max_step,
+        }),
+        (true, _, _, _, _) => {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "含 orbit 终端时 mu_cr3bp、rtol、atol、max_step 均必填",
+            ));
+        }
+        (false, _, _, _, _) => None,
+    };
+    let lambert = LambertParams {
+        mu_central,
+        long_way,
+        revs,
+    };
+
+    let use_parallel = porkchop_parallel_enabled(parallel);
+
+    // 释放 GIL：终端传播与 Lambert 均为纯 Rust（不回调 Python），Rayon 真并行。
+    py.allow_threads(move || {
+        if use_parallel {
+            porkchop_grid_parallel(&t_dep, &tof, &dep, &arr, propagation.as_ref(), &lambert)
+        } else {
+            porkchop_grid_serial(&t_dep, &tof, &dep, &arr, propagation.as_ref(), &lambert)
+        }
+    })
+    .map_err(|e| propagate_error_to_pyerr(py, "CR3BP 轨道状态传播失败", e))
+}
+
+/// porkchop 网格扫描 Rust 后端（状态网格路径，#446）：终端状态已由 Python
+/// 按 `get_arrival_state` 协议预提取，本入口只做 Lambert + ΔV 组装。
+///
+/// **参数**
+///
+/// - ``dep_states``：展平 ``n*6``，``dep_states[i*6..]`` 为 ``t_dep[i]`` 时刻出发状态。
+/// - ``arr_states``：展平 ``n*m*6``，行优先（t_dep 主序），``arr_states[(i*m+j)*6..]``
+///   为 ``t_dep[i] + tof[j]`` 时刻到达状态。
+/// - ``tof`` / ``mu_central`` / ``long_way`` / ``revs`` / ``parallel``：同
+///   ``porkchop_grid_py``。
+///
+/// **返回** 同 ``porkchop_grid_py``。
+#[pyfunction]
+#[pyo3(signature = (dep_states, arr_states, tof, mu_central, long_way, revs, *, parallel=None))]
+#[allow(clippy::too_many_arguments)]
+fn porkchop_grid_states_py(
+    dep_states: Vec<f64>,
+    arr_states: Vec<f64>,
+    tof: Vec<f64>,
+    mu_central: f64,
+    long_way: bool,
+    revs: u32,
+    parallel: Option<bool>,
+    py: Python<'_>,
+) -> PyResult<(Vec<f64>, Vec<f64>)> {
+    use e2m2e_forces::porkchop::{
+        porkchop_grid_states_parallel, porkchop_grid_states_serial, LambertParams,
+    };
+
+    if !dep_states.len().is_multiple_of(6) {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "dep_states 长度必须为 6 的整数倍，得到 {}",
+            dep_states.len()
+        )));
+    }
+    let n = dep_states.len() / 6;
+    let m = tof.len();
+    if arr_states.len() != n * m * 6 {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "arr_states 长度必须为 n*m*6 = {}，得到 {}",
+            n * m * 6,
+            arr_states.len()
+        )));
+    }
+    let dep_grid: Vec<[f64; 6]> = dep_states
+        .chunks_exact(6)
+        .map(|c| {
+            let mut s = [0.0_f64; 6];
+            s.copy_from_slice(c);
+            s
+        })
+        .collect();
+    let arr_grid: Vec<[f64; 6]> = arr_states
+        .chunks_exact(6)
+        .map(|c| {
+            let mut s = [0.0_f64; 6];
+            s.copy_from_slice(c);
+            s
+        })
+        .collect();
+    let lambert = LambertParams {
+        mu_central,
+        long_way,
+        revs,
+    };
+
+    let use_parallel = porkchop_parallel_enabled(parallel);
+
+    Ok(py.allow_threads(move || {
+        if use_parallel {
+            porkchop_grid_states_parallel(&dep_grid, &arr_grid, m, &tof, &lambert)
+        } else {
+            porkchop_grid_states_serial(&dep_grid, &arr_grid, m, &tof, &lambert)
+        }
+    }))
+}
+
 /// N×M 网格批量 Lambert 求解（porkchop 用）的 Python 接口。
 ///
 /// # 参数
@@ -3669,6 +3859,8 @@ fn _integrators(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(cowell_step, m)?)?;
     m.add_function(wrap_pyfunction!(lambert_izzo_py, m)?)?;
     m.add_function(wrap_pyfunction!(lambert_batch_py, m)?)?;
+    m.add_function(wrap_pyfunction!(porkchop_grid_py, m)?)?;
+    m.add_function(wrap_pyfunction!(porkchop_grid_states_py, m)?)?;
     m.add_function(wrap_pyfunction!(spherical_harmonic_accel, m)?)?;
     m.add_function(wrap_pyfunction!(solid_tide_step1, m)?)?;
     m.add_function(wrap_pyfunction!(solid_tide_step2, m)?)?;

--- a/docs/architecture/numerics-migration-status.md
+++ b/docs/architecture/numerics-migration-status.md
@@ -32,6 +32,7 @@ ADR 0011 决策：部分计算功能由 Python 执行，正在逐步迁移至 Ru
 | `algorithm/transfer/qlaw.py`（反馈积分与 Q 函数；Python 仅组装初猜） | Rust（`e2m2e-forces` + `e2m2e-integrators`） | #442 |
 | `algorithm/transfer/nsga2.py`（演化算子；Python 保留评估与编排） | Rust（`e2m2e-integrators`） | #444 |
 | `algorithm/transfer/lowthrust_shooting.py`、`lowthrust_collocation.py`（直接法数值评估） | Rust（`e2m2e-integrators`；SLSQP 编排留 Python） | #445 |
+| `algorithm/transfer/porkchop.py`（网格评估：终端传播 + Lambert + ΔV） | Rust（`e2m2e-forces` + `e2m2e-integrators`；Python 仅问题构造与存档/查询） | #446 |
 | `algorithm/design`（打靶/传播路径） | Rust（`e2m2e-integrators`） | — |
 | `algorithm/coordinate/synodic_j2000.py`（批量转换） | Rust（`e2m2e-integrators`） | — |
 | `algorithm/proximity/relative_dynamics.py`（传播） | Rust（`e2m2e-integrators`） | — |
@@ -43,7 +44,6 @@ ADR 0011 决策：部分计算功能由 Python 执行，正在逐步迁移至 Ru
 | 模块 | 数值内核 | 工作 issue |
 |---|---|---|
 | `algorithm/solver/MultipleShooting` 类（transfer/hohmann） | Python | 待单独迁移 |
-| `algorithm/transfer/porkchop.py` | Python（Lambert 已 Rust） | #446 |
 | `algorithm/manifold/manifolds.py` | Python | #448 |
 | `algorithm/normal_form`（FFT/多项式/化简、多重打靶 Newton） | Python（积分已 Rust） | #449 |
 
@@ -119,6 +119,15 @@ SLSQP 外层编排、初猜与结果解释；`backend="python"` 提供原有实�
 对照和降级路径。对照测试见
 `tests/algorithm/transfer/test_lowthrust_rust_backend.py`。迁移完成于 #445。
 
+**`algorithm/transfer/porkchop.py`。** 网格评估（终端传播 + Lambert +
+ΔV 组装 + Rayon 分发）在 `e2m2e-forces` 的 Rust 核完成，经
+`e2m2e-integrators` 暴露。Python 只做问题构造与结果解释：内置终端
+（`OrbitTerminal`/`StateTerminal` + 未 patch 的 `CR3BP_Dynamics`）把终端
+规格直接交给 Rust（轨道终端传播同步下沉）；自定义终端或 patch 场景经
+`get_arrival_state` 协议提取状态网格后交同一 Rust 核，无 Python 数值
+回退（#378）。SQLite 存档、插值查询、Pareto 前沿留 Python。对照测试见
+`tests/algorithm/transfer/test_porkchop_rust_backend.py`。迁移完成于 #446。
+
 **`algorithm/solver`（星历修正路径）。** 多重打靶迭代
 `multiple_shooting_correct_py` 在 Rust，segmented 与稳定轨道修正默认走它。
 `MultipleShooting` 类（transfer/hohmann 仍使用）本身还是 Python 实现，见
@@ -174,11 +183,6 @@ ADR 0011 明示的过渡状态，每个条目有独立工作项。`MultipleShoot
 
 **`algorithm/solver/MultipleShooting` 类。** transfer/hohmann 使用的多重
 打靶类仍是泛型 Python 实现，后续需单独评估和迁移。
-
-**`algorithm/transfer/porkchop.py`。** 网格循环与几何评估是 Python；
-网格上的 Lambert 求解已 Rust（`lambert_batch_py`）。ADR 0017 边界列
-porkchop 后续迁移，可复用 `transfer_grid_search` 的 Rayon 分发范式。
-工作项：#446。
 
 **`algorithm/manifold/manifolds.py`。** 单值矩阵特征分解、STM 转运、种子
 生成纯 Python（numpy）。ADR 0026 后续工作第三条点名的过渡状态之一。

--- a/e2m2e/algorithm/transfer/porkchop.py
+++ b/e2m2e/algorithm/transfer/porkchop.py
@@ -24,13 +24,14 @@ from typing import TYPE_CHECKING
 import numpy as np
 import numpy.typing as npt
 
-from .lambert import solve_lambert_batch
-from .terminal import TerminalCondition
+from e2m2e import integrators
+
+from ..dynamics import CR3BP_Dynamics
+from .lambert import _parse_direction
+from .terminal import OrbitTerminal, StateTerminal, TerminalCondition
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
-
-    from ..dynamics import CR3BP_Dynamics
 
 
 @dataclass
@@ -477,6 +478,22 @@ def porkchop(
     状态取 ``t_dep + tof`` 时刻，解二体 Lambert 得转移速度，脉冲为转移
     速度与终端轨道速度之差。
 
+    数值网格评估（终端传播 + Lambert + ΔV 组装 + 分发）全部在 Rust
+    （#446，ADR 0017 范式）；Python 只做问题构造与结果解释：
+
+    - **规格路径**：两端均为内置终端（``OrbitTerminal``/``StateTerminal``
+      且未被 monkeypatch）、涉及轨道终端时 dynamics 为未 patch 的
+      ``CR3BP_Dynamics``——终端规格直接交给 Rust，轨道终端的传播在
+      Rust 内逐点并行进行。
+    - **协议路径**：其余情况（自定义 ``TerminalCondition`` 子类、终端
+      方法被 patch、动力学不满足上条）由 Python 按 ``get_arrival_state``
+      协议逐点提取状态网格，再交给同一 Rust 评估核。patch 语义因此
+      保持有效。
+
+    两条路径共用同一 Rust Lambert/ΔV 核，无 Python 数值回退；扩展缺失
+    按 #378 抛 ``RustExtensionUnavailableError``。并行由 Rayon 执行，
+    ``E2M2E_PORKCHOP_PARALLEL=0`` 可强制串行（与并行逐位一致）。
+
     Args:
         dep: 出发终端（如 :class:`OrbitTerminal`）
         arr: 到达终端
@@ -494,24 +511,169 @@ def porkchop(
     tof = np.atleast_1d(np.asarray(tof_range, dtype=float))
     n, m = t_dep.shape[0], tof.shape[0]
 
-    # 出发端状态只依赖 t_dep，循环外取一次
-    r0_grid = np.empty((n, 3))
-    v_dep_grid = np.empty((n, 3))
-    for i, td in enumerate(t_dep):
-        r0_grid[i], v_dep_grid[i] = dep.get_arrival_state(float(td), dynamics)
+    integrators.require_rust_extension("porkchop_grid_py", "porkchop_grid_states_py")
 
-    dv1 = np.full((n, m), np.nan)
-    dv2 = np.full((n, m), np.nan)
-    # 同一 tof 下各出发时刻的几何组成一列，逐列批量求解
-    for j, t in enumerate(tof):
-        rf_col = np.empty((n, 3))
-        v_arr_col = np.empty((n, 3))
-        for i, td in enumerate(t_dep):
-            rf_col[i], v_arr_col[i] = arr.get_arrival_state(float(td + t), dynamics)
-        velocities = solve_lambert_batch(r0_grid, rf_col, [t], mu, direction=direction, revs=revs)
-        col = velocities[:, 0, :, :]  # (n, 2, 3)
-        valid = ~np.isnan(col[:, 0, 0])
-        dv1[valid, j] = np.linalg.norm(col[valid, 0, :] - v_dep_grid[valid], axis=1)
-        dv2[valid, j] = np.linalg.norm(v_arr_col[valid] - col[valid, 1, :], axis=1)
+    spec = _builtin_grid_spec(dep, arr, dynamics)
+    if spec is not None:
+        long_way = _parse_direction(direction)
+        dv1_flat, dv2_flat = integrators.porkchop_grid_py(
+            t_dep.tolist(),
+            tof.tolist(),
+            spec.dep.kind,
+            spec.dep.state.tolist(),
+            spec.dep.t0,
+            spec.dep.period,
+            spec.arr.kind,
+            spec.arr.state.tolist(),
+            spec.arr.t0,
+            spec.arr.period,
+            spec.mu_cr3bp,
+            spec.rtol,
+            spec.atol,
+            spec.max_step,
+            float(mu),
+            long_way,
+            int(revs),
+        )
+    else:
+        # 保持原路径的错误优先级：无效轨道/终端先在状态提取时上抛，
+        # direction 仅在即将调用 Lambert 前校验。
+        dep_states, arr_states = _extract_state_grids(dep, arr, t_dep, tof, dynamics)
+        long_way = _parse_direction(direction)
+        dv1_flat, dv2_flat = integrators.porkchop_grid_states_py(
+            dep_states.ravel().tolist(),
+            arr_states.ravel().tolist(),
+            tof.tolist(),
+            float(mu),
+            long_way,
+            int(revs),
+        )
 
+    dv1 = np.asarray(dv1_flat, dtype=float).reshape(n, m)
+    dv2 = np.asarray(dv2_flat, dtype=float).reshape(n, m)
     return PorkchopData(t_dep=t_dep, tof=tof, dv1=dv1, dv2=dv2, total=dv1 + dv2)
+
+
+@dataclass
+class _TerminalSpec:
+    """内置终端的展平规格（传给 Rust 规格路径）。"""
+
+    kind: str  # "orbit" | "state"
+    state: np.ndarray  # (6,)：orbit 为首点状态，state 为固定状态
+    t0: float
+    period: float
+
+
+@dataclass
+class _BuiltinGridSpec:
+    """规格路径的全部输入：两端内置终端规格 + CR3BP 传播配置。"""
+
+    dep: _TerminalSpec
+    arr: _TerminalSpec
+    # 两端均为 state 终端时全为 None（无需传播）。
+    mu_cr3bp: float | None
+    rtol: float | None
+    atol: float | None
+    max_step: float | None
+
+
+def _terminal_unpatched(term: TerminalCondition, cls: type) -> bool:
+    """检测终端的 ``get_arrival_state`` 是否保持类的原始实现。
+
+    Rust 规格路径不经过 Python 方法分发；若方法被 monkeypatch（类级或
+    实例级），必须走协议路径让 patch 生效。判定依据 ``__qualname__``
+    （类级 patch）与绑定方法的 ``__func__`` 身份（实例级 patch），
+    与 ``search_parallel._geometry_methods_monkeypatched`` 同范式。
+    """
+    method = getattr(cls, "get_arrival_state", None)
+    if getattr(method, "__qualname__", None) != f"{cls.__name__}.get_arrival_state":
+        return False
+    bound = getattr(term, "get_arrival_state", None)
+    return getattr(bound, "__func__", None) is method
+
+
+def _terminal_spec(term: TerminalCondition) -> _TerminalSpec | None:
+    """提取内置终端规格；非内置类型、被 patch 或规格无效时返回 None。
+
+    规格无效（如轨道无周期）返回 None 走协议路径，保留原
+    ``propagate_orbit_state_at_time`` 的 ValueError 语义。
+    """
+    if type(term) is OrbitTerminal and _terminal_unpatched(term, OrbitTerminal):
+        orbit = term.orbit
+        if orbit.states.shape[0] < 1 or orbit.period is None or orbit.period <= 0:
+            return None
+        state0 = np.asarray(orbit.states[0], dtype=float)
+        if state0.shape != (6,):
+            return None
+        return _TerminalSpec("orbit", state0, float(orbit.times[0]), float(orbit.period))
+    if type(term) is StateTerminal and _terminal_unpatched(term, StateTerminal):
+        state = np.asarray(term.state, dtype=float)
+        if state.shape != (6,):
+            return None
+        return _TerminalSpec("state", state, 0.0, 0.0)
+    return None
+
+
+def _builtin_grid_spec(
+    dep: TerminalCondition,
+    arr: TerminalCondition,
+    dynamics: CR3BP_Dynamics,
+) -> _BuiltinGridSpec | None:
+    """判断是否可走 Rust 规格路径；可以则返回全部输入规格。
+
+    条件：两端均为内置终端且未 patch；涉及轨道终端时 dynamics 是
+    未 patch 的 ``CR3BP_Dynamics``（星历/BCR4BP 动力学或自定义子类
+    一律走协议路径，行为与原 Python 路径一致）。检测缝限于终端的
+    ``get_arrival_state`` 与 dynamics 的 ``propagate_orbit_state_at_time``；
+    更深的 ``propagate`` 实现是该公开协议内部细节，不作为 monkeypatch 缝。
+    """
+    dep_spec = _terminal_spec(dep)
+    arr_spec = _terminal_spec(arr)
+    if dep_spec is None or arr_spec is None:
+        return None
+    if "orbit" not in (dep_spec.kind, arr_spec.kind):
+        return _BuiltinGridSpec(dep_spec, arr_spec, None, None, None, None)
+    if type(dynamics) is not CR3BP_Dynamics:
+        return None
+    method = CR3BP_Dynamics.propagate_orbit_state_at_time
+    if getattr(method, "__qualname__", None) != "CR3BP_Dynamics.propagate_orbit_state_at_time":
+        return None
+    bound = getattr(dynamics, "propagate_orbit_state_at_time", None)
+    if getattr(bound, "__func__", None) is not method:
+        return None
+    return _BuiltinGridSpec(
+        dep_spec,
+        arr_spec,
+        float(dynamics.system.mu),
+        float(dynamics.rtol),
+        float(dynamics.atol),
+        float(dynamics.max_step),
+    )
+
+
+def _extract_state_grids(
+    dep: TerminalCondition,
+    arr: TerminalCondition,
+    t_dep: np.ndarray,
+    tof: np.ndarray,
+    dynamics: CR3BP_Dynamics,
+) -> tuple[np.ndarray, np.ndarray]:
+    """按 ``get_arrival_state`` 协议提取出发/到达状态网格（协议路径）。
+
+    返回 ``(dep_states, arr_states)``：``dep_states[i]`` 为 ``t_dep[i]``
+    时刻出发状态，形状 ``(n, 6)``；``arr_states[i*m+j]`` 为
+    ``t_dep[i] + tof[j]`` 时刻到达状态，形状 ``(n*m, 6)``（行优先）。
+    """
+    n, m = t_dep.shape[0], tof.shape[0]
+    dep_states = np.empty((n, 6))
+    for i, td in enumerate(t_dep):
+        r, v = dep.get_arrival_state(float(td), dynamics)
+        dep_states[i, :3] = r
+        dep_states[i, 3:] = v
+    arr_states = np.empty((n * m, 6))
+    for i, td in enumerate(t_dep):
+        for j, t in enumerate(tof):
+            r, v = arr.get_arrival_state(float(td + t), dynamics)
+            arr_states[i * m + j, :3] = r
+            arr_states[i * m + j, 3:] = v
+    return dep_states, arr_states

--- a/e2m2e/integrators.py
+++ b/e2m2e/integrators.py
@@ -43,6 +43,8 @@ if TYPE_CHECKING:
     pal_f_df_tangent_py: Any
     pal_newton_step_py: Any
     pole_tide: Any
+    porkchop_grid_py: Any
+    porkchop_grid_states_py: Any
     project_hamiltonian_qf_py: Any
     qlaw_propagate_py: Any
     qlaw_segment_direction_py: Any
@@ -124,6 +126,8 @@ _RUST_SYMBOLS = (
     "pal_newton_step_py",
     "planar_full_period_pal_py",
     "pole_tide",
+    "porkchop_grid_py",
+    "porkchop_grid_states_py",
     "project_hamiltonian_qf_py",
     "qlaw_propagate_py",
     "qlaw_segment_direction_py",
@@ -329,6 +333,8 @@ __all__ = [
     "pal_newton_step_py",
     "planar_full_period_pal_py",
     "pole_tide",
+    "porkchop_grid_py",
+    "porkchop_grid_states_py",
     "project_hamiltonian_qf_py",
     "qlaw_propagate_py",
     "qlaw_segment_direction_py",

--- a/tests/algorithm/transfer/test_porkchop_rust_backend.py
+++ b/tests/algorithm/transfer/test_porkchop_rust_backend.py
@@ -1,0 +1,209 @@
+"""porkchop Rust 后端（#446）：规格路径等价性、串/并位级一致、路由与错误语义。
+
+porkchop 的数值网格评估（Lambert + ΔV + 分发）全部在 Rust；Python 只做
+问题构造：内置终端（``OrbitTerminal``/``StateTerminal``）+ CR3BP 动力学时
+把终端规格直接交给 Rust（终端传播同步下沉）；其余终端经
+``get_arrival_state`` 协议提取状态网格后交给同一 Rust 评估核。本文件验证：
+
+- 规格路径与协议路径逐点逐位一致——规格路径逐式复现
+  ``propagate_orbit_state_at_time`` 的周期取模、`linspace` 与传播参数，
+  两条路径共用同一 Rust Lambert/ΔV 核。
+- ``E2M2E_PORKCHOP_PARALLEL=0`` 强制串行，与并行执行逐位一致。
+- monkeypatch / 自定义子类路由到协议路径，patch 语义生效。
+- 扩展符号缺失抛 ``RustExtensionUnavailableError``（#378，无静默回退）。
+- 无效轨道（无周期）保留原 ``ValueError``。
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+# 扩展未构建时（doc build 等场景）整模块跳过。
+pytest.importorskip("e2m2e._integrators")
+
+from e2m2e import integrators
+from e2m2e.algorithm.transfer.porkchop import (
+    PorkchopData,
+    _builtin_grid_spec,
+    porkchop,
+)
+from e2m2e.algorithm.transfer.terminal import OrbitTerminal, StateTerminal, TerminalCondition
+from e2m2e.data.types.orbit import Orbit
+from e2m2e.exceptions import RustExtensionUnavailableError
+
+pytestmark = pytest.mark.orchestration
+
+# Lambert 中心天体 GM：CR3BP 无量纲单位下的示意值。等价性对照不依赖物理
+# 合理性；网格内容许无解组合，以同时覆盖 NaN 分支。
+MU_CENTRAL = 1.0
+
+T_DEP = np.linspace(0.0, 1.5, 4)
+TOF = np.linspace(0.5, 3.0, 5)
+
+
+@pytest.fixture
+def porkchop_dynamics(cr3bp_dynamics):
+    """网格扫描用的 CR3BP 动力学（显式容差与步长，控制测试耗时）。"""
+    cr3bp_dynamics.rtol = cr3bp_dynamics.atol = 1e-9
+    cr3bp_dynamics.max_step = 0.05
+    return cr3bp_dynamics
+
+
+@pytest.fixture
+def orbit_terminals(corrected_dro):
+    """出发/到达终端均为同一修正后 DRO（不同相位的几何组合）。"""
+    return OrbitTerminal(corrected_dro), OrbitTerminal(corrected_dro)
+
+
+def _assert_grid_equal(data: PorkchopData, ref: PorkchopData) -> None:
+    for field in ("dv1", "dv2", "total"):
+        actual = getattr(data, field)
+        expected = getattr(ref, field)
+        assert np.array_equal(actual, expected, equal_nan=True), f"{field} 逐位结果不一致"
+
+
+class TestSpecPathEquivalence:
+    """规格路径（内置终端 + CR3BP）与协议路径（get_arrival_state 提取）等价。
+
+    类级 monkeypatch 一个行为恒等的 wrapper 即迫使路由走协议路径——
+    既充当对照基准，又验证 patch 检测本身。
+    """
+
+    def test_orbit_terminal_grid_matches_protocol_path(
+        self, orbit_terminals, porkchop_dynamics, monkeypatch
+    ):
+        dep, arr = orbit_terminals
+        assert _builtin_grid_spec(dep, arr, porkchop_dynamics) is not None
+        data = porkchop(dep, arr, T_DEP, TOF, mu=MU_CENTRAL, dynamics=porkchop_dynamics)
+
+        original = OrbitTerminal.get_arrival_state
+
+        def passthrough(self, t_ins, dynamics):
+            return original(self, t_ins, dynamics)
+
+        monkeypatch.setattr(OrbitTerminal, "get_arrival_state", passthrough)
+        assert _builtin_grid_spec(dep, arr, porkchop_dynamics) is None
+        ref = porkchop(dep, arr, T_DEP, TOF, mu=MU_CENTRAL, dynamics=porkchop_dynamics)
+
+        _assert_grid_equal(data, ref)
+
+    def test_state_terminal_grid_matches_protocol_path(self, monkeypatch):
+        dep = StateTerminal([0.8, 0.0, 0.0, 0.0, 0.5, 0.0], time=0.0)
+        arr = StateTerminal([1.0, 0.2, 0.1, 0.0, 0.3, 0.0], time=0.0)
+        assert _builtin_grid_spec(dep, arr, None) is not None
+        data = porkchop(dep, arr, T_DEP, TOF, mu=MU_CENTRAL, dynamics=None)
+
+        original = StateTerminal.get_arrival_state
+
+        def passthrough(self, t_ins, dynamics):
+            return original(self, t_ins, dynamics)
+
+        monkeypatch.setattr(StateTerminal, "get_arrival_state", passthrough)
+        assert _builtin_grid_spec(dep, arr, None) is None
+        ref = porkchop(dep, arr, T_DEP, TOF, mu=MU_CENTRAL, dynamics=None)
+
+        _assert_grid_equal(data, ref)
+
+    def test_serial_parallel_bit_identical(self, orbit_terminals, porkchop_dynamics, monkeypatch):
+        """E2M2E_PORKCHOP_PARALLEL=0 强制串行，与并行执行逐位一致。"""
+        dep, arr = orbit_terminals
+        monkeypatch.setenv("E2M2E_PORKCHOP_PARALLEL", "0")
+        serial = porkchop(dep, arr, T_DEP, TOF, mu=MU_CENTRAL, dynamics=porkchop_dynamics)
+        monkeypatch.setenv("E2M2E_PORKCHOP_PARALLEL", "1")
+        parallel = porkchop(dep, arr, T_DEP, TOF, mu=MU_CENTRAL, dynamics=porkchop_dynamics)
+        for field in ("dv1", "dv2", "total"):
+            assert np.array_equal(
+                getattr(serial, field), getattr(parallel, field), equal_nan=True
+            ), f"{field} 串/并结果不逐位一致"
+
+
+class TestRouting:
+    """终端/动力学不满足规格路径条件时，走协议提取路径，patch 语义生效。"""
+
+    def test_instance_level_monkeypatch_takes_effect(
+        self, orbit_terminals, porkchop_dynamics, monkeypatch
+    ):
+        """实例级 patch 必须被协议路径执行，而不是被 Rust 规格路径绕过。"""
+        dep, arr = orbit_terminals
+        calls = []
+        original = OrbitTerminal.get_arrival_state
+
+        def spy(t_ins, dynamics):
+            calls.append(t_ins)
+            return original(dep, t_ins, dynamics)
+
+        monkeypatch.setattr(dep, "get_arrival_state", spy)
+        assert _builtin_grid_spec(dep, arr, porkchop_dynamics) is None
+        porkchop(dep, arr, T_DEP, TOF, mu=MU_CENTRAL, dynamics=porkchop_dynamics)
+        # 出发终端按 t_dep 逐点调用（协议路径）
+        assert sorted(calls) == sorted(float(t) for t in T_DEP)
+
+    def test_custom_terminal_subclass_uses_protocol_path(self, porkchop_dynamics):
+        calls = []
+
+        class CustomTerminal(TerminalCondition):
+            def get_initial_state(self):
+                return np.zeros(6)
+
+            def get_arrival_state(self, t_ins, dynamics):
+                calls.append(float(t_ins))
+                return np.array([0.8, 0.0, 0.0]), np.array([0.0, 0.5, 0.0])
+
+        term = CustomTerminal()
+        fixed = StateTerminal([1.0, 0.2, 0.1, 0.0, 0.3, 0.0], time=0.0)
+        data = porkchop(
+            term,
+            fixed,
+            T_DEP,
+            TOF,
+            mu=MU_CENTRAL,
+            dynamics=porkchop_dynamics,
+        )
+        assert data.total.shape == (T_DEP.shape[0], TOF.shape[0])
+        assert sorted(calls) == sorted(float(t) for t in T_DEP)
+
+    def test_empty_departure_grid_keeps_empty_result(self):
+        class CustomTerminal(TerminalCondition):
+            def get_initial_state(self):
+                return np.zeros(6)
+
+            def get_arrival_state(self, t_ins, dynamics):
+                raise AssertionError("空出发网格不应提取终端状态")
+
+        dep = CustomTerminal()
+        arr = CustomTerminal()
+        data = porkchop(dep, arr, [], TOF, mu=MU_CENTRAL, dynamics=None)
+        assert data.dv1.shape == (0, TOF.shape[0])
+        assert data.dv2.shape == (0, TOF.shape[0])
+        assert data.total.shape == (0, TOF.shape[0])
+
+    def test_invalid_orbit_keeps_value_error(self, porkchop_dynamics):
+        """无效轨道（无周期）走协议路径，保留原 ValueError 语义。"""
+        orbit = Orbit(states=np.zeros((1, 6)), times=[0.0])
+        term = OrbitTerminal(orbit)
+        assert _builtin_grid_spec(term, term, porkchop_dynamics) is None
+        with pytest.raises(ValueError, match="轨道周期无效"):
+            porkchop(term, term, [0.0], [1.0], mu=MU_CENTRAL, dynamics=porkchop_dynamics)
+        # 原路径先提取终端状态、后校验 Lambert 方向；双重无效时维持该优先级。
+        with pytest.raises(ValueError, match="轨道周期无效"):
+            porkchop(
+                term,
+                term,
+                [0.0],
+                [1.0],
+                mu=MU_CENTRAL,
+                dynamics=porkchop_dynamics,
+                direction="invalid",
+            )
+
+
+class TestExtensionMissing:
+    """扩展符号缺失即抛 RustExtensionUnavailableError（#378），无静默回退。"""
+
+    @pytest.mark.parametrize("symbol", ["porkchop_grid_py", "porkchop_grid_states_py"])
+    def test_missing_symbol_raises(self, orbit_terminals, porkchop_dynamics, monkeypatch, symbol):
+        dep, arr = orbit_terminals
+        monkeypatch.setattr(integrators, symbol, None)
+        with pytest.raises(RustExtensionUnavailableError):
+            porkchop(dep, arr, T_DEP, TOF, mu=MU_CENTRAL, dynamics=porkchop_dynamics)


### PR DESCRIPTION
## 关联 issue

Closes #446

## 改动摘要

- 将 porkchop 网格评估下沉到 `e2m2e-forces` Rust 核：终端传播、Lambert、双脉冲 ΔV 组装和 Rayon 分发。
- 内置 `OrbitTerminal` / `StateTerminal` 与 CR3BP 动力学直接传递规格；自定义终端或 monkeypatch 按 `get_arrival_state` 协议构造状态网格，再交同一 Rust 评估核。
- 删除 Python 数值回退；Rust 扩展缺失时按 #378 抛出 `RustExtensionUnavailableError`。
- 增加 `E2M2E_PORKCHOP_PARALLEL=0` 串行对照开关，并逐式复现 Python 周期取模和 `linspace` 采样，保证两条路径逐位一致。
- 更新数值内核迁移状态清单，补充 Rust 单测和 Python 等价性、路由、串并一致性及边界测试。

## 验证

- `uv run pytest tests/algorithm/transfer/ -n auto --dist loadscope`：312 passed，16 skipped
- `cargo test -p e2m2e-forces --lib -- --test-threads=1`：77 passed
- `cargo test -p e2m2e-integrators --lib -- --test-threads=1`：31 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy e2m2e/ --ignore-missing-imports`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace -- -D warnings`
