### PR TITLE
fix(build): 固定 Rust 1.98.0 并修复 Windows Rust 测试（#494、#495）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.98.0
         with:
           components: rustfmt, clippy
       - uses: astral-sh/setup-uv@v7

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.98.0
       - uses: astral-sh/setup-uv@v7
       # conf.py 导入 e2m2e 取版本号，autodoc 也要导入包，需构建 Rust 扩展；
       # downloadcspice 已禁用（a80dbd8），构建前须先下 CSPICE 编译包并设 CSPICE_DIR

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.98.0
       - uses: astral-sh/setup-uv@v7
       # spice 为默认 feature：cargo test --workspace 编译并跑 spice-gated 代码，
       # 须先下 CSPICE 编译包（CSPICE_DIR）与 SPICE 内核（kernels/）。

--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,22 @@ dev-release: setup  ## 同 dev，以 --release 构建（性能基准 / 长期预
 
 test: test-rust test-python  ## 全量测试（Rust 工作区 + Python）
 
-test-rust:  ## Rust 工作区测试（spice 默认；串行）
+# cargo test 不启用 extension-module，测试 EXE 需运行时加载 python3.dll
+#（issue #495）；虚拟环境 Scripts/ 没有该 DLL，必须由 Python 安装根目录提供。
+# 探测放在 recipe 中执行：仅在跑 Rust 测试时求值，失败即终止，不影响其他目标。
+# Windows 分支按 POSIX sh 编写（Git Bash/Scoop make）；PATH 采用 Windows 原生
+# 路径与分号，MSYS 会在启动原生 cargo 前转换为 Windows loader 可识别的形式。
+ifeq ($(OS),Windows_NT)
+TEST_RUST = set -e; \
+	PYTHON_DLL_DIR="$$($(PYTHON) scripts/python_dll_dir.py $(if $(PYTHON_DLL_DIR),--override '$(PYTHON_DLL_DIR)'))"; \
+	export PATH="$$PYTHON_DLL_DIR;$$PATH"; \
 	cargo test --workspace -- --test-threads=1
+else
+TEST_RUST = cargo test --workspace -- --test-threads=1
+endif
+
+test-rust:  ## Rust 工作区测试（spice 默认；串行）
+	$(TEST_RUST)
 
 test-python:  ## Python 测试（默认 xdist 并行；含 spice-gated，需先 make setup 拉内核）
 	$(UV) pytest tests/ -n $(PYTEST_WORKERS) --dist $(PYTEST_DIST)

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ scoop install make
 
 安装完成后重开 PowerShell，回到仓库目录执行 `make dev`（唯一入口：同步依赖 + 拉取数据 + 构建安装，见上方）。若已安装 Scoop，只需执行 `scoop install make`。
 
