### PR TITLE
docs(normal_form): 按 #449 拆包更新数值迁移清单

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- **normal_form 迁移状态按 #449 拆包更新**：已下沉（积分、共线点 CR3BP Hamiltonian、H→QF 标量投影）登记补全；数值主链拆为完整实现工作项 #464（多项式核）、#465（复值积分+QF↔CM）、#466（中心流形化简）；符号 Legendre/星历 H、NAFF、pipeline 编排有意留 Python；P5/P6 后置未派发。更新 `docs/architecture/numerics-migration-status.md`。
+
 ## [5.7.1] - 2026-08-17
 
 ### Added

--- a/docs/architecture/numerics-migration-status.md
+++ b/docs/architecture/numerics-migration-status.md
@@ -38,7 +38,9 @@ ADR 0011 决策：部分计算功能由 Python 执行，正在逐步迁移至 Ru
 | `algorithm/coordinate/synodic_j2000.py`（批量转换） | Rust（`e2m2e-integrators`） | — |
 | `algorithm/proximity/relative_dynamics.py`（传播） | Rust（`e2m2e-integrators`） | — |
 | `algorithm/station_keeping/monte_carlo.py`（传播） | Rust（`e2m2e-integrators`） | — |
-| `algorithm/normal_form`（积分路径） | Rust（`e2m2e-integrators`） | — |
+| `algorithm/normal_form`（积分路径） | Rust（`e2m2e-integrators`） | #336/#340 |
+| `algorithm/normal_form`（CR3BP Hamiltonian 数值构造） | Rust（`e2m2e-integrators`） | — |
+| `algorithm/normal_form`（H→QF 标量多项式投影） | Rust（`e2m2e-integrators`） | — |
 
 ### 迁移中
 
@@ -46,7 +48,9 @@ ADR 0011 决策：部分计算功能由 Python 执行，正在逐步迁移至 Ru
 |---|---|---|
 | `algorithm/solver/MultipleShooting` 类（transfer/hohmann） | Python | 待单独迁移 |
 | `algorithm/manifold/manifolds.py` | Python | #448 |
-| `algorithm/normal_form`（FFT/多项式/化简、多重打靶 Newton） | Python（积分已 Rust） | #449 |
+| `algorithm/normal_form`（数值多项式核） | Python | #464 |
+| `algorithm/normal_form`（复值积分 + QF↔CM Lie 流） | Python（实值积分已 Rust） | #465 |
+| `algorithm/normal_form`（中心流形化简） | Python | #466 |
 
 ### 有意留 Python
 
@@ -58,6 +62,7 @@ ADR 0011 决策：部分计算功能由 Python 执行，正在逐步迁移至 Ru
 | `algorithm/transfer` 二体/解析与编排模块 | Python（Lambert 已 Rust） | — |
 | `algorithm/transfer/search_geometry.py`、`search_progress.py`、`solution_database.py`（搜索辅助） | Python | — |
 | `algorithm/manifold/sections.py`（截面事件函数） | Python | — |
+| `algorithm/normal_form`（符号 Legendre/星历 H、NAFF、pipeline 编排） | Python | #449 |
 | `algorithm/stability.py` | Python | — |
 | `algorithm/station_keeping`（控制律） | Python（传播已 Rust） | — |
 | `algorithm/coordinate`（单次转换） | Python | — |
@@ -184,8 +189,16 @@ Rust（`solve_ivp_events`）。
 传播走 Rust（`propagate_compiled_stm_py`）。
 
 **`algorithm/normal_form`（积分路径）。** 传播积分走 Rust（`solve_ivp_rust`，
-见 #336/#340）；FFT/多项式/化简、多重打靶 Newton 迭代仍是 Python，见
-迁移中 #449。
+见 #336/#340）。QF↔CM 复值 Lie 流仍保留 `scipy.integrate.solve_ivp`（Rust
+`solve_ivp_py` 仅支持实值，#336 明示例外）。
+
+**`algorithm/normal_form`（CR3BP Hamiltonian 数值构造）。** 共线点
+`build_cr3bp_hamiltonian` 走 `build_cr3bp_hamiltonian_py`（JM `c_n` 形式，
+ms 级）；三角点无该输入语义，保留 sympy 符号路径。
+
+**`algorithm/normal_form`（H→QF 标量多项式投影）。** CR3BP 标量系数的
+`project_hamiltonian_to_qf` 走 `project_hamiltonian_qf_py`（multinomial
+数值展开）；星历时间序列系数回退 sympy。
 
 ## 迁移中
 
