### PR TITLE
chore(release): 发布 5.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 ## [Unreleased]
 
+## [5.8.1] - 2026-08-20
+
 ### Fixed
 - **Axial 星历修正固定时刻打靶**（#485）：`AXIAL` 加入 `_FIXED_TIME_ORBIT_TYPES`。Axial 从 Lyapunov 族 1:1 共振分岔（Gómez Type B）产生，分岔邻域面内/面外周期相等，自由时间打靶的时间平移与面外相位平移近似简并，雅可比列病态，LM 停滞（STAGNATION_DETECTED；GUI 默认参数 L2/5000 km 下 15 次迭代后位置残差卡 1.5e-01 km，与 #366 的 Lissajous/L4/L5 同型）。固定时刻后约 10 s 收敛到容差内，two_level 与 segmented 两路径同时生效。新增 GUI 默认量级端到端回归（`test_axial_ephemeris_correction.py`）。建议下游固定到含本修复的版本。
+- **DPO 列入不稳定轨道族，星历修正重定向 segmented**（#484）：DPO 族不稳定（vy0↔x0 映射非线性强），沿用 DRO 的单圈修正+自由外推在 GUI 默认参数下必发散（实测位置残差 1.31e+03 km）。现与 Halo/NRHO 同族对待，two_level/standard 入参自动重定向全程分段打靶；DPO 族策略为等时间 64 点/圈 + 最多 2 圈同组 + 固定节点时刻，GUI 默认量级收敛到 max_residual 6.1e-03 km。
+- **Windows 源码构建修复**（#487）：修复 Windows 下 CSPICE 与 LIBCLANG_PATH 环境配置；make 依赖链改用 `python`（官方 Windows Python 无 `python3` 命令），`make dev` 在 Windows 可一路跑通。
 
 ### Added
 - **catalog_sweep 参数空间补全：能量网格与 Lissajous 二维网格**（#476）：扫描主参数维度增至三选一（同传结构化报错）——既有振幅/近月点高度网格之外，新增 `jacobi_windows` 能量（Jacobi）窗口网格与 `amplitude_ins_km` × `amplitude_outs_km` LISSAJOUS 面内×面外二维振幅网格。能量窗口经新增 Rust 入口 `generate_cr3bp_family_windows_py`（ABI v20）实现：同一（族、平动点）只走一次延拓 trace，各窗口分别筛选成员（窗口边界包含），记录 jacobi 包络落在窗口内，窗口零成员时该点无记录、结局逐点可查；LISSAJOUS 二维网格逐点采样入库（相位取请求默认值），不再被扫描排除。

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "5.8.0"
+version = "5.8.1"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://github.com/cislunarspace/e2m2e"

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ make check    # cargo fmt/clippy + ruff
   author = {ouyangjiahong},
   email = {ouyangjiahong22@nudt.edu.cn},
   url = {https://github.com/cislunarspace/e2m2e},
-  version = {5.8.0},
+  version = {5.8.1},
   year = {2026},
 }
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "e2m2e"
-version = "5.8.0"
+version = "5.8.1"
 description = "Earth to Moon, Moon to Earth — 地月空间转移轨道设计库"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -897,7 +897,7 @@ wheels = [
 
 [[package]]
 name = "e2m2e"
-version = "5.8.0"
+version = "5.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "calcephpy", version = "5.0.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.14' and sys_platform == 'win32') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and sys_platform != 'win32')" },


### PR DESCRIPTION
## 发布 5.8.1

同步 Python/Rust 版本与变更日志（pyproject.toml、Cargo.toml、uv.lock、README 引用块 5.8.0 → 5.8.1）。

### Fixed
- **Axial 星历修正固定时刻打靶**（#485）：AXIAL 加入固定时刻打靶族，消除分岔邻域时间平移/面外相位近似简并导致的 LM 停滞，GUI 默认量级约 10 s 收敛。
- **DPO 列入不稳定轨道族，星历修正重定向 segmented**（#484）：two_level/standard 入参自动重定向全程分段打靶，等时间 64 点/圈 + 最多 2 圈同组 + 固定节点时刻，GUI 默认量级收敛到 max_residual 6.1e-03 km。
- **Windows 源码构建修复**（#487）：CSPICE 与 LIBCLANG_PATH 环境配置修复，make 依赖链改用 python（官方 Windows Python 无 python3 命令）。

### Added
- **catalog_sweep 参数空间补全**（#476）：新增 jacobi_windows 能量窗口网格（Rust 入口 generate_cr3bp_family_windows_py，ABI v20）与 LISSAJOUS 面内×面外二维振幅网格。

### Changed
- **源码开发入口统一为 make dev**（#478）：依赖同步 + CSPICE/内核拉取 + maturin develop 一条命令，全过程仅一次 debug 构建；Makefile 内 uv run 均带 --no-sync。

合入后将在 master 上打 v5.8.1 tag 触发 release 工作流（tag 与 pyproject 版本一致性校验已通过本地核对）。