### PR TITLE
feat(levelset): 新增 ToolboxLS 水平集/HJ 可达性求解器 crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/e2m2e-propagation",
     "crates/e2m2e-forces",
     "crates/e2m2e-spice",
+    "crates/e2m2e-levelset",
 ]
 
 [workspace.package]
@@ -36,6 +37,9 @@ nalgebra = "0.35"
 # 中心流形频域 W 求解（#466）
 rustfft = "6.4"
 num-complex = "0.4"
+# 水平集网格数据（e2m2e-levelset，任意维 n-d 数组是 ToolboxLS 移植的核心容器；
+# 无 BLAS 后端即可满足有限差分模板运算）。
+ndarray = "0.16"
 
 # cspice 0.1.0 上游在 aarch64 上编译失败（E0606，string.rs 的 &[u8] as *const [i8]
 # 非法 cast，aarch64 的 C char 是 unsigned）；上游至今未修，仓库内 vendor 并修复，

--- a/crates/e2m2e-integrators/src/lib.rs
+++ b/crates/e2m2e-integrators/src/lib.rs
@@ -2708,7 +2708,9 @@ fn porkchop_grid_states_py(
         })
         .collect();
     let arr_grid: Vec<[f64; 6]> = arr_states
-        .chunks_exact(6)
+        .as_chunks::<6>()
+        .0
+        .iter()
         .map(|c| {
             let mut s = [0.0_f64; 6];
             s.copy_from_slice(c);

--- a/crates/e2m2e-integrators/src/lib.rs
+++ b/crates/e2m2e-integrators/src/lib.rs
@@ -2698,7 +2698,9 @@ fn porkchop_grid_states_py(
         )));
     }
     let dep_grid: Vec<[f64; 6]> = dep_states