+Windows 上运行 Rust 测试请使用 `make test-rust`：测试二进制依赖 Python 的 `python3.dll`，该 DLL 在 Python 安装根目录而不在虚拟环境 `Scripts/`；Makefile 会自动探测并加入测试进程 PATH。若自动探测失败，可显式执行 `make test-rust PYTHON_DLL_DIR=<含 python*.dll 的目录>`。手工排查时先对失败的测试 EXE 执行 `dumpbin /DEPENDENTS` 或 `dumpbin /IMPORTS`，确认实际缺失的 DLL，不要把 CSPICE 的 `lib/`（静态库目录）加入 PATH。
+
 ### SPICE 内核
 
 星历动力学需要 NASA SPICE 内核文件。本项目测试所需的全部内核（行星星历、地球自转、月球姿态、闰秒与行星常数）已打包在 [GitHub Release](https://github.com/cislunarspace/e2m2e/releases) 的 `kernels-v1` 中。三种配置方式：

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![PyPI](https://img.shields.io/pypi/v/e2m2e)](https://pypi.org/project/e2m2e/)
 [![CI](https://github.com/cislunarspace/e2m2e/actions/workflows/ci.yml/badge.svg)](https://github.com/cislunarspace/e2m2e/actions/workflows/ci.yml)
 [![GitHub stars](https://img.shields.io/github/stars/cislunarspace/e2m2e.svg)](https://github.com/cislunarspace/e2m2e/stargazers)
-[![Rust: stable](https://img.shields.io/badge/rust-stable-orange.svg)](https://www.rust-lang.org/)
+[![Rust: 1.98.0](https://img.shields.io/badge/rust-1.98.0-orange.svg)](https://www.rust-lang.org/)
 
 e2m2e 是面向地月空间任务规划的**算法工具集基础设施**。在“LLM+Agent”式自主任务规划系统中，大模型负责理解任务意图、分解与编排子任务，e2m2e 负责提供精确可靠的轨道计算工具：建立地月空间的动力学模型，生成周期轨道族，设计轨道之间的转移路径，并把结果画出来检查。
 
@@ -26,7 +26,7 @@ uv init my-project && cd my-project
 uv add e2m2e
 ```
 
-从源码开发（需要 [Rust 工具链](https://www.rust-lang.org/tools/install)，用于构建积分器内核）：
+从源码开发（需要 [Rust 1.98.0 工具链](https://www.rust-lang.org/tools/install)，仓库通过 `rust-toolchain.toml` 固定版本，用于构建积分器内核）：
 
 ```bash
 git clone https://github.com/cislunarspace/e2m2e.git

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -88,6 +88,16 @@ pip 安装
 杜绝走国内不可达的 NAIF 源码下载）。裸 ``cargo`` / ``maturin`` 命令需自行
 ``export CSPICE_DIR=$(python3 scripts/download_cspice.py --print-cspice-dir)``。
 
+.. note::
+
+   Windows 上运行 Rust 测试请使用 ``make test-rust``。测试二进制依赖
+   ``python3.dll``；该 DLL 位于 Python 安装根目录（``sys.base_prefix``），不在
+   虚拟环境 ``Scripts/``。Makefile 会自动探测并把该目录加入测试进程 PATH；
+   若自动探测失败，可显式执行 ``make test-rust PYTHON_DLL_DIR=<含 python*.dll 的目录>``。
+   手工排查 ``0xc0000135`` 时，先对失败测试 EXE 执行 ``dumpbin /DEPENDENTS``
+   或 ``dumpbin /IMPORTS`` 确认实际缺失的 DLL，不要把 CSPICE 的 ``lib/``（静态库
+   目录）加入 PATH。
+
 spice 是默认 feature（``crates/*/Cargo.toml default=["spice"]`` +
 ``pyproject features=["spice"]`` 双保险），不再产无 spice 子集；Rust 扩展
 不可用时显式报错，不静默降级到纯 Python 路径（ADR 0020）。

--- a/docs/research/issue-495-windows-dll.md
+++ b/docs/research/issue-495-windows-dll.md
@@ -1,0 +1,95 @@
+# Issue #495：Windows Rust 测试的 DLL 加载失败调研
+
+## 结论
+
+Issue #495 报告的 `0xc0000135` 是 Windows NTSTATUS `STATUS_DLL_NOT_FOUND`。它只能证明测试进程启动时的 DLL 加载链失败，不能从错误码本身判断缺少的是 Python、CSPICE、LLVM 还是 MSVC 运行库。Win32 的 `ERROR_MOD_NOT_FOUND` 是另一个数值 `126 (0x7e)`，不要将两者混写。
+
+结合当前仓库的构建配置，本机诊断已确认缺失项是 Python DLL：测试 EXE 的直接导入表包含 `python3.dll`，默认 PATH 找不到它；把当前解释器的 base prefix 加入 PATH 后，同一测试 EXE 与 `cargo test -p e2m2e-integrators --lib -- normal_form nsga2` 均成功运行。Issue 中把 `.venv/Scripts` 加入 `PATH` 不能解决该问题，因为 Python DLL 位于 Python 安装根目录。CSPICE Windows 包中的 `cspice.lib` 是静态库，`CSPICE_DIR` 主要用于编译期链接和 bindgen；不能把 `lib/` 目录当成 DLL 目录来解决启动期加载问题。
+
+修复 `make test-rust` 前已经取得 PE 依赖清单和 loader 行为证据；其他 Windows 环境若再出现 `0xc0000135`，仍应按下面的诊断流程确认实际缺失 DLL。
+
+## 已确认事实
+
+- Issue 复现的是 `cargo test -p e2m2e-integrators --lib -- normal_form nsga2`：测试二进制编译成功，启动时报 `0xc0000135`；同环境 `cargo check` 通过。
+- 当前 `Makefile` 的 `test-rust` 直接执行 `cargo test --workspace -- --test-threads=1`，没有 Windows 专用的运行时 DLL 配置。
+- 当前 CI 的 `ci.yml` 只有 Ubuntu lint/typecheck，没有 Windows Rust 测试 job。
+- `Cargo.toml` 的 PyO3 workspace feature 只有 `abi3-py310`；`extension-module` 仅由 maturin 构建路径显式启用。`cargo test` 不应使用 `extension-module`，而是由 PyO3 配置链接 Python。
+- `cspice-sys` 从 `CSPICE_DIR/lib` 添加 native link search，并链接静态 `cspice` 库。静态库本身不是一个运行时 DLL。
+- 历史提交中对 `/NODEFAULTLIB:LIBCMT` 的修改处理的是 Windows 静态 CSPICE 与 PyO3 的 CRT 混链风险，属于链接期问题，不等同于本 issue 的启动期 `STATUS_DLL_NOT_FOUND`。
+
+## 必须先完成的诊断
+
+在 Windows x64 Native Tools Command Prompt 或等价环境中执行：
+
+```powershell
+$env:CSPICE_DIR = "$pwd/.cspice/mice_windows"
+cargo test -p e2m2e-integrators --lib --no-run --message-format=json
+```
+
+从 JSON 输出的 `executable` 字段取得测试 EXE，然后检查其直接依赖：
+
+```powershell
+dumpbin /DEPENDENTS path\to\e2m2e_integrators-<hash>.exe
+dumpbin /IMPORTS path\to\e2m2e_integrators-<hash>.exe
+```
+
+对其中的非系统 DLL 继续执行 `/DEPENDENTS`。同时记录 Python 实际安装位置和 DLL 名称：
+
+```powershell
+python -c "import sys,sysconfig; print(sys.executable); print(sys.base_prefix); print(sysconfig.get_config_var('prefix')); print(sysconfig.get_config_var('LIBDIR')); print(sysconfig.get_config_var('LDLIBRARY'))"
+where.exe python
+Get-ChildItem (python -c "import sys;print(sys.base_prefix)") -Filter '*.dll'
+Get-ChildItem .venv/Scripts -Recurse -Filter 'python*.dll'
+```
+
+若 `/DEPENDENTS` 仍不能确定具体缺失项，使用 Microsoft Process Monitor 过滤失败 EXE 的 `CreateFile` 操作，查找 DLL 路径返回 `NAME NOT FOUND` 的记录。也可使用 Dependencies 等 PE 依赖查看工具。
+
+还应记录以下信息，以排除环境误判：
+
+```powershell
+where.exe dumpbin
+where.exe link
+where.exe clang
+rustc -vV
+cargo tree -e features -p e2m2e-integrators
+dumpbin /DIRECTIVES .cspice\mice_windows\lib\cspice.lib | findstr /i "DEFAULTLIB LIBCMT MSVCRT"
+```
+
+## 方案取舍
+
+### 1. 仅补充文档
+
+明确 Windows 上的 CSPICE、LLVM、Python base prefix 准备步骤，并给出上述依赖诊断命令。风险最低，但每台机器仍需手工设置 PATH，不能保证新贡献者直接成功。
+
+### 2. 修复 Makefile 入口
+
+若诊断确认缺失的是 Python DLL，可让 Windows `test-rust` 自动从当前 Python 解释器计算 base prefix，并把该目录加入当前命令的 PATH；同时保留 `PYTHON_DLL_DIR` 作为显式覆盖。不要把 CSPICE 的 `.lib` 目录加入 DLL PATH。该方案直接修复仓库规定的 `make test-rust` 入口，但必须覆盖 Git Bash、PowerShell、多个 Python 安装和路径含空格等情况。
+
+### 3. 增加 Windows CI 测试
+
+在 Windows runner 上固定 Rust 1.98/MSVC、Python、LLVM，下载并解压 `cspice-windows.zip`，设置 `CSPICE_DIR`，先运行 `e2m2e-integrators` 的最小测试，再决定是否扩大到整个 workspace。它能真实暴露启动链问题并填补 PR 覆盖空档，但需要维护依赖准备、缓存和运行时间。CI 不能替代本地文档或 Makefile 入口。
+
+推荐顺序是：先完成 PE/loader 诊断；确认缺失 DLL 后，优先修复 Makefile 并补文档，再考虑增加 Windows CI 回归任务。
+
+## 来源
+
+一手资料：
+
+- GitHub issue #495：<https://github.com/cislunarspace/e2m2e/issues/495>
+- Microsoft 系统错误码：<https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes--0-499->
+- Microsoft DLL 搜索顺序：<https://learn.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-search-order>
+- Microsoft DUMPBIN `/DEPENDENTS`：<https://learn.microsoft.com/en-us/cpp/build/reference/dependents?view=msvc-170>
+- Microsoft DUMPBIN `/IMPORTS`：<https://learn.microsoft.com/en-us/cpp/build/reference/imports-dumpbin?view=msvc-170>
+- Microsoft PE 格式与导入目录：<https://learn.microsoft.com/en-us/windows/win32/debug/pe-format>
+- PyO3 0.24 构建与发布指南：<https://pyo3.rs/v0.24.0/building-and-distribution.html>
+- PyO3 0.24 构建配置源码：<https://github.com/PyO3/pyo3/tree/v0.24.0/pyo3-build-config>
+- cspice-rs `cspice-sys` 构建源码：<https://github.com/jacob-pro/cspice-rs/blob/master/cspice-sys/build.rs>
+
+仓库证据：
+
+- `Makefile`：Windows 环境变量与 `test-rust` 目标
+- `Cargo.toml`：PyO3 workspace features 与 CSPICE 依赖
+- `crates/e2m2e-integrators/Cargo.toml`：`extension-module` 与 `spice` feature
+- `pyproject.toml`：maturin 专用 features
+- `.github/workflows/ci.yml`：当前 CI job 范围
+- `.cargo/config.toml`：Windows CRT 链接参数

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.98.0"
+components = ["rustfmt", "clippy"]
+profile = "minimal"

--- a/scripts/python_dll_dir.py
+++ b/scripts/python_dll_dir.py
@@ -1,0 +1,53 @@
+"""定位 Windows Rust 测试所需的 Python DLL 目录，供 Makefile 注入 PATH。
+
+``cargo test`` 不启用 PyO3 ``extension-module``：测试 EXE 会链接 Python（当前 ABI3 链接
+``python3.dll``），但该 DLL 不在测试 EXE 目录，需要由 PATH 提供给 Windows loader。
+虚拟环境的 ``Scripts`` 目录不含该 DLL，实际安装目录见 ``sys.base_prefix``（issue #495）。
+
+用法：
+    python scripts/python_dll_dir.py [--override DIR]
+
+正常时在 stdout 打印目录纯路径（供 ``$(...)`` 捕获）；找不到任何 ``python*.dll`` 时
+向 stderr 报告并返回非零。
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+
+
+def _dlls_in(directory: pathlib.Path) -> list[pathlib.Path]:
+    return sorted(directory.glob("python*.dll"))
+
+
+def find_python_dll_dir(override: str | None) -> pathlib.Path:
+    """返回含 python*.dll 的目录；override 优先，其次 sys.base_prefix。"""
+    candidates: list[tuple[str, pathlib.Path]] = []
+    if override is not None:
+        candidates.append(("--override", pathlib.Path(override).expanduser()))
+    else:
+        candidates.append(("sys.base_prefix", pathlib.Path(sys.base_prefix)))
+        candidates.append(("sys.executable 所在目录", pathlib.Path(sys.executable).parent))
+
+    for _source, directory in candidates:
+        if directory.is_dir() and _dlls_in(directory):
+            return directory.resolve()
+
+    detail = "、".join(f"{source}（{directory}）" for source, directory in candidates)
+    raise SystemExit(
+        f"找不到 Python DLL：已检查 {detail}，均无 python*.dll。"
+        "请用 --override 或 make PYTHON_DLL_DIR=... 指定含 python*.dll 的目录。"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--override", help="直接使用该目录，仍验证其中含 python*.dll")
+    args = parser.parse_args()
+    print(find_python_dll_dir(args.override))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
关联 issue：#494、#495。

改动摘要：
- 新增仓库级 rust-toolchain.toml，将本地与 CI 的 Rust 工具链固定到 1.98.0，CI、文档构建与发布工作流不再随 stable 漂移。
- 修复 Windows 下 make test-rust：测试二进制运行时依赖 python3.dll，探测当前解释器的 DLL 目录后注入测试进程 PATH，支持 PYTHON_DLL_DIR 覆盖。
- 更新 README、安装文档与 issue #495 调研记录。

验证：
- cargo fmt --all -- --check 通过。
- make test-rust 在 Windows 上完整通过（含 SPICE 内核依赖测试）。
- scripts/python_dll_dir.py 的自动探测、覆盖与失败路径均验证通过。