### PR TITLE
feat(api): 实现 MCP server 本体：create_server 落地 + 工具纯派生注册（ADR 0014）

### DIFF
--- a/e2m2e/api/cli/main.py
+++ b/e2m2e/api/cli/main.py
@@ -1,8 +1,66 @@
 """e2m2e 命令入口。
 
-实现状态：骨架。待 Facade + models 实现后生成子命令（含 mcp-serve 薄包装）。
+实现状态：``mcp-serve`` 子命令（MCP 部署薄包装，ADR 0014 §6，issue #510）。
+完整 CLI 子命令（= Facade 方法，参数从同一份 Pydantic 模型生成）另立 issue。
 """
 
 from __future__ import annotations
 
-__all__: list[str] = []
+import argparse
+import sys
+from collections.abc import Sequence
+
+__all__ = ["main", "build_parser"]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="e2m2e",
+        description="e2m2e 命令行（地月空间转移轨道设计库）",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser(
+        "mcp-serve",
+        help="启动 MCP 服务器（stdio 传输），把 Facade 工具暴露给 LLM Agent",
+    )
+    return parser
+
+
+def _run_mcp_serve() -> int:
+    try:
+        from e2m2e.api.config import Config
+        from e2m2e.api.facade import Facade
+        from e2m2e.api.mcp import create_server
+    except ImportError as exc:
+        print(
+            f"MCP 协议层未安装（{exc}）。请安装 [mcp] extra："
+            "uv sync --extra mcp / pip install 'e2m2e[mcp]'",
+            file=sys.stderr,
+        )
+        return 1
+
+    import anyio
+    from mcp.server.stdio import stdio_server
+
+    facade = Facade(config=Config())
+    server = create_server(facade)
+
+    async def _serve() -> None:
+        options = server.create_initialization_options()
+        async with stdio_server() as (read, write):
+            await server.run(read, write, options, raise_exceptions=True)
+
+    anyio.run(_serve)
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.command == "mcp-serve":
+        return _run_mcp_serve()
+    raise AssertionError(f"未知子命令 {args.command!r}（应由 subparser 拦截）")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/e2m2e/api/mcp/__init__.py
+++ b/e2m2e/api/mcp/__init__.py
@@ -1,1 +1,23 @@
-"""MCP 服务子包。"""
+"""MCP 服务子包（ADR 0014）。
+
+- ``envelope``：统一信封 {status, data, error, meta} 与异常翻译。
+- ``tools``：由 Facade 纯派生的工具规格（placeholder 不注册）。
+- ``server``：``create_server(facade)``（依赖 ``[mcp]`` extra）。
+"""
+
+from __future__ import annotations
+
+from .envelope import error_envelope, invoke_tool, ok_envelope
+from .server import create_server, handle_call_tool, handle_list_tools
+from .tools import ToolSpec, tool_specs
+
+__all__ = [
+    "ToolSpec",
+    "create_server",
+    "error_envelope",
+    "handle_call_tool",
+    "handle_list_tools",
+    "invoke_tool",
+    "ok_envelope",
+    "tool_specs",
+]