@@ -199,11 +212,21 @@ ADR 0011 明示的过渡状态，每个条目有独立工作项。`MultipleShoot
 生成纯 Python（numpy）。ADR 0026 后续工作第三条点名的过渡状态之一。
 工作项：#448。
 
-**`algorithm/normal_form`（FFT/多项式/化简、多重打靶 Newton）。** 频率提取、
-Legendre 系数、多项式环、Hamiltonian 化简、`multiple_shooting.py` 的块三对角
-Newton 迭代等是 Python（numpy/sympy 惰性导入）；积分路径已 Rust（见上）。
-是否下沉需先评估（研究性算法链，受 #426"qiao 对拍不在范围"约束），故为
-评估任务。工作项：#449。
+**`algorithm/normal_form`（数值多项式核）。** `poly_poisson` /
+`poly_simplify` / `polylist_simplify` 及核内幂次工具仍为 Python 数值实现；
+完整下沉 Rust（禁止简化子集合入）。工作项：#464（#449 拆包 P1）。
+
+**`algorithm/normal_form`（复值积分 + QF↔CM Lie 流）。** `qf_to_cm` /
+`cm_to_qf` 仍走 scipy 复值 `solve_ivp`（#336 例外）；完整下沉须先具备
+复值（或 12 实维等价）积分能力，再迁全阶 Lie 流与实↔复基底。工作项：
+#465（#449 拆包 P3）。
+
+**`algorithm/normal_form`（中心流形化简）。** `CenterManifoldReducer` 两步
+Lie 同调、两套频域 W 求解器、全阶 Poisson 链仍为 Python；完整下沉，
+逻辑前置 #464。工作项：#466（#449 拆包 P4）。
+
+后置未派发（#449 评估）：quasi-Floquet 全矩阵法（P5）、多重打靶 Newton
+壳（P6）；独立 FFT 产品化（P2）若 #466 内已覆盖特解所需 FFT 可不单开。
 
 ## 有意留 Python
 
@@ -246,6 +269,18 @@ numpy 纯函数实现，ADR 0017 边界固化的 thin-wrapper / numpy 对照基�
 函数定义（穿越检测交给 `Dynamics.propagate(events=...)`，由积分器步内
 定位，传播已 Rust），本身无独立数值迭代。
 
+**`algorithm/normal_form`（符号 Legendre/星历 H、NAFF、pipeline 编排）。**
+理由（#449 评估）：
+
+- **符号构造不是数值热路径。** sympy Legendre / 星历 `build_hamiltonian`
+  属 CAS；共线点 CR3BP 数值构造已 Rust。无对等「下沉收益」。
+- **NAFF** 是外部可执行文件封装，不进 Rust crate。
+- **pipeline / catalog 编排** 是串联与结果组装；数值段由 #464/#465/#466
+  下沉后自然变薄，不单独迁编排层。
+- 数值主链（多项式核、QF↔CM、中心流形）见迁移中 #464/#465/#466，
+  **完整实现、禁止简化**；quasi-Floquet 全矩阵法与 MS Newton 壳后置
+  未派发。正确性不以 qiao 为 oracle（#426）。
+
 **`algorithm/design/frozen_orbit.py`（ELFO 辅助）。** 理由：经典根数↔笛卡尔
 转换是解析公式，漂移统计是编排；传播已 Rust（查询已下沉 Rust 实例）。
 
@@ -279,8 +314,9 @@ Rust，见上。
 - **状态词固定**：新登记项只能用"已下沉 / 迁移中 / 有意留 Python"三词，
   保证全文 grep 可枚举。
 - **粒度**：登记粒度到文件/路径。同一模块可拆多条（如 `algorithm/design`：
-  打靶/传播路径已下沉、编排有意留 Python；`algorithm/normal_form`：积分
-  路径已下沉、算法链迁移中），以速查表路径为准。
+  打靶/传播路径已下沉、编排有意留 Python；`algorithm/normal_form`：积分/
+  CR3BP Hamiltonian/H→QF 已下沉，多项式核/QF↔CM/中心流形迁移中
+  #464/#465/#466，符号与 NAFF/编排有意留 Python），以速查表路径为准。
 - **迁移中条目**：issue 关闭（下沉完成或改判）时，把条目移到对应状态节，
   保留 issue 编号作为历史指针。
 - **有意留 Python 条目**：必须带理由，理由应引用 ADR 或文档决策，不写


### PR DESCRIPTION
## 关联

- 关闭评估任务：#449
- 拆包完整实现（已开、本 PR 不实现代码）：#464 #465 #466

## 改动摘要

更新 `docs/architecture/numerics-migration-status.md` 与 `CHANGELOG.md`：

- **已下沉**：补全 normal_form 积分、共线点 CR3BP Hamiltonian、H→QF 标量投影
- **迁移中**：数值主链拆为 #464（多项式核）、#465（复值积分+QF↔CM）、#466（中心流形）；完整实现、禁止简化
- **有意留 Python**：符号 Legendre/星历 H、NAFF、pipeline 编排（能力边界）
- **后置未派发**：P5 quasi-Floquet 全矩阵法、P6 MS Newton 壳

纯文档，无行为变更。

## 测试

- 未跑测试套件（仅文档/CHANGELOG）
- 已人工核对清单速查表与正文、issue 编号交叉引用