### PR TITLE
fix(design): Axial 列入固定时刻打靶族，修默认参数星历修正不收敛 (#485)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Axial 星历修正固定时刻打靶**（#485）：`AXIAL` 加入 `_FIXED_TIME_ORBIT_TYPES`。Axial 从 Lyapunov 族 1:1 共振分岔（Gómez Type B）产生，分岔邻域面内/面外周期相等，自由时间打靶的时间平移与面外相位平移近似简并，雅可比列病态，LM 停滞（STAGNATION_DETECTED；GUI 默认参数 L2/5000 km 下 15 次迭代后位置残差卡 1.5e-01 km，与 #366 的 Lissajous/L4/L5 同型）。固定时刻后约 10 s 收敛到容差内，two_level 与 segmented 两路径同时生效。新增 GUI 默认量级端到端回归（`test_axial_ephemeris_correction.py`）。建议下游固定到含本修复的版本。
+
 ### Added
 - **catalog_sweep 参数空间补全：能量网格与 Lissajous 二维网格**（#476）：扫描主参数维度增至三选一（同传结构化报错）——既有振幅/近月点高度网格之外，新增 `jacobi_windows` 能量（Jacobi）窗口网格与 `amplitude_ins_km` × `amplitude_outs_km` LISSAJOUS 面内×面外二维振幅网格。能量窗口经新增 Rust 入口 `generate_cr3bp_family_windows_py`（ABI v20）实现：同一（族、平动点）只走一次延拓 trace，各窗口分别筛选成员（窗口边界包含），记录 jacobi 包络落在窗口内，窗口零成员时该点无记录、结局逐点可查；LISSAJOUS 二维网格逐点采样入库（相位取请求默认值），不再被扫描排除。
 

--- a/e2m2e/algorithm/design/design_orbit.py
+++ b/e2m2e/algorithm/design/design_orbit.py
@@ -131,8 +131,8 @@ _PATCH_SAMPLING_PERILUNE_CLUSTERED = "perilune_clustered"
 _PATCH_SAMPLING_DROP_NEAR_PERILUNE = "drop_near_perilune"
 
 #: 星历修正用固定时间打靶（var_time=False）的轨道族：Halo/NRHO（不稳定，
-#: 分段打靶全程固定时刻，对齐杨洪伟 2015）与拟周期/无周期闭合族
-#: （Lissajous / 三角平动点 L4/L5）。
+#: 分段打靶全程固定时刻，对齐杨洪伟 2015）、拟周期/无周期闭合族
+#: （Lissajous / 三角平动点 L4/L5）与 Axial。
 #:
 #: 拟周期族用固定时间的机理（#366）：CR3BP 初猜无周期闭合（Lissajous
 #: 面内/面外频率不可约；L4/L5 短/长周期模态耦合），自由时间模式下时间
@@ -141,7 +141,13 @@ _PATCH_SAMPLING_DROP_NEAR_PERILUNE = "drop_near_perilune"
 #: 80 次上限不收敛）。固定时间下节点时刻保持 CR3BP 名义周期均匀采样，
 #: 位置/速度修正直接吸收星历偏差，Gauss-Newton 二次收敛（实测 4–6 迭代，
 #: 秒级到几十秒）。
-_FIXED_TIME_ORBIT_TYPES = frozenset({"HALO", "NRHO", "LISSAJOUS", "L4", "L5"})
+#:
+#: Axial 同属此病态：它从 Lyapunov 族 1:1 共振分岔（Gómez Type B）产生，
+#: 分岔邻域面内周期 = 面外周期，时间平移与面外相位平移近似简并，自由
+#: 时间打靶雅可比列病态——实测 L2/L1 默认参数 LM 停滞（
+#: STAGNATION_DETECTED，15/17 次迭代后位置残差停在 1.5e-01 / 1.1e+01 km）；
+#: 固定时间后两种修正方法均在约 10 s 内收敛到容差内。
+_FIXED_TIME_ORBIT_TYPES = frozenset({"HALO", "NRHO", "LISSAJOUS", "L4", "L5", "AXIAL"})
 
 #: body-fixed 帧（ITRF93 / MOON_PA）所需内核文件名，与 tests/kernel_helpers.py 一致
 _BODY_FIXED_KERNELS = [
@@ -1119,7 +1125,7 @@ def design_orbit(
             # NRHO 单独 1 圈/段（#473）：默认相位 0.5、约 1 个月弧上
             # revs_per_group=3 合并层残差可卡在约 10² km；1 圈/段与等时间
             # 采样组合下 GUI 默认量级收敛。配合下方 var_time 固定时刻族
-            # （_FIXED_TIME_ORBIT_TYPES，含 Halo/NRHO 与拟周期族）。
+            # （_FIXED_TIME_ORBIT_TYPES，含 Halo/NRHO、拟周期族与 Axial）。
             #
             # 对照论文的三项差异评估（issue #400 需求②）：论文每段 9 圈（对应
             # 972 圈/15 年量级的 12→3→3 层级拼接），合并层节点稀疏化为每圈 1 个

--- a/tests/algorithm/design/test_axial_ephemeris_correction.py
+++ b/tests/algorithm/design/test_axial_ephemeris_correction.py
@@ -1,0 +1,67 @@
+"""Axial 星历修正回归。
+
+GUI 默认参数（L2、振幅 5000 km、phase=0、约 1 个月、two_level）曾因
+Axial 未列入 ``_FIXED_TIME_ORBIT_TYPES`` 走自由时间打靶而不收敛：
+Axial 从 Lyapunov 族 1:1 共振分岔（Gómez Type B）产生，分岔邻域面内
+周期 = 面外周期，时间平移与面外相位平移近似简并，雅可比列病态，LM
+停滞（STAGNATION_DETECTED，15/17 次迭代后位置残差停在 1.5e-01 /
+1.1e+01 km）。固定时间后约 10 s 收敛到容差内。
+
+本文件只锁 ``design_orbit`` 对外行为：GUI 默认量级收敛 + 星历与时间
+网格等长。
+"""
+
+from __future__ import annotations
+
+import pytest
+from kernel_helpers import requires_spice
+
+from e2m2e.algorithm.design import design_orbit
+from e2m2e.data.templates import ConvergenceState
+from tests.algorithm.design.conftest import make_design_request
+
+pytestmark = [
+    pytest.mark.orchestration,
+    pytest.mark.spice,
+    requires_spice,
+]
+
+# GUI 默认量级：L2、5000 km、phase=0、约 1 个月、1 h 输出、two_level。
+GUI_DURATION_SEC = 30 * 86400.0
+GUI_OUTPUT_STEP_SEC = 3600.0
+
+
+@pytest.fixture(scope="module")
+def axial_gui_default_result():
+    """GUI 默认参数 Axial——固定时间打靶回归样本。"""
+    return design_orbit(
+        make_design_request(
+            orbit_type="AXIAL",
+            collinear_point=2,
+            amplitude=5000.0,
+            phase=0.0,
+            duration=GUI_DURATION_SEC,
+            output_step=GUI_OUTPUT_STEP_SEC,
+            correction_method="two_level",
+        )
+    )
+
+
+def test_gui_default_axial_converges(axial_gui_default_result):
+    """GUI 默认量级 Axial 收敛（自由时间打靶曾因简并停滞，不得回退）。"""
+    res = axial_gui_default_result
+    assert res.correction is not None
+    assert res.correction.status is ConvergenceState.CONVERGED
+    assert res.correction.max_residual < 2e-2
+
+
+def test_gui_default_axial_ephemeris_aligned(axial_gui_default_result):
+    """星历非空且点数与时间网格严格一致。"""
+    eph = axial_gui_default_result.ephemeris
+    # et_grid = arange(0, duration + 0.5*step, step) → 30 天 / 1 h = 721 点
+    n_expected = int(GUI_DURATION_SEC / GUI_OUTPUT_STEP_SEC) + 1
+    assert eph is not None
+    assert len(eph) == n_expected
+    assert len(eph.position_km) == n_expected
+    assert len(eph.velocity_mps) == n_expected
+    assert len(eph.synodic_position) == n_expected


### PR DESCRIPTION
Closes #485。

## 根因

Axial 从 Lyapunov 族 1:1 共振分岔（Gómez Type B）产生，分岔邻域面内周期 = 面外周期。自由时间打靶（`var_time=True`）下时间平移自由度与面外相位平移自由度近似简并（δt ≈ 沿轨道移动 δt·f），雅可比列病态，LM 停滞：`STAGNATION_DETECTED`，L2 默认参数 15 次迭代后位置残差卡 1.512e-01 km，L1 卡 1.125e+01 km（族内普遍）。与 #366 的 Lissajous/L4/L5 同型——`_FIXED_TIME_ORBIT_TYPES` 注释写明了同一机理，Axial 只是漏加。

## 改动

- `design_orbit.py`：`_FIXED_TIME_ORBIT_TYPES` 加入 `"AXIAL"`，two_level 与 segmented 两路径共用该集合、同时生效；注释补 Axial 机理与实测数据
- `test_axial_ephemeris_correction.py`（新增）：GUI 默认量级（L2、5000 km、phase=0、30 天、two_level）端到端回归，锁收敛 + 星历与时间网格等长
- CHANGELOG `[Unreleased]` Fixed 条目

## 验证

| 场景 | 修复前 | 修复后 |
|------|--------|--------|
| L2 默认 two_level | 停滞 1.5e-01 km（60 s） | 收敛（~10 s） |
| L1 默认 two_level | 停滞 1.1e+01 km | 收敛 |
| L2 segmented | 段 1 不收敛（7.6e1） | 收敛（~14 s） |

- 红绿验证：无修复时新回归测试 60 s 抛 `DesignNotConvergedError`，有修复时 9 s 通过
- `pytest tests/algorithm/design/correction tests/algorithm/design/initial_guess`：123 passed（改动只影响 AXIAL 的 var_time，其余族行为不变）
- `ruff check` / `ruff format --check`：通过

下游影响：transfer-orbit-design#381 已在 GUI 侧挂 strict xfail 守门员，本修复发版后会 XPASS 报错提醒摘除，默认 Axial 设计恢复可用。