--- a/e2m2e/api/mcp/envelope.py
+++ b/e2m2e/api/mcp/envelope.py
@@ -1,0 +1,74 @@
+"""统一信封：MCP 传输层输出形状（ADR 0014 §4）。
+
+所有工具调用的返回都包成 ``{status, data, error, meta}``：成功时
+``status="ok"``、``data`` 为 Response 模型的 JSON 序列化；失败时
+``status="error"``、``error`` 为结构化错误（错误码 + message + details）。
+异常在 api/ 边界翻译，不向 Agent 泄漏原始 traceback。
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from pydantic import BaseModel, ValidationError
+
+from ..models import OrbitError
+
+__all__ = ["Envelope", "ok_envelope", "error_envelope", "invoke_tool"]
+
+# 信封的 JSON 形状（不是 Pydantic 模型：传输层只做序列化，不再校验自己）。
+Envelope = dict[str, Any]
+
+
+def _jsonify(data: Any) -> Any:
+    """把 Response 模型/普通对象转成可 JSON 序列化的结构。"""
+    if isinstance(data, BaseModel):
+        return data.model_dump(mode="json")
+    return data
+
+
+def ok_envelope(data: Any, meta: dict[str, Any] | None = None) -> Envelope:
+    """构造成功信封。"""
+    return {"status": "ok", "data": _jsonify(data), "error": None, "meta": meta or {}}
+
+
+def error_envelope(code: str, message: str, details: dict[str, Any] | None = None) -> Envelope:
+    """构造失败信封。"""
+    return {
+        "status": "error",
+        "data": None,
+        "error": {"code": code, "message": message, "details": details or {}},
+        "meta": {},
+    }
+
+
+def invoke_tool(method: Any, arguments: dict[str, Any]) -> Envelope:
+    """执行一个 Facade 工具方法并包成信封。
+
+    入参经 ``request_model`` 校验（ValidationError → ``INVALID_PARAMS``），
+    ``OrbitError`` 原样翻译，其余异常归为 ``INTERNAL_ERROR``（只保留异常类型
+    名，不泄漏 traceback）。
+    """
+    request_model = getattr(method, "request_model", None)
+    try:
+        if request_model is not None:
+            request = request_model.model_validate(arguments)
+            result = method(**request.model_dump())
+        else:
+            result = method(**arguments)
+    except OrbitError as exc:
+        return error_envelope(exc.code, exc.message, exc.details)
+    except ValidationError as exc:
+        # exc.json() 走 Pydantic 自己的序列化，避免 details 里残留不可 JSON 化对象。
+        return error_envelope(
+            "INVALID_PARAMS",
+            "输入参数校验失败",
+            {"errors": json.loads(exc.json(include_url=False))},
+        )
+    except TypeError as exc:
+        # 方法签名不匹配（如多余参数已由 forbid 校验拦下，此处兜底）。
+        return error_envelope("INVALID_PARAMS", f"参数与工具签名不匹配：{exc}")
+    except Exception as exc:
+        return error_envelope("INTERNAL_ERROR", f"未预期的内部错误（{type(exc).__name__}）")
+    return ok_envelope(result)

--- a/e2m2e/api/mcp/server.py
+++ b/e2m2e/api/mcp/server.py
@@ -2,28 +2,96 @@
 
 进程内库为主体 + CLI 薄包装 mcp-serve（ADR 0014）：``create_server(facade)``
 函数（进程内、可测试）+ ``e2m2e mcp-serve`` 子命令。一个 Facade 实例 = 一个
-server。MCP 工具 = facade 上 mcp_exposed=True 的方法（纯派生），传输层包统一信封
-（{status, data, error, meta}）。
+server。MCP 工具 = facade 上 mcp_exposed=True 的方法（纯派生，见 tools.py），
+传输层包统一信封（见 envelope.py）。
 
-实现状态：骨架。协议层依赖 ``[mcp]`` extra。
+依赖 ``[mcp]`` extra：本模块在缺 ``mcp`` 库时导入即失败，调用方（CLI）负责
+给出安装提示。
 """
 
 from __future__ import annotations
 
-from typing import Any
+import json
+from typing import TYPE_CHECKING, Any
 
-__all__ = ["create_server"]
+import anyio.to_thread
+from mcp.server import Server
+from mcp.types import (
+    CallToolRequestParams,
+    CallToolResult,
+    ListToolsResult,
+    PaginatedRequestParams,
+    TextContent,
+    Tool,
+)
+
+from . import envelope, tools
+
+if TYPE_CHECKING:
+    from ..facade import Facade
+
+__all__ = ["create_server", "handle_list_tools", "handle_call_tool"]
 
 
-def create_server(facade) -> Any:
+def handle_list_tools(facade: Facade) -> list[Tool]:
+    """列出工具（纯函数，便于测试）。"""
+    return [
+        Tool(
+            name=spec.name,
+            description=spec.description,
+            input_schema=spec.input_schema,
+        )
+        for spec in tools.tool_specs(facade)
+    ]
+
+
+def _to_result(env: envelope.Envelope) -> CallToolResult:
+    """信封 → MCP CallToolResult（JSON 文本 + isError 标志）。"""
+    return CallToolResult(
+        content=[TextContent(type="text", text=json.dumps(env, ensure_ascii=False))],
+        is_error=env["status"] == "error",
+    )
+
+
+def handle_call_tool(facade: Facade, name: str, arguments: dict[str, Any]) -> CallToolResult:
+    """调用工具并包信封（纯函数，便于测试）。"""
+    spec = next((s for s in tools.tool_specs(facade) if s.name == name), None)
+    if spec is None:
+        env = envelope.error_envelope(
+            "TOOL_NOT_FOUND", f"未知工具 {name!r}（placeholder 或未暴露的方法不注册）"
+        )
+    else:
+        env = envelope.invoke_tool(spec.method, arguments)
+    return _to_result(env)
+
+
+def create_server(facade: Facade) -> Server:
     """创建 MCP 服务器（绑定传入的 Facade）。
 
-    实现状态：待实现（依赖 [mcp] extra）。
+    一个 Facade 实例 = 一个 server；工具清单在每次 tools/list 时由 Facade
+    纯派生，与 ``tool_inventory()`` 单一同源。注册走
+    ``add_request_handler``（mcp 1.x/2.x 兼容：2.0 移除了装饰器 API）。
 
     Args:
         facade: Facade 实例。
 
     Returns:
-        MCP server 对象。
+        ``mcp.server.Server`` 对象（配合 ``mcp.server.stdio.stdio_server`` 运行）。
     """
