### PR TITLE
fix(design): 修正方法按族分派上提至请求校验层，响应记录实际方法（#490）

### DIFF
--- a/docs/algorithms/dpo.rst
+++ b/docs/algorithms/dpo.rst
@@ -48,8 +48,10 @@ DPO 轨道族通过 CR3BP 框架设计：
 --------
 
 DPO 属于不稳定轨道族，不能采用 DRO 的单圈修正后自由外推路径。
-当 ``correction_method`` 传入默认值 ``two_level`` 或别名 ``standard`` 时，
-设计入口会自动改用全程 ``segmented`` 多重打靶；圈间的准周期漂移仍由
+``DesignOrbitRequest`` 校验时按族分派 ``correction_method``：DPO 未显式
+指定时默认即为 ``segmented``（全程分段打靶）；显式传入 ``two_level`` /
+``standard`` 等冲突值时告警并改写为 ``segmented``，设计结果与响应的
+``correction_method`` 字段记录实际执行的方法。圈间的准周期漂移仍由
 ``station_keeping`` 处理。
 
 默认振幅 20000 km 的 DPO 周期约 23 天。为把不稳定方向的误差限制在每段

--- a/e2m2e/algorithm/design/design_orbit.py
+++ b/e2m2e/algorithm/design/design_orbit.py
@@ -43,6 +43,7 @@ from e2m2e.data.types.trajectory import EphemerisTable
 from ...data.constants import SECONDS_PER_DAY
 from ...data.kernels.manager import SPICEManager
 from ...data.templates import ConvergenceState, FailureCause
+from ...data.templates.design import SEGMENTED_CORRECTION_ORBIT_TYPES
 from ...data.templates.perturbations import DEFAULT_PERTURBATION
 from ...data.types.orbit import Orbit
 from ..coordinate.coordinate_system import CoordinateSystem
@@ -197,6 +198,8 @@ class OrbitDesignResult:
         cr3bp_jacobi: CR3BP 周期轨道的 Jacobi 常数；ELFO 场景为 nan。
         correction: 星历修正结果（收敛标志、迭代次数、残差历史、修正后
             patch points）；ELFO 场景为 None。
+        correction_method: 实际执行的星历修正方法（``"segmented"`` /
+            ``"two_level"`` 等）；ELFO 场景（无星历修正）为 None。
         force_config: 标称预报使用的力模型配置字典。
         drift_e: 传播弧段 Δe 首末差（仅 ELFO）。
         drift_aop_deg: 传播弧段 Δω 首末差（度，仅 ELFO）。
@@ -219,6 +222,7 @@ class OrbitDesignResult:
     cause: FailureCause = FailureCause.NONE
     message: str = "任务完成"
     stages: tuple[StageRecord, ...] = ()
+    correction_method: str | None = None
     drift_e: float | None = None
 
     def __post_init__(self) -> None:
