### PR TITLE
feat(forces): 变质量 SRP 契约——SRPVariableMass 与 acceleration_with_mass（#506）

### DIFF
--- a/crates/e2m2e-forces/src/forces/augmented_state.rs
+++ b/crates/e2m2e-forces/src/forces/augmented_state.rs
@@ -17,7 +17,10 @@
 //! - m：航天器质量（kg）
 //! - û：推力方向单位向量
 
-use super::compiled::{compute_total_acceleration, CompiledForce};
+use super::compiled::{
+    compute_total_acceleration_and_jacobian_with_mass, compute_total_acceleration_with_mass,
+    compute_total_mass_derivative, CompiledForce,
+};
 
 /// 7D 增广状态：[r(3), v(3), m(1)]
 pub type AugmentedState7 = [f64; 7];
@@ -62,7 +65,7 @@ pub fn augmented_eom_7d(
 
     // 1. 计算重力加速度（6D）
     let state6 = [r[0], r[1], r[2], v[0], v[1], v[2]];
-    let a_gravity = compute_total_acceleration(forces, et, &state6, observer)?;
+    let a_gravity = compute_total_acceleration_with_mass(forces, et, &state6, m, observer)?;
 
     // 2. 计算推力加速度
     // T_max 单位为 N (kg·m/s²)，质量单位为 kg，加速度单位为 m/s²
@@ -130,7 +133,7 @@ pub fn augmented_eom_7d_with_stm(
     // 1. 计算重力加速度 + 雅可比（6D）
     let state6 = [r[0], r[1], r[2], v[0], v[1], v[2]];
     let (a_gravity, jac_da_dr, dadv) =
-        super::compiled::compute_total_acceleration_and_jacobian(forces, et, &state6, observer)?;
+        compute_total_acceleration_and_jacobian_with_mass(forces, et, &state6, m, observer)?;
 
     // 2. 计算推力加速度
     let a_thrust_mag_m_s2 = (thrust.t_max / m) * thrust.throttle;
@@ -213,7 +216,8 @@ pub fn augmented_eom_7d_with_sensitivity(
 
     // 1. 重力加速度 + 雅可比 ∂a_grav/∂r（3×3）
     let (a_gravity, jac_da_dr, dadv) =
-        super::compiled::compute_total_acceleration_and_jacobian(forces, et, &state6, observer)?;
+        compute_total_acceleration_and_jacobian_with_mass(forces, et, &state6, m, observer)?;
+    let da_dm_force = compute_total_mass_derivative(forces, et, &state6, m, observer)?;
 
     // 2. 推力加速度（与 augmented_eom_7d 一致）
     let t_max = thrust.t_max;
@@ -246,7 +250,7 @@ pub fn augmented_eom_7d_with_sensitivity(
         for j in 0..3 {
             a_mat[3 + i][j] = jac_da_dr[i][j]; // A[v_i, r_j] = ∂a/∂r
         }
-        a_mat[3 + i][6] = da_dm[i]; // A[v_i, m] = ∂a/∂m
+        a_mat[3 + i][6] = da_dm[i] + da_dm_force[i]; // A[v_i, m] = ∂a/∂m
     }
 
     // 4. 组装 7×3 控制雅可比 B（行优先），列序 [throttle, θ₁, θ₂]

--- a/crates/e2m2e-forces/src/forces/compiled.rs
+++ b/crates/e2m2e-forces/src/forces/compiled.rs
@@ -52,6 +52,12 @@ pub enum CompiledForce {
         cr: f64,
         shadow_bodies: Vec<String>,
     },
+    /// 随增广状态质量变化的 cannonball 光压模型。
+    SRPVariableMass {
+        area: f64,
+        cr: f64,
+        shadow_bodies: Vec<String>,
+    },
     EcomSrp {
         dyb: [f64; 9],
         shadow_bodies: Vec<String>,
@@ -267,6 +273,9 @@ impl CompiledForce {
                 srp::srp_acceleration(et, &sc_pos, *area, *mass, *cr, shadow_bodies, observer)
                     .map_err(|e| format!("{:?}", e))
             }
+            Self::SRPVariableMass { .. } => {
+                Err("SRPVariableMass requires acceleration_with_mass".to_string())
+            }
             Self::EcomSrp { dyb, shadow_bodies } => {
                 let sc_pos = [state[0], state[1], state[2]];
                 ecom::ecom_acceleration(et, &sc_pos, dyb, shadow_bodies, observer)
@@ -338,6 +347,55 @@ impl CompiledForce {
                 .map_err(|e| format!("{:?}", e)),
         }
     }
+
+    /// 计算含增广状态质量的力。固定质量力保持原有路径。
+    pub fn acceleration_with_mass(
+        &self,
+        et: f64,
+        state: &[f64; 6],
+        mass: f64,
+        observer: &str,
+    ) -> Result<[f64; 3], String> {
+        match self {
+            Self::SRPVariableMass {
+                area,
+                cr,
+                shadow_bodies,
+            } => {
+                if mass <= 0.0 {
+                    return Err(format!("spacecraft mass must be positive, got {mass}"));
+                }
+                let sc_pos = [state[0], state[1], state[2]];
+                srp::srp_acceleration(et, &sc_pos, *area, mass, *cr, shadow_bodies, observer)
+                    .map_err(|e| format!("{:?}", e))
+            }
+            _ => self.acceleration(et, state, observer),
+        }
+    }
+
+    /// 当前质量对该力加速度的偏导 `∂a/∂m`。
+    pub fn mass_derivative(
+        &self,
+        et: f64,
+        state: &[f64; 6],
+        mass: f64,
+        observer: &str,
+    ) -> Result<[f64; 3], String> {
+        if mass <= 0.0 {
+            return Err(format!("spacecraft mass must be positive, got {mass}"));
+        }
+        match self {
+            Self::SRPVariableMass { .. } => {
+                let acceleration = self.acceleration_with_mass(et, state, mass, observer)?;
+                Ok([
+                    -acceleration[0] / mass,
+                    -acceleration[1] / mass,
+                    -acceleration[2] / mass,
+                ])
+            }
+            _ => Ok([0.0; 3]),
+        }
+    }
 }
 
 /// 返回 `(t, tf]` 内最早的编译力不连续时刻。
@@ -377,6 +435,42 @@ pub fn compute_total_acceleration(
     Ok(total)
 }
 
+/// 计算总加速度，并把可变质量传给质量相关力（当前为 SRP）。
+pub fn compute_total_acceleration_with_mass(
+    forces: &[CompiledForce],
+    et: f64,
+    state: &[f64; 6],
+    mass: f64,
+    observer: &str,
+) -> Result<[f64; 3], String> {
+    let mut total = [0.0_f64; 3];
+    for force in forces {
+        let a = force.acceleration_with_mass(et, state, mass, observer)?;
+        total[0] += a[0];
+        total[1] += a[1];
+        total[2] += a[2];
+    }
+    Ok(total)
+}
+
+/// 计算所有质量相关力的 `∂a/∂m`。
+pub fn compute_total_mass_derivative(
+    forces: &[CompiledForce],
+    et: f64,
+    state: &[f64; 6],
+    mass: f64,
+    observer: &str,
+) -> Result<[f64; 3], String> {
+    let mut total = [0.0_f64; 3];
+    for force in forces {
+        let derivative = force.mass_derivative(et, state, mass, observer)?;
+        for i in 0..3 {
+            total[i] += derivative[i];
+        }
+    }
+    Ok(total)
+}
+
 /// 单个 force 是否支持解析/Rust FD 雅可比。
 pub fn supports_jacobian(force: &CompiledForce) -> bool {
     matches!(
@@ -386,6 +480,7 @@ pub fn supports_jacobian(force: &CompiledForce) -> bool {
             | CompiledForce::ThirdBody { .. }
             | CompiledForce::IndirectTerm { .. }
             | CompiledForce::SRP { .. }
+            | CompiledForce::SRPVariableMass { .. }
             | CompiledForce::EcomSrp { .. }
             | CompiledForce::LowThrust { .. }
             | CompiledForce::Drag { .. }
@@ -403,6 +498,26 @@ pub fn acceleration_and_jacobian(
     force: &CompiledForce,
     et: f64,
     state: &[f64; 6],
+    observer: &str,
+) -> AccelJacobiResult {
+    acceleration_and_jacobian_with_optional_mass(force, et, state, None, observer)
+}
+
+pub fn acceleration_and_jacobian_with_mass(
+    force: &CompiledForce,
+    et: f64,
+    state: &[f64; 6],
+    mass: f64,
+    observer: &str,
+) -> AccelJacobiResult {
+    acceleration_and_jacobian_with_optional_mass(force, et, state, Some(mass), observer)
+}
+
+fn acceleration_and_jacobian_with_optional_mass(
+    force: &CompiledForce,
+    et: f64,
+    state: &[f64; 6],
+    mass: Option<f64>,
     observer: &str,
 ) -> AccelJacobiResult {
     match force {
@@ -485,22 +600,55 @@ pub fn acceleration_and_jacobian(
             let dadv = [[0.0_f64; 3]; 3];
             Ok((acc, [[0.0; 3]; 3], dadv))
         }
-        CompiledForce::SRP { .. } => {
+        CompiledForce::SRP { .. } | CompiledForce::SRPVariableMass { .. } => {
             // 数值差分（与 GravityField::jacobian_fd 同模式，步长 sqrt(eps)*|r|）。
             // SRP 加速度含阴影几何（太阳/遮挡体位置随 et 变化但本步内固定），
             // 差分自动包含光照份额对位置的贡献；阴影边界处不连续引入的
             // 差分误差只影响边界点，对 STM 积分可接受。
             let r_norm = (state[0] * state[0] + state[1] * state[1] + state[2] * state[2]).sqrt();
             let h = (f64::EPSILON.sqrt() * r_norm).max(1e-6);
-            let acc0 = force.acceleration(et, state, observer)?;
+            let current_mass = mass;
+            let acc0 = match force {
+                CompiledForce::SRPVariableMass { .. } => force.acceleration_with_mass(
+                    et,
+                    state,
+                    current_mass.ok_or_else(|| {
+                        "SRPVariableMass requires acceleration_and_jacobian_with_mass".to_string()
+                    })?,
+                    observer,
+                )?,
+                _ => force.acceleration(et, state, observer)?,
+            };
             let mut jac = [[0.0_f64; 3]; 3];
             for dim in 0..3 {
                 let mut state_plus = *state;
                 let mut state_minus = *state;
                 state_plus[dim] += h;
                 state_minus[dim] -= h;
-                let a_plus = force.acceleration(et, &state_plus, observer)?;
-                let a_minus = force.acceleration(et, &state_minus, observer)?;
+                let a_plus = match force {
+                    CompiledForce::SRPVariableMass { .. } => force.acceleration_with_mass(
+                        et,
+                        &state_plus,
+                        current_mass.ok_or_else(|| {
+                            "SRPVariableMass requires acceleration_and_jacobian_with_mass"
+                                .to_string()
+                        })?,
+                        observer,
+                    )?,
+                    _ => force.acceleration(et, &state_plus, observer)?,
+                };
+                let a_minus = match force {
+                    CompiledForce::SRPVariableMass { .. } => force.acceleration_with_mass(
+                        et,
+                        &state_minus,
+                        current_mass.ok_or_else(|| {
+                            "SRPVariableMass requires acceleration_and_jacobian_with_mass"
+                                .to_string()
+                        })?,
+                        observer,
+                    )?,
+                    _ => force.acceleration(et, &state_minus, observer)?,
+                };
                 for i in 0..3 {
                     jac[i][dim] = (a_plus[i] - a_minus[i]) / (2.0 * h);
                 }
@@ -606,4 +754,82 @@ pub fn compute_total_acceleration_and_jacobian(
         }
     }
     Ok((total_acc, total_jac, total_dadv))
+}
+
+/// 计算总加速度和雅可比，并把当前质量传给质量相关力。
+pub fn compute_total_acceleration_and_jacobian_with_mass(
+    forces: &[CompiledForce],
+    et: f64,
+    state: &[f64; 6],
+    mass: f64,
+    observer: &str,
+) -> AccelJacobiResult {
+    let mut total_acc = [0.0_f64; 3];
+    let mut total_jac = [[0.0_f64; 3]; 3];
+    let mut total_dadv = [[0.0_f64; 3]; 3];
+    for force in forces {
+        let (acc, jac, dadv) =
+            acceleration_and_jacobian_with_mass(force, et, state, mass, observer)?;
+        for i in 0..3 {
+            total_acc[i] += acc[i];
+            for j in 0..3 {
+                total_jac[i][j] += jac[i][j];
+                total_dadv[i][j] += dadv[i][j];
+            }
+        }
+    }
+    Ok((total_acc, total_jac, total_dadv))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_state() -> [f64; 6] {
+        [7000.0, 0.0, 0.0, 0.0, 7.5, 0.0]
+    }
+
+    fn variable_mass_srp() -> CompiledForce {
+        CompiledForce::SRPVariableMass {
+            area: 20.0,
+            cr: 1.3,
+            shadow_bodies: vec![],
+        }
+    }
+
+    #[test]
+    fn srp_variable_mass_rejects_fixed_mass_path() {
+        // 固定质量路径对 SRPVariableMass 必须报明确错误，引导调用方走
+        // acceleration_with_mass（6D 传播误用变质量力时不能静默用错质量）。
+        let err = variable_mass_srp()
+            .acceleration(0.0, &sample_state(), "EARTH")
+            .unwrap_err();
+        assert!(err.contains("acceleration_with_mass"), "unexpected: {err}");
+    }
+
+    #[test]
+    fn srp_variable_mass_rejects_nonpositive_mass() {
+        let state = sample_state();
+        let err = variable_mass_srp()
+            .acceleration_with_mass(0.0, &state, 0.0, "EARTH")
+            .unwrap_err();
+        assert!(err.contains("mass must be positive"), "unexpected: {err}");
+        let err = variable_mass_srp()
+            .mass_derivative(0.0, &state, -1.0, "EARTH")
+            .unwrap_err();
+        assert!(err.contains("mass must be positive"), "unexpected: {err}");
+    }
+
+    #[test]
+    fn fixed_mass_forces_ignore_mass_channel() {
+        // 固定质量力在 with_mass 路径下与原路径逐位一致，质量导数为零。
+        let forces = vec![CompiledForce::PointMass { mu: 398600.4418 }];
+        let state = sample_state();
+        let plain = compute_total_acceleration(&forces, 0.0, &state, "EARTH").unwrap();
+        let with_mass =
+            compute_total_acceleration_with_mass(&forces, 0.0, &state, 1500.0, "EARTH").unwrap();
+        assert_eq!(plain, with_mass);
+        let dm = compute_total_mass_derivative(&forces, 0.0, &state, 1500.0, "EARTH").unwrap();
+        assert_eq!(dm, [0.0; 3]);
+    }
 }

--- a/crates/e2m2e-forces/src/forces/srp.rs
+++ b/crates/e2m2e-forces/src/forces/srp.rs
@@ -133,6 +133,9 @@ pub(crate) fn body_position_cached(
     observer: &str,
     et: f64,
 ) -> Result<[f64; 3], SpiceFfiError> {
+    if target.eq_ignore_ascii_case(observer) {
+        return Ok([0.0; 3]);
+    }
     match e2m2e_spice::ephem_cache::lookup_body_position(target, observer, et) {
         Ok(Some(p)) => Ok(p),
         Ok(None) => {

--- a/crates/e2m2e-integrators/src/lib.rs
+++ b/crates/e2m2e-integrators/src/lib.rs
@@ -1094,6 +1094,16 @@ pub(crate) fn parse_force_tuple(
                 shadow_bodies,
             })
         }
+        "srp_variable_mass" => {
+            let area: f64 = tuple.get_item(1)?.extract()?;
+            let cr: f64 = tuple.get_item(2)?.extract()?;
+            let shadow_bodies: Vec<String> = tuple.get_item(3)?.extract()?;
+            Ok(CompiledForce::SRPVariableMass {
+                area,
+                cr,
+                shadow_bodies,
+            })
+        }
         "ecom_srp" => {
             let dyb_vec: Vec<f64> = tuple.get_item(1)?.extract().map_err(|_| {
                 pyo3::exceptions::PyTypeError::new_err("ecom_srp dyb must be a list of floats")

--- a/e2m2e/algorithm/forces/__init__.py
+++ b/e2m2e/algorithm/forces/__init__.py
@@ -26,7 +26,7 @@ from .physical_model import PhysicalModel
 from .point_mass_gravity import PointMassGravity
 from .relativistic_correction import RelativisticCorrection
 from .shadow import ConicalShadowModel
-from .srp import SolarRadiationPressure
+from .srp import SolarRadiationPressure, VariableMassSolarRadiationPressure
 from .third_body_gravity import ThirdBodyGravity
 from .thrust import BurnApplication, FiniteBurn, ImpulsiveBurn, VariableMassFiniteBurn
 
@@ -40,6 +40,7 @@ __all__ = [
     "IndirectTerm",
     "DragModel",
     "SolarRadiationPressure",
+    "VariableMassSolarRadiationPressure",
     "EcomSolarRadiationPressure",
     "ConicalShadowModel",
     "ImpulsiveBurn",

--- a/e2m2e/algorithm/forces/srp.py
+++ b/e2m2e/algorithm/forces/srp.py
@@ -75,3 +75,47 @@ class SolarRadiationPressure(PhysicalModel):
         """序列化为 ``("srp", area, mass, cr, shadow_bodies)``。"""
         shadow_bodies = list(self._shadow.bodies) if self._shadow is not None else []
         return ("srp", self._area, self._mass, self._cr, shadow_bodies)
+
+
+class VariableMassSolarRadiationPressure(PhysicalModel):
+    """质量由增广状态提供的 cannonball 光压模型。
+
+    小推力任务质量在线衰减，固定质量的 :class:`SolarRadiationPressure` 会
+    在整个传播区间用同一初始质量。本类只存截面积 ``area``（m²）与 ``cr``，
+    质量在每个增广状态里取出，因此 ``a = flux·P·(1AU/r)²·cr·area/m`` 随
+    推进耗质量自动更新。
+
+    Args:
+        area: 航天器迎风截面积，单位 m²。
+        cr: 辐射反射系数，默认 1.5。
+        shadow: 阴影模型（注入）；``None`` 表示全光照。
+    """
+
+    def __init__(
+        self,
+        area: float,
+        cr: float = 1.5,
+        shadow: ConicalShadowModel | None = None,
+    ) -> None:
+        self._area = float(area)
+        self._cr = float(cr)
+        self._shadow = shadow
+        if self._area <= 0:
+            raise ValueError("area must be positive")
+
+    @property
+    def area(self) -> float:
+        return self._area
+
+    @property
+    def cr(self) -> float:
+        return self._cr
+
+    @property
+    def shadow(self) -> ConicalShadowModel | None:
+        return self._shadow
+
+    def to_rust_spec(self, system) -> tuple | None:
+        """序列化为 ``("srp_variable_mass", area, cr, shadow_bodies)``。"""
+        shadow_bodies = list(self._shadow.bodies) if self._shadow is not None else []
+        return ("srp_variable_mass", self._area, self._cr, shadow_bodies)

--- a/tests/numerical/forces/contract/test_srp.py
+++ b/tests/numerical/forces/contract/test_srp.py
@@ -58,3 +58,39 @@ def test_srp_stores_injected_shadow() -> None:
     shadow = ConicalShadowModel(bodies=["EARTH", "MOON"])
     srp = SolarRadiationPressure(area=10.0, mass=1000.0, shadow=shadow)
     assert srp.shadow is shadow
+
+
+def test_variable_mass_srp_is_physical_model() -> None:
+    """VariableMassSolarRadiationPressure 是 PhysicalModel 的具体子类。"""
+    from e2m2e.algorithm.forces.srp import VariableMassSolarRadiationPressure
+
+    srp = VariableMassSolarRadiationPressure(area=20.0)
+    assert isinstance(srp, PhysicalModel)
+
+
+def test_variable_mass_srp_rejects_nonpositive_area() -> None:
+    """截面积必须为正。"""
+    from e2m2e.algorithm.forces.srp import VariableMassSolarRadiationPressure
+
+    with pytest.raises(ValueError, match="area"):
+        VariableMassSolarRadiationPressure(area=0.0)
+
+
+def test_variable_mass_srp_to_rust_spec_without_shadow() -> None:
+    """无阴影时 to_rust_spec 返回 ("srp_variable_mass", area, cr, [])，不带质量。"""
+    from e2m2e.algorithm.forces.srp import VariableMassSolarRadiationPressure
+
+    srp = VariableMassSolarRadiationPressure(area=20.0, cr=1.3)
+    spec = srp.to_rust_spec(None)
+    assert spec == ("srp_variable_mass", 20.0, 1.3, [])
+
+
+def test_variable_mass_srp_to_rust_spec_with_shadow() -> None:
+    """含阴影时 to_rust_spec 把 shadow bodies 带进元组。"""
+    from e2m2e.algorithm.forces.shadow import ConicalShadowModel
+    from e2m2e.algorithm.forces.srp import VariableMassSolarRadiationPressure
+
+    shadow = ConicalShadowModel(bodies=["EARTH", "MOON"])
+    srp = VariableMassSolarRadiationPressure(area=20.0, cr=1.3, shadow=shadow)
+    spec = srp.to_rust_spec(None)
+    assert spec == ("srp_variable_mass", 20.0, 1.3, ["EARTH", "MOON"])

--- a/tests/numerical/forces/physics/test_low_thrust_variable_mass.py
+++ b/tests/numerical/forces/physics/test_low_thrust_variable_mass.py
@@ -1,7 +1,13 @@
 import numpy as np
 import pytest
 
-from e2m2e.algorithm.forces import ForceModel, GravityField, VariableMassFiniteBurn
+from e2m2e.algorithm.forces import (
+    ForceModel,
+    GravityField,
+    SolarRadiationPressure,
+    VariableMassFiniteBurn,
+    VariableMassSolarRadiationPressure,
+)
 from tests.numerical.forces.conftest import (
     EARTH_RE,
     keplerian_to_cartesian,
@@ -173,3 +179,77 @@ def test_variable_mass_zero_thrust_no_fuel_consumption(earth_icrf_system):
     a0 = semi_major_axis(y0, mu)
     a_final = semi_major_axis(result["states"][-1], mu)
     assert abs(a_final - a0) / a0 < 1e-6
+
+
+def _build_srp_problem(system, srp_force, thrust):
+    """构造含 SRP 的 7D 变质量传播问题（LEO 圆轨道，固定方向推力）。"""
+    mu = system.gravitational_parameter("EARTH")
+    a0 = EARTH_RE + 300.0
+    y0_6 = keplerian_to_cartesian(a0, 0.0, 0.0, 0.0, 0.0, 0.0, mu)
+    mass = 1000.0
+    burn = VariableMassFiniteBurn(
+        thrust=thrust,
+        isp=3000.0,
+        initial_mass=mass,
+        direction=np.array([0.0, 1.0, 0.0]),
+    )
+    gravity = GravityField(body="EARTH", degree=0, order=0)
+    fm = ForceModel(system, forces=[gravity, srp_force, burn])
+    y0 = np.concatenate([y0_6, [mass]])
+    return fm, y0
+
+
+@pytest.mark.spice
+def test_variable_mass_srp_matches_fixed_when_mass_constant(earth_icrf_system):
+    """零推力质量恒定时，变质量 SRP 必须退化为同面质比的固定质量 SRP。"""
+    system = earth_icrf_system
+    area, mass, cr = 20.0, 1000.0, 1.3
+    fm_var, y0 = _build_srp_problem(
+        system, VariableMassSolarRadiationPressure(area=area, cr=cr), thrust=0.0
+    )
+    fm_fix, _ = _build_srp_problem(
+        system, SolarRadiationPressure(area=area, mass=mass, cr=cr), thrust=0.0
+    )
+
+    et0 = system.spice.utc_to_et("2025-06-21T11:00:06")
+    t_span = (et0, et0 + 86400.0)
+    t_eval = np.array([et0 + 86400.0])
+
+    state_var = fm_var.propagate(y0, t_span, t_eval=t_eval, max_steps=200_000)["states"][-1]
+    state_fix = fm_fix.propagate(y0, t_span, t_eval=t_eval, max_steps=200_000)["states"][-1]
+
+    diff_km = float(np.linalg.norm(state_var[:3] - state_fix[:3]))
+    assert diff_km < 1e-9, f"质量恒定时两模型应逐位一致: diff={diff_km:.3e} km"
+
+
+@pytest.mark.spice
+def test_variable_mass_srp_mass_channel_active_under_burn(earth_icrf_system):
+    """点火耗质量后，变质量 SRP 与取初始质量的固定 SRP 的轨迹应可分辨地分离。
+
+    两天点火约耗 11.7 kg（约 1.2%），SRP 加速度同比增大；实测 LEO 两天弧
+    轨迹差异约 9e-5 km（0.1 m 级，差异大部分被轨道相位吸收而非随 t²
+    累积）。同物理零推力对照（上一测试）的差异 < 1e-9 km，故下限取
+    1e-6 km 足以区分真实信号与数值噪声，上限 1 km 是 sanity 界。
+    """
+    system = earth_icrf_system
+    area, mass, cr = 20.0, 1000.0, 1.3
+    thrust = 2.0  # N
+    duration_s = 2.0 * 86400.0
+
+    fm_var, y0 = _build_srp_problem(
+        system, VariableMassSolarRadiationPressure(area=area, cr=cr), thrust=thrust
+    )
+    fm_fix, _ = _build_srp_problem(
+        system, SolarRadiationPressure(area=area, mass=mass, cr=cr), thrust=thrust
+    )
+
+    et0 = system.spice.utc_to_et("2025-06-21T11:00:06")
+    t_span = (et0, et0 + duration_s)
+    t_eval = np.array([et0 + duration_s])
+
+    state_var = fm_var.propagate(y0, t_span, t_eval=t_eval, max_steps=400_000)["states"][-1]
+    state_fix = fm_fix.propagate(y0, t_span, t_eval=t_eval, max_steps=400_000)["states"][-1]
+
+    diff_km = float(np.linalg.norm(state_var[:3] - state_fix[:3]))
+    assert state_var[6] < mass, "点火两天质量应下降"
+    assert 1e-6 < diff_km < 1.0, f"质量通道未生效或差异异常: diff={diff_km:.3e} km"


### PR DESCRIPTION
Closes #506。

## 背景

geo-nrho 的 `lowthrust_rs` 高保真分支已在调用 `CompiledForce::SRPVariableMass`，但该契约此前只存在于未提交工作区。本 PR 把它独立落地（ADR 0034 决策 5）。

## 改动

- `CompiledForce::SRPVariableMass { area, cr, shadow_bodies }`：不存质量，经新接口 `acceleration_with_mass` 从增广状态取当前质量；固定质量 `acceleration()` 路径对其报明确错误，6D 传播误用不静默。
- `mass_derivative`（∂a/∂m = −a/m）与 `compute_total_acceleration_with_mass` / `compute_total_mass_derivative` / `compute_total_acceleration_and_jacobian_with_mass` 求和入口；固定质量力在 with_mass 路径下行为不变。
- `augmented_eom_7d` 及 STM/灵敏度变体改走 with_mass 路径，质量列雅可比补力模型贡献。
- Python `VariableMassSolarRadiationPressure`（面积、Cr、可选圆锥阴影），`to_rust_spec` 为 `("srp_variable_mass", area, cr, shadow_bodies)`；`parse_force_tuple` 增加对应分支。无新增 PyO3 符号，ABI 戳不变。
- `srp::body_position_cached` 增加 target==observer 归零守卫。

## 验证

- 新增 Rust 契约单测 3 项（固定质量路径报错、非正质量报错、固定质量力不受质量通道影响）。
- 新增 Python 序列化契约测试 4 项、7D 传播物理对照 2 项：零推力质量恒定时与固定质量 SRP 逐位一致（diff < 1e-9 km）；点火两天质量通道生效（轨迹差约 9e-5 km，显著高于 1e-9 噪声底）。
- `cargo test -p e2m2e-integrators --lib` 54 项通过；`tests/numerical/forces/` 311 项通过；`test_lowthrust_shooting.py` + 绑定层 50 项通过；ruff、mypy、cargo fmt、clippy --workspace 全绿。
- 已知既有失败：`cargo test -p e2m2e-forces` 中 nbody_stm 5 项在本环境报 cspice 多线程守卫 panic，干净 master 上同样失败，与本改动无关。
- 未跑全量 pytest：改动集中在力模型编译层与 7D 增广路径，受影响面（forces 全目录、低推力打靶、绑定层）已定向覆盖。