-    raise NotImplementedError("MCP create_server 待实现（依赖 [mcp] extra）")
+    server: Server = Server("e2m2e")
+
+    async def _list_tools(context: Any, params: Any) -> ListToolsResult:
+        # 纯派生不走 Facade 方法本体，直接在事件循环里做即可。
+        return ListToolsResult(tools=handle_list_tools(facade))
+
+    async def _call_tool(context: Any, params: Any) -> CallToolResult:
+        # Facade 方法是同步长计算，放线程池避免阻塞事件循环。
+        arguments = dict(params.arguments or {})
+        env = await anyio.to_thread.run_sync(
+            lambda: handle_call_tool(facade, params.name, arguments)
+        )
+        return env
+
+    server.add_request_handler("tools/list", PaginatedRequestParams, _list_tools)
+    server.add_request_handler("tools/call", CallToolRequestParams, _call_tool)
+    return server

--- a/e2m2e/api/mcp/tools.py
+++ b/e2m2e/api/mcp/tools.py
@@ -1,11 +1,54 @@
 """MCP 工具注册：由 Facade 方法自动派生。
 
-纯派生 + 元数据标记（ADR 0014）：MCP 工具 = Facade 方法全集，凡 mcp_exposed=True
-的方法都注册。清单单一来源，一档也会增加。
+纯派生 + 元数据标记（ADR 0014）：MCP 工具 = Facade 方法全集，凡
+``mcp_exposed=True`` 的方法都注册。清单单一来源是 ``tool_inventory()``，
+本模块只消费它，不维护第二份清单。
 
-实现状态：骨架。待 create_server 落地后实现派生逻辑。
+placeholder 状态的工具**不注册**（issue #510 决策）：Agent 不应调到空实现；
+待其落地为 implemented 后由清单单一来源自动出现在 server 上。
 """
 
 from __future__ import annotations
 
-__all__: list[str] = []
+import dataclasses
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from ..facade import tool_inventory
+
+if TYPE_CHECKING:
+    from ..facade import Facade
+
+__all__ = ["ToolSpec", "tool_specs"]
+
+
+@dataclasses.dataclass(frozen=True)
+class ToolSpec:
+    """一个可注册的 MCP 工具规格。"""
+
+    name: str
+    description: str
+    input_schema: dict[str, Any]
+    method: Callable[..., Any]
+
+
+def tool_specs(facade: Facade) -> list[ToolSpec]:
+    """由 Facade 纯派生工具规格（placeholder 不注册）。"""
+    specs: list[ToolSpec] = []
+    for info in tool_inventory(facade):
+        if info.status != "implemented":
+            continue
+        method = getattr(facade, info.name)
+        if info.request_model is not None:
+            schema = info.request_model.model_json_schema()
+        else:
+            schema = {"type": "object", "properties": {}, "additionalProperties": False}
+        specs.append(
+            ToolSpec(
+                name=info.name,
+                description=(method.__doc__ or info.name).strip().splitlines()[0],
+                input_schema=schema,
+                method=method,
+            )
+        )
+    return specs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,9 +52,14 @@ normal-form = [
     "sympy>=1.12",
 ]
 # MCP 协议层（api/mcp）：部署 MCP 服务器时装。
+# anyio 显式声明（server 的线程池与 CLI 事件循环直接用它，不只是 mcp 传递依赖）。
 mcp = [
-    "mcp>=1.0",
+    "mcp>=2.0",
+    "anyio>=3",
 ]
+
+[project.scripts]
+e2m2e = "e2m2e.api.cli.main:main"
 
 [project.urls]
 Homepage = "https://github.com/cislunarspace/e2m2e"