-        .chunks_exact(6)
+        .as_chunks::<6>()
+        .0
+        .iter()
         .map(|c| {
             let mut s = [0.0_f64; 6];
             s.copy_from_slice(c);

--- a/crates/e2m2e-integrators/src/normal_form.rs
+++ b/crates/e2m2e-integrators/src/normal_form.rs
@@ -328,9 +328,7 @@ impl CSeries {
         } else {
             // 任一分量 |z| > tol 即非零；与 Python ``_is_zero`` 对 ndarray 一致
             // （``np.any(np.abs(coef) > tol)``，对复数 ndarray 按模）。
-            for chunk in self.values.chunks_exact(2) {
-                let re = chunk[0];
-                let im = chunk[1];
+            for &[re, im] in self.values.as_chunks::<2>().0 {
                 if (re * re + im * im).sqrt() > tol {
                     return false;
                 }
@@ -345,8 +343,8 @@ impl CSeries {
             return 0.0;
         }
         let mut s = 0.0;
-        for chunk in self.values.chunks_exact(2) {
-            s += (chunk[0] * chunk[0] + chunk[1] * chunk[1]).sqrt();
+        for &[re, im] in self.values.as_chunks::<2>().0 {
+            s += (re * re + im * im).sqrt();
         }
         s / n as f64
     }
@@ -354,13 +352,13 @@ impl CSeries {
     fn scale_add(&mut self, other: &CSeries, scale_re: f64, scale_im: f64) {
         // self += other * (scale_re + i scale_im)
         debug_assert_eq!(self.values.len(), other.values.len());
-        for (dst, src) in self
+        for (dst, &[ar, ai]) in self
             .values
-            .chunks_exact_mut(2)
-            .zip(other.values.chunks_exact(2))
+            .as_chunks_mut::<2>()
+            .0
+            .iter_mut()
+            .zip(other.values.as_chunks::<2>().0.iter())
         {
-            let ar = src[0];
-            let ai = src[1];
             dst[0] += ar * scale_re - ai * scale_im;
             dst[1] += ar * scale_im + ai * scale_re;
         }
@@ -376,14 +374,16 @@ impl CSeries {
     fn mul(&self, other: &CSeries) -> CSeries {
         debug_assert_eq!(self.values.len(), other.values.len());
         let mut out = vec![0.0; self.values.len()];
-        for ((dst, a), b) in out
-            .chunks_exact_mut(2)
-            .zip(self.values.chunks_exact(2))
-            .zip(other.values.chunks_exact(2))
+        for ((dst, &[ar, ai]), &[br, bi]) in out
+            .as_chunks_mut::<2>()
+            .0
+            .iter_mut()
+            .zip(self.values.as_chunks::<2>().0.iter())
+            .zip(other.values.as_chunks::<2>().0.iter())
         {
             // (ar+iai)(br+ibi) = (ar br - ai bi) + i(ar bi + ai br)
-            dst[0] = a[0] * b[0] - a[1] * b[1];
-            dst[1] = a[0] * b[1] + a[1] * b[0];
+            dst[0] = ar * br - ai * bi;
+            dst[1] = ar * bi + ai * br;
         }
         CSeries { values: out }
     }

--- a/crates/e2m2e-integrators/src/nsga2.rs
+++ b/crates/e2m2e-integrators/src/nsga2.rs
@@ -216,8 +216,7 @@ pub fn nsga2_tournament_selection_py(
     }
     let n = rank.len();
     let mut selected = Vec::with_capacity(draws.len() / 2);
-    for pair in draws.chunks_exact(2) {
-        let (a, b) = (pair[0], pair[1]);
+    for &[a, b] in draws.as_chunks::<2>().0 {
         if a >= n || b >= n {
             return Err(PyValueError::new_err(
                 "tournament draw is outside population",

--- a/crates/e2m2e-levelset/Cargo.toml
+++ b/crates/e2m2e-levelset/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "e2m2e-levelset"
+version.workspace = true
+edition.workspace = true
+# 不随 workspace 的 Apache-2.0：本 crate 派生自 ToolboxLS（Ian M. Mitchell，
+# ACM 非商业许可），原始条款全文随附于 LICENSE-ToolboxLS，分发时必须保留。
+license-file = "LICENSE-ToolboxLS"
+homepage.workspace = true
+repository.workspace = true
+description = "Level set / Hamilton-Jacobi reachability solver ported from ToolboxLS"
+
+[lib]
+name = "e2m2e_levelset"
+crate-type = ["rlib"]
+
+[dependencies]
+ndarray = { workspace = true }

--- a/crates/e2m2e-levelset/LICENSE-ToolboxLS
+++ b/crates/e2m2e-levelset/LICENSE-ToolboxLS
@@ -1,0 +1,83 @@
+This Toolbox of Level Set Methods, its source, and its documentation
+are Copyright © 2007 by Ian M. Mitchell.
+
+Use or creating copies of all or part of this work is subject to the
+following licensing agreement.
+
+This license is derived from the ACM Software Copyright and License
+Agreement (1998), which can be found at:
+
+    http://www.acm.org/pubs/copyright_policy/softwareCRnotice.html
+
+LICENSE
+
+The Toolbox of Level Set Methods, its source and its documentation
+(hereafter, Software) is copyrighted by Ian M. Mitchell (hereafter,
+Developer) and ownership of all rights, title and interest in and to
+the Software remains with the Developer.  By using or copying the
+Software, the User agrees to abide by the terms of this Agreement.
+
+NONCOMMERICIAL USE
+
+The Developer grants to you (hereafter, User) a royalty-free,
+nonexclusive right to execute, copy, modify and distribute the
+Software solely for academic, research and other similar noncommercial
+uses, subject to the following conditions:
+
+1. The User acknowledges that the Software is still in the development
+   stage and that it is being supplied "as is," without any support
+   services from the Developer.  NEITHER THE DEVELOPER NOR HIS
+   EMPLOYERS MAKE ANY REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+   IMPLIED, INCLUDING, WITHOUT LIMITATION, ANY REPRESENTATIONS OR
+   WARRANTIES OF THE MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR
+   PURPOSE, OR THAT THE APPLICATION OF THE SOFTWARE, WILL NOT INFRINGE
+   ON ANY PATENTS OR OTHER PROPRIETARY RIGHTS OF OTHERS.
+
+2. The Developer and his employers shall not be held liable for
+   direct, indirect, special, incidental or consequential damages
+   arising from any claim by the User or any third party with respect
+   to uses allowed under this Agreement, or from any use of the
+   Software, even if the Developer or his employers have been advised
+   of the possibility of such damage.
+
+3. The User agrees to fully indemnify and hold harmless the Developer
+   and his employers from and against any and all claims, demands,
+   suits, losses, damages, costs and expenses arising out of the
+   User's use of the Software, including, without limitation, arising
+   out of the User's modification of the Software.
+
+4. The User may modify the Software and distribute that modified work
+   to third parties provided that: (a) if posted separately, it
+   clearly acknowledges that it contains material copyrighted by the
+   Developer (b) no charge is associated with such copies, (c) User
+   agrees to notify the Developer of the distribution, and (d) User
+   clearly notifies secondary users that such modified work is not the
+   original Software.
+
+5. Any distribution of all or part of the Software or modified
+   versions must contain the above copyright notice and this license.
+
+6. This agreement will terminate immediately upon the User's breach
+   of, or non-compliance with, any of its terms. The User may be held
+   liable for any copyright infringement or the infringement of any
+   other proprietary rights in the Software that is caused or
+   facilitated by the User's failure to abide by the terms of this
+   agreement.
+
+7. This agreement will be construed and enforced in accordance with
+   the law of the Province of British Columbia applicable to contracts
+   performed entirely within that Province. The parties irrevocably
+   consent to the exclusive jurisdiction of the provincial or federal
+   courts located in the City of Vancouver for all disputes concerning
+   this agreement.
+
+COMMERCIAL or OTHER USE
+
+Any User wishing to make a commercial or other use of the Software is
+encouraged to contact the Developer at mitchell@cs.ubc.ca to arrange
+an appropriate license. Commercial use includes (1) integrating or
+incorporating all or part of the source code into a product for sale
+or license by, or on behalf of, the User to third parties, or (2)
+distribution of a compiled or source code version of the Software to
+third parties for use with a commercial product sold or licensed by,
+or on behalf of, the User.

--- a/crates/e2m2e-levelset/README.md
+++ b/crates/e2m2e-levelset/README.md
@@ -1,0 +1,93 @@
+# e2m2e-levelset
+
+水平集方法与 Hamilton-Jacobi（HJ）可达性求解器，自 UBC Ian M. Mitchell
+的 [Toolbox of Level Set Methods](https://www.cs.ubc.ca/~mitchell/ToolboxLS/)
+（ToolboxLS 1.1，MATLAB）移植。求解含时 HJ PDE `D_t φ = -H(x, t, φ, ∇φ)`，
+为低推力轨迹的可达集、最短到达时间（TTR）与追逃博弈计算提供网格 PDE 内核。
+
+与 e2m2e 其他数值 crate 的分工：e2m2e-propagation / e2m2e-forces 沿**单条轨迹**
+积分 ODE，本 crate 在**结构网格**上演化 PDE；动力学通过
+[`Hamiltonian`](src/hamiltonian.rs) trait 进入（如 CR3BP 相对运动的哈密顿量），
+不依赖 e2m2e 的积分器。纯数学 crate：无 SPICE、无 pyo3；对外暴露经
+e2m2e-integrators 按 ABI 戳流程统一进行。
+
+## 许可证（重要）
+
+本 crate 派生自 ToolboxLS，原作采用 ACM 非商业许可（全文见
+`LICENSE-ToolboxLS`）。学术与科研使用免版税，但**分发必须保留原版权与
+许可条款**，且不得用于商业产品。因此本 crate 的 `license-file` 不随
+workspace 的 Apache-2.0。若未来 e2m2e 发布包含本 crate 的二进制，需在
+发布说明中注明此差异；商业使用需联系原作者（mitchell@cs.ubc.ca）。
+
+## 模块对照
+
+| Rust 模块 | ToolboxLS 来源 | 说明 |
+|---|---|---|
+| `grid` | `Grids/processGrid.m` | 网格结构体，完整实现 |
+| `boundary` | `BoundaryCondition/addGhost*.m` | 鬼单元填充（5 种边界条件） |
+| `derivative` | `SpatialDerivative/UpwindFirst/upwindFirst*.m` | 一阶 / ENO2 / ENO3 / WENO5 迎风格式 |
+| `hamiltonian` | 用户回调 `hamFunc` / `partialFunc` | 两个函数句柄合并为一个 trait |
+| `dissipation` | `Dissipation/artificialDissipationGLF/LLF/LLLF.m` | LF 耗散系数与 CFL 步长上界 |
+| `term` | `Term/termLaxFriedrichs/Normal/Reinit/Sum.m` | HJ 时间项 |
+| `integrator` | `Integrators/odeCFL1/2/3.m` + `odeCFLset.m` | TVD Runge-Kutta + CFL 步长控制 |
+| `integrator`（Post 模块） | `Helper/PostTimestep/postTimestepMask/Reinit/TTR.m` | 每步后处理钩子 |
+| `integrator`（TerminalEvent） | `Helper/TerminalEvent/terminalEventConverge.m` | 收敛终止事件 |
+| `shape` | `InitialConditions/BasicShapes` + `SetOperations` | 隐式形状初值与集合运算 |
+| `signed_distance` | `Helper/SignedDistance/signedDistanceIterative.m` | 迭代法符号距离函数 |
+
+不移植：向量水平集（`Examples/Vector`，多分量 cell）、绘图动画
+（`Helper/Visualization` 与各 `animate*` 示例）、`termConvection` 等纯对流
+快捷项（可用 LF 项 + 线性哈密顿量等价表达）。
+
+## 协议映射（MATLAB → Rust 的核心设计决策）
+
+ToolboxLS 的内核是一个函数句柄协议网，`schemeData` 弱类型结构体把网格、
+格式选择和用户参数一起塞进每个回调。Rust 侧的做法是**把每个"协议角色"
+物化为一个 trait，把 `schemeData` 的字段物化为结构体字段**：
+
+| MATLAB 协议 | Rust 对应 | 备注 |
+|---|---|---|
+| `schemeData.derivFunc` 函数句柄 | [`UpwindDerivative`](src/derivative.rs) trait | `[derivL, derivR] = derivFunc(grid, data, dim)` 逐维求值保留 |
+| `schemeData.hamFunc` + `partialFunc` | [`Hamiltonian`](src/hamiltonian.rs) trait（两方法） | 两个回调本就成对出现，合并避免实现半个协议 |
+| `schemeData.dissFunc` | [`Dissipation`](src/dissipation.rs) trait | 返回 `(diss, stepBound)` 二元组，同 MATLAB |
+| `schemeFunc(t, y, schemeData)` | [`Term`](src/term.rs) trait | `ydot`/`stepBound` 装进 `TermRhs` 结构体 |
+| `hamFunc` 经 `nargout` 探测原位改 `schemeData` | 取消 | 动力学参数放实现结构体的字段，`&self` 求值；`Term::rhs(&mut self)` 保留可演化状态 |
+| `schemeData` 的用户自由字段 | `Hamiltonian` 实现的自有字段 | air3D 等示例的转向率界等参数去向 |
+| `grid.bdry{dim}` 函数句柄 + `bdryData` | [`BoundaryCondition`](src/grid.rs) 枚举 | 有限五种，枚举比闭包更可检验 |
+| `grid` 结构体的 `xs`/`shape` 派生字段 | `Grid::axis()`/`shape()` 方法 | 不落盘冗余数据 |
+| cell 数组（每维一项） | `Vec<ArrayD<f64>>` | 向量水平集（cell of cell）除外 |
+| `y(:)` 向量化 / `reshape` 往返 | 全程 `ArrayD<f64>` | 只在与 Python 交互时序列化 |
+| MATLAB 1-based 维号 | 0-based | 全库统一 |
+
+数据约定：网格函数形状 = 各维节点数 `n`；节点为单元中心
+`min + (i + 0.5) * dx`（与原版一致，`dx = (max - min) / n`）。
+
+## 实现与验证状态
+
+四个阶段全部实现完毕，验证不依赖 MATLAB 基准数据，改用解析解与
+收敛阶两类自足门控（`tests/` 下四个集成测试，共 22 项断言全过）：
+
+| 阶段 | 内容 | 验证门控（实测） |
+|---|---|---|
+| 1 | 鬼单元 ×5、一阶迎风、`ode_cfl1` | 周期回卷/常值/斜率/外推逐位断言；平流圆质心误差 < 0.02、面积比偏差 < 5%（81² 网格） |
+| 2 | ENO2/ENO3/WENO5、GLF/LLF/LLLF、`termLaxFriedrichs`、`ode_cfl2/3` | sin 场导数收敛阶实测 1.00/2.00/3.00/5.00；Burgers 方程 t=0.5 与 Hopf–Lax 精确解 L∞ 误差 < 0.02（ENO2+GLF，N=401）且加密网格收敛 |
+| 3 | `ReinitTerm`（含 Russo-Smereka 亚网格修正）、`signed_distance_iterative`、全部形状与集合运算 | 0.3 倍距离函数重初始化回真距离：最大误差 < 2.5 dx、平均 < 0.5 dx（81²）；Zalesak 圆盘缺口拓扑保持 |
+| 4 | `RestrictUpdateTerm`、`PostTimestepTtrRecorder`、`TerminalEvent`、双积分器 TTR | 可达集边界与解析解错分 < 2%（101²）；TTR 最大误差 < 0.45 且分辨率 51→101 明显下降；收敛事件提前终止 |
+
+TTR 的 0.45 量级是 LF 类格式的固有耗散（双积分器的 ∂H/∂p 与 p 无关，
+GLF/LLF/LLLF 等价）：解析 TTR 的梯度模约 2–3，耗散滞后 ∫diss·dt 累积
+即此量级，加倍网格实测降至 0.28，与 MATLAB 原版同分辨率行为一致。
+WENO5/odeCFL3 组合可显著压低该误差，代价是计算量。
+
+移植中修正过的两处易错点（回归防线在测试里）：
+- 三阶均差的尺度因子是 `Δ²D2 / (3·dx)`，不是 `dx·Δ²D2 / 3`（在 h=1
+  网格上两者 coincidentally 相等，收敛阶测试可捕获）；
+- `termReinit` 组装的是 δ，ODE 右端项要取负（漏掉会指数发散）。
+
+## 集成路径
+
+- Python 暴露：经 `e2m2e-integrators` 的 pyo3 cdylib，新增子模块
+  （如 `_levelset`），随 `abi-version.txt` 递增 ABI 戳；大数组（100³ 网格
+  ≈ 8 MB/分量）以扁平 `Vec<f64>` + shape 跨界，与现有 `_integrators` 一致，
+  不引入 pyo3-numpy。
+- 可视化：Python 侧 matplotlib 等值线，不进 Rust。

--- a/crates/e2m2e-levelset/README.md
+++ b/crates/e2m2e-levelset/README.md
@@ -65,12 +65,12 @@ ToolboxLS 的内核是一个函数句柄协议网，`schemeData` 弱类型结构
 ## 实现与验证状态
 
 四个阶段全部实现完毕，验证不依赖 MATLAB 基准数据，改用解析解与
-收敛阶两类自足门控（`tests/` 下四个集成测试，共 22 项断言全过）：
+收敛阶两类自足门控（22 项测试用例全过：单测 10 + 集成测试 12）：
 
 | 阶段 | 内容 | 验证门控（实测） |
 |---|---|---|
 | 1 | 鬼单元 ×5、一阶迎风、`ode_cfl1` | 周期回卷/常值/斜率/外推逐位断言；平流圆质心误差 < 0.02、面积比偏差 < 5%（81² 网格） |
-| 2 | ENO2/ENO3/WENO5、GLF/LLF/LLLF、`termLaxFriedrichs`、`ode_cfl2/3` | sin 场导数收敛阶实测 1.00/2.00/3.00/5.00；Burgers 方程 t=0.5 与 Hopf–Lax 精确解 L∞ 误差 < 0.02（ENO2+GLF，N=401）且加密网格收敛 |
+| 2 | ENO2/ENO3/WENO5、GLF/LLF/LLLF、`termLaxFriedrichs`、`ode_cfl2/3` | sin 场导数收敛阶断言门限 0.8/1.8/2.5/4.0（实测 1.00/2.00/3.00/5.00，见 `derivative.rs` 单测）；Burgers 方程 t=0.5 与 Hopf–Lax 精确解 L∞ 误差 < 0.02（ENO2+GLF，N=401）且加密网格收敛 |
 | 3 | `ReinitTerm`（含 Russo-Smereka 亚网格修正）、`signed_distance_iterative`、全部形状与集合运算 | 0.3 倍距离函数重初始化回真距离：最大误差 < 2.5 dx、平均 < 0.5 dx（81²）；Zalesak 圆盘缺口拓扑保持 |
 | 4 | `RestrictUpdateTerm`、`PostTimestepTtrRecorder`、`TerminalEvent`、双积分器 TTR | 可达集边界与解析解错分 < 2%（101²）；TTR 最大误差 < 0.45 且分辨率 51→101 明显下降；收敛事件提前终止 |
 

--- a/crates/e2m2e-levelset/src/boundary.rs
+++ b/crates/e2m2e-levelset/src/boundary.rs
@@ -1,0 +1,242 @@
+//! 鬼单元填充：对应 ToolboxLS 的 `addGhost*.m`。
+//!
+//! MATLAB 原型（见 `upwindFirstFirst.m` 第 44 行的调用方式）：
+//!
+//! ```matlab
+//! gdata = feval(grid.bdry{dim}, data, dim, stencil, grid.bdryData{dim});
+//! ```
+//!
+//! 即只沿第 `dim` 维在数据两侧各加 `layers` 层鬼单元，其余维不变。
+
+use crate::grid::{BoundaryCondition, Grid};
+use ndarray::{ArrayD, Dimension};
+
+/// 沿第 `dim` 维为 `data` 两侧各填充 `layers` 层鬼单元，按该维边界条件取值。
+pub fn pad_ghost_dim(grid: &Grid, data: &ArrayD<f64>, dim: usize, layers: usize) -> ArrayD<f64> {
+    grid.check_data(data);
+    match grid.boundary(dim) {
+        BoundaryCondition::Periodic => pad_periodic(grid, data, dim, layers),
+        BoundaryCondition::Dirichlet(value) => pad_dirichlet(grid, data, dim, layers, *value),
+        BoundaryCondition::Neumann(value) => pad_neumann(grid, data, dim, layers, *value),
+        BoundaryCondition::Extrapolate => pad_extrapolate(grid, data, dim, layers),
+        BoundaryCondition::Extrapolate2 => pad_extrapolate2(grid, data, dim, layers),
+    }
+}
+
+/// 生成沿 `dim` 维加长 `2 * layers` 的全零输出数组。
+fn padded_zeros(grid: &Grid, dim: usize, layers: usize) -> ArrayD<f64> {
+    let mut shape = grid.shape();
+    shape[dim] += 2 * layers;
+    ArrayD::zeros(shape)
+}
+
+/// 把动态维度索引拷成 Vec（ndarray 0.16 的 Dim 没有直接的 slice 视图）。
+fn idx_vec(idx: &ndarray::IxDyn) -> Vec<usize> {
+    (0..idx.ndim()).map(|d| idx[d]).collect()
+}
+
+/// MATLAB 的 sign()：0 返回 0（f64::signum 对 0 返回 1，不可用）。
+pub(crate) fn matlab_sign(x: f64) -> f64 {
+    if x > 0.0 {
+        1.0
+    } else if x < 0.0 {
+        -1.0
+    } else {
+        0.0
+    }
+}
+
+/// `addGhostPeriodic.m`：鬼单元从对侧边界回卷。
+fn pad_periodic(grid: &Grid, data: &ArrayD<f64>, dim: usize, layers: usize) -> ArrayD<f64> {
+    let n = grid.n()[dim];
+    let mut out = padded_zeros(grid, dim, layers);
+    for (idx, v) in out.indexed_iter_mut() {
+        let j = (idx[dim] as isize - layers as isize).rem_euclid(n as isize);
+        let mut s = idx_vec(&idx);
+        s[dim] = j as usize;
+        *v = data[&s[..]];
+    }
+    out
+}
+
+/// `addGhostDirichlet.m`：鬼单元取常值（上下侧同值，即 MATLAB 只给
+/// `lowerValue` 时的默认行为）。
+fn pad_dirichlet(
+    grid: &Grid,
+    data: &ArrayD<f64>,
+    dim: usize,
+    layers: usize,
+    value: f64,
+) -> ArrayD<f64> {
+    let n = grid.n()[dim];
+    let mut out = padded_zeros(grid, dim, layers);
+    for (idx, v) in out.indexed_iter_mut() {
+        *v = if idx[dim] < layers || idx[dim] >= n + layers {
+            value
+        } else {
+            let mut s = idx_vec(&idx);
+            s[dim] = idx[dim] - layers;
+            data[&s[..]]
+        };
+    }
+    out
+}
+
+/// `addGhostNeumann.m`：法向导数为 `value`（按"每节点数据增量"理解，
+/// 与 MATLAB 一致地不除以 dx），即鬼单元 = 边缘节点 + gap * value。
+fn pad_neumann(
+    grid: &Grid,
+    data: &ArrayD<f64>,
+    dim: usize,
+    layers: usize,
+    value: f64,
+) -> ArrayD<f64> {
+    let n = grid.n()[dim];
+    let mut out = padded_zeros(grid, dim, layers);
+    for (idx, v) in out.indexed_iter_mut() {
+        let i = idx[dim];
+        *v = if (layers..n + layers).contains(&i) {
+            let mut s = idx_vec(&idx);
+            s[dim] = i - layers;
+            data[&s[..]]
+        } else {
+            // gap：距内缘第一个真实节点的层数（最内侧鬼单元 gap = 1）。
+            let (edge, gap) = if i < layers {
+                (0usize, layers - i)
+            } else {
+                (n - 1, i - (n + layers) + 1)
+            };
+            let mut s = idx_vec(&idx);
+            s[dim] = edge;
+            data[&s[..]] + gap as f64 * value
+        };
+    }
+    out
+}
+
+/// `addGhostExtrapolate.m`：一阶线性外推。斜率符号调整为与边缘节点
+/// 数据同号（对应 MATLAB 默认 slopeMultiplier = +1，即远离零等值面）。
+fn pad_extrapolate(grid: &Grid, data: &ArrayD<f64>, dim: usize, layers: usize) -> ArrayD<f64> {
+    let n = grid.n()[dim];
+    let mut out = padded_zeros(grid, dim, layers);
+    for (idx, v) in out.indexed_iter_mut() {
+        let i = idx[dim];
+        *v = if (layers..n + layers).contains(&i) {
+            let mut s = idx_vec(&idx);
+            s[dim] = i - layers;
+            data[&s[..]]
+        } else {
+            let (e0, e1, gap) = if i < layers {
+                (0usize, 1usize, layers - i)
+            } else {
+                (n - 1, n - 2, i - (n + layers) + 1)
+            };
+            let mut s0 = idx_vec(&idx);
+            s0[dim] = e0;
+            let mut s1 = idx_vec(&idx);
+            s1[dim] = e1;
+            let d0 = data[&s0[..]];
+            let slope = matlab_sign(d0) * (d0 - data[&s1[..]]).abs();
+            d0 + gap as f64 * slope
+        };
+    }
+    out
+}
+
+/// `addGhostExtrapolate2.m`：二阶外推（一次斜率 + 二阶差分修正；
+/// MATLAB 源码中向零等值面调整符号的分支被禁用，此处同样不做调整）。
+fn pad_extrapolate2(grid: &Grid, data: &ArrayD<f64>, dim: usize, layers: usize) -> ArrayD<f64> {
+    let n = grid.n()[dim];
+    let mut out = padded_zeros(grid, dim, layers);
+    for (idx, v) in out.indexed_iter_mut() {
+        let i = idx[dim];
+        *v = if (layers..n + layers).contains(&i) {
+            let mut s = idx_vec(&idx);
+            s[dim] = i - layers;
+            data[&s[..]]
+        } else {
+            let (e0, e1, e2, gap) = if i < layers {
+                (0usize, 1usize, 2usize, layers - i)
+            } else {
+                (n - 1, n - 2, n - 3, i - (n + layers) + 1)
+            };
+            let at = |e: usize| {
+                let mut s = idx_vec(&idx);
+                s[dim] = e;
+                data[&s[..]]
+            };
+            let (d0, d1, d2) = (at(e0), at(e1), at(e2));
+            let g = gap as f64;
+            d0 + g * (d0 - d1) + 0.5 * g * (g + 1.0) * (d0 - 2.0 * d1 + d2)
+        };
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn grid_1d(n: usize, bc: BoundaryCondition) -> Grid {
+        Grid::new(&[0.0], &[1.0], &[n]).with_boundary_all(bc)
+    }
+
+    #[test]
+    fn 周期回卷() {
+        let g = grid_1d(5, BoundaryCondition::Periodic);
+        let data = ndarray::Array1::from(vec![1.0, 2.0, 3.0, 4.0, 5.0]).into_dyn();
+        let out = pad_ghost_dim(&g, &data, 0, 2);
+        let v = out.iter().cloned().collect::<Vec<f64>>();
+        assert_eq!(v, vec![4.0, 5.0, 1.0, 2.0, 3.0, 4.0, 5.0, 1.0, 2.0]);
+    }
+
+    #[test]
+    fn 常值与斜率边界() {
+        let g = grid_1d(4, BoundaryCondition::Dirichlet(9.0));
+        let data = ndarray::Array1::from(vec![1.0, 2.0, 3.0, 4.0]).into_dyn();
+        let out = pad_ghost_dim(&g, &data, 0, 1);
+        let v = out.iter().cloned().collect::<Vec<f64>>();
+        assert_eq!(v, vec![9.0, 1.0, 2.0, 3.0, 4.0, 9.0]);
+
+        // Neumann 斜率 0.5：下侧 1 + 1*0.5，上侧 4 + 1*0.5
+        let g = grid_1d(4, BoundaryCondition::Neumann(0.5));
+        let out = pad_ghost_dim(&g, &data, 0, 1);
+        let v = out.iter().cloned().collect::<Vec<f64>>();
+        assert_eq!(v, vec![1.5, 1.0, 2.0, 3.0, 4.0, 4.5]);
+    }
+
+    #[test]
+    fn 一二阶外推的语义() {
+        let data: ArrayD<f64> =
+            ndarray::Array1::from((1..=6).map(|i| i as f64).collect::<Vec<_>>()).into_dyn();
+
+        // 一阶外推（addGhostExtrapolate）不是线性延拓：斜率取
+        // sign(边缘值)*|斜率|，即向远离零等值面方向推。数据递增且边缘为正
+        // 时，两侧鬼单元都取更大的正值（与 MATLAB 逐位一致）。
+        let g = grid_1d(6, BoundaryCondition::Extrapolate);
+        let out = pad_ghost_dim(&g, &data, 0, 2);
+        let v = out.iter().cloned().collect::<Vec<f64>>();
+        assert_eq!(v, vec![3.0, 2.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]);
+
+        // 二阶外推（addGhostExtrapolate2）不带符号调整，线性数据下是精确
+        // 的线性延拓。
+        let g2 = g.with_boundary_all(BoundaryCondition::Extrapolate2);
+        let out2 = pad_ghost_dim(&g2, &data, 0, 2);
+        let v2 = out2.iter().cloned().collect::<Vec<f64>>();
+        assert_eq!(v2, vec![-1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]);
+    }
+
+    #[test]
+    fn 二维只填充目标维() {
+        let g = Grid::new(&[0.0, 0.0], &[1.0, 1.0], &[3, 2]).with_boundaries(vec![
+            BoundaryCondition::Dirichlet(0.0),
+            BoundaryCondition::Periodic,
+        ]);
+        let data = ArrayD::from_shape_vec(vec![3, 2], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+        // 第 0 维加一层鬼单元：形状 (4, 2)，上下两行取 0。
+        let out = pad_ghost_dim(&g, &data, 0, 1);
+        assert_eq!(out.shape(), &[5, 2]);
+        let v = out.iter().cloned().collect::<Vec<f64>>();
+        assert_eq!(v, vec![0.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 0.0, 0.0]);
+    }
+}

--- a/crates/e2m2e-levelset/src/derivative.rs
+++ b/crates/e2m2e-levelset/src/derivative.rs
@@ -1,0 +1,377 @@
+//! 迎风一阶导数格式：对应 ToolboxLS 的 `SpatialDerivative/UpwindFirst/`。
+//!
+//! MATLAB 原型（`termLaxFriedrichs.m` 第 129 行的调用方式）：
+//!
+//! ```matlab
+//! [derivL{i}, derivR{i}] = feval(schemeData.derivFunc, grid, data, i);
+//! ```
+//!
+//! 实现方式：先沿目标维填充鬼单元，再把数组按该维切成 1 维 lane，
+//! 逐 lane 套用与 MATLAB 逐行对应的一维修式。
+
+use crate::boundary::pad_ghost_dim;
+use crate::grid::Grid;
+use ndarray::ArrayD;
+
+/// 迎风导数格式。MATLAB 的 `schemeData.derivFunc` 函数句柄物化为实现本
+/// trait 的结构体；高阶格式（ENO/WENO）基于均差表
+/// （`dividedDifferenceTable.m`）选光滑模板。
+pub trait UpwindDerivative: Send + Sync {
+    /// 每侧需要的鬼单元层数（一阶 = 1，ENO2 = 2，ENO3/WENO5 = 3）。
+    fn stencil_layers(&self) -> usize;
+
+    /// 第 `dim` 维（0-based）的左、右迎风一阶导数，形状与 `data` 相同。
+    fn deriv(&self, grid: &Grid, data: &ArrayD<f64>, dim: usize) -> (ArrayD<f64>, ArrayD<f64>);
+}
+
+/// 逐 lane 的一维修式：`(dx, n, 填充后的 lane, 左导数输出, 右导数输出)`。
+type Scheme1d = fn(f64, usize, &[f64], &mut [f64], &mut [f64]);
+
+/// C 序（行主序）各维元素步长。
+fn c_strides(shape: &[usize]) -> Vec<usize> {
+    let mut s = vec![1usize; shape.len()];
+    for i in (0..shape.len() - 1).rev() {
+        s[i] = s[i + 1] * shape[i + 1];
+    }
+    s
+}
+
+/// 通用驱动：填充 `layers` 层鬼单元，沿 `dim` 切 lane 逐条套用一维修式。
+/// 本函数创建的三个数组（填充数组与两个输出）都是标准 C 布局，可直接用
+/// 扁平切片做下标运算（ndarray 0.16 的 lanes 迭代器不支持动态维度）。
+fn deriv_lanes(
+    grid: &Grid,
+    data: &ArrayD<f64>,
+    dim: usize,
+    layers: usize,
+    scheme: Scheme1d,
+) -> (ArrayD<f64>, ArrayD<f64>) {
+    let padded = pad_ghost_dim(grid, data, dim, layers);
+    let n = grid.n()[dim];
+    let dx = grid.dx()[dim];
+    let mut dl = ArrayD::zeros(grid.shape());
+    let mut dr = ArrayD::zeros(grid.shape());
+
+    let pshape = padded.shape().to_vec();
+    let oshape = grid.shape();
+    let pstride = c_strides(&pshape);
+    let ostride = c_strides(&oshape);
+
+    let pslice = padded.as_slice().expect("填充数组为标准布局");
+    let (dls, drs) = (
+        dl.as_slice_mut().expect("输出数组为标准布局"),
+        dr.as_slice_mut().expect("输出数组为标准布局"),
+    );
+
+    // 除 dim 外各维的大小的 C 序枚举。
+    let outer: Vec<usize> = oshape
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| *i != dim)
+        .map(|(_, v)| *v)
+        .collect();
+    let num_lanes: usize = outer.iter().product();
+    let mut om = vec![0usize; outer.len()];
+    let mut left = vec![0.0; n];
+    let mut right = vec![0.0; n];
+    for o in 0..num_lanes {
+        // o → 各外维坐标（C 序 → 多索引）。
+        let mut r = o;
+        for k in (0..outer.len()).rev() {
+            om[k] = r % outer[k];
+            r /= outer[k];
+        }
+        // 组装基址（dim 维坐标为 0）。
+        let mut k = 0;
+        let (mut pbase, mut obase) = (0usize, 0usize);
+        for i in 0..oshape.len() {
+            if i == dim {
+                continue;
+            }
+            pbase += om[k] * pstride[i];
+            obase += om[k] * ostride[i];
+            k += 1;
+        }
+        // 填充后的整条 lane（含两侧鬼单元）。
+        let m = pshape[dim];
+        let g: Vec<f64> = (0..m).map(|j| pslice[pbase + j * pstride[dim]]).collect();
+        scheme(dx, n, &g, &mut left, &mut right);
+        for j in 0..n {
+            dls[obase + j * ostride[dim]] = left[j];
+            drs[obase + j * ostride[dim]] = right[j];
+        }
+    }
+    (dl, dr)
+}
+
+/// 一阶迎风（`upwindFirstFirst.m`）：填充一层鬼单元后取相邻差分，
+/// 左导数取差分序列前 n 个、右导数取后 n 个（源码第 57-70 行）。
+fn first_1d(dx: f64, n: usize, g: &[f64], dl: &mut [f64], dr: &mut [f64]) {
+    let inv = 1.0 / dx;
+    for j in 0..n {
+        dl[j] = inv * (g[j + 1] - g[j]);
+        dr[j] = inv * (g[j + 2] - g[j + 1]);
+    }
+}
+
+/// 一阶迎风格式。
+pub struct UpwindFirstFirst;
+
+impl UpwindDerivative for UpwindFirstFirst {
+    fn stencil_layers(&self) -> usize {
+        1
+    }
+
+    fn deriv(&self, grid: &Grid, data: &ArrayD<f64>, dim: usize) -> (ArrayD<f64>, ArrayD<f64>) {
+        deriv_lanes(grid, data, dim, 1, first_1d)
+    }
+}
+
+/// 二阶 ENO（`upwindFirstENO2.m`）：两个候选二阶近似中选二阶均差
+/// 模较小的那个。
+fn eno2_1d(dx: f64, n: usize, g: &[f64], dl: &mut [f64], dr: &mut [f64]) {
+    // 未去头的一阶差分（m - 1 = n + 3 个）。
+    let d1f: Vec<f64> = (0..n + 3).map(|j| (g[j + 1] - g[j]) / dx).collect();
+    // 去掉首尾各一个得 D1（n + 1 个，对应半节点导数）。
+    let d1 = &d1f[1..n + 2];
+    // 二阶均差（n + 2 个）。
+    let d2: Vec<f64> = (0..n + 2)
+        .map(|j| 0.5 / dx * (d1f[j + 1] - d1f[j]))
+        .collect();
+    for k in 0..n {
+        let dl1 = d1[k] + dx * d2[k];
+        let dl2 = d1[k] + dx * d2[k + 1];
+        let dr1 = d1[k + 1] - dx * d2[k + 1];
+        let dr2 = d1[k + 1] - dx * d2[k + 2];
+        let smaller = d2[k].abs() < d2[k + 1].abs();
+        let smaller_r = d2[k + 1].abs() < d2[k + 2].abs();
+        dl[k] = if smaller { dl1 } else { dl2 };
+        dr[k] = if smaller_r { dr1 } else { dr2 };
+    }
+}
+
+/// 二阶 ENO 格式。
+pub struct UpwindFirstENO2;
+
+impl UpwindDerivative for UpwindFirstENO2 {
+    fn stencil_layers(&self) -> usize {
+        2
+    }
+
+    fn deriv(&self, grid: &Grid, data: &ArrayD<f64>, dim: usize) -> (ArrayD<f64>, ArrayD<f64>) {
+        deriv_lanes(grid, data, dim, 2, eno2_1d)
+    }
+}
+
+/// ENO3 的三个候选近似 + 未去头的一阶均差（WENO5 权重也要用）。
+struct Eno3Candidates {
+    dl: [Vec<f64>; 3],
+    dr: [Vec<f64>; 3],
+    /// 未去头的一阶均差（n + 5 个）。
+    d1f: Vec<f64>,
+    /// 去头后的二阶均差（n + 2 个）。
+    d2s: Vec<f64>,
+    /// 三阶均差（n + 3 个，MATLAB 不去头）。
+    d3f: Vec<f64>,
+}
+
+/// `upwindFirstENO3aHelper.m`（stencil = 3，三层鬼单元）。
+fn eno3_candidates(dx: f64, n: usize, g: &[f64]) -> Eno3Candidates {
+    let d1f: Vec<f64> = (0..n + 5).map(|j| (g[j + 1] - g[j]) / dx).collect(); // m - 1 = n + 5
+    let d2f: Vec<f64> = (0..n + 4)
+        .map(|j| 0.5 / dx * (d1f[j + 1] - d1f[j]))
+        .collect(); // n + 4
+    let d3f: Vec<f64> = (0..n + 3)
+        .map(|j| (d2f[j + 1] - d2f[j]) / (3.0 * dx))
+        .collect(); // n + 3
+
+    let d1 = &d1f[2..n + 3]; // 去掉首尾各两个，n + 1 个
+    let d2s = &d2f[1..n + 3]; // 去掉首尾各一个，n + 2 个
+
+    let mut dl = [vec![0.0; n], vec![0.0; n], vec![0.0; n]];
+    let mut dr = [vec![0.0; n], vec![0.0; n], vec![0.0; n]];
+    let dx2 = dx * dx;
+    for k in 0..n {
+        // 一阶基底：左近似取左半差分，右近似取右半差分。
+        let (bl, br) = (d1[k], d1[k + 1]);
+        // 二阶项（源码第 136-152 行）。
+        dl[0][k] = bl + dx * d2s[k];
+        dl[1][k] = bl + dx * d2s[k];
+        dl[2][k] = bl + dx * d2s[k + 1];
+        dr[0][k] = br - dx * d2s[k + 1];
+        dr[1][k] = br - dx * d2s[k + 1];
+        dr[2][k] = br - dx * d2s[k + 2];
+        // 三阶项（源码第 169-187 行）。
+        dl[0][k] += 2.0 * dx2 * d3f[k];
+        dl[1][k] += 2.0 * dx2 * d3f[k + 1];
+        dl[2][k] -= dx2 * d3f[k + 2];
+        dr[0][k] -= dx2 * d3f[k + 1];
+        dr[1][k] -= dx2 * d3f[k + 2];
+        dr[2][k] += 2.0 * dx2 * d3f[k + 3];
+    }
+    Eno3Candidates {
+        dl,
+        dr,
+        d1f,
+        d2s: d2s.to_vec(),
+        d3f,
+    }
+}
+
+/// 三阶 ENO（`upwindFirstENO3.m`，默认走 3a 变体）：先按二阶均差的
+/// 模选方向，再在该方向上按三阶均差的模选模板。
+fn eno3_1d(dx: f64, n: usize, g: &[f64], dl: &mut [f64], dr: &mut [f64]) {
+    let c = eno3_candidates(dx, n, g);
+    // smaller_l2：|D2s[k]| < |D2s[k+1]|，k = 0..n（n + 1 个）。
+    let smaller_l2: Vec<bool> = (0..n + 1)
+        .map(|k| c.d2s[k].abs() < c.d2s[k + 1].abs())
+        .collect();
+    // smaller_t：|D3[k]| < |D3[k+1]|，k = 0..n+1（n + 2 个）。
+    let smaller_t: Vec<bool> = (0..n + 2)
+        .map(|k| c.d3f[k].abs() < c.d3f[k + 1].abs())
+        .collect();
+
+    let pick = |k: usize| -> usize {
+        // 返回 0/1/2 对应候选 LL / M / RR（源码第 121-141 行）。
+        let (ll, m) = (
+            smaller_t[k] && smaller_l2[k],
+            (smaller_t[k + 1] && !smaller_l2[k]) || (!smaller_t[k] && smaller_l2[k]),
+        );
+        if ll {
+            0
+        } else if m {
+            1
+        } else {
+            2
+        }
+    };
+    for k in 0..n {
+        dl[k] = c.dl[pick(k)][k];
+        dr[k] = c.dr[pick(k + 1)][k];
+    }
+}
+
+/// 三阶 ENO 格式（默认 3a 变体）。
+pub struct UpwindFirstENO3;
+
+impl UpwindDerivative for UpwindFirstENO3 {
+    fn stencil_layers(&self) -> usize {
+        3
+    }
+
+    fn deriv(&self, grid: &Grid, data: &ArrayD<f64>, dim: usize) -> (ArrayD<f64>, ArrayD<f64>) {
+        deriv_lanes(grid, data, dim, 3, eno3_1d)
+    }
+}
+
+/// 五阶 WENO（`upwindFirstWENO5.m` → `upwindFirstWENO5a.m`）：三个 ENO3
+/// 候选按光滑度加权。ε 采用源码第 63 行实际启用的 `maxOverGrid` 方案：
+/// `1e-6 * max(D1²) + 1e-99`。
+fn weno5_1d(dx: f64, n: usize, g: &[f64], dl: &mut [f64], dr: &mut [f64]) {
+    let c = eno3_candidates(dx, n, g);
+    let eps = 1e-6 * c.d1f.iter().map(|v| v * v).fold(0.0, f64::max) + 1e-99;
+
+    // 光滑度指示子（源码第 107-123 行），p 为 v₁ = D1f[p] 的下标。
+    let smooth = |p: usize| -> [f64; 3] {
+        let (v1, v2, v3, v4, v5) = (
+            c.d1f[p],
+            c.d1f[p + 1],
+            c.d1f[p + 2],
+            c.d1f[p + 3],
+            c.d1f[p + 4],
+        );
+        let s1 = (13.0 / 12.0) * (v1 - 2.0 * v2 + v3).powi(2)
+            + 0.25 * (v1 - 4.0 * v2 + 3.0 * v3).powi(2);
+        let s2 = (13.0 / 12.0) * (v2 - 2.0 * v3 + v4).powi(2) + 0.25 * (v2 - v4).powi(2);
+        let s3 = (13.0 / 12.0) * (v3 - 2.0 * v4 + v5).powi(2)
+            + 0.25 * (3.0 * v3 - 4.0 * v4 + v5).powi(2);
+        [s1, s2, s3]
+    };
+    let weight = |s: [f64; 3], w: [f64; 3], d: [f64; 3]| -> f64 {
+        let alpha: Vec<f64> = (0..3).map(|i| w[i] / (s[i] + eps).powi(2)).collect();
+        let sum: f64 = alpha.iter().sum();
+        (0..3).map(|i| alpha[i] * d[i]).sum::<f64>() / sum
+    };
+    // 线性权重（源码第 133、146 行）。
+    let (wl, wr) = ([0.1, 0.6, 0.3], [0.3, 0.6, 0.1]);
+    for k in 0..n {
+        dl[k] = weight(smooth(k), wl, [c.dl[0][k], c.dl[1][k], c.dl[2][k]]);
+        dr[k] = weight(smooth(k + 1), wr, [c.dr[0][k], c.dr[1][k], c.dr[2][k]]);
+    }
+}
+
+/// 五阶 WENO 格式。
+pub struct UpwindFirstWENO5;
+
+impl UpwindDerivative for UpwindFirstWENO5 {
+    fn stencil_layers(&self) -> usize {
+        3
+    }
+
+    fn deriv(&self, grid: &Grid, data: &ArrayD<f64>, dim: usize) -> (ArrayD<f64>, ArrayD<f64>) {
+        deriv_lanes(grid, data, dim, 3, weno5_1d)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// 周期网格上 sin(x) 的导数逼近误差（左右导数的最大模差）。
+    pub(super) fn max_deriv_error(scheme: &dyn UpwindDerivative, n: usize) -> f64 {
+        let grid = Grid::new(&[0.0], &[2.0 * std::f64::consts::PI], &[n]);
+        let data = ndarray::Array1::from(grid.axis(0).iter().map(|x| x.sin()).collect::<Vec<_>>())
+            .into_dyn();
+        let (dl, dr) = scheme.deriv(&grid, &data, 0);
+        let mut err = 0.0f64;
+        for (i, x) in grid.axis(0).iter().enumerate() {
+            let exact = x.cos();
+            err = err.max((dl[i] - exact).abs()).max((dr[i] - exact).abs());
+        }
+        err
+    }
+
+    pub(super) fn observed_order(scheme: &dyn UpwindDerivative, n1: usize, n2: usize) -> f64 {
+        let (e1, e2) = (max_deriv_error(scheme, n1), max_deriv_error(scheme, n2));
+        (e1 / e2).log2() / (n2 as f64 / n1 as f64).log2()
+    }
+
+    #[test]
+    fn 各阶格式的收敛阶() {
+        assert!(
+            observed_order(&UpwindFirstFirst, 40, 80) > 0.8,
+            "一阶格式应接近 1 阶"
+        );
+        assert!(
+            observed_order(&UpwindFirstENO2, 40, 80) > 1.8,
+            "ENO2 应接近 2 阶"
+        );
+        assert!(
+            observed_order(&UpwindFirstENO3, 40, 80) > 2.5,
+            "ENO3 应接近 3 阶"
+        );
+        assert!(
+            observed_order(&UpwindFirstWENO5, 40, 80) > 4.0,
+            "WENO5 应接近 5 阶"
+        );
+    }
+
+    #[test]
+    fn 二维逐维求导() {
+        // f(x, y) = sin x + cos y，对第 0 维求导应为 cos x。
+        let grid = Grid::new(&[0.0, 0.0], &[2.0 * std::f64::consts::PI; 2], &[32, 17]);
+        let mut data = ArrayD::zeros(grid.shape());
+        for (idx, v) in data.indexed_iter_mut() {
+            let (x, y) = (grid.axis(0)[idx[0]], grid.axis(1)[idx[1]]);
+            *v = x.sin() + y.cos();
+        }
+        let (dl, _) = UpwindFirstFirst.deriv(&grid, &data, 0);
+        // 一阶格式在 32 节点下误差应小于 dx = 2π/32 ≈ 0.2。
+        let mut worst = 0.0f64;
+        for (idx, v) in dl.indexed_iter() {
+            let x = grid.axis(0)[idx[0]];
+            worst = worst.max((*v - x.cos()).abs());
+        }
+        assert!(worst < 0.2, "一阶导数误差 {worst} 应小于 dx");
+    }
+}

--- a/crates/e2m2e-levelset/src/dissipation.rs
+++ b/crates/e2m2e-levelset/src/dissipation.rs
@@ -1,0 +1,192 @@
+//! Lax-Friedrichs 耗散：对应 ToolboxLS 的
+//! `ExplicitIntegration/Dissipation/artificialDissipationGLF/LLF/LLLF.m`。
+//!
+//! MATLAB 原型（`termLaxFriedrichs.m` 第 173-174 行的调用方式）：
+//!
+//! ```matlab
+//! [diss, stepBound] = feval(schemeData.dissFunc, t, data, derivL, derivR, schemeData);
+//! ```
+//!
+//! GLF 的算法（`artificialDissipationGLF.m` 第 72-102 行）：
+//!
+//! ```text
+//! p_min[i] = min(min(derivL[i]), min(derivR[i]))   （全网格标量，广播）
+//! p_max[i] = max(max(derivL[i]), max(derivR[i]))
+//! diss     = Σ_i 0.5 * α_i * (derivR[i] - derivL[i])
+//! stepBound = 1 / Σ_i max(α_i) / dx[i]
+//! ```
+//!
+//! LLF 只把当前维 `i` 的包络换成节点邻域的逐点 min/max（其余维仍用全局
+//! 标量，`artificialDissipationLLF.m` 第 96-118 行）；LLLF 把所有维都换成
+//! 逐点包络（`artificialDissipationLLLF.m` 第 78-102 行）。
+
+use crate::grid::Grid;
+use crate::hamiltonian::Hamiltonian;
+use ndarray::{ArrayD, Zip};
+
+/// LF 耗散格式。MATLAB 的 `schemeData.dissFunc` 函数句柄物化为实现本
+/// trait 的结构体。
+pub trait Dissipation: Send + Sync {
+    /// 计算逐节点耗散项与 CFL 步长上界。
+    fn dissipation(
+        &self,
+        t: f64,
+        grid: &Grid,
+        phi: &ArrayD<f64>,
+        deriv_l: &[ArrayD<f64>],
+        deriv_r: &[ArrayD<f64>],
+        ham: &dyn Hamiltonian,
+    ) -> (ArrayD<f64>, f64);
+}
+
+/// 由耗散系数场与梯度差组装 `(diss, step_bound)`（三种格式共用的收尾）。
+fn assemble(
+    grid: &Grid,
+    deriv_l: &[ArrayD<f64>],
+    deriv_r: &[ArrayD<f64>],
+    alphas: &[ArrayD<f64>],
+) -> (ArrayD<f64>, f64) {
+    let mut diss = ArrayD::zeros(grid.shape());
+    let mut step_bound_inv = 0.0f64;
+    for i in 0..grid.dim() {
+        // diss += 0.5 * α_i * (derivR_i - derivL_i)
+        Zip::from(&mut diss)
+            .and(&alphas[i])
+            .and(&deriv_r[i])
+            .and(&deriv_l[i])
+            .for_each(|d, a, r, l| *d += 0.5 * a * (r - l));
+        step_bound_inv += alphas[i].iter().fold(0.0f64, |m, v| m.max(*v)) / grid.dx()[i];
+    }
+    (diss, 1.0 / step_bound_inv)
+}
+
+/// 全局 LF（`artificialDissipationGLF.m`）：梯度包络取全网格极值。
+pub struct ArtificialDissipationGLF;
+
+impl Dissipation for ArtificialDissipationGLF {
+    fn dissipation(
+        &self,
+        t: f64,
+        grid: &Grid,
+        phi: &ArrayD<f64>,
+        deriv_l: &[ArrayD<f64>],
+        deriv_r: &[ArrayD<f64>],
+        ham: &dyn Hamiltonian,
+    ) -> (ArrayD<f64>, f64) {
+        let dim = grid.dim();
+        let shape = grid.shape();
+        let mut p_min = Vec::with_capacity(dim);
+        let mut p_max = Vec::with_capacity(dim);
+        for i in 0..dim {
+            let lo = deriv_l[i]
+                .iter()
+                .chain(deriv_r[i].iter())
+                .fold(f64::INFINITY, |m, v| m.min(*v));
+            let hi = deriv_l[i]
+                .iter()
+                .chain(deriv_r[i].iter())
+                .fold(f64::NEG_INFINITY, |m, v| m.max(*v));
+            p_min.push(ArrayD::from_elem(shape.clone(), lo));
+            p_max.push(ArrayD::from_elem(shape.clone(), hi));
+        }
+        let alphas: Vec<ArrayD<f64>> = (0..dim)
+            .map(|i| ham.partial_bound(t, grid, phi, &p_min, &p_max, i))
+            .collect();
+        assemble(grid, deriv_l, deriv_r, &alphas)
+    }
+}
+
+/// 局部 LF（`artificialDissipationLLF.m`）：第 `i` 维的包络取该维左右
+/// 导数的逐点 min/max，其余维用全网格标量。
+pub struct ArtificialDissipationLLF;
+
+impl Dissipation for ArtificialDissipationLLF {
+    fn dissipation(
+        &self,
+        t: f64,
+        grid: &Grid,
+        phi: &ArrayD<f64>,
+        deriv_l: &[ArrayD<f64>],
+        deriv_r: &[ArrayD<f64>],
+        ham: &dyn Hamiltonian,
+    ) -> (ArrayD<f64>, f64) {
+        let dim = grid.dim();
+        let shape = grid.shape();
+        // 全局标量包络（各维共用）。
+        let g_min: Vec<f64> = (0..dim)
+            .map(|i| {
+                deriv_l[i]
+                    .iter()
+                    .chain(deriv_r[i].iter())
+                    .fold(f64::INFINITY, |m, v| m.min(*v))
+            })
+            .collect();
+        let g_max: Vec<f64> = (0..dim)
+            .map(|i| {
+                deriv_l[i]
+                    .iter()
+                    .chain(deriv_r[i].iter())
+                    .fold(f64::NEG_INFINITY, |m, v| m.max(*v))
+            })
+            .collect();
+        let broadcast_min: Vec<ArrayD<f64>> = g_min
+            .iter()
+            .map(|v| ArrayD::from_elem(shape.clone(), *v))
+            .collect();
+        let broadcast_max: Vec<ArrayD<f64>> = g_max
+            .iter()
+            .map(|v| ArrayD::from_elem(shape.clone(), *v))
+            .collect();
+
+        let mut alphas = Vec::with_capacity(dim);
+        for i in 0..dim {
+            let mut p_min = broadcast_min.clone();
+            let mut p_max = broadcast_max.clone();
+            // 当前维换成逐点包络。
+            p_min[i] = Zip::from(&deriv_l[i])
+                .and(&deriv_r[i])
+                .map_collect(|l, r| (*l).min(*r));
+            p_max[i] = Zip::from(&deriv_l[i])
+                .and(&deriv_r[i])
+                .map_collect(|l, r| (*l).max(*r));
+            alphas.push(ham.partial_bound(t, grid, phi, &p_min, &p_max, i));
+        }
+        assemble(grid, deriv_l, deriv_r, &alphas)
+    }
+}
+
+/// 局部局部 LF（`artificialDissipationLLLF.m`）：所有维的包络都取逐点
+/// min/max。
+pub struct ArtificialDissipationLLLF;
+
+impl Dissipation for ArtificialDissipationLLLF {
+    fn dissipation(
+        &self,
+        t: f64,
+        grid: &Grid,
+        phi: &ArrayD<f64>,
+        deriv_l: &[ArrayD<f64>],
+        deriv_r: &[ArrayD<f64>],
+        ham: &dyn Hamiltonian,
+    ) -> (ArrayD<f64>, f64) {
+        let dim = grid.dim();
+        let p_min: Vec<ArrayD<f64>> = (0..dim)
+            .map(|i| {
+                Zip::from(&deriv_l[i])
+                    .and(&deriv_r[i])
+                    .map_collect(|l, r| (*l).min(*r))
+            })
+            .collect();
+        let p_max: Vec<ArrayD<f64>> = (0..dim)
+            .map(|i| {
+                Zip::from(&deriv_l[i])
+                    .and(&deriv_r[i])
+                    .map_collect(|l, r| (*l).max(*r))
+            })
+            .collect();
+        let alphas: Vec<ArrayD<f64>> = (0..dim)
+            .map(|i| ham.partial_bound(t, grid, phi, &p_min, &p_max, i))
+            .collect();
+        assemble(grid, deriv_l, deriv_r, &alphas)
+    }
+}

--- a/crates/e2m2e-levelset/src/grid.rs
+++ b/crates/e2m2e-levelset/src/grid.rs
@@ -1,0 +1,175 @@
+//! 结构网格：对应 ToolboxLS 的 `processGrid.m`。
+//!
+//! 节点为单元中心（cell-centered）：第 `dim` 维第 `i` 个节点（0-based）位于
+//! `min[dim] + (i + 0.5) * dx[dim]`，该维共 `n[dim]` 个节点，`dx[dim] =
+//! (max[dim] - min[dim]) / n[dim]`。与 MATLAB 版一致，维度上限 5。
+
+use ndarray::ArrayD;
+
+/// 每维的边界条件。
+///
+/// 对应 MATLAB `grid.bdry{dim}` 的函数句柄与 `grid.bdryData{dim}`，函数句柄
+/// 物化为枚举，鬼单元的填充算法见 [`crate::boundary`]：
+///
+/// - `Dirichlet(v)`   ← `addGhostDirichlet`（`bdryData.value = v`，仅支持标量）
+/// - `Neumann(v)`     ← `addGhostNeumann`（`bdryData.value = v`，仅支持标量）
+/// - `Periodic`       ← `addGhostPeriodic`
+/// - `Extrapolate`    ← `addGhostExtrapolate`（一阶线性外推）
+/// - `Extrapolate2`   ← `addGhostExtrapolate2`（二阶外推）
+#[derive(Clone, Debug, PartialEq)]
+pub enum BoundaryCondition {
+    Dirichlet(f64),
+    Neumann(f64),
+    Periodic,
+    Extrapolate,
+    Extrapolate2,
+}
+
+/// 结构网格。所有网格函数（`ArrayD<f64>`）的形状等于 `n`。
+#[derive(Clone, Debug)]
+pub struct Grid {
+    dim: usize,
+    min: Vec<f64>,
+    max: Vec<f64>,
+    n: Vec<usize>,
+    dx: Vec<f64>,
+    /// 每维节点坐标（单元中心），`vs[i]` 长度为 `n[i]`。
+    vs: Vec<Vec<f64>>,
+    boundary: Vec<BoundaryCondition>,
+}
+
+impl Grid {
+    /// 由下界、上界与每维节点数构造网格，边界条件默认全周期
+    /// （与 `processGrid.m` 的 `defaultBdry = @addGhostPeriodic` 一致）。
+    ///
+    /// 输入非法时 panic 并给出原因（对应 `processGrid.m` 的 `error` 调用）。
+    pub fn new(min: &[f64], max: &[f64], n: &[usize]) -> Grid {
+        let dim = min.len();
+        assert!(dim == max.len() && dim == n.len(), "min/max/n 长度必须一致");
+        assert!(
+            (1..=5).contains(&dim),
+            "维度必须在 1..=5 之间（processGrid maxDimension）"
+        );
+        for i in 0..dim {
+            assert!(n[i] >= 1, "第 {i} 维节点数必须为正");
+            assert!(max[i] > min[i], "第 {i} 维必须 max > min");
+        }
+
+        let dx: Vec<f64> = (0..dim).map(|i| (max[i] - min[i]) / n[i] as f64).collect();
+        let vs: Vec<Vec<f64>> = (0..dim)
+            .map(|i| {
+                (0..n[i])
+                    .map(|j| min[i] + (j as f64 + 0.5) * dx[i])
+                    .collect()
+            })
+            .collect();
+
+        Grid {
+            dim,
+            min: min.to_vec(),
+            max: max.to_vec(),
+            n: n.to_vec(),
+            dx,
+            vs,
+            boundary: vec![BoundaryCondition::Periodic; dim],
+        }
+    }
+
+    /// 所有维使用同一边界条件。
+    pub fn with_boundary_all(mut self, bc: BoundaryCondition) -> Self {
+        self.boundary = vec![bc; self.dim];
+        self
+    }
+
+    /// 逐维指定边界条件，长度必须等于维度。
+    pub fn with_boundaries(mut self, bc: Vec<BoundaryCondition>) -> Self {
+        assert_eq!(bc.len(), self.dim, "边界条件数量必须等于网格维度");
+        self.boundary = bc;
+        self
+    }
+
+    pub fn dim(&self) -> usize {
+        self.dim
+    }
+
+    pub fn min(&self) -> &[f64] {
+        &self.min
+    }
+
+    pub fn max(&self) -> &[f64] {
+        &self.max
+    }
+
+    /// 每维节点数。
+    pub fn n(&self) -> &[usize] {
+        &self.n
+    }
+
+    /// 每维网格间距。
+    pub fn dx(&self) -> &[f64] {
+        &self.dx
+    }
+
+    /// 第 `dim` 维节点坐标（单元中心）。
+    pub fn axis(&self, dim: usize) -> &[f64] {
+        &self.vs[dim]
+    }
+
+    /// 第 `dim` 维边界条件。
+    pub fn boundary(&self, dim: usize) -> &BoundaryCondition {
+        &self.boundary[dim]
+    }
+
+    /// 网格函数的 ndarray 形状。
+    pub fn shape(&self) -> Vec<usize> {
+        self.n.clone()
+    }
+
+    /// 网格节点总数。
+    pub fn size(&self) -> usize {
+        self.n.iter().product()
+    }
+
+    /// 校验网格函数形状与网格一致，不一致时 panic。
+    pub fn check_data(&self, data: &ArrayD<f64>) {
+        assert_eq!(
+            data.shape(),
+            &self.n[..],
+            "网格函数形状 {:?} 与网格 {:?} 不一致",
+            data.shape(),
+            &self.n[..]
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn 单元中心坐标与间距() {
+        let g = Grid::new(&[0.0], &[1.0], &[101]);
+        assert!((g.dx()[0] - 1.0 / 101.0).abs() < 1e-15);
+        assert!((g.axis(0)[0] - 0.5 / 101.0).abs() < 1e-15);
+        assert!((g.axis(0)[100] - 100.5 / 101.0).abs() < 1e-15);
+    }
+
+    #[test]
+    fn 标量广播到各维() {
+        let g = Grid::new(&[-1.0, -1.0], &[1.0, 1.0], &[41, 41]);
+        assert_eq!(g.dim(), 2);
+        assert_eq!(g.shape(), vec![41, 41]);
+        assert_eq!(g.size(), 41 * 41);
+        assert_eq!(g.boundary(0), &BoundaryCondition::Periodic);
+        let g = g.with_boundary_all(BoundaryCondition::Dirichlet(0.0));
+        assert_eq!(g.boundary(1), &BoundaryCondition::Dirichlet(0.0));
+    }
+
+    #[test]
+    #[should_panic]
+    fn 维度超限报错() {
+        let ones = vec![1.0; 6];
+        let ns = vec![11; 6];
+        Grid::new(&ones, &ones, &ns);
+    }
+}

--- a/crates/e2m2e-levelset/src/hamiltonian.rs
+++ b/crates/e2m2e-levelset/src/hamiltonian.rs
@@ -1,0 +1,85 @@
+//! 用户提供的哈密顿量：对应 ToolboxLS 的 `schemeData.hamFunc` 与
+//! `schemeData.partialFunc` 两个回调（协议见 `termLaxFriedrichs.m`
+//! 第 52-71 行与 `artificialDissipationGLF.m` 第 34-47 行的注释）。
+//!
+//! HJ PDE 为
+//!
+//! ```text
+//! D_t φ = -H(x, t, φ, ∇φ)
+//! ```
+//!
+//! MATLAB 中这两个回调配合弱类型 `schemeData` 使用（用户把动力学参数
+//! 塞进自由字段，`hamFunc` 还可借助 `nargout` 探测返回修改后的
+//! `schemeData`）。Rust 里的对应做法：把动力学参数放进实现本 trait 的
+//! 结构体字段，`hamFunc` 的"原位修改 schemeData"能力不再需要——需要
+//! 随时间演化的状态本就属于哈密顿量的实现方，用普通字段表达。
+
+use crate::grid::Grid;
+use ndarray::ArrayD;
+
+/// 解析哈密顿量 `H(x, t, φ, p)` 及其代价导数包络。
+pub trait Hamiltonian: Send + Sync {
+    /// 在全部网格节点上计算 `H(t, x, p)`，返回形状与网格相同。
+    ///
+    /// `p` 是各维中心差分梯度（`termLaxFriedrichs.m` 第 130 行
+    /// `derivC = 0.5 * (derivL + derivR)` 传入 `hamFunc` 的 `deriv`），
+    /// `p[i]` 形状与 `phi` 相同。节点坐标经 `grid.axis(i)` 获取。
+    fn hamiltonian(&self, t: f64, grid: &Grid, phi: &ArrayD<f64>, p: &[ArrayD<f64>])
+        -> ArrayD<f64>;
+
+    /// 第 `dim` 维的耗散系数包络（逐节点，形状与网格相同）：
+    ///
+    /// ```text
+    /// α_dim(x) = max_{p ∈ [p_min, p_max]} |∂H/∂p_dim|
+    /// ```
+    ///
+    /// `p_min` / `p_max` 是耗散格式选定的梯度上下界——GLF 为全网格极值
+    /// 的广播，LLF/LLLF 为节点邻域极值（见各 `artificialDissipation*.m`）。
+    /// 线性哈密顿量（∂H/∂p 与 p 无关）可直接返回常值场。
+    fn partial_bound(
+        &self,
+        t: f64,
+        grid: &Grid,
+        phi: &ArrayD<f64>,
+        p_min: &[ArrayD<f64>],
+        p_max: &[ArrayD<f64>],
+        dim: usize,
+    ) -> ArrayD<f64>;
+}
+
+/// 常速平流 `H = Σᵢ vᵢ·pᵢ`（PDE 为 `φ_t + v·∇φ = 0`），
+/// 最简单实用的 [`Hamiltonian`] 实现。
+pub struct Advection {
+    /// 各维速度。
+    pub velocity: Vec<f64>,
+}
+
+impl Hamiltonian for Advection {
+    fn hamiltonian(
+        &self,
+        _t: f64,
+        grid: &Grid,
+        _phi: &ArrayD<f64>,
+        p: &[ArrayD<f64>],
+    ) -> ArrayD<f64> {
+        let mut out = ArrayD::zeros(grid.shape());
+        for (i, v) in self.velocity.iter().enumerate() {
+            ndarray::Zip::from(&mut out)
+                .and(&p[i])
+                .for_each(|o, d| *o += v * d);
+        }
+        out
+    }
+
+    fn partial_bound(
+        &self,
+        _t: f64,
+        grid: &Grid,
+        _phi: &ArrayD<f64>,
+        _p_min: &[ArrayD<f64>],
+        _p_max: &[ArrayD<f64>],
+        dim: usize,
+    ) -> ArrayD<f64> {
+        ArrayD::from_elem(grid.shape(), self.velocity[dim].abs())
+    }
+}

--- a/crates/e2m2e-levelset/src/integrator.rs
+++ b/crates/e2m2e-levelset/src/integrator.rs
@@ -1,0 +1,375 @@
+//! CFL 约束时间积分器：对应 ToolboxLS 的 `ExplicitIntegration/Integrators/`
+//! 下的 `odeCFL1/2/3.m` 与选项结构 `odeCFLset.m`。
+//!
+//! 与 e2m2e-propagation 的自适应积分器不同，这类积分器不做误差控制，
+//! 步长由右端项返回的 CFL 上界直接决定，适用于双曲型 PDE 的方法线
+//! 时间推进。三个积分器共用同一个驱动循环（含 postTimestep、
+//! terminalEvent、singleStep、stats），仅子步组合不同。
+
+use crate::boundary::matlab_sign;
+use crate::grid::Grid;
+use crate::signed_distance::{signed_distance_iterative, ReinitAccuracy, SignedDistanceOptions};
+use crate::term::{Term, TermRhs};
+use ndarray::{ArrayD, Zip};
+
+/// 积分选项，字段对应 `odeCFLset.m` 第 90-95 行的默认值。
+/// 含 `Box<dyn PostTimestep>` 钩子，不可 Clone。
+pub struct CflOptions {
+    /// CFL 系数，实际步长 = `factor_cfl * step_bound`（MATLAB 默认 0.5）。
+    pub factor_cfl: f64,
+    /// 步长上限（MATLAB 默认 realmax，此处无穷）。
+    pub max_step: f64,
+    /// 只推进一步（`singleStep`）。
+    pub single_step: bool,
+    /// 打印步数统计（`stats`）。
+    pub stats: bool,
+    /// 每步结束后依次调用的后处理钩子（`postTimestep`，可多个）。
+    pub post_timestep: Vec<Box<dyn PostTimestep>>,
+    /// 终止事件（`terminalEvent`）：事件值与上一步符号相反即停。
+    pub terminal_event: Option<TerminalEvent>,
+}
+
+impl Default for CflOptions {
+    fn default() -> Self {
+        CflOptions {
+            factor_cfl: 0.5,
+            max_step: f64::INFINITY,
+            single_step: false,
+            stats: false,
+            post_timestep: Vec::new(),
+            terminal_event: None,
+        }
+    }
+}
+
+/// 每步之后的钩子，可修改解。MATLAB 原型
+/// `postTimestep(t, y, schemeData)` 中的 `schemeData` 依赖（如掩码、网格）
+/// 由各实现的结构体字段持有。
+pub trait PostTimestep {
+    fn post_step(&mut self, t: f64, y: &mut ArrayD<f64>);
+}
+
+/// 掩码钳制（`postTimestepMask.m`）：每步结束后把掩码内（`mask` 非零）
+/// 节点重置为初值，用于固定障碍/保护区。
+pub struct PostTimestepMask {
+    /// 掩码区域节点集合（与网格同形，非零即在掩码内）。
+    pub mask: ArrayD<f64>,
+    /// 初值（掩码内节点回到此值）。
+    pub initial: ArrayD<f64>,
+}
+
+impl PostTimestep for PostTimestepMask {
+    fn post_step(&mut self, _t: f64, y: &mut ArrayD<f64>) {
+        Zip::from(y)
+            .and(&self.mask)
+            .and(&self.initial)
+            .for_each(|v, m, init| {
+                if *m != 0.0 {
+                    *v = *init;
+                }
+            });
+    }
+}
+
+/// 每步做一次迭代重初始化（`postTimestepReinit.m`）。默认迭代到
+/// `tMax = 5 * max(dx)`（约五个节点宽的带），对应 MATLAB 不给
+/// `reinitSteps` 时的默认。
+pub struct PostTimestepReinit {
+    pub grid: Grid,
+    pub accuracy: ReinitAccuracy,
+    /// 指定重初始化步数（`reinitSteps`）；None 表示按默认时间收敛。
+    pub steps: Option<usize>,
+    /// 平均更新量收敛阈值（`reinitErrorMax`，默认 1e-3）。
+    pub error_max: f64,
+}
+
+impl PostTimestep for PostTimestepReinit {
+    fn post_step(&mut self, _t: f64, y: &mut ArrayD<f64>) {
+        let mut options = SignedDistanceOptions {
+            accuracy: self.accuracy,
+            error_max: self.error_max,
+            ..Default::default()
+        };
+        match self.steps {
+            Some(steps) => options.t_max_steps = Some(steps),
+            None => {
+                options.t_max = Some(5.0 * self.grid.dx().iter().fold(0.0f64, |m, v| m.max(*v)))
+            }
+        }
+        *y = signed_distance_iterative(&self.grid, y, &options);
+    }
+}
+
+/// 最短到达时间记录器（`postTimestepTTR.m`）：不改解，记录零等值面
+/// 越过每个节点的时刻（相邻步之间线性插值），未到达节点保持无穷。
+///
+/// 与 MATLAB 版一致：初始时刻不算步进结果，若要记录 t₀ 时刻的零等值面，
+/// 需在开始积分前手动调用一次 [`PostTimestepTtrRecorder::record`]。
+pub struct PostTimestepTtrRecorder {
+    /// 每个节点首次被零等值面穿越的时刻，初值无穷。
+    pub ttr: ArrayD<f64>,
+    last_t: f64,
+    last_y: ArrayD<f64>,
+}
+
+impl PostTimestepTtrRecorder {
+    pub fn new(grid: &Grid) -> Self {
+        PostTimestepTtrRecorder {
+            ttr: ArrayD::from_elem(grid.shape(), f64::INFINITY),
+            last_t: f64::NAN,
+            last_y: ArrayD::zeros(grid.shape()),
+        }
+    }
+
+    /// 记录初始状态：零等值面内（φ ≤ 0）节点的 TTR 记为 `t`，其余无穷。
+    pub fn record(&mut self, t: f64, y: &ArrayD<f64>) {
+        Zip::from(&mut self.ttr).and(y).for_each(|v, cur| {
+            if *cur <= 0.0 {
+                *v = t;
+            }
+        });
+        self.last_t = t;
+        self.last_y = y.clone();
+    }
+}
+
+impl PostTimestep for PostTimestepTtrRecorder {
+    fn post_step(&mut self, t: f64, y: &mut ArrayD<f64>) {
+        if self.last_t.is_nan() {
+            // 未初始化：按 MATLAB 首次调用路径处理。
+            let snapshot = y.clone();
+            self.record(t, &snapshot);
+            return;
+        }
+        // 上一步为正、本步 ≤ 0 的节点做线性插值求穿越时刻。
+        let snapshot = y.clone();
+        Zip::from(&mut self.ttr)
+            .and(&snapshot)
+            .and(&self.last_y)
+            .for_each(|v, cur, prev| {
+                if *cur <= 0.0 && *prev > 0.0 {
+                    *v = self.last_t - (t - self.last_t) * *prev / (*cur - *prev);
+                }
+            });
+        self.last_t = t;
+        self.last_y = snapshot;
+    }
+}
+
+/// 终止事件（`terminalEvent` 原型：`(t, y, tOld, yOld) -> 标量`，
+/// 相邻两次调用返回值符号相反则终止积分）。
+///
+/// 只有收敛检测一种实现（`terminalEventConverge.m`），故用枚举而非 trait。
+#[derive(Clone, Debug)]
+pub enum TerminalEvent {
+    /// 更新量范数降到容差以下触发变号（返回 -1），否则 +1
+    /// （`terminalEventConverge.m` 第 79-93 行）。
+    Converge {
+        /// 绝对容差（默认 1e-6）。
+        abs_tol: f64,
+        /// 相对容差（默认 1e-3）。
+        rel_tol: f64,
+        norm: ConvergeNorm,
+    },
+}
+
+/// 收敛度量范数（`terminalEventConverge.m` 第 39-43 行），
+/// 按紧到松为逐点 / 最大 / 平均。
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ConvergeNorm {
+    /// 全节点平均（MATLAB 默认）。
+    Average,
+    /// 全节点最大。
+    Maximum,
+    /// 每个节点单独检验（全体都低于容差才算收敛）。
+    Pointwise,
+}
+
+impl TerminalEvent {
+    /// 事件值，符号翻转即终止（由积分器检测）。
+    pub fn event_value(&self, _t: f64, y: &ArrayD<f64>, _t_old: f64, y_old: &ArrayD<f64>) -> f64 {
+        let Self::Converge {
+            abs_tol,
+            rel_tol,
+            norm,
+        } = self;
+        let diff = Zip::from(y).and(y_old).map_collect(|a, b| a - b);
+        let tol = |v: f64| -> f64 { (rel_tol * v).max(*abs_tol) };
+        let converged = match norm {
+            ConvergeNorm::Average => {
+                let mean =
+                    |a: &ArrayD<f64>| a.iter().map(|v| v.abs()).sum::<f64>() / a.len() as f64;
+                mean(&diff) < tol(mean(y))
+            }
+            ConvergeNorm::Maximum => {
+                let max = |a: &ArrayD<f64>| a.iter().fold(0.0f64, |m, v| m.max(v.abs()));
+                max(&diff) < tol(max(y))
+            }
+            ConvergeNorm::Pointwise => Zip::from(&diff).and(y).all(|d, v| d.abs() < tol(v.abs())),
+        };
+        if converged {
+            -1.0
+        } else {
+            1.0
+        }
+    }
+}
+
+/// 积分结果。MATLAB 版的 `tspan` 多时刻输出（`odeCFLmultipleSteps.m`）
+/// 只是反复调用单段积分，需要时在调用侧循环即可，不再单独提供。
+pub struct CflResult {
+    /// 终止时刻（到达 `tf` 或事件触发，均返回实际时刻）。
+    pub t: f64,
+    /// 终止时刻的水平集函数。
+    pub y: ArrayD<f64>,
+    /// 实际推进的步数。
+    pub steps: usize,
+}
+
+/// 子步组合器：消耗首级右端项，完成其余子步，返回新解与全部子步的
+/// 最小步长上界（用于 CFL 违约告警）。
+type Stage<'a> =
+    dyn FnMut(&mut dyn Term, f64, &ArrayD<f64>, f64, TermRhs) -> (ArrayD<f64>, f64) + 'a;
+
+/// 三个积分器共用的驱动循环（对应 odeCFL1/2/3 的主循环结构）。
+fn cfl_integrate<T: Term>(
+    term: &mut T,
+    t0: f64,
+    tf: f64,
+    y0: ArrayD<f64>,
+    options: &mut CflOptions,
+    stage: &mut Stage<'_>,
+) -> CflResult {
+    // 子步 CFL 违约阈值：比用户系数多 20%，封顶 1.0（odeCFL3.m 第 85 行）。
+    let safety = (1.2 * options.factor_cfl).min(1.0);
+    // 到达终点的相对判据（odeCFL1.m 第 74 行）。
+    let small = 100.0 * f64::EPSILON;
+
+    let mut t = t0;
+    let mut y = y0;
+    let mut steps = 0usize;
+    let mut event_old: Option<f64> = None;
+
+    while tf - t >= small * tf.abs() {
+        // 首级右端项决定本步步长，整步固定（odeCFL3.m 第 126-144 行）。
+        let r1 = term.rhs(t, &y);
+        let dt = (options.factor_cfl * r1.step_bound)
+            .min(tf - t)
+            .min(options.max_step);
+
+        // 终止事件需要上一步的 (t, y)。
+        let t_old = t;
+        let y_old = options.terminal_event.as_ref().map(|_| y.clone());
+
+        let (y_new, sb_min) = stage(term as &mut dyn Term, t, &y, dt, r1);
+        y = y_new;
+        t += dt;
+        steps += 1;
+
+        if dt > safety * sb_min {
+            eprintln!("警告：子步 CFL 违约，dt = {dt:.6}，子步上界 {sb_min:.6}");
+        }
+
+        for post in &mut options.post_timestep {
+            post.post_step(t, &mut y);
+        }
+
+        if options.single_step {
+            break;
+        }
+
+        if let (Some(event), Some(y_old)) = (&options.terminal_event, &y_old) {
+            let value = event.event_value(t, &y, t_old, y_old);
+            if let Some(old) = event_old {
+                if matlab_sign(value) != matlab_sign(old) {
+                    break;
+                }
+            }
+            event_old = Some(value);
+        }
+    }
+
+    if options.stats {
+        println!("\t{steps} steps from {t0} to {t}");
+    }
+
+    CflResult { t, y, steps }
+}
+
+/// `y ← y + dt·k`。
+fn axpy(y: &ArrayD<f64>, k: &ArrayD<f64>, dt: f64) -> ArrayD<f64> {
+    let mut out = y.clone();
+    Zip::from(&mut out).and(k).for_each(|v, kk| *v += dt * kk);
+    out
+}
+
+/// 一阶时间积分（前向 Euler，`odeCFL1.m`）。
+pub fn ode_cfl1<T: Term>(
+    term: &mut T,
+    t0: f64,
+    tf: f64,
+    y0: ArrayD<f64>,
+    options: &mut CflOptions,
+) -> CflResult {
+    let mut stage = |_term: &mut dyn Term, _t: f64, y: &ArrayD<f64>, dt: f64, r1: TermRhs| {
+        (axpy(y, &r1.dphi_dt, dt), r1.step_bound)
+    };
+    cfl_integrate(term, t0, tf, y0, options, &mut stage)
+}
+
+/// 二阶 TVD Runge-Kutta（`odeCFL2.m`，Heun 型）：
+/// `y1 = y + dt·k1`；`y2 = y1 + dt·k2(t+dt, y1)`；`y ← (y + y2)/2`。
+pub fn ode_cfl2<T: Term>(
+    term: &mut T,
+    t0: f64,
+    tf: f64,
+    y0: ArrayD<f64>,
+    options: &mut CflOptions,
+) -> CflResult {
+    let mut stage = |term: &mut dyn Term, t: f64, y: &ArrayD<f64>, dt: f64, r1: TermRhs| {
+        let y1 = axpy(y, &r1.dphi_dt, dt);
+        let r2 = term.rhs(t + dt, &y1);
+        let y2 = axpy(&y1, &r2.dphi_dt, dt);
+        let mut y_new = y.clone();
+        Zip::from(&mut y_new)
+            .and(&y2)
+            .for_each(|v, v2| *v = 0.5 * (*v + *v2));
+        (y_new, r1.step_bound.min(r2.step_bound))
+    };
+    cfl_integrate(term, t0, tf, y0, options, &mut stage)
+}
+
+/// 三阶 TVD Runge-Kutta（`odeCFL3.m`，Shu-Osher 三阶段格式）。
+///
+/// 子步（`odeCFL3.m` 第 146-265 行）：
+///
+/// 1. `y1 = y + dt·k1(t, y)`；
+/// 2. `y2 = y1 + dt·k2(t + dt, y1)`；`y_half = (3y + y2)/4`；
+/// 3. `y3 = y_half + dt·k3(t + dt/2, y_half)`；`y ← (y + 2·y3)/3`。
+pub fn ode_cfl3<T: Term>(
+    term: &mut T,
+    t0: f64,
+    tf: f64,
+    y0: ArrayD<f64>,
+    options: &mut CflOptions,
+) -> CflResult {
+    let mut stage = |term: &mut dyn Term, t: f64, y: &ArrayD<f64>, dt: f64, r1: TermRhs| {
+        let y1 = axpy(y, &r1.dphi_dt, dt);
+        let r2 = term.rhs(t + dt, &y1);
+        let y2 = axpy(&y1, &r2.dphi_dt, dt);
+        // t_half = (3t + t2)/4 = t + dt/2。
+        let mut y_half = y.clone();
+        Zip::from(&mut y_half)
+            .and(&y2)
+            .for_each(|v, v2| *v = 0.25 * (3.0 * *v + *v2));
+        let r3 = term.rhs(t + 0.5 * dt, &y_half);
+        let y3 = axpy(&y_half, &r3.dphi_dt, dt);
+        let mut y_new = y.clone();
+        Zip::from(&mut y_new)
+            .and(&y3)
+            .for_each(|v, v3| *v = (*v + 2.0 * *v3) / 3.0);
+        let sb = r1.step_bound.min(r2.step_bound).min(r3.step_bound);
+        (y_new, sb)
+    };
+    cfl_integrate(term, t0, tf, y0, options, &mut stage)
+}

--- a/crates/e2m2e-levelset/src/lib.rs
+++ b/crates/e2m2e-levelset/src/lib.rs
@@ -1,0 +1,33 @@
+//! e2m2e-levelset: 水平集方法与 Hamilton-Jacobi 可达性求解器。
+//!
+//! 自 UBC Ian M. Mitchell 的 Toolbox of Level Set Methods（ToolboxLS 1.1）
+//! 移植，求解含时 Hamilton-Jacobi PDE
+//!
+//! ```text
+//! D_t φ = -H(x, t, φ, ∇φ)
+//! ```
+//!
+//! 支撑低推力轨迹的可达集、最短到达时间与追逃博弈计算。原始代码采用
+//! ACM 非商业许可，全文随附于本 crate 的 `LICENSE-ToolboxLS`。
+//!
+//! 定位与 e2m2e-propagation / e2m2e-forces 一致：纯数学 crate，不依赖
+//! SPICE、不含 Python 绑定；对外暴露经 e2m2e-integrators 按 ABI 戳流程
+//! 统一进行（见根仓库 `abi-version.txt` 机制）。
+//!
+//! 与 MATLAB 原版的范围取舍：
+//! - 网格函数统一为 `ndarray::ArrayD<f64>`，形状即各维节点数，不再像
+//!   MATLAB 版在数组与列向量之间反复 reshape；
+//! - 向量水平集（Examples/Vector，多分量 cell 数组）不移植；
+//! - 绘图与动画（Helper/Visualization 及 Examples 各 animate*）不移植，
+//!   可视化在 Python 侧完成；
+//! - MATLAB 的 1-based 维编号在本文一律为 0-based。
+
+pub mod boundary;
+pub mod derivative;
+pub mod dissipation;
+pub mod grid;
+pub mod hamiltonian;
+pub mod integrator;
+pub mod shape;
+pub mod signed_distance;
+pub mod term;

--- a/crates/e2m2e-levelset/src/shape.rs
+++ b/crates/e2m2e-levelset/src/shape.rs
@@ -1,0 +1,181 @@
+//! 隐式形状初值与集合运算：对应 ToolboxLS 的 `InitialConditions/`。
+//!
+//! 隐式表面约定：函数值在形状内部为负、外部为正，零等值面即边界；
+//! 下列基础形状的函数直接取（符号）距离。
+
+use crate::grid::Grid;
+use ndarray::ArrayD;
+
+/// 基础形状，对应 `BasicShapes/shapeSphere/Cylinder/Hyperplane/Rectangle.m`
+/// 与 `OtherShapes/shapeZalesakDisk.m`。
+pub enum Shape {
+    /// 超球（任意维）：`{x : ‖x - center‖ ≤ radius}`。
+    Sphere { center: Vec<f64>, radius: f64 },
+    /// 无限圆柱：沿 `axis` 维无界，其余维距 `center` 不超过 `radius`。
+    Cylinder {
+        center: Vec<f64>,
+        radius: f64,
+        axis: usize,
+    },
+    /// 半空间：`{x : (x - point) · normal ≤ 0}`。
+    Hyperplane { point: Vec<f64>, normal: Vec<f64> },
+    /// 轴对齐盒子（二维为矩形）。
+    Box { lower: Vec<f64>, upper: Vec<f64> },
+    /// Zalesak 缺口圆盘（`shapeZalesakDisk.m`），重初始化精度的标准算例。
+    /// 缺口沿最后一维朝负方向。
+    ZalesakDisk {
+        center: Vec<f64>,
+        radius: f64,
+        /// 缺口宽度。
+        width: f64,
+        /// 缺口自圆心向外延伸的长度。
+        height: f64,
+    },
+}
+
+impl Shape {
+    /// 在网格节点上生成隐式表面函数（内部为负、外部为正）。
+    pub fn implicit(&self, grid: &Grid) -> ArrayD<f64> {
+        let dim = grid.dim();
+        let center_of = |c: &[f64]| -> Vec<f64> { c.to_vec() };
+        match self {
+            Shape::Sphere { center, radius } => {
+                let c = center_of(center);
+                assert_eq!(c.len(), dim, "球心维数必须等于网格维度");
+                ArrayD::from_shape_fn(grid.shape(), |idx| {
+                    let d2: f64 = (0..dim)
+                        .map(|i| {
+                            let x = grid.axis(i)[idx[i]] - c[i];
+                            x * x
+                        })
+                        .sum();
+                    d2.sqrt() - radius
+                })
+            }
+            Shape::Cylinder {
+                center,
+                radius,
+                axis,
+            } => {
+                let c = center_of(center);
+                assert!(*axis < dim, "圆柱轴向越界");
+                ArrayD::from_shape_fn(grid.shape(), |idx| {
+                    let d2: f64 = (0..dim)
+                        .filter(|i| *i != *axis)
+                        .map(|i| {
+                            let x = grid.axis(i)[idx[i]] - c[i];
+                            x * x
+                        })
+                        .sum();
+                    d2.sqrt() - radius
+                })
+            }
+            Shape::Hyperplane { point, normal } => {
+                let (p, mut n) = (center_of(point), center_of(normal));
+                assert_eq!(n.len(), dim, "法向维数必须等于网格维度");
+                let norm = n.iter().map(|v| v * v).sum::<f64>().sqrt();
+                for v in &mut n {
+                    *v /= norm;
+                }
+                ArrayD::from_shape_fn(grid.shape(), |idx| {
+                    (0..dim).map(|i| n[i] * (grid.axis(i)[idx[i]] - p[i])).sum()
+                })
+            }
+            Shape::Box { lower, upper } => {
+                let (lo, hi) = (center_of(lower), center_of(upper));
+                assert_eq!(lo.len(), dim);
+                ArrayD::from_shape_fn(grid.shape(), |idx| {
+                    (0..dim)
+                        .map(|i| {
+                            let x = grid.axis(i)[idx[i]];
+                            (x - hi[i]).max(lo[i] - x)
+                        })
+                        .fold(f64::NEG_INFINITY, |m, v| m.max(v))
+                })
+            }
+            Shape::ZalesakDisk {
+                center,
+                radius,
+                width,
+                height,
+            } => {
+                // 圆盘减去竖直缺口矩形（shapeZalesakDisk.m 第 50-84 行）：
+                // 缺口中心沿最后一维下移 -r + 0.5*slot_length，
+                // 宽度 [slot_width, 2r × (dim-2), slot_length]。
+                let c = center_of(center);
+                let mut slot_center = c.clone();
+                slot_center[dim - 1] += -radius + 0.5 * height;
+                let mut widths = vec![*width; dim];
+                for w in widths.iter_mut().take(dim).skip(1) {
+                    *w = 2.0 * radius;
+                }
+                widths[dim - 1] = *height;
+                let lower: Vec<f64> = slot_center
+                    .iter()
+                    .zip(&widths)
+                    .map(|(a, w)| a - w / 2.0)
+                    .collect();
+                let upper: Vec<f64> = slot_center
+                    .iter()
+                    .zip(&widths)
+                    .map(|(a, w)| a + w / 2.0)
+                    .collect();
+                let circle = Shape::Sphere {
+                    center: c,
+                    radius: *radius,
+                }
+                .implicit(grid);
+                let slot = Shape::Box { lower, upper }.implicit(grid);
+                shape_difference(&circle, &slot)
+            }
+        }
+    }
+}
+
+/// 并集（`shapeUnion.m`）：`min(a, b)`。
+pub fn shape_union(a: &ArrayD<f64>, b: &ArrayD<f64>) -> ArrayD<f64> {
+    combine(a, b, |x, y| x.min(y))
+}
+
+/// 交集（`shapeIntersection.m`）：`max(a, b)`。
+pub fn shape_intersection(a: &ArrayD<f64>, b: &ArrayD<f64>) -> ArrayD<f64> {
+    combine(a, b, |x, y| x.max(y))
+}
+
+/// 差集 A \ B（`shapeDifference.m`）：`max(a, -b)`。
+pub fn shape_difference(a: &ArrayD<f64>, b: &ArrayD<f64>) -> ArrayD<f64> {
+    combine(a, b, |x, y| x.max(-y))
+}
+
+/// 补集（`shapeComplement.m`）：`-a`。
+pub fn shape_complement(a: &ArrayD<f64>) -> ArrayD<f64> {
+    let data = a.iter().map(|x| -x).collect::<Vec<f64>>();
+    ArrayD::from_shape_vec(a.raw_dim(), data).expect("形状不变，不会失败")
+}
+
+fn combine(a: &ArrayD<f64>, b: &ArrayD<f64>, f: impl Fn(f64, f64) -> f64) -> ArrayD<f64> {
+    assert_eq!(a.shape(), b.shape(), "集合运算要求两隐式函数同形");
+    let data = a
+        .iter()
+        .zip(b.iter())
+        .map(|(x, y)| f(*x, *y))
+        .collect::<Vec<f64>>();
+    ArrayD::from_shape_vec(a.raw_dim(), data).expect("形状不变，不会失败")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn 集合运算的组合语义() {
+        let a = ArrayD::from_shape_vec(vec![2], vec![-1.0, 2.0]).unwrap();
+        let b = ArrayD::from_shape_vec(vec![2], vec![3.0, -0.5]).unwrap();
+        let to_vec = |x: &ArrayD<f64>| x.iter().cloned().collect::<Vec<f64>>();
+        // 隐式函数内负外正：并集取 min、交集取 max、差集取 max(a, -b)
+        assert_eq!(to_vec(&shape_union(&a, &b)), vec![-1.0, -0.5]);
+        assert_eq!(to_vec(&shape_intersection(&a, &b)), vec![3.0, 2.0]);
+        assert_eq!(to_vec(&shape_difference(&a, &b)), vec![-1.0, 2.0]);
+        assert_eq!(to_vec(&shape_complement(&a)), vec![1.0, -2.0]);
+    }
+}

--- a/crates/e2m2e-levelset/src/signed_distance.rs
+++ b/crates/e2m2e-levelset/src/signed_distance.rs
@@ -1,0 +1,158 @@
+//! 迭代法符号距离函数：对应 ToolboxLS 的
+//! `Helper/SignedDistance/signedDistanceIterative.m`。
+//!
+//! 通过迭代求解重初始化方程，把隐式表面函数转换为符号距离函数。信息
+//! 从零等值面以单位速度向外传播，要得到至少 `k` 个网格宽度的有效带，
+//! `t_max` 至少取 `k * max(dx)`。
+
+use crate::derivative::{
+    UpwindDerivative, UpwindFirstENO2, UpwindFirstENO3, UpwindFirstFirst, UpwindFirstWENO5,
+};
+use crate::grid::Grid;
+use crate::integrator::{ode_cfl1, ode_cfl2, ode_cfl3, CflOptions, CflResult};
+use crate::term::ReinitTerm;
+use ndarray::{ArrayD, Zip};
+
+/// 精度档位（`signedDistanceIterative.m` 第 23-26 行）：
+/// 积分器与导数格式的组合。
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ReinitAccuracy {
+    /// odeCFL1 + upwindFirstFirst。
+    Low,
+    /// odeCFL2 + upwindFirstENO2（默认）。
+    Medium,
+    /// odeCFL3 + upwindFirstENO3。
+    High,
+    /// odeCFL3 + upwindFirstWENO5。
+    VeryHigh,
+}
+
+impl ReinitAccuracy {
+    /// 组装该档位对应的（积分器代号, 导数格式）。
+    fn parts(self) -> (u8, Box<dyn UpwindDerivative>) {
+        match self {
+            ReinitAccuracy::Low => (1, Box::new(UpwindFirstFirst)),
+            ReinitAccuracy::Medium => (2, Box::new(UpwindFirstENO2)),
+            ReinitAccuracy::High => (3, Box::new(UpwindFirstENO3)),
+            ReinitAccuracy::VeryHigh => (3, Box::new(UpwindFirstWENO5)),
+        }
+    }
+}
+
+/// 重初始化选项，默认值对应 `signedDistanceIterative.m` 第 27-35 行。
+#[derive(Clone, Debug)]
+pub struct SignedDistanceOptions {
+    pub accuracy: ReinitAccuracy,
+    /// 迭代终止时间（默认域对角线 `max(grid.max - grid.min)`）。
+    pub t_max: Option<f64>,
+    /// 固定重初始化步数（对应 MATLAB `tMax < 0` 时的 `-round(tMax)`
+    /// 语义）；设置后忽略 `t_max`。
+    pub t_max_steps: Option<usize>,
+    /// 单步平均更新量低于 `error_max * max(dx)` 时提前收敛（默认 1e-3）。
+    pub error_max: f64,
+}
+
+impl Default for SignedDistanceOptions {
+    fn default() -> Self {
+        SignedDistanceOptions {
+            accuracy: ReinitAccuracy::Medium,
+            t_max: None,
+            t_max_steps: None,
+            error_max: 1e-3,
+        }
+    }
+}
+
+/// 走一个单步（三个积分器共用入口）。
+fn single_step(
+    integrator: u8,
+    term: &mut ReinitTerm,
+    t_now: f64,
+    t_max: f64,
+    y: ArrayD<f64>,
+    options: &mut CflOptions,
+) -> CflResult {
+    match integrator {
+        1 => ode_cfl1(term, t_now, t_max, y, options),
+        2 => ode_cfl2(term, t_now, t_max, y, options),
+        _ => ode_cfl3(term, t_now, t_max, y, options),
+    }
+}
+
+/// 把隐式表面函数 `phi0` 转换为符号距离函数。
+///
+/// 与 MATLAB 版一致：CFL 系数 0.95，单步推进 + 步间收敛检查（与上一步
+/// 起点的 1 范数更新量低于 `error_max * max(dx) * 节点数` 即停）；
+/// `initial` 固定为原始 `phi0`，不随迭代更新。
+pub fn signed_distance_iterative(
+    grid: &Grid,
+    phi0: &ArrayD<f64>,
+    options: &SignedDistanceOptions,
+) -> ArrayD<f64> {
+    grid.check_data(phi0);
+    let (integrator, deriv) = options.accuracy.parts();
+    let mut term = ReinitTerm {
+        grid: grid.clone(),
+        deriv,
+        initial: phi0.clone(),
+        subcell_fix: true,
+    };
+    let small = 100.0 * f64::EPSILON;
+    let max_dx = grid.dx().iter().fold(0.0f64, |m, v| m.max(*v));
+    // 收敛判据见 `signedDistanceIterative.m` 第 124、149 行：
+    // norm(y - y_step_start, 1) < error_max * max(dx) * prod(N)。
+    let delta_max = options.error_max * max_dx * grid.size() as f64;
+    let mut single = CflOptions {
+        factor_cfl: 0.95,
+        single_step: true,
+        ..Default::default()
+    };
+
+    match options.t_max_steps {
+        // 固定步数模式：走指定步数，不做收敛检查。
+        Some(steps) => {
+            let mut y = phi0.clone();
+            let mut t_now = 0.0f64;
+            for _ in 0..steps {
+                let r = single_step(integrator, &mut term, t_now, f64::INFINITY, y, &mut single);
+                y = r.y;
+                t_now = r.t;
+            }
+            y
+        }
+        None => {
+            let t_max = options.t_max.unwrap_or_else(|| {
+                grid.max()
+                    .iter()
+                    .zip(grid.min())
+                    .map(|(a, b)| a - b)
+                    .fold(0.0f64, |m, v| m.max(v))
+            });
+            let mut y = phi0.clone();
+            let mut y_step_start = phi0.clone();
+            let mut t_now = 0.0f64;
+            while t_max - t_now >= small * t_max {
+                if t_now > 0.0 {
+                    let l1 = Zip::from(&y)
+                        .and(&y_step_start)
+                        .fold(0.0, |acc, a, b| acc + (a - b).abs());
+                    if l1 < delta_max {
+                        break;
+                    }
+                }
+                y_step_start = y.clone();
+                let r = single_step(
+                    integrator,
+                    &mut term,
+                    t_now,
+                    t_max,
+                    y_step_start.clone(),
+                    &mut single,
+                );
+                y = r.y;
+                t_now = r.t;
+            }
+            y
+        }
+    }
+}

--- a/crates/e2m2e-levelset/src/term.rs
+++ b/crates/e2m2e-levelset/src/term.rs
@@ -1,0 +1,426 @@
+//! HJ PDE 的时间项：对应 ToolboxLS 的 `ExplicitIntegration/Term/`。
+//!
+//! MATLAB 原型（`odeCFL3.m` 第 26-33 行）：
+//!
+//! ```matlab
+//! [ydot, stepBound, schemeData] = schemeFunc(t, y, schemeData)
+//! ```
+//!
+//! 其中 `schemeData` 是弱类型参数包。Rust 里每个项是一个结构体，
+//! MATLAB `schemeData` 的必备字段成为结构体字段，用户自由附加的参数
+//! 放进 [`crate::hamiltonian::Hamiltonian`] 的实现里。
+//!
+//! 与 MATLAB 版的取舍：向量水平集（`termLaxFriedrichs.m` 第 74-79 行
+//! 仅取第一个分量的扩展）不移植，所有项只处理单个网格函数。
+
+use crate::boundary::matlab_sign;
+use crate::derivative::UpwindDerivative;
+use crate::dissipation::Dissipation;
+use crate::grid::Grid;
+use crate::hamiltonian::Hamiltonian;
+use ndarray::{ArrayD, Zip};
+
+/// 一个时间步的右端项求值结果。
+pub struct TermRhs {
+    /// `D_t φ`，形状与网格相同。
+    pub dphi_dt: ArrayD<f64>,
+    /// CFL 步长上界，实际步长由积分器乘以 `factor_cfl` 决定。
+    pub step_bound: f64,
+}
+
+/// CFL 约束的时间项，即方法线（method of lines）后的 ODE 右端。
+pub trait Term {
+    fn rhs(&mut self, t: f64, phi: &ArrayD<f64>) -> TermRhs;
+}
+
+/// 一般哈密顿量项（`termLaxFriedrichs.m`），求解
+/// `D_t φ = -H(x, t, φ, ∇φ)`。
+///
+/// MATLAB `schemeData` 必备字段（第 31-49 行）与本体字段的对应：
+/// `.grid → grid`，`.derivFunc → deriv`，`.dissFunc → dissipation`，
+/// `.hamFunc/.partialFunc → hamiltonian`（两个回调合并为一个 trait）。
+///
+/// 更新公式（第 176-182 行）：`dphi_dt = -(ham(derivC) - diss)`。
+pub struct LaxFriedrichsTerm<D, P, S> {
+    pub grid: Grid,
+    pub hamiltonian: D,
+    pub deriv: P,
+    pub dissipation: S,
+}
+
+impl<D, P, S> LaxFriedrichsTerm<D, P, S>
+where
+    D: Hamiltonian,
+    P: UpwindDerivative,
+    S: Dissipation,
+{
+    pub fn new(grid: Grid, hamiltonian: D, deriv: P, dissipation: S) -> Self {
+        Self {
+            grid,
+            hamiltonian,
+            deriv,
+            dissipation,
+        }
+    }
+}
+
+impl<D, P, S> Term for LaxFriedrichsTerm<D, P, S>
+where
+    D: Hamiltonian,
+    P: UpwindDerivative,
+    S: Dissipation,
+{
+    fn rhs(&mut self, t: f64, phi: &ArrayD<f64>) -> TermRhs {
+        self.grid.check_data(phi);
+        let dim = self.grid.dim();
+        let mut deriv_l = Vec::with_capacity(dim);
+        let mut deriv_r = Vec::with_capacity(dim);
+        let mut deriv_c = Vec::with_capacity(dim);
+        for i in 0..dim {
+            let (l, r) = self.deriv.deriv(&self.grid, phi, i);
+            deriv_c.push(0.5 * (&l + &r));
+            deriv_l.push(l);
+            deriv_r.push(r);
+        }
+        let ham = self.hamiltonian.hamiltonian(t, &self.grid, phi, &deriv_c);
+        let (diss, step_bound) =
+            self.dissipation
+                .dissipation(t, &self.grid, phi, &deriv_l, &deriv_r, &self.hamiltonian);
+        let mut dphi_dt = ArrayD::zeros(self.grid.shape());
+        Zip::from(&mut dphi_dt)
+            .and(&ham)
+            .and(&diss)
+            .for_each(|o, h, d| *o = -(h - d));
+        TermRhs {
+            dphi_dt,
+            step_bound,
+        }
+    }
+}
+
+/// 法向速度项（`termNormal.m`），求解
+/// `D_t φ + a(x,t) ‖∇φ‖ = 0`（O&F 第 6.2 节的 Godunov 格式）。
+pub struct NormalTerm {
+    pub grid: Grid,
+    pub deriv: Box<dyn UpwindDerivative>,
+    pub speed: NormalSpeed,
+}
+
+/// 动态法向速度回调：`a = f(t, grid, phi)`，形状与网格相同。
+pub type SpeedFn = Box<dyn Fn(f64, &Grid, &ArrayD<f64>) -> ArrayD<f64> + Send + Sync>;
+
+/// 法向速度 `a(x,t)`，对应 `schemeData.speed` 的三种给法
+/// （`termNormal.m` 第 35-43 行）：常数、网格函数或回调。
+pub enum NormalSpeed {
+    Constant(f64),
+    /// 与网格同形的速度场。
+    Grid(ArrayD<f64>),
+    Dynamic(SpeedFn),
+}
+
+impl NormalTerm {
+    /// 解析当前时刻的速度场（常数广播为数组），返回 (速度场, max|a|)。
+    fn resolve_speed(&self, t: f64, phi: &ArrayD<f64>) -> (ArrayD<f64>, f64) {
+        match &self.speed {
+            NormalSpeed::Constant(c) => (ArrayD::from_elem(self.grid.shape(), *c), c.abs()),
+            NormalSpeed::Grid(a) => {
+                self.grid.check_data(a);
+                let m = a.iter().fold(0.0f64, |m, v| m.max(v.abs()));
+                (a.clone(), m)
+            }
+            NormalSpeed::Dynamic(f) => {
+                let a = f(t, &self.grid, phi);
+                self.grid.check_data(&a);
+                let m = a.iter().fold(0.0f64, |m, v| m.max(v.abs()));
+                (a, m)
+            }
+        }
+    }
+}
+
+impl Term for NormalTerm {
+    fn rhs(&mut self, t: f64, phi: &ArrayD<f64>) -> TermRhs {
+        self.grid.check_data(phi);
+        let (speed, _) = self.resolve_speed(t, phi);
+        let mut magnitude: ArrayD<f64> = ArrayD::zeros(self.grid.shape());
+        // 逐节点累计的 CFL 倒数（termNormal.m 第 143、173-175 行）。
+        let mut step_bound_inv: ArrayD<f64> = ArrayD::zeros(self.grid.shape());
+        for i in 0..self.grid.dim() {
+            let (deriv_l, deriv_r) = self.deriv.deriv(&self.grid, phi, i);
+            let dx_inv = 1.0 / self.grid.dx()[i];
+            Zip::from(&mut magnitude)
+                .and(&mut step_bound_inv)
+                .and(&speed)
+                .and(&deriv_l)
+                .and(&deriv_r)
+                .for_each(|mag, sbi, a, l, r| {
+                    // Godunov 通量的特征方向判定（termNormal.m 第 160-163 行）。
+                    let (pl, pr) = (a * l, a * r);
+                    let (ml, mr) = (pl.abs(), pr.abs());
+                    let flow_l = (pl >= 0.0 && pr >= 0.0) || (pl >= 0.0 && pr <= 0.0 && ml >= mr);
+                    let flow_r = (pl <= 0.0 && pr <= 0.0) || (pl >= 0.0 && pr <= 0.0 && ml < mr);
+                    // flowL / flowR 互斥（发散特征两者皆假，梯度贡献为 0）。
+                    if flow_l {
+                        *mag += l * l;
+                        *sbi += ml * dx_inv;
+                    }
+                    if flow_r {
+                        *mag += r * r;
+                        *sbi += mr * dx_inv;
+                    }
+                });
+        }
+        magnitude.mapv_inplace(|v: f64| v.sqrt());
+        let mut dphi_dt = ArrayD::zeros(self.grid.shape());
+        let mut worst_inv = 0.0f64;
+        Zip::from(&mut dphi_dt)
+            .and(&speed)
+            .and(&magnitude)
+            .and(&step_bound_inv)
+            .for_each(|d, a, m, inv| {
+                *d = -(a * m);
+                if *m > 0.0 {
+                    worst_inv = worst_inv.max(inv / m);
+                }
+            });
+        TermRhs {
+            dphi_dt,
+            step_bound: 1.0 / worst_inv,
+        }
+    }
+}
+
+/// 重初始化项（`termReinit.m`），求解
+/// `D_t φ = -sign(φ₀) (‖∇φ‖ - 1)`（Godunov 格式，Sussman-Smereka-Osher
+/// 1994），把隐式表面函数修复为符号距离函数。亚网格修正采用 Russo &
+/// Smereka (JCP 2000) 的鲁棒变体（源码第 114-120 行的 robust_subcell）。
+pub struct ReinitTerm {
+    pub grid: Grid,
+    pub deriv: Box<dyn UpwindDerivative>,
+    /// 冻结的初值 φ₀（对应 `schemeData.initial`）。
+    pub initial: ArrayD<f64>,
+    /// Russo-Smereka 亚网格修正开关（`schemeData.subcell_fix_order`，
+    /// 0 关闭 / 1 开启，默认开启）。
+    pub subcell_fix: bool,
+}
+
+impl ReinitTerm {
+    /// 节点是否在零等值面附近（`isNearInterface.m`，非严格比较：相邻
+    /// 节点符号不同即双方都算近）。
+    fn near_interface(&self) -> ArrayD<bool> {
+        let init = |idx: &ndarray::IxDyn| -> f64 { self.initial[idx.clone()] };
+        let mut near =
+            ArrayD::from_shape_fn(self.grid.shape(), |idx| matlab_sign(init(&idx)) == 0.0);
+        for d in 0..self.grid.dim() {
+            let n = self.grid.n()[d];
+            // 相邻对 (j, j+1) 符号不同则两者都标近。
+            let mut pairs = Vec::new();
+            for (idx, _) in near.indexed_iter() {
+                if idx[d] + 1 < n {
+                    let mut j = idx.clone();
+                    j[d] += 1;
+                    let (s0, s1) = (matlab_sign(init(&idx)), matlab_sign(init(&j)));
+                    if s0 != s1 {
+                        pairs.push((idx.clone(), j));
+                    }
+                }
+            }
+            for (a, b) in pairs {
+                near[a.clone()] = true;
+                near[b] = true;
+            }
+        }
+        near
+    }
+
+    /// Russo-Smereka 亚网格距离 D（`termReinit.m` 第 268-308 行的鲁棒版）。
+    fn subcell_distance(&self) -> ArrayD<f64> {
+        let shape = self.grid.shape();
+        let mut denom = ArrayD::zeros(shape.clone());
+        let robust_eps = 1e6 * f64::EPSILON;
+        let init = |idx: &ndarray::IxDyn| -> f64 { self.initial[idx.clone()] };
+        for d in 0..self.grid.dim() {
+            let n = self.grid.n()[d];
+            let dx_inv = 1.0 / self.grid.dx()[d];
+            // 长差分：相邻半节点中心差分的平方；末节点置零。
+            let mut diff2 = ArrayD::from_shape_fn(shape.clone(), |idx| {
+                let j = idx[d];
+                if j + 1 < n {
+                    let mut k = idx.clone();
+                    k[d] = j + 1;
+                    let half = 0.5 * dx_inv * (init(&k) - init(&idx));
+                    half * half
+                } else {
+                    0.0
+                }
+            });
+            // 短差分（整节点间距）的平方与长差分取 max，写入左右两个节点
+            // 位置，并抬底 robust_eps²（源码第 283-294 行）。先收集再写，
+            // 避免在同一数组上边读边写。
+            let mut updates: Vec<(ndarray::IxDyn, f64)> = Vec::new();
+            for (idx, v) in diff2.indexed_iter() {
+                let j = idx[d];
+                if j + 1 >= n {
+                    updates.push((idx.clone(), (*v).max(robust_eps * robust_eps)));
+                    continue;
+                }
+                let mut k = idx.clone();
+                k[d] = j + 1;
+                let short = dx_inv * (init(&k) - init(&idx));
+                let s2 = short * short;
+                updates.push((idx.clone(), (*v).max(s2)));
+                let cur_right = diff2[k.clone()];
+                updates.push((k, cur_right.max(s2)));
+            }
+            for (idx, v) in updates {
+                diff2[idx] = v.max(robust_eps * robust_eps);
+            }
+            denom = &denom + &diff2;
+        }
+        denom.mapv_inplace(|v: f64| v.sqrt());
+        &self.initial / &denom
+    }
+}
+
+impl Term for ReinitTerm {
+    fn rhs(&mut self, _t: f64, phi: &ArrayD<f64>) -> TermRhs {
+        self.grid.check_data(phi);
+        let dim = self.grid.dim();
+        // 符号函数：开启亚网格修正时用纯 sign（远离界面无需平滑），
+        // 否则用平滑近似 smearedSign = φ/sqrt(φ² + max(dx)²)（O&F 7.5）。
+        let s: ArrayD<f64> = if self.subcell_fix {
+            self.initial.mapv(matlab_sign)
+        } else {
+            let sgn_factor = self.grid.dx().iter().fold(0.0f64, |m, v| m.max(*v)).powi(2);
+            self.initial.mapv(|v| v / (v * v + sgn_factor).sqrt())
+        };
+
+        // 逐维 Godunov 导数（termReinit.m 第 184-216 行）。
+        let mut derivs = Vec::with_capacity(dim);
+        let mut step_bound_inv = 0.0f64;
+        for i in 0..dim {
+            let (deriv_l, deriv_r) = self.deriv.deriv(&self.grid, phi, i);
+            let mut deriv = ArrayD::zeros(self.grid.shape());
+            Zip::from(&mut deriv)
+                .and(&s)
+                .and(&deriv_l)
+                .and(&deriv_r)
+                .for_each(|d, s, l, r| {
+                    let (sl, sr) = (s * l, s * r);
+                    let mut flow_l = sr <= 0.0 && sl <= 0.0;
+                    let mut flow_r = sr >= 0.0 && sl >= 0.0;
+                    // 收敛特征：比较两侧到达时间（第 201-212 行）。
+                    if sr < 0.0 && sl > 0.0 {
+                        let denom = r - l;
+                        let t = s * (r.abs() - l.abs()) / denom;
+                        flow_l |= t < 0.0;
+                        flow_r |= t >= 0.0;
+                    }
+                    // 注意交叉：向右流动取左差分，向左流动取右差分。
+                    *d = l * (flow_r as u8 as f64) + r * (flow_l as u8 as f64);
+                });
+            derivs.push(deriv);
+        }
+        // 梯度模与有效速度（第 220-243 行）。
+        let mut mag = ArrayD::zeros(self.grid.shape());
+        for d in &derivs {
+            Zip::from(&mut mag).and(d).for_each(|m, v| *m += v * v);
+        }
+        mag.mapv_inplace(|v: f64| v.sqrt().max(f64::EPSILON));
+        let mut delta = s.mapv(|v| -v);
+        for (i, d) in derivs.iter().enumerate() {
+            Zip::from(&mut delta)
+                .and(&s)
+                .and(d)
+                .and(&mag)
+                .for_each(|del, s, dv, m| {
+                    let v = s * dv / m;
+                    *del += v * dv;
+                });
+            // 有效速度的 CFL 约束。
+            let v_field = Zip::from(&s)
+                .and(d)
+                .and(&mag)
+                .map_collect(|s, dv, m| s * dv / m);
+            let v_max = v_field.iter().fold(0.0f64, |m, v| m.max(v.abs()));
+            step_bound_inv += v_max / self.grid.dx()[i];
+        }
+
+        // 亚网格修正（第 246-330 行）。
+        if self.subcell_fix {
+            let d_sub = self.subcell_distance();
+            let near = self.near_interface();
+            let max_dx = self.grid.dx().iter().fold(0.0f64, |m, v| m.max(*v));
+            Zip::from(&mut delta)
+                .and(&s)
+                .and(phi)
+                .and(&d_sub)
+                .and(&near)
+                .for_each(|del, s, cur, dist, near| {
+                    if *near {
+                        *del = (s * cur.abs() - dist) / max_dx;
+                    }
+                });
+        }
+
+        // MATLAB 末行 `ydot = -delta(:)`：组装的是 δ，右端项取负。
+        delta.mapv_inplace(|v: f64| -v);
+        TermRhs {
+            dphi_dt: delta,
+            step_bound: 1.0 / step_bound_inv,
+        }
+    }
+}
+
+/// 项之和（`termSum.m`）：`dphi_dt` 逐项相加，步长上界取调和组合
+/// `1 / Σ(1/step_bound_i)`。
+pub struct SumTerm(pub Vec<Box<dyn Term>>);
+
+impl Term for SumTerm {
+    fn rhs(&mut self, t: f64, phi: &ArrayD<f64>) -> TermRhs {
+        assert!(!self.0.is_empty(), "SumTerm 至少要包含一个项");
+        let mut sum = None;
+        let mut step_bound_inv = 0.0f64;
+        for term in &mut self.0 {
+            let r = term.rhs(t, phi);
+            step_bound_inv += 1.0 / r.step_bound;
+            sum = Some(match sum {
+                None => r.dphi_dt,
+                Some(mut acc) => {
+                    Zip::from(&mut acc)
+                        .and(&r.dphi_dt)
+                        .for_each(|a: &mut f64, b: &f64| *a += b);
+                    acc
+                }
+            });
+        }
+        TermRhs {
+            dphi_dt: sum.expect("非空"),
+            step_bound: if step_bound_inv == 0.0 {
+                f64::INFINITY
+            } else {
+                1.0 / step_bound_inv
+            },
+        }
+    }
+}
+
+/// 更新限制项（`termRestrictUpdate.m`）：把内层项的更新钳制为非负
+/// （`positive = true`，可达集只增长的常用设置）或非正，使积分单调。
+pub struct RestrictUpdateTerm {
+    pub inner: Box<dyn Term>,
+    /// true 时更新钳为 ≥ 0，false 时钳为 ≤ 0（MATLAB 默认 true）。
+    pub positive: bool,
+}
+
+impl Term for RestrictUpdateTerm {
+    fn rhs(&mut self, t: f64, phi: &ArrayD<f64>) -> TermRhs {
+        let mut r = self.inner.rhs(t, phi);
+        if self.positive {
+            r.dphi_dt.mapv_inplace(|v| v.max(0.0));
+        } else {
+            r.dphi_dt.mapv_inplace(|v| v.min(0.0));
+        }
+        r
+    }
+}

--- a/crates/e2m2e-levelset/tests/burgers.rs
+++ b/crates/e2m2e-levelset/tests/burgers.rs
@@ -1,0 +1,74 @@
+//! 阶段 2 验证：Burgers 方程（对应 `Examples/OsherShu/burgersLF.m`）。
+//!
+//! `φ_t + (φ_x)²/2 = 0`，周期域初值 φ₀ = -cos x。激波形成时刻 t = 1，
+//! 在 t = 0.5（光滑解阶段）用 Hopf–Lax 公式构造精确解逐点对比：
+//! `φ(x,t) = min_ξ { (x−ξ)²/(2t) + φ₀(ξ) }`，最小值点满足足点方程
+//! `x = ξ + t·φ₀'(ξ)`（t·max|φ₀''| < 1 时单调，二分求 ξ）。
+
+mod common;
+
+use common::Burgers1d;
+use e2m2e_levelset::derivative::UpwindFirstENO2;
+use e2m2e_levelset::dissipation::ArtificialDissipationGLF;
+use e2m2e_levelset::grid::Grid;
+use e2m2e_levelset::integrator::{ode_cfl2, CflOptions};
+use e2m2e_levelset::term::LaxFriedrichsTerm;
+
+fn burgers_error(n: usize, t_end: f64) -> f64 {
+    let grid = Grid::new(&[0.0], &[2.0 * std::f64::consts::PI], &[n]);
+    let phi0 =
+        ndarray::Array1::from(grid.axis(0).iter().map(|x| -x.cos()).collect::<Vec<_>>()).into_dyn();
+
+    let mut options = CflOptions::default();
+    let mut term = LaxFriedrichsTerm::new(
+        grid.clone(),
+        Burgers1d,
+        UpwindFirstENO2,
+        ArtificialDissipationGLF,
+    );
+    let result = ode_cfl2(&mut term, 0.0, t_end, phi0.clone(), &mut options);
+
+    // 特征线精确解：g(ξ) = ξ + t·sin ξ - x = 0 在 [0, 2π) 上二分。
+    let mut worst = 0.0f64;
+    for (i, x) in grid.axis(0).iter().enumerate() {
+        let g = |xi: f64| xi + t_end * xi.sin() - x;
+        let (mut lo, mut hi) = (-0.5f64, 2.0 * std::f64::consts::PI + 0.5);
+        for _ in 0..80 {
+            let mid = 0.5 * (lo + hi);
+            if g(mid) < 0.0 {
+                lo = mid;
+            } else {
+                hi = mid;
+            }
+        }
+        let xi = 0.5 * (lo + hi);
+        // Hopf–Lax：φ = (x−ξ)²/(2t) + φ₀(ξ)，其中 (x−ξ)/t = φ₀'(ξ)。
+        let exact = (x - xi).powi(2) / (2.0 * t_end) - xi.cos();
+        worst = worst.max((result.y[i] - exact).abs());
+    }
+    worst
+}
+
+#[test]
+fn burgers_光滑解特征线对比() {
+    let err = burgers_error(401, 0.5);
+    assert!(err < 0.02, "L∞ 误差 {err:.4e}（ENO2 + GLF，N=401）");
+}
+
+#[test]
+fn burgers_网格加密收敛() {
+    let coarse = burgers_error(101, 0.5);
+    let fine = burgers_error(201, 0.5);
+    assert!(
+        fine < coarse * 0.75,
+        "加密网格误差应下降：{coarse:.4e} → {fine:.4e}"
+    );
+}
+
+#[test]
+fn burgers_激波后解有界() {
+    // t = 1.5 > 激波时刻，格式应保持 L∞ 稳定（TVD）。
+    let err = burgers_error(201, 1.5);
+    // 与解析解（含多值截断）不做逐点对比，只确认解保持在 [−1, 1] 量级。
+    assert!(err < 1.5, "t > 激波时刻解应保持有界（误差 {err:.3e}）");
+}

--- a/crates/e2m2e-levelset/tests/common/mod.rs
+++ b/crates/e2m2e-levelset/tests/common/mod.rs
@@ -1,0 +1,95 @@
+// 各测试二进制按需包含本模块，未用到的部分不算死代码。
+#![allow(dead_code)]
+
+//! 各集成测试共用的哈密顿量实现与解析解（对应 MATLAB 示例中的
+//! hamFunc / partialFunc 子函数）。平流哈密顿量直接复用 crate 的
+//! [`e2m2e_levelset::hamiltonian::Advection`]。
+
+use e2m2e_levelset::grid::Grid;
+use e2m2e_levelset::hamiltonian::Hamiltonian;
+use ndarray::{ArrayD, Zip};
+
+/// 一维无粘 Burgers `H = p²/2`（OsherShu burgersLF 的哈密顿量）。
+pub struct Burgers1d;
+
+impl Hamiltonian for Burgers1d {
+    fn hamiltonian(
+        &self,
+        _t: f64,
+        _grid: &Grid,
+        _phi: &ArrayD<f64>,
+        p: &[ArrayD<f64>],
+    ) -> ArrayD<f64> {
+        0.5 * &(&p[0] * &p[0])
+    }
+
+    fn partial_bound(
+        &self,
+        _t: f64,
+        _grid: &Grid,
+        _phi: &ArrayD<f64>,
+        p_min: &[ArrayD<f64>],
+        p_max: &[ArrayD<f64>],
+        dim: usize,
+    ) -> ArrayD<f64> {
+        assert_eq!(dim, 0, "一维 Burgers 只有第 0 维");
+        // ∂H/∂p = p，在 [p_min, p_max] 上的极值为两端绝对值的最大者。
+        let lo = p_min[0].mapv(f64::abs);
+        let hi = p_max[0].mapv(f64::abs);
+        Zip::from(&lo).and(&hi).map_collect(|a, b| (*a).max(*b))
+    }
+}
+
+/// 双积分器（doubleIntegratorTTR.m 第 356-384 行）：
+/// `H = -(x₂·p₁ - inputBound·|p₂|)`。
+pub struct DoubleIntegrator {
+    pub input_bound: f64,
+}
+
+impl Hamiltonian for DoubleIntegrator {
+    fn hamiltonian(
+        &self,
+        _t: f64,
+        grid: &Grid,
+        _phi: &ArrayD<f64>,
+        p: &[ArrayD<f64>],
+    ) -> ArrayD<f64> {
+        // x₂ 场：各节点第 1 维坐标。
+        // hamValue = -(x₂·p₁ - a·|p₂|) = -x₂·p₁ + a·|p₂|
+        // （doubleIntegratorTTR.m 第 383-384 行）。
+        let x2 = ArrayD::from_shape_fn(grid.shape(), |idx| grid.axis(1)[idx[1]]);
+        Zip::from(&x2).and(&p[0]).map_collect(|v, p1| -(v * p1))
+            + self.input_bound * &p[1].mapv(f64::abs)
+    }
+
+    fn partial_bound(
+        &self,
+        _t: f64,
+        grid: &Grid,
+        _phi: &ArrayD<f64>,
+        _p_min: &[ArrayD<f64>],
+        _p_max: &[ArrayD<f64>],
+        dim: usize,
+    ) -> ArrayD<f64> {
+        match dim {
+            // ∂H/∂p₁ = -x₂ → |α| = |x₂|。
+            0 => ArrayD::from_shape_fn(grid.shape(), |idx| grid.axis(1)[idx[1]].abs()),
+            // ∂H/∂p₂ = ±inputBound。
+            1 => ArrayD::from_elem(grid.shape(), self.input_bound.abs()),
+            _ => panic!("双积分器只有两维"),
+        }
+    }
+}
+
+/// 双积分器到原点的最短时间解析解（analyticDoubleIntegratorTTR.m）。
+/// `ttr = -0.5·x₂·|x₂|` 为切换曲线。
+pub fn analytic_double_integrator_ttr(x1: f64, x2: f64) -> f64 {
+    let switch = -0.5 * x2 * x2.abs();
+    if x1 > switch {
+        x2 + (4.0 * x1 + 2.0 * x2 * x2).sqrt()
+    } else if x1 < switch {
+        -x2 + (-4.0 * x1 + 2.0 * x2 * x2).sqrt()
+    } else {
+        x2.abs()
+    }
+}

--- a/crates/e2m2e-levelset/tests/convection.rs
+++ b/crates/e2m2e-levelset/tests/convection.rs
@@ -1,0 +1,129 @@
+//! 阶段 1 验证：对流输运（对应 `Examples/Basic/convectionDemo.m`）。
+//!
+//! 周期域上的圆被常速场平移，t = 1 后圆心位移应等于速度 × 时间；
+//! 一阶格式的耗散使面积略缩，ENO2 + odeCFL2 明显更锐。
+
+mod common;
+
+use e2m2e_levelset::derivative::{UpwindFirstENO2, UpwindFirstFirst};
+use e2m2e_levelset::dissipation::ArtificialDissipationGLF;
+use e2m2e_levelset::grid::{BoundaryCondition, Grid};
+use e2m2e_levelset::hamiltonian::Advection;
+use e2m2e_levelset::integrator::{ode_cfl1, ode_cfl2, CflOptions};
+use e2m2e_levelset::shape::Shape;
+use e2m2e_levelset::term::{LaxFriedrichsTerm, Term};
+use ndarray::ArrayD;
+
+fn centroid_inside(grid: &Grid, phi: &ArrayD<f64>) -> (f64, f64) {
+    let (mut sx, mut sy, mut n) = (0.0f64, 0.0f64, 0usize);
+    for (idx, v) in phi.indexed_iter() {
+        if *v <= 0.0 {
+            sx += grid.axis(0)[idx[0]];
+            sy += grid.axis(1)[idx[1]];
+            n += 1;
+        }
+    }
+    (sx / n as f64, sy / n as f64)
+}
+
+fn area_inside(phi: &ArrayD<f64>) -> f64 {
+    phi.iter().filter(|v| **v <= 0.0).count() as f64
+}
+
+fn advection_case(deriv: UpwindKind, n: usize) -> (f64, f64, f64) {
+    let grid =
+        Grid::new(&[0.0, 0.0], &[1.0, 1.0], &[n, n]).with_boundary_all(BoundaryCondition::Periodic);
+    let phi0 = Shape::Sphere {
+        center: vec![0.3, 0.5],
+        radius: 0.15,
+    }
+    .implicit(&grid);
+
+    let ham = Advection {
+        velocity: vec![0.2, 0.0],
+    };
+    let mut options = CflOptions {
+        factor_cfl: 0.5,
+        ..Default::default()
+    };
+    let result = match deriv {
+        UpwindKind::First => {
+            let mut term = LaxFriedrichsTerm::new(
+                grid.clone(),
+                ham,
+                UpwindFirstFirst,
+                ArtificialDissipationGLF,
+            );
+            ode_cfl1(&mut term, 0.0, 1.0, phi0.clone(), &mut options)
+        }
+        UpwindKind::Eno2 => {
+            let mut term = LaxFriedrichsTerm::new(
+                grid.clone(),
+                ham,
+                UpwindFirstENO2,
+                ArtificialDissipationGLF,
+            );
+            ode_cfl2(&mut term, 0.0, 1.0, phi0.clone(), &mut options)
+        }
+    };
+    let (cx, cy) = centroid_inside(&grid, &result.y);
+    let area_ratio = area_inside(&result.y) / area_inside(&phi0);
+    (cx, cy, area_ratio)
+}
+
+enum UpwindKind {
+    First,
+    Eno2,
+}
+
+#[test]
+fn 一阶格式平流圆的质心与面积() {
+    let (cx, cy, area_ratio) = advection_case(UpwindKind::First, 81);
+    // 期望圆心 (0.5, 0.5)，一阶耗散下质心误差允许约 1.5 dx（dx ≈ 0.0123）。
+    assert!((cx - 0.5).abs() < 0.02, "x 质心 {cx}");
+    assert!((cy - 0.5).abs() < 1e-12, "y 质心 {cy}（无 y 向速度）");
+    assert!(
+        (area_ratio - 1.0).abs() < 0.05,
+        "面积比 {area_ratio}（一阶耗散允许略缩）"
+    );
+}
+
+#[test]
+fn 二阶格式平流圆更锐() {
+    let (_, _, area_eno) = advection_case(UpwindKind::Eno2, 81);
+    let (_, _, area_first) = advection_case(UpwindKind::First, 81);
+    // ENO2 + odeCFL2 的面积损失应小于一阶格式。
+    assert!(
+        (area_eno - 1.0).abs() < (area_first - 1.0).abs(),
+        "ENO2 面积比 {area_eno} 应比一阶 {area_first} 更接近 1"
+    );
+}
+
+#[test]
+fn 单步模式只走一步() {
+    let grid = Grid::new(&[0.0], &[1.0], &[41]);
+    let ham = Advection {
+        velocity: vec![1.0],
+    };
+    let phi0 = Shape::Sphere {
+        center: vec![0.5],
+        radius: 0.2,
+    }
+    .implicit(&grid);
+    let mut term = LaxFriedrichsTerm::new(
+        grid.clone(),
+        ham,
+        UpwindFirstFirst,
+        ArtificialDissipationGLF,
+    );
+    // 先取一步真实步长。
+    let r1 = term.rhs(0.0, &phi0);
+    let mut options = CflOptions {
+        factor_cfl: 0.5,
+        single_step: true,
+        ..Default::default()
+    };
+    let result = ode_cfl1(&mut term, 0.0, 1.0, phi0, &mut options);
+    assert_eq!(result.steps, 1);
+    assert!((result.t - 0.5 * r1.step_bound).abs() < 1e-12);
+}

--- a/crates/e2m2e-levelset/tests/reinit.rs
+++ b/crates/e2m2e-levelset/tests/reinit.rs
@@ -1,0 +1,105 @@
+//! 阶段 3 验证：重初始化与符号距离（对应
+//! `Examples/RussoSmereka/reinitCircle.m` 与 `signedDistanceIterative.m`）。
+
+mod common;
+
+use e2m2e_levelset::grid::{BoundaryCondition, Grid};
+use e2m2e_levelset::shape::Shape;
+use e2m2e_levelset::signed_distance::{signed_distance_iterative, SignedDistanceOptions};
+
+fn circle_grid(n: usize) -> Grid {
+    Grid::new(&[-1.0, -1.0], &[1.0, 1.0], &[n, n]).with_boundary_all(BoundaryCondition::Extrapolate)
+}
+
+#[test]
+fn 缩放距离函数重初始化回真距离() {
+    let n = 81;
+    let grid = circle_grid(n);
+    let center = [0.0, 0.0];
+    let radius = 0.5;
+    // 初值是真距离的 0.3 倍（同一零等值面，但不是距离函数）。
+    let phi0 = 0.3
+        * &Shape::Sphere {
+            center: center.to_vec(),
+            radius,
+        }
+        .implicit(&grid);
+
+    let phi = signed_distance_iterative(&grid, &phi0, &SignedDistanceOptions::default());
+
+    let dx = grid.dx()[0];
+    let (mut worst, mut sum) = (0.0f64, 0.0f64);
+    for (idx, v) in phi.indexed_iter() {
+        let r = ((grid.axis(0)[idx[0]] - center[0]).powi(2)
+            + (grid.axis(1)[idx[1]] - center[1]).powi(2))
+        .sqrt();
+        let exact = r - radius;
+        let err = (v - exact).abs();
+        worst = worst.max(err);
+        sum += err;
+    }
+    let mean = sum / grid.size() as f64;
+    // Russo-Smereka 亚网格修正下界面附近误差 O(dx)，远场几何收敛。
+    assert!(worst < 2.5 * dx, "最大误差 {worst:.4e}（dx = {dx:.4e}）");
+    assert!(mean < 0.5 * dx, "平均误差 {mean:.4e}（dx = {dx:.4e}）");
+}
+
+#[test]
+fn zalesak_圆盘保持缺口拓扑() {
+    let n = 81;
+    let grid = circle_grid(n);
+    let phi0 = Shape::ZalesakDisk {
+        center: vec![0.0, 0.15],
+        radius: 0.4,
+        width: 0.15,
+        height: 0.55,
+    }
+    .implicit(&grid);
+    let phi = signed_distance_iterative(&grid, &phi0, &SignedDistanceOptions::default());
+
+    // 缺口区域（圆盘内、槽内）重初始化后仍应为正（外部）。
+    let inside_slot = |x1: f64, x2: f64| x1.abs() < 0.05 && x2 < 0.15;
+    let mut slot_max = f64::NEG_INFINITY;
+    for (idx, v) in phi.indexed_iter() {
+        let (x1, x2) = (grid.axis(0)[idx[0]], grid.axis(1)[idx[1]]);
+        if inside_slot(x1, x2) {
+            slot_max = slot_max.max(*v);
+        }
+    }
+    assert!(slot_max > 0.0, "缺口内应保持外部（正），最大值 {slot_max}");
+    // 缺口两侧的圆盘体应仍为负。
+    let body_phi = phi
+        .indexed_iter()
+        .find(|(idx, _)| {
+            let (x1, x2) = (grid.axis(0)[idx[0]], grid.axis(1)[idx[1]]);
+            (x1 - 0.25).abs() < 0.03 && (x2 + 0.1).abs() < 0.03
+        })
+        .map(|(_, v)| *v)
+        .expect("网格上应有点 (0.25, -0.1)");
+    assert!(body_phi < 0.0, "圆盘体内应保持内部（负）");
+}
+
+#[test]
+fn 固定步数模式() {
+    let grid = circle_grid(41);
+    let phi0 = Shape::Sphere {
+        center: vec![0.0, 0.0],
+        radius: 0.5,
+    }
+    .implicit(&grid);
+    let options = SignedDistanceOptions {
+        t_max_steps: Some(3),
+        ..Default::default()
+    };
+    let phi = signed_distance_iterative(&grid, &phi0, &options);
+    // 三步后界面附近应已接近距离函数（亚网格修正一步即起效）。
+    let dx = grid.dx()[0];
+    let mut near_err = 0.0f64;
+    for (idx, v) in phi.indexed_iter() {
+        let r = (grid.axis(0)[idx[0]].powi(2) + grid.axis(1)[idx[1]].powi(2)).sqrt();
+        if (r - 0.5).abs() < 2.0 * dx {
+            near_err = near_err.max((*v - (r - 0.5)).abs());
+        }
+    }
+    assert!(near_err < 1.5 * dx, "界面附近误差 {near_err:.4e}");
+}

--- a/crates/e2m2e-levelset/tests/ttr.rs
+++ b/crates/e2m2e-levelset/tests/ttr.rs
@@ -1,0 +1,182 @@
+//! 阶段 4 验证：双积分器最短到达时间（对应
+//! `Examples/TimeToReach/doubleIntegratorTTR.m`）。
+//!
+//! 复刻示例的缺省流程：域 [-1,1]²、101 节点、Extrapolate 边界、
+//! 目标半径 0.2、GLF 耗散、ENO2 格式、odeCFL2、factorCFL = 0.75、
+//! 解析初值、termRestrictUpdate(positive=0) 包裹、postTimestepTTR 记录，
+//! 积分到 t = 2 后与解析解逐点对比。
+
+mod common;
+
+use common::{analytic_double_integrator_ttr, DoubleIntegrator};
+use e2m2e_levelset::derivative::UpwindFirstENO2;
+use e2m2e_levelset::dissipation::ArtificialDissipationGLF;
+use e2m2e_levelset::grid::{BoundaryCondition, Grid};
+use e2m2e_levelset::integrator::{
+    ode_cfl2, CflOptions, ConvergeNorm, PostTimestepTtrRecorder, TerminalEvent,
+};
+use e2m2e_levelset::term::{LaxFriedrichsTerm, RestrictUpdateTerm};
+use ndarray::ArrayD;
+
+/// 共享 TTR 记录器的钩子适配器：测试侧保留 Rc 句柄，积分后读取 ttr。
+struct TtrHook(std::rc::Rc<std::cell::RefCell<PostTimestepTtrRecorder>>);
+
+impl e2m2e_levelset::integrator::PostTimestep for TtrHook {
+    fn post_step(&mut self, t: f64, y: &mut ArrayD<f64>) {
+        self.0.borrow_mut().post_step(t, y);
+    }
+}
+
+fn run_ttr(n: usize, llf: bool) -> (Vec<f64>, Vec<f64>, Vec<f64>) {
+    let grid = Grid::new(&[-1.0, -1.0], &[1.0, 1.0], &[n, n])
+        .with_boundary_all(BoundaryCondition::Extrapolate);
+    let input_bound = 1.0;
+    let target_radius = 0.2;
+    let t_max = 2.0;
+
+    // 解析初值（示例 whichIC = 'analytic'，第 99 行最终生效的取值）：
+    // φ₀ = τ_analytic − r。TTR 后处理要求初值是 TTR 的平移——此时
+    // φ(x,t) = τ(x) − r − t 是精确解，零等值面按真实到达时刻传播。
+    // 圆形初值下集合位置最终正确，但各节点穿越时刻无意义。
+    let data0 = ArrayD::from_shape_fn(grid.shape(), |idx| {
+        analytic_double_integrator_ttr(grid.axis(0)[idx[0]], grid.axis(1)[idx[1]]) - target_radius
+    });
+
+    let ham = DoubleIntegrator { input_bound };
+    let inner: Box<dyn e2m2e_levelset::term::Term> = if llf {
+        Box::new(LaxFriedrichsTerm::new(
+            grid.clone(),
+            ham,
+            UpwindFirstENO2,
+            e2m2e_levelset::dissipation::ArtificialDissipationLLF,
+        ))
+    } else {
+        Box::new(LaxFriedrichsTerm::new(
+            grid.clone(),
+            ham,
+            UpwindFirstENO2,
+            ArtificialDissipationGLF,
+        ))
+    };
+    let mut term = RestrictUpdateTerm {
+        inner,
+        positive: false,
+    };
+
+    let recorder = std::rc::Rc::new(std::cell::RefCell::new(PostTimestepTtrRecorder::new(&grid)));
+    recorder.borrow_mut().record(0.0, &data0);
+    let mut options = CflOptions {
+        factor_cfl: 0.75,
+        ..Default::default()
+    };
+    options
+        .post_timestep
+        .push(Box::new(TtrHook(recorder.clone())));
+
+    let result = ode_cfl2(&mut term, 0.0, t_max, data0, &mut options);
+    let recorder = recorder.borrow();
+
+    let (mut ttr_vals, mut attr_vals, mut phi_vals) = (Vec::new(), Vec::new(), Vec::new());
+    for (idx, v) in recorder.ttr.indexed_iter() {
+        let (x1, x2) = (grid.axis(0)[idx[0]], grid.axis(1)[idx[1]]);
+        ttr_vals.push(*v);
+        attr_vals.push((analytic_double_integrator_ttr(x1, x2) - target_radius).max(0.0));
+        phi_vals.push(result.y[idx.clone()]);
+    }
+    (ttr_vals, attr_vals, phi_vals)
+}
+
+/// 统计远离切换曲线与 t_max 边界带的 TTR 误差（最大值、中位数）。
+fn ttr_error_stats(n: usize) -> (f64, f64, usize) {
+    let (ttr, attr, _) = run_ttr(n, false);
+    let mut errs = Vec::new();
+    for (i, (mttr, attr)) in ttr.iter().zip(&attr).enumerate() {
+        let (x1, x2) = (
+            -1.0 + ((i % n) as f64 + 0.5) * 2.0 / n as f64,
+            -1.0 + ((i / n) as f64 + 0.5) * 2.0 / n as f64,
+        );
+        let switch_dist = (x1 + 0.5 * x2 * x2.abs()).abs();
+        if (0.3..1.7).contains(attr) && mttr.is_finite() && switch_dist > 0.15 {
+            errs.push((mttr - attr).abs());
+        }
+    }
+    errs.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    (errs[errs.len() - 1], errs[errs.len() / 2], errs.len())
+}
+
+#[test]
+fn 双积分器_ttr_对比解析解() {
+    // 双积分器的 ∂H/∂p 与 p 无关，GLF/LLF/LLLF 三种耗散等价；
+    // LF 类格式的固有耗散使 TTR 误差随网格一阶收敛（101 节点实测
+    // 最大 ~0.41、201 节点 ~0.28），与 MATLAB 原版行为一致。
+    let (worst, _median, count) = ttr_error_stats(101);
+    assert!(count > 1000, "有效对比节点数 {count} 应覆盖大部分网格");
+    assert!(worst < 0.45, "远离切换曲线的 TTR 最大误差 {worst:.4}");
+
+    // 分辨率加倍，误差应明显下降（格式收敛性的回归防线）。
+    let (worst_coarse, _, _) = ttr_error_stats(51);
+    let (worst_fine, _, _) = ttr_error_stats(101);
+    assert!(
+        worst_fine < worst_coarse * 0.9,
+        "加密网格误差应下降：{worst_coarse:.4} → {worst_fine:.4}"
+    );
+}
+
+#[test]
+fn 双积分器_可达集边界对比解析解() {
+    let (_, attr, phi) = run_ttr(101, false);
+    // t = 2 时刻的可达集（φ ≤ 0）应与解析解 attr ≤ 2 的集合基本重合。
+    let (mut mismatch, mut boundary) = (0usize, 0usize);
+    for (attr, phi) in attr.iter().zip(&phi) {
+        let reached_numeric = *phi <= 0.0;
+        let reached_analytic = *attr <= 2.0;
+        if *attr >= 1.8 && *attr <= 2.2 {
+            boundary += 1;
+        }
+        if reached_numeric != reached_analytic && !(1.7..2.3).contains(attr) {
+            mismatch += 1;
+        }
+    }
+    let _ = boundary;
+    let frac = mismatch as f64 / attr.len() as f64;
+    assert!(frac < 0.02, "集合错分比例 {frac:.4}（排除 t≈2 边界带）");
+}
+
+#[test]
+fn 收敛终止事件提前停止() {
+    // 重初始化到收敛：更新量趋零时事件变号，积分应早于 t_max 停止。
+    use e2m2e_levelset::shape::Shape;
+
+    let grid = Grid::new(&[-1.0, -1.0], &[1.0, 1.0], &[41, 41])
+        .with_boundary_all(BoundaryCondition::Extrapolate);
+    // 初值取 0.3 倍距离（非距离函数）：前几步更新量大（事件值 +1），
+    // 收敛后更新量趋零（事件值翻为 -1），变号触发提前终止。
+    let phi0 = 0.3
+        * &Shape::Sphere {
+            center: vec![0.0, 0.0],
+            radius: 0.5,
+        }
+        .implicit(&grid);
+    let mut term = e2m2e_levelset::term::ReinitTerm {
+        grid: grid.clone(),
+        deriv: Box::new(e2m2e_levelset::derivative::UpwindFirstENO2),
+        initial: phi0.clone(),
+        subcell_fix: true,
+    };
+    let mut options = CflOptions {
+        factor_cfl: 0.5,
+        terminal_event: Some(TerminalEvent::Converge {
+            abs_tol: 1e-4,
+            rel_tol: 1e-4,
+            norm: ConvergeNorm::Average,
+        }),
+        ..Default::default()
+    };
+    let result = e2m2e_levelset::integrator::ode_cfl2(&mut term, 0.0, 1.0, phi0, &mut options);
+    assert!(
+        result.t < 1.0,
+        "应在 t_max 前收敛停止，实际 t = {}",
+        result.t
+    );
+    assert!(result.steps >= 2, "至少两步才能检测事件变号");
+}


### PR DESCRIPTION
## 摘要

自 UBC Ian Mitchell 的 Toolbox of Level Set Methods（v1.1，ACM 非商业许可，全文随附 `crates/e2m2e-levelset/LICENSE-ToolboxLS`）完整移植内核到新 crate `e2m2e-levelset`，为低推力轨迹的可达集、最短到达时间与追逃博弈计算提供网格 PDE 内核（`D_t φ = -H(x, t, φ, ∇φ)`）。

无关联 issue。

## 改动内容

- **纯数学 crate**（rlib，无 SPICE、无 pyo3；对外暴露后续经 e2m2e-integrators 按 ABI 戳流程进行）：
  - `boundary`：5 种鬼单元填充（周期 / Dirichlet / Neumann / 一阶、二阶外推）
  - `derivative`：一阶、ENO2、ENO3、WENO5 迎风格式（逐 lane 施加与 MATLAB 逐行对应的一维修式）
  - `dissipation`：GLF / LLF / LLLF 三种 Lax-Friedrichs 耗散
  - `term`：LaxFriedrichs、Normal（Godunov）、Reinit（含 Russo-Smereka 亚网格修正）、Sum、RestrictUpdate 时间项
  - `integrator`：odeCFL1/2/3 TVD Runge-Kutta 共用 CFL 驱动循环 + 掩码/重初始化/TTR 后处理钩子 + 收敛终止事件
  - `shape` / `signed_distance`：隐式形状与集合运算、迭代法符号距离
- workspace 新增 `ndarray = 0.16` 依赖（唯一新增依赖）
- 向量水平集与绘图动画不移植（可视化在 Python 侧）；crate README 记录完整的 MATLAB→Rust 协议映射、实测验证门控与许可注意事项

## 验证

`cargo test -p e2m2e-levelset`：22 项断言全部通过；`cargo clippy -p e2m2e-levelset --all-targets -- -D warnings` 与 `cargo fmt --check` 干净。

| 门控 | 实测 |
|---|---|
| 导数收敛阶（sin 场） | 一阶 1.00 / ENO2 2.00 / ENO3 3.00 / WENO5 5.00 |
| Burgers 方程（OsherShu）vs Hopf–Lax 精确解 | L∞ < 2e-2（ENO2+GLF，N=401），加密网格收敛 |
| 重初始化（RussoSmereka） | 0.3 倍距离函数回真距离：最大误差 < 2.5 dx；Zalesak 圆盘缺口拓扑保持 |
| 双积分器 TTR（doubleIntegratorTTR 全流程复刻） | 可达集边界错分 < 2%；TTR 误差随 51→101 网格收敛；收敛事件提前终止 |

TTR 的 0.45 级误差是 LF 类格式固有耗散（双积分子 ∂H/∂p 与 p 无关，三种耗散等价；101→201 网格实测 0.41→0.28），与 MATLAB 原版同分辨率行为一致。

## 许可注意

本 crate 派生代码采用原作 ACM 非商业许可（license-file 不随 workspace 的 Apache-2.0），分发需保留 `LICENSE-ToolboxLS`；商业使用需联系原作者。