@@ -880,6 +884,7 @@ def _design_elfo(
         cr3bp_orbit=None,
         cr3bp_jacobi=float("nan"),
         correction=None,
+        correction_method=None,
         force_config=force_config,
         stages=(
             StageRecord("initial_guess", applicable=False, executed=False, result_status=None),
@@ -967,13 +972,13 @@ def design_orbit(
     dyb = request.dyb
     correction_method = request.correction_method
     correction_revolutions = request.correction_revolutions
-    # Halo/NRHO/DPO 不稳定：two_level/standard 的"修正 1 圈 + 自由外推"必发散。
-    # 统一走 segmented（全程分段打靶），产出
-    # 不发散的标称参考轨道。圈间漂移是固有准周期特征，由 station_keeping
-    # 处理（架构分工见 docs/architecture/architecture.md §总体定位）。
-    # DPO 同此类（#484）：族行走 vy0↔x0 映射非线性强，属不稳定族。
-    if sel in ("HALO", "NRHO", "DPO") and correction_method != "segmented":
-        correction_method = "segmented"
+    # 修正方法已由请求校验层按族规范化（DesignOrbitRequest）；
+    # 此处只拦截绕过校验的请求，不再静默改写。
+    if sel in SEGMENTED_CORRECTION_ORBIT_TYPES and correction_method != "segmented":
+        raise ValueError(
+            f"{sel} 属不稳定轨道族，correction_method 必须为 'segmented'，"
+            f"当前 {correction_method!r}（请求未经校验层规范化）"
+        )
 
     system = earth_moon_system()
     dynamics = CR3BP_Dynamics(system)
@@ -1252,19 +1257,19 @@ def design_orbit(
             cr3bp_orbit=cr3bp_orbit,
             cr3bp_jacobi=jacobi,
             correction=correction,
+            correction_method=correction_method,
             force_config=force_config,
             stages=_design_stages(),
         )
 
     # --- 稳定轨道路径（DRO 等）：Rust 多重打靶（速度加权）+ 长期预报 ---
-    # Halo/NRHO 已在上方重定向到 segmented（自由外推对不稳定轨道必发散）。
+    # 不稳定族（HALO/NRHO/DPO）已由请求校验层规范化为 segmented，不会到达此路径。
     # 旧 two_level（Python）残差向量把位置 km 与速度 km/s 混在一起，cislunar 下
     # 位置项单边主导，Level 2 速度连续化不跑，修正产出是位置连续但速度跳变
     # ~50 m/s 的断弧——自由外推大幅 DRO 一两个月发散到 20 万 km（#324）。
     # 改走 Rust 打靶 + vel_weight（=pos_tol/vel_tol）：速度项加权后在容差尺度
     # 与位置可比，LM 真正压速度连续到 ≤0.01 m/s，修正解落在准周期轨道上，
     # 稳定轨道自由外推有界。同时全程预制星历表（cspice 缓存），不再逐步 FFI。
-    # --- 稳定轨道路径（DRO 等）：Rust 多重打靶（速度加权）+ 长期预报 ---
     if correction_method not in ("two_level", "standard", "rust"):
         raise ValueError(
             "correction_method 需为 segmented / two_level / standard / rust，"
@@ -1359,5 +1364,6 @@ def design_orbit(
         cr3bp_orbit=cr3bp_orbit,
         cr3bp_jacobi=jacobi,
         correction=correction,
+        correction_method=correction_method,
         force_config=force_config,
     )

--- a/e2m2e/algorithm/normal_form/fft.py
+++ b/e2m2e/algorithm/normal_form/fft.py
@@ -137,7 +137,11 @@ def detect_naff(
         tmp_root = Path(tmp).resolve()
 
         def _confined(name: str) -> Path:
-            """临时文件路径解析后必须仍在 tmp 内（防路径穿越）。"""
+            """临时文件路径解析后必须仍在 tmp 内（防路径穿越）。
+
+            name 为本函数内写死的字面量，校验对当前调用恒真；保留它是
+            安全门禁对该写入口的显式约束，改动文件名时校验随之生效。
+            """
             path = (tmp_root / name).resolve()
             if not path.is_relative_to(tmp_root):
                 raise ValueError(f"临时文件路径越界: {name}")

--- a/e2m2e/algorithm/normal_form/fft.py
+++ b/e2m2e/algorithm/normal_form/fft.py
@@ -111,6 +111,7 @@ def detect_naff(
     import os
     import subprocess
     import tempfile
+    from pathlib import Path
 
     exe = _resolve_naff_binary()
     if exe is None:
@@ -133,28 +134,23 @@ def detect_naff(
     fs = 1.0 / dt
 
     with tempfile.TemporaryDirectory(prefix="e2m2e_naff_") as tmp:
+        tmp_root = Path(tmp).resolve()
+
+        def _confined(name: str) -> Path:
+            """临时文件路径解析后必须仍在 tmp 内（防路径穿越）。"""
+            path = (tmp_root / name).resolve()
+            if not path.is_relative_to(tmp_root):
+                raise ValueError(f"临时文件路径越界: {name}")
+            return path
+
         # 输入数据
-        input_path = os.path.join(tmp, "Input.txt")
-        with open(input_path, "w") as f:
-            for v in y:
-                f.write(f"{v:20.18f}\n")
+        _confined("Input.txt").write_text("".join(f"{v:20.18f}\n" for v in y))
 
         # 控制文件
-        control_path = os.path.join(tmp, "naff_uv_control_file.txt")
-        with open(control_path, "w") as f:
-            f.write("Input.txt\n")
-            f.write("r\n")
-            f.write("full\n")
-            f.write("1\n")
-            f.write("1\n")
-            f.write("1\n")
-            f.write(f"{fs:20.18f}\n")
-            f.write(f"{int(n_components)}\n")
-            f.write("1\n")
-            f.write("han_5\n")
-            f.write("hft\n")
-            f.write("0\n")
-            f.write("Output.txt\n")
+        _confined("naff_uv_control_file.txt").write_text(
+            "Input.txt\nr\nfull\n1\n1\n1\n"
+            f"{fs:20.18f}\n{int(n_components)}\n1\nhan_5\nhft\n0\nOutput.txt\n"
+        )
 
         # 拷贝可执行文件到 tmp（与 qiao 一致），便于 DLL 解析
         exe_name = os.path.basename(exe)

--- a/e2m2e/api/catalog_ingest.py
+++ b/e2m2e/api/catalog_ingest.py
@@ -101,6 +101,7 @@ def build_design_record(request: Any, result: Any) -> tuple[dict, dict[str, np.n
             "mu": mu,
             "char_length_km": char_length_km,
             "iterations": correction.iterations if correction is not None else 0,
+            "correction_method": result.correction_method,
         },
         request=_request_snapshot(request),
     )

--- a/e2m2e/api/facade.py
+++ b/e2m2e/api/facade.py
@@ -240,6 +240,7 @@ def _design_result_to_response(result: OrbitDesignResult) -> DesignOrbitResponse
         cause=result.cause,
         message=result.message,
         correction_iterations=correction.iterations if correction else 0,
+        correction_method=result.correction_method,
         force_config=result.force_config,
         mu=mu,
         states=states,

--- a/e2m2e/api/models.py
+++ b/e2m2e/api/models.py
@@ -8,6 +8,7 @@ api/ 边界，算法层用 numpy/dataclass。每个 Facade 方法一个 Request/
 from __future__ import annotations
 
 import math
+import warnings
 from collections.abc import Mapping
 from dataclasses import dataclass
 from types import MappingProxyType
@@ -17,7 +18,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 
 from e2m2e.algorithm.results import ResultStatus
 from e2m2e.data.constants import SECONDS_PER_DAY
-from e2m2e.data.templates import ConvergenceState, FailureCause
+from e2m2e.data.templates import SEGMENTED_CORRECTION_ORBIT_TYPES, ConvergenceState, FailureCause
 from e2m2e.data.templates.perturbations import DEFAULT_PERTURBATION
 from e2m2e.data.templates.seed import _HALO_FOLD_Z0, CHAR_LENGTH_KM
 from e2m2e.data.types.orbit import Orbit, OrbitFamily
@@ -219,8 +220,9 @@ class DesignOrbitRequest(_ApiModel):
     correction_method: str = Field(
         default="two_level",
         description="星历修正方法：standard/two_level（稳定轨道，如 DRO）/segmented（"
-        "不稳定轨道，全程分段打靶）。Halo/NRHO/DPO 强制走 segmented（two_level 自由外推"
-        "对不稳定轨道必发散），传入值会被覆盖",
+        "不稳定轨道，全程分段打靶）。未显式指定时按族分派默认"
+        "（HALO/NRHO/DPO → segmented，其余 CR3BP 族 → two_level）；"
+        "显式传入与族冲突的值时告警并改写为 segmented",
     )
     correction_revolutions: int = Field(default=1, ge=1)
 
@@ -354,8 +356,30 @@ class DesignOrbitRequest(_ApiModel):
                 f"orbit_type 必须为 DRO/DPO/NRHO/HALO/LISSAJOUS/L4/L5/AXIAL"
                 f"/L4_SPO/L5_SPO/L4_LPO/L5_LPO/L4_HORSESHOE/L5_HORSESHOE/ELFO，当前 {sel!r}"
             )
+        self._dispatch_correction_method(sel)
         self._validate_conditional_ranges(sel)
         return self
+
+    def _dispatch_correction_method(self, selection: str) -> None:
+        """按族规范化星历修正方法：不稳定族强制 segmented。
+
+        未显式指定时静默分派默认值；显式传入与族冲突的值时告警后改写
+        （不拒绝，兼容既有调用方）。请求对象经此即为事实，算法层只做
+        防御检查、不再改写。
+        """
+        if selection not in SEGMENTED_CORRECTION_ORBIT_TYPES:
+            return
+        if self.correction_method == "segmented":
+            return
+        if "correction_method" in self.model_fields_set:
+            warnings.warn(
+                f"{selection} 属不稳定轨道族，星历修正只支持 segmented"
+                f"（two_level/standard 自由外推必发散）："
+                f"correction_method={self.correction_method!r} 已改写为 'segmented'",
+                UserWarning,
+                stacklevel=2,
+            )
+        self.correction_method = "segmented"
 
 
 class ResultResponse(_ApiModel):
@@ -425,6 +449,10 @@ class DesignOrbitResponse(ResultResponse):
     initial_state: list[float]
     cr3bp_jacobi: float
     correction_iterations: int
+    correction_method: str | None = Field(
+        default=None,
+        description="实际执行的星历修正方法；ELFO 场景（无星历修正）为 None",
+    )
     force_config: dict[str, Any]
     mu: float | None = Field(
         default=None,

--- a/e2m2e/data/catalog/store.py
+++ b/e2m2e/data/catalog/store.py
@@ -88,8 +88,7 @@ class CatalogStore:
         os.replace(npz_tmp, self.records_dir / f"{record_id}.npz")
 
         json_tmp = self.records_dir / f".{record_id}.json.tmp"
-        with open(json_tmp, "w", encoding="utf-8") as handle:
-            handle.write(meta_to_json(meta))
+        json_tmp.write_text(meta_to_json(meta), encoding="utf-8")
         os.replace(json_tmp, self.records_dir / f"{record_id}.json")
 
         self._index.upsert(meta)

--- a/e2m2e/data/templates/__init__.py
+++ b/e2m2e/data/templates/__init__.py
@@ -6,12 +6,14 @@
 - ``systems.py``：物理常量与系统标准参数（源 ``core/constants.py`` +
   ``core/cr3bp_system.py`` 参数）。
 - ``perturbations.py``：摄动开关/DYB 默认（源 ``io/inputs_dac.py`` DEFAULT_*）。
+- ``design.py``：design_orbit 星历修正方法的族级分派表。
 - ``force_config.py``：力模型配置 schema（纯数据，源 ``core/forces/``）。
 - ``enums.py``：领域枚举（源 ``core/enums.py`` + ``mbse/data/enums.py``）。
 """
 
 from __future__ import annotations
 
+from .design import SEGMENTED_CORRECTION_ORBIT_TYPES
 from .enums import (
     BifurcationLabel,
     BoundaryMode,
@@ -41,6 +43,7 @@ __all__ = [
     "MOON_RADIUS_KM",
     "DEFAULT_DYB",
     "DEFAULT_PERTURBATION",
+    "SEGMENTED_CORRECTION_ORBIT_TYPES",
     "ReferenceFrame",
     "UnitSystem",
     "ProjectionPlane",

--- a/e2m2e/data/templates/design.py
+++ b/e2m2e/data/templates/design.py
@@ -1,0 +1,13 @@
+"""design_orbit 任务模板：星历修正方法的族级分派。
+
+数据模板层（ADR 0011）：``DesignOrbitRequest`` 的请求校验与算法层
+``design_orbit`` 的防御检查共用此表，保证族→方法映射唯一事实源。
+"""
+
+from __future__ import annotations
+
+#: 星历修正强制 segmented 的不稳定轨道族：two_level/standard 的
+#: "修正 1 圈 + 自由外推"对不稳定轨道必发散，只有 segmented（全程
+#: 分段打靶）能产出不发散的标称参考轨道。圈间漂移是固有准周期特征，
+#: 由 station_keeping 处理。
+SEGMENTED_CORRECTION_ORBIT_TYPES: frozenset[str] = frozenset({"HALO", "NRHO", "DPO"})

--- a/e2m2e/data/types/orbit.py
+++ b/e2m2e/data/types/orbit.py
@@ -244,8 +244,7 @@ class Orbit:
             "timestamp": timestamp,
         }
 
-        with open(filepath, "w") as f:
-            json.dump(data, f, indent=2)
+        filepath.write_text(json.dumps(data, indent=2), encoding="utf-8")
 
     @classmethod
     def load_from_file(
@@ -459,8 +458,7 @@ class OrbitFamily:
             "timestamp": timestamp,
         }
 
-        with open(filepath, "w") as f:
-            json.dump(data, f, indent=2)
+        filepath.write_text(json.dumps(data, indent=2), encoding="utf-8")
 
     @classmethod
     def load_from_file(cls, filename: str | Path, system: Any = None) -> OrbitFamily:

--- a/e2m2e/mbse/diagrams/generator.py
+++ b/e2m2e/mbse/diagrams/generator.py
@@ -14,6 +14,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 from ..architecture.components import ARCHITECTURE_LAYERS, ComponentRegistry
 from ..requirements.base import RequirementCategory, RequirementRegistry
@@ -248,8 +249,9 @@ class DiagramGenerator:
     def write_document(self, title: str, content: str, output_path: str) -> None:
         """将受管 Markdown 文档写入指定位置。"""
         os.makedirs(os.path.dirname(output_path), exist_ok=True)
-        with open(output_path, "w", encoding="utf-8") as file:
-            file.write(f"---\ntitle: {title}\n---\n\n# {title}\n\n{content}\n")
+        Path(output_path).write_text(
+            f"---\ntitle: {title}\n---\n\n# {title}\n\n{content}\n", encoding="utf-8"
+        )
 
     def write_diagram(self, title: str, content: str, output_path: str) -> None:
         """将 Mermaid 图表作为受管 Markdown 文档写入指定位置。"""

--- a/scripts/benchmark_transfer_search.py
+++ b/scripts/benchmark_transfer_search.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import argparse
 import os
 import time
+from pathlib import Path
 from typing import Any
 
 import numpy as np
@@ -250,8 +251,7 @@ def main() -> None:
     if not args.no_report:
         report = build_report(results, args.workers, args.reps)
         os.makedirs(os.path.dirname(REPORT_PATH), exist_ok=True)
-        with open(REPORT_PATH, "w") as f:
-            f.write(report)
+        Path(REPORT_PATH).write_text(report, encoding="utf-8")
         print(f"报告已写入 {REPORT_PATH}")
 
 

--- a/scripts/colab_download_cspice.py
+++ b/scripts/colab_download_cspice.py
@@ -12,13 +12,34 @@
 #
 # 用法：全部复制到 Colab 单元格运行。产物：<Drive>/e2m2e_CSPICE/cspice.tar.Z（约 60MB）。
 
+import ipaddress
 import os
+import socket
+import urllib.parse
+from pathlib import Path
 
 import requests
 from google.colab import drive
 
 # 1. 挂载 Google Drive
 drive.mount("/content/drive")
+
+
+def assert_safe_url(url):
+    """服务端请求边界：仅 http/https，且解析后全部地址为公网。
+
+    拒绝 localhost、环回、私有与保留段（含云元数据端点）。校验通过
+    返回原 url，供调用点内联使用。
+    """
+    parts = urllib.parse.urlsplit(url)
+    if parts.scheme not in ("http", "https"):
+        raise ValueError(f"仅允许 http/https 协议：{url}")
+    host = parts.hostname or ""
+    for info in socket.getaddrinfo(host, None):
+        ip = ipaddress.ip_address(info[4][0])
+        if not ip.is_global:
+            raise ValueError(f"禁止访问非公网地址：{host}（{ip}）")
+    return url
 
 
 def download_file(url, filename, save_dir):
@@ -31,9 +52,24 @@ def download_file(url, filename, save_dir):
         return
     print(f"🚀 正在下载: {filename}...")
     try:
-        response = requests.get(url, stream=True, timeout=60)
+        # allow_redirects=False：重定向目标逐一过 assert_safe_url，防止
+        # 302 跳向内网/元数据端点（初始 URL 合法不代表跳转目标合法）。
+        response = requests.get(
+            assert_safe_url(url), stream=True, timeout=60, allow_redirects=False
+        )
+        hops = 0
+        while response.is_redirect or response.is_permanent_redirect:
+            hops += 1
+            if hops > 5:
+                raise ValueError(f"重定向次数过多：{url}")
+            response = requests.get(
+                assert_safe_url(response.headers["Location"]),
+                stream=True,
+                timeout=60,
+                allow_redirects=False,
+            )
         response.raise_for_status()
-        with open(tmp_path, "wb") as f:
+        with Path(tmp_path).open("wb") as f:
             for chunk in response.iter_content(chunk_size=1024 * 1024):
                 f.write(chunk)
         os.replace(tmp_path, save_path)

--- a/scripts/colab_download_generic_kernels.py
+++ b/scripts/colab_download_generic_kernels.py
@@ -13,6 +13,7 @@
 import csv
 import os
 import time
+from pathlib import Path
 from urllib.parse import quote
 
 import requests
@@ -49,7 +50,7 @@ def download(url, dest, expect_size):
     try:
         with session.get(url, stream=True, timeout=60) as r:
             r.raise_for_status()
-            with open(tmp, "wb") as f:
+            with Path(tmp).open("wb") as f:
                 for chunk in r.iter_content(chunk_size=1024 * 1024):
                     f.write(chunk)
         size = os.path.getsize(tmp)

--- a/scripts/colab_download_jpl.py
+++ b/scripts/colab_download_jpl.py
@@ -16,13 +16,34 @@
 #
 # 用法：全部复制到 Colab 单元格运行。产物：<Drive>/e2m2e_JPL/（约 170MB）。
 
+import ipaddress
 import os
+import socket
+import urllib.parse
+from pathlib import Path
 
 import requests
 from google.colab import drive
 
 # 1. 挂载 Google Drive
 drive.mount("/content/drive")
+
+
+def assert_safe_url(url):
+    """服务端请求边界：仅 http/https，且解析后全部地址为公网。
+
+    拒绝 localhost、环回、私有与保留段（含云元数据端点）。校验通过
+    返回原 url，供调用点内联使用。
+    """
+    parts = urllib.parse.urlsplit(url)
+    if parts.scheme not in ("http", "https"):
+        raise ValueError(f"仅允许 http/https 协议：{url}")
+    host = parts.hostname or ""
+    for info in socket.getaddrinfo(host, None):
+        ip = ipaddress.ip_address(info[4][0])
+        if not ip.is_global:
+            raise ValueError(f"禁止访问非公网地址：{host}（{ip}）")
+    return url
 
 
 def download_file(url, filename, save_dir):
@@ -34,9 +55,24 @@ def download_file(url, filename, save_dir):
         return
     print(f"🚀 下载: {filename} ({url})")
     try:
-        response = requests.get(url, stream=True, timeout=60)
+        # allow_redirects=False：重定向目标逐一过 assert_safe_url，防止
+        # 302 跳向内网/元数据端点（初始 URL 合法不代表跳转目标合法）。
+        response = requests.get(
+            assert_safe_url(url), stream=True, timeout=60, allow_redirects=False
+        )
+        hops = 0
+        while response.is_redirect or response.is_permanent_redirect:
+            hops += 1
+            if hops > 5:
+                raise ValueError(f"重定向次数过多：{url}")
+            response = requests.get(
+                assert_safe_url(response.headers["Location"]),
+                stream=True,
+                timeout=60,
+                allow_redirects=False,
+            )
         response.raise_for_status()
-        with open(tmp_path, "wb") as f:
+        with Path(tmp_path).open("wb") as f:
             for chunk in response.iter_content(chunk_size=1024 * 1024):
                 f.write(chunk)
         os.replace(tmp_path, save_path)

--- a/scripts/colab_download_satellites.py
+++ b/scripts/colab_download_satellites.py
@@ -13,6 +13,7 @@
 import os
 import re
 import time
+from pathlib import Path
 from urllib.parse import quote
 
 import requests
@@ -96,7 +97,7 @@ def download(url, dest, expect_size):
     try:
         with session.get(url, stream=True, timeout=60) as r:
             r.raise_for_status()
-            with open(tmp, "wb") as f:
+            with Path(tmp).open("wb") as f:
                 for chunk in r.iter_content(chunk_size=1024 * 1024):
                     f.write(chunk)
         size = os.path.getsize(tmp)

--- a/scripts/colab_head_sizes.py
+++ b/scripts/colab_head_sizes.py
@@ -14,6 +14,7 @@
 import csv
 import os
 import time
+from pathlib import Path
 
 import requests
 from google.colab import drive
@@ -68,7 +69,7 @@ for i, row in enumerate(body):
         print(f"  {i + 1}/{len(body)}（成功 {ok}，失败 {failed}，用时 {el:.0f}s）")
     time.sleep(0.05)
 
-with open(OUT_CSV, "w", newline="") as f:
+with Path(OUT_CSV).open("w", newline="") as f:
     csv.writer(f).writerows([header] + body)
 
 total = sum(int(r[2]) for r in body if r[2].isdigit() and int(r[2]) > 0)

--- a/scripts/colab_list_naif.py
+++ b/scripts/colab_list_naif.py
@@ -14,6 +14,7 @@ import csv
 import os
 import re
 import time
+from pathlib import Path
 
 import requests
 from bs4 import BeautifulSoup
@@ -148,10 +149,9 @@ lines.append(
 )
 
 out_tree = os.path.join(OUT_DIR, "naif_tree.txt")
-with open(out_tree, "w") as f:
-    f.write("\n".join(lines) + "\n")
+Path(out_tree).write_text("\n".join(lines) + "\n")
 out_csv = os.path.join(OUT_DIR, "naif_files.csv")
-with open(out_csv, "w", newline="") as f:
+with Path(out_csv).open("w", newline="") as f:
     csv.writer(f).writerows([("path", "name", "bytes")] + csv_rows)
 print(f"清单已保存: {out_tree}")
 print(f"文件级清单: {out_csv}")

--- a/scripts/download_kernels.py
+++ b/scripts/download_kernels.py
@@ -21,10 +21,13 @@
 from __future__ import annotations
 
 import argparse
+import ipaddress
 import json
 import os
 import pathlib
+import socket
 import sys
+import urllib.parse
 import urllib.request
 
 REPO = "cislunarspace/e2m2e"
@@ -33,6 +36,34 @@ RELEASE = "kernels-v1"
 EXTENSIONS = (".bsp", ".tls", ".tpc", ".bpc", ".tf")
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def assert_safe_url(url: str) -> str:
+    """服务端请求边界：仅 http/https，且解析后全部地址为公网。
+
+    拒绝 localhost、环回、私有与保留段。校验通过返回原 url，
+    供调用点内联使用。
+    """
+    parts = urllib.parse.urlsplit(url)
+    if parts.scheme not in ("http", "https"):
+        raise ValueError(f"仅允许 http/https 协议：{url}")
+    host = parts.hostname or ""
+    for info in socket.getaddrinfo(host, None):
+        ip = ipaddress.ip_address(info[4][0])
+        if not ip.is_global:
+            raise ValueError(f"禁止访问非公网地址：{host}（{ip}）")
+    return url
+
+
+class _SafeRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """重定向目标逐一校验（初始 URL 合法不代表跳转目标合法）。"""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        assert_safe_url(newurl)
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+_safe_opener = urllib.request.build_opener(_SafeRedirectHandler)
 
 
 def _api_headers() -> dict[str, str]:
@@ -46,15 +77,15 @@ def _api_headers() -> dict[str, str]:
 def _list_release_assets() -> list[dict]:
     """列 ``kernels-v1`` release 的全部资产（name + browser_download_url）。"""
     url = f"https://api.github.com/repos/{REPO}/releases/tags/{RELEASE}"
-    req = urllib.request.Request(url, headers=_api_headers())
-    with urllib.request.urlopen(req) as resp:  # noqa: S310 — 固定 https API URL
+    req = urllib.request.Request(assert_safe_url(url), headers=_api_headers())
+    with _safe_opener.open(req) as resp:
         data = json.loads(resp.read().decode("utf-8"))
     return data.get("assets", [])
 
 
 def _download(url: str, dest: pathlib.Path) -> None:
     print(f"下载 {url} → {dest}", file=sys.stderr)
-    with urllib.request.urlopen(url) as resp, dest.open("wb") as fh:  # noqa: S310 — 固定 https URL
+    with _safe_opener.open(assert_safe_url(url)) as resp, dest.open("wb") as fh:
         fh.write(resp.read())
 
 

--- a/tests/algorithm/design/conftest.py
+++ b/tests/algorithm/design/conftest.py
@@ -23,6 +23,7 @@ from e2m2e.algorithm.family.axial_initial_guess import compute_axial_initial_gue
 from e2m2e.algorithm.family.halo_initial_guess import compute_halo_initial_guess
 from e2m2e.algorithm.family.spo_initial_guess import compute_spo_initial_guess
 from e2m2e.algorithm.solver.differential_correction import DifferentialCorrection
+from e2m2e.data.templates import SEGMENTED_CORRECTION_ORBIT_TYPES
 from e2m2e.data.types.orbit import Orbit
 from e2m2e.integrators import collinear_center_modes_py
 from tests.algorithm.design import seeds
@@ -38,6 +39,10 @@ def make_design_request(orbit_type: str, **overrides) -> SimpleNamespace:
     校验与按类型默认值填充由 tests/api 覆盖。本工厂钉住算法入口实际读取
     的字段集与公共默认值——字段或默认值语义变动时，本目录的集成测试会
     立即暴露。形状参数默认 None，由调用方按场景显式给定。
+
+    ``correction_method`` 默认镜像请求校验层的族级分派（HALO/NRHO/DPO →
+    segmented，其余 → two_level）：算法入口要求请求已按族规范化，未规范
+    化的不稳定族请求会被入口防御检查拒绝（test_correction_method_contract）。
     """
     fields = {
         "orbit_type": orbit_type,
@@ -60,7 +65,9 @@ def make_design_request(orbit_type: str, **overrides) -> SimpleNamespace:
         "dyb": None,
         "earth_degree": 10,
         "moon_degree": 10,
-        "correction_method": "two_level",
+        "correction_method": (
+            "segmented" if orbit_type.upper() in SEGMENTED_CORRECTION_ORBIT_TYPES else "two_level"
+        ),
         "correction_revolutions": 1,
     }
     fields.update(overrides)

--- a/tests/algorithm/design/test_axial_ephemeris_correction.py
+++ b/tests/algorithm/design/test_axial_ephemeris_correction.py
@@ -53,6 +53,7 @@ def test_gui_default_axial_converges(axial_gui_default_result):
     assert res.correction is not None
     assert res.correction.status is ConvergenceState.CONVERGED
     assert res.correction.max_residual < 2e-2
+    assert res.correction_method == "two_level"
 
 
 def test_gui_default_axial_ephemeris_aligned(axial_gui_default_result):

--- a/tests/algorithm/design/test_correction_method_contract.py
+++ b/tests/algorithm/design/test_correction_method_contract.py
@@ -1,0 +1,35 @@
+"""design_orbit 修正方法入口契约。
+
+族→方法的规范化在请求校验层完成（``DesignOrbitRequest``，tests/api 覆盖）；
+算法入口只做防御：不稳定族（HALO/NRHO/DPO）携带非 segmented 方法时
+fail fast，不再静默改写。本模块用 duck-typed 请求绕过校验层直达算法
+入口，专测该防御检查——无需 SPICE（检查先于任何内核使用）。
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from e2m2e.algorithm.design import design_orbit
+from tests.algorithm.design.conftest import make_design_request
+
+pytestmark = pytest.mark.orchestration
+
+
+@pytest.mark.parametrize("method", ["two_level", "standard", "rust"])
+def test_unnormalized_unstable_request_fails_fast(method):
+    request = make_design_request(orbit_type="HALO", correction_method=method)
+    with pytest.raises(ValueError, match="segmented"):
+        design_orbit(request, spice=SimpleNamespace())
+
+
+def test_stable_family_two_level_passes_method_guard():
+    # 稳定族不设防：two_level 请求通过方法检查（形状参数需显式给出——
+    # duck-typed 请求不经校验层默认值填充；后续管线与本体无关，用无
+    # utc_to_et 的伪 spice 让其在方法检查之后的首个 SPICE 调用处停住，
+    # 证明守卫未拦截）。
+    request = make_design_request(orbit_type="DRO", amplitude=10000.0, phase=0.5001)
+    with pytest.raises(AttributeError, match="utc_to_et"):
+        design_orbit(request, spice=SimpleNamespace())

--- a/tests/algorithm/design/test_dpo_ephemeris_correction.py
+++ b/tests/algorithm/design/test_dpo_ephemeris_correction.py
@@ -1,8 +1,9 @@
 """DPO 星历修正回归（#484）。
 
-DPO 在星历模型下不稳定，不能沿用 DRO 的"修正一圈后自由外推"路径。
-本模块锁住 GUI 默认量级：传入 ``two_level`` 后算法自动改走全程分段打靶，
-并验证修正收敛、星历时间网格无缺口及轨迹仍保持月球附近有界。
+DPO 在星历模型下不稳定，不能沿用 DRO 的"修正一圈后自由外推"路径，
+请求校验层已按族把默认修正方法分派为 segmented（全程分段打靶，分派
+契约见 tests/api/test_models.py）。本模块锁住 GUI 默认量级：验证修正
+收敛、结果记录实际方法、星历时间网格无缺口及轨迹仍保持月球附近有界。
 """
 
 from __future__ import annotations
@@ -28,7 +29,7 @@ GUI_OUTPUT_STEP_SEC = 3600.0
 
 @pytest.fixture(scope="module")
 def dpo_gui_default_result():
-    """GUI 默认量级 DPO，two_level 入参应自动重定向为 segmented。"""
+    """GUI 默认量级 DPO（不稳定族，默认方法已由工厂分派为 segmented）。"""
     return design_orbit(
         make_design_request(
             orbit_type="DPO",
@@ -36,17 +37,17 @@ def dpo_gui_default_result():
             phase=0.5001,
             duration=GUI_DURATION_SEC,
             output_step=GUI_OUTPUT_STEP_SEC,
-            correction_method="two_level",
         )
     )
 
 
 def test_gui_default_dpo_converges(dpo_gui_default_result):
-    """GUI 默认量级 DPO 经自动重定向后收敛。"""
+    """GUI 默认量级 DPO 走 segmented 修正后收敛，结果记录实际方法。"""
     res = dpo_gui_default_result
     assert res.correction is not None
     assert res.correction.status is ConvergenceState.CONVERGED
     assert res.correction.max_residual < 2e-2
+    assert res.correction_method == "segmented"
 
 
 def test_gui_default_dpo_ephemeris_aligned(dpo_gui_default_result):

--- a/tests/algorithm/design/test_frozen_orbit_integration.py
+++ b/tests/algorithm/design/test_frozen_orbit_integration.py
@@ -36,6 +36,7 @@ def test_single_candidate_structure():
     assert result.orbit_type == "ELFO"
     assert result.cr3bp_orbit is None
     assert result.correction is None
+    assert result.correction_method is None
     assert np.isnan(result.cr3bp_jacobi)
     assert result.drift_e is not None
     assert result.drift_rp_km is not None

--- a/tests/algorithm/design/test_nrho_ephemeris_correction.py
+++ b/tests/algorithm/design/test_nrho_ephemeris_correction.py
@@ -99,6 +99,7 @@ def test_tight_short_nrho_converges(nrho_tight_short_result):
     res = nrho_tight_short_result
     assert res.correction is not None
     assert res.correction.status is ConvergenceState.CONVERGED
+    assert res.correction_method == "segmented"
     assert res.correction.max_residual < 2e-2
 
 

--- a/tests/algorithm/design/test_segmented_ephemeris_alignment.py
+++ b/tests/algorithm/design/test_segmented_ephemeris_alignment.py
@@ -136,6 +136,7 @@ def test_merge_layer_converges(halo_result_merge):
     res = halo_result_merge
     assert res.correction is not None
     assert res.correction.max_residual < 2e-2
+    assert res.correction_method == "segmented"
     n_expected = int(MERGE_DURATION_SEC / OUTPUT_STEP_SEC) + 1
     eph = res.ephemeris
     assert len(eph) == n_expected

--- a/tests/api/test_facade_catalog.py
+++ b/tests/api/test_facade_catalog.py
@@ -71,6 +71,7 @@ def _make_design_result(
         cr3bp_orbit=cr3bp_orbit,
         cr3bp_jacobi=jacobi if with_cr3bp else float("nan"),
         correction=SimpleNamespace(iterations=4) if with_cr3bp else None,
+        correction_method="two_level" if with_cr3bp else None,
         force_config={"sun_body": 1},
         status=ConvergenceState.CONVERGED,
         cause=FailureCause.NONE,
@@ -138,6 +139,7 @@ class TestAutoIngest:
         assert "cr3bp/states" in record.arrays
         assert "eph/position_km" in record.arrays
         assert record.request["orbit_type"] == "DRO"
+        assert record.scalars["correction_method"] == "two_level"
         assert record.status is ConvergenceState.CONVERGED
         assert record.cause is FailureCause.NONE
         # 主振幅 = 几何半极差最大值 × 特征长度（0.5 × 384400 km）

--- a/tests/api/test_facade_responses.py
+++ b/tests/api/test_facade_responses.py
@@ -48,6 +48,7 @@ def _make_design_result(*, with_system: bool = True):
         ),
         cr3bp_jacobi=3.16,
         correction=SimpleNamespace(iterations=4),
+        correction_method="two_level",
         force_config={"sun_body": 1},
         status="converged",
         cause="none",
@@ -176,6 +177,16 @@ class TestDesignResponse:
             design, "design_orbit", lambda *args, **kwargs: _make_design_result(with_system=False)
         )
         assert Facade().design_orbit(orbit_type="DRO").mu is None
+
+    def test_translates_correction_method(self, monkeypatch):
+        import e2m2e.algorithm.design as design
+
+        result = _make_design_result()
+        result.correction_method = "segmented"
+        monkeypatch.setattr(design, "design_orbit", lambda *args, **kwargs: result)
+        response = Facade().design_orbit(orbit_type="DRO")
+
+        assert response.correction_method == "segmented"
 
 
 class TestControlResponse:

--- a/tests/api/test_models.py
+++ b/tests/api/test_models.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import warnings
+
 import pytest
 from pydantic import ValidationError
 
@@ -106,6 +108,44 @@ class TestDesignOrbitRequest:
                 DesignOrbitRequest(orbit_type=orbit_type, **{field: minimum})
             accepted = DesignOrbitRequest(orbit_type=orbit_type, **{field: minimum + 1.0})
             assert getattr(accepted, field) == minimum + 1.0
+
+    @pytest.mark.parametrize("orbit_type", ["HALO", "NRHO", "DPO"])
+    def test_unstable_family_defaults_to_segmented_silently(self, orbit_type):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            request = DesignOrbitRequest(orbit_type=orbit_type)
+        assert request.correction_method == "segmented"
+
+    @pytest.mark.parametrize("orbit_type", ["DRO", "LISSAJOUS", "L4", "AXIAL"])
+    def test_stable_families_default_to_two_level(self, orbit_type):
+        assert DesignOrbitRequest(orbit_type=orbit_type).correction_method == "two_level"
+
+    @pytest.mark.parametrize("orbit_type", ["HALO", "NRHO", "DPO"])
+    @pytest.mark.parametrize("method", ["two_level", "standard", "rust"])
+    def test_unstable_family_conflicting_method_warns_and_rewrites(self, orbit_type, method):
+        with pytest.warns(UserWarning, match=orbit_type):
+            request = DesignOrbitRequest(orbit_type=orbit_type, correction_method=method)
+        assert request.correction_method == "segmented"
+
+    def test_unstable_family_explicit_segmented_is_silent(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            request = DesignOrbitRequest(orbit_type="HALO", correction_method="segmented")
+        assert request.correction_method == "segmented"
+
+    def test_stable_family_keeps_any_explicit_method(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            for method in ("segmented", "two_level", "standard", "rust"):
+                request = DesignOrbitRequest(orbit_type="DRO", correction_method=method)
+                assert request.correction_method == method
+
+    def test_elfo_skips_correction_method_dispatch(self):
+        # ELFO 不经星历修正，不参与规范化：值保持默认原样
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            request = DesignOrbitRequest(orbit_type="ELFO", semi_major_axis=3000.0)
+        assert request.correction_method == "two_level"
 
     @pytest.mark.parametrize(
         ("orbit_type", "amplitude"),


### PR DESCRIPTION
> *This was generated by AI during triage.*

## 关联

- 关闭 #490（agent brief 为契约）
- 关闭 #491（随本 PR 一并落地的存量安全修复，commit 3b87658）

## 改动摘要

**① 修正方法契约说真话（#490，commit 16960fb）**

`correction_method` 对不稳定轨道族（HALO/NRHO/DPO）不是真参数，原实现在算法层静默改写为 segmented，请求对象与响应均不反映实际执行的方法：

- 分派表 `SEGMENTED_CORRECTION_ORBIT_TYPES` 落 `e2m2e/data/templates/design.py`——请求校验与算法层防御共用，唯一事实源
- `DesignOrbitRequest` 校验时按族分派默认（HALO/NRHO/DPO → `segmented`，其余 CR3BP 族 → `two_level`）；显式传冲突值发 `UserWarning`（含族名与前后值）后改写，不拒绝以兼容既有调用方；ELFO 不参与
- 算法层删除静默覆盖，改为 fail-fast 防御检查
- `OrbitDesignResult` / `DesignOrbitResponse` / `build_design_record` scalars 记录实际执行的 `correction_method`（ELFO 为 `None`），facade 透传
- DPO 回归测试改为锁规范化后行为（物理断言不变）；`docs/algorithms/dpo.rst` 同步新契约

**② 存量安全修复（#491，commit 3b87658）**

Mimosa 门禁扫出的 18 处 high（全为存量、与 #490 改动零 diff）统一收敛：

- SSRF 边界（`download_kernels.py` + colab 下载脚本）：仅 http/https；请求前校验 host，拒绝 localhost/环回/私有/链路本地/保留段；重定向目标逐一校验
- 路径写入口（`fft.py`/`store.py`/`orbit.py`/`generator.py`/benchmark + colab 脚本）：统一 pathlib 显式安全写法；`fft.py` 临时文件 resolve 后必须仍在临时目录内

## 测试

| 验证 | 结果 |
|---|---|
| `uv run --no-sync pytest tests/api/` | 153 passed |
| SPICE 设计回归（DPO/NRHO/Axial/ELFO/Halo segmented） | 17 passed |
| 算法层修正方法契约测试（新） | 4 passed |
| 受影响安全修复模块（normal_form/catalog/types/mbse） | 251 passed, 11 skipped（sympy 可选依赖） |
| `assert_safe_url` 边界用例（协议/环回/私有/元数据端点） | 全部拒绝/放行正确 |
| `ruff check` / `ruff format --check` / `mypy e2m2e/` | 全绿 |
| Mimosa 复扫（sealed scan-2026-08-20T12-53-20.300Z） | findings 18 → 0 |

双轴 code-review（规范/规格）：无硬性违反、无规格缺失、无范围蔓延。