--- a/tests/api/test_mcp.py
+++ b/tests/api/test_mcp.py
@@ -1,0 +1,164 @@
+"""MCP 协议层测试（issue #510 / ADR 0014）：纯派生注册、schema、统一信封。
+
+只测进程内逻辑（tool_specs / handle_call_tool / envelope），不需要真实
+stdio 传输；handler 纯函数与 create_server 注册的是同一批。
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytestmark = [pytest.mark.interface]
+
+pytest.importorskip("mcp")  # [mcp] extra 未装时整文件跳过（协议层依赖，ADR 0014）
+
+from e2m2e.api.config import Config  # noqa: E402
+from e2m2e.api.facade import Facade, tool_inventory  # noqa: E402
+from e2m2e.api.mcp import (  # noqa: E402
+    envelope,
+    handle_call_tool,
+    handle_list_tools,
+    tool_specs,
+)
+from e2m2e.api.models import DesignOrbitRequest  # noqa: E402
+
+
+@pytest.fixture
+def facade(tmp_path, monkeypatch) -> Facade:
+    monkeypatch.setenv("E2M2E_CATALOG_DIR", str(tmp_path / "catalog"))
+    return Facade(Config())
+
+
+def test_registered_tools_match_inventory(facade):
+    """注册清单 = tool_inventory() 中 implemented 的条目（单一来源，不漂移）。"""
+    specs = tool_specs(facade)
+    expected = [i.name for i in tool_inventory(facade) if i.status == "implemented"]
+    assert [s.name for s in specs] == expected
+    # placeholder 不注册（issue #510 决策）
+    placeholders = {i.name for i in tool_inventory(facade) if i.status == "placeholder"}
+    assert placeholders, "前提：Facade 至少有一个 placeholder 工具"
+    assert not placeholders & {s.name for s in specs}
+
+
+def test_input_schema_derived_from_request_model(facade):
+    specs = {s.name: s for s in tool_specs(facade)}
+    assert specs["design_orbit"].input_schema == DesignOrbitRequest.model_json_schema()
+    # 独立验证关键字段确实进了 schema（不是仅对照同一来源的同义反复）
+    props = specs["design_orbit"].input_schema["properties"]
+    assert props["orbit_type"]["type"] == "string"
+    assert props["output_step"]["default"] == 3600.0
+    # 无 request_model 的方法以无参 schema 注册
+    no_model = [
+        i.name
+        for i in tool_inventory(facade)
+        if i.request_model is None and i.status == "implemented"
+    ]
+    for name in no_model:
+        assert specs[name].input_schema == {
+            "type": "object",
+            "properties": {},
+            "additionalProperties": False,
+        }
+
+
+def test_handle_list_tools(facade):
+    listing = handle_list_tools(facade)
+    assert [t.name for t in listing] == [s.name for s in tool_specs(facade)]
+    assert all(t.description for t in listing)
+
+
+def test_ok_envelope_wraps_response(facade):
+    # 用便宜的 catalog_query（空库即成功）验证信封；design_orbit 会跑真算法，太慢。
+    result = handle_call_tool(facade, "catalog_query", {})
+    assert not result.is_error
+    env = json.loads(result.content[0].text)
+    assert set(env) == {"status", "data", "error", "meta"}
+    assert env["status"] == "ok"
+    assert env["error"] is None
+    assert env["data"], "catalog_query 成功时 data 应为 Response 序列化"
+
+
+def test_invalid_params_envelope(facade):
+    result = handle_call_tool(facade, "catalog_query", {"libration_point": 99})
+    assert result.is_error
+    env = json.loads(result.content[0].text)
+    assert env["status"] == "error"
+    assert env["error"]["code"] == "INVALID_PARAMS"
+    assert env["error"]["details"]["errors"]
+
+
+def test_orbit_error_translated_without_traceback(facade):
+    # catalog_get 对空库报 RECORD_NOT_FOUND（OrbitError 路径），无 traceback 泄漏
+    result = handle_call_tool(facade, "catalog_get", {"record_id": "no-such-record"})
+    env = json.loads(result.content[0].text)
+    assert env["status"] == "error"
+    assert env["error"]["code"] == "RECORD_NOT_FOUND"
+    assert "Traceback" not in result.content[0].text
+
+
+def test_missing_required_field_invalid_params(facade):
+    # design_orbit 缺必填字段 → Pydantic ValidationError → INVALID_PARAMS
+    result = handle_call_tool(facade, "design_orbit", {})
+    env = json.loads(result.content[0].text)
+    assert env["error"]["code"] == "INVALID_PARAMS"
+
+
+def test_unknown_tool_envelope(facade):
+    result = handle_call_tool(facade, "no_such_tool", {})
+    assert result.is_error
+    env = json.loads(result.content[0].text)
+    assert env["error"]["code"] == "TOOL_NOT_FOUND"
+
+
+def test_placeholder_tool_not_registered(facade):
+    placeholders = [i.name for i in tool_inventory(facade) if i.status == "placeholder"]
+    for name in placeholders:
+        result = handle_call_tool(facade, name, {})
+        env = json.loads(result.content[0].text)
+        assert env["error"]["code"] == "TOOL_NOT_FOUND"
+
+
+def test_create_server_binds_facade(facade):
+    import anyio
+    from mcp.types import ListToolsRequest, PaginatedRequestParams
+
+    from e2m2e.api.mcp import create_server
+
+    server = create_server(facade)
+    assert server.name == "e2m2e"
+
+    async def run():
+        entry = server.get_request_handler("tools/list")
+        assert entry is not None
+        result = await entry.handler(
+            None, ListToolsRequest(method="tools/list", params=PaginatedRequestParams())
+        )
+        return result
+
+    listing = anyio.run(run)
+    listed = listing.tools if hasattr(listing, "tools") else listing
+    assert [t.name for t in listed] == [t.name for t in handle_list_tools(facade)]
+
+
+def test_invoke_tool_internal_error():
+    class Boom:
+        request_model = None
+
+        def __call__(self, **kwargs):
+            raise RuntimeError("secret detail")
+
+    env = envelope.invoke_tool(Boom(), {})
+    assert env["status"] == "error"
+    assert env["error"]["code"] == "INTERNAL_ERROR"
+    assert "secret detail" not in env["error"]["message"]
+    assert "RuntimeError" in env["error"]["message"]
+
+
+def test_cli_parser_has_mcp_serve():
+    from e2m2e.api.cli.main import build_parser
+
+    parser = build_parser()
+    args = parser.parse_args(["mcp-serve"])
+    assert args.command == "mcp-serve"


### PR DESCRIPTION
Closes #510

## 改动摘要

- `e2m2e/api/mcp/envelope.py`（新）：统一信封 `{status, data, error, meta}`（ADR 0014 §4）。`OrbitError` 原码翻译；`ValidationError` → `INVALID_PARAMS`（细节经 Pydantic 自身序列化，可 JSON 化）；未预期异常 → `INTERNAL_ERROR`（只留异常类型名，不泄漏 traceback）。
- `e2m2e/api/mcp/tools.py`：由 `tool_inventory()` 纯派生 `ToolSpec`（清单单一来源，不维护第二份清单）；**placeholder 工具不注册**（brief 决策）；schema 来自各方法 `request_model.model_json_schema()`，无 `request_model` 的以无参 schema 注册。
- `e2m2e/api/mcp/server.py`：`create_server(facade)` 落地。走 `add_request_handler`（mcp 2.0 handler 语义，extra 已收紧 `mcp>=2.0`）；工具调用经 `anyio.to_thread` 线程池，避免同步长计算阻塞事件循环。
- `e2m2e/api/cli/main.py`：`e2m2e mcp-serve` 薄包装（stdio 传输，ADR 0014 §6）；缺 `[mcp]` extra 时给出安装提示。
- `pyproject.toml`：新增 `[project.scripts] e2m2e` 入口；`[mcp]` extra = `mcp>=2.0` + 显式 `anyio>=3`。
- `tests/api/test_mcp.py`（新）：12 例——注册清单与 `tool_inventory()` 单一同源、schema 显式字段断言、成功/失败信封、未知工具、placeholder 不注册、CLI 解析。

## 测试

- `uv run --no-sync pytest tests/api/test_mcp.py -q` → 12 passed
- `uv run --no-sync pytest tests/api -q` → 166 passed（全量接口层）
- 端到端 smoke：`ClientSession` 真握手 → 14 个工具、成功/失败信封正确
- `ruff check` / `ruff format --check` / `mypy e2m2e/` 全绿

## 备注

- CI 若用 `--extra mcp` 同步依赖，需要先跑一次 `uv lock` 提交锁文件（`mcp>=2.0` 与 `anyio` 尚未进 uv.lock）。
- 完整 CLI 子命令（CLI 与 MCP 对称的其余部分）按 brief 另立 issue，不在本 PR 范围。
