### PR TITLE
fix(design): NRHO n_rev=2 合并层不收敛时回退单段两圈（#508）

### DIFF
--- a/e2m2e/algorithm/design/design_orbit.py
+++ b/e2m2e/algorithm/design/design_orbit.py
@@ -1165,18 +1165,40 @@ def design_orbit(
                 revs_per_group = min(n_rev, 3)
             else:
                 revs_per_group = max(1, min(3, n_rev))
-            t_patch_long, s_patch_long, max_residual = _design_apolune_segmented(
-                forces_py,
-                "EARTH",
-                t_patch_j2000_n,
-                state_patch_j2000_n,
-                revs_per_group,
-                per_rev,
-                max_iter=50,
-                tolerance=CORRECTION_TOL_KM,
-                var_time=sel not in _FIXED_TIME_ORBIT_TYPES,
-                verbose=verbose,
-            )
+            try:
+                t_patch_long, s_patch_long, max_residual = _design_apolune_segmented(
+                    forces_py,
+                    "EARTH",
+                    t_patch_j2000_n,
+                    state_patch_j2000_n,
+                    revs_per_group,
+                    per_rev,
+                    max_iter=50,
+                    tolerance=CORRECTION_TOL_KM,
+                    var_time=sel not in _FIXED_TIME_ORBIT_TYPES,
+                    verbose=verbose,
+                )
+            except DesignNotConvergedError:
+                # NRHO n_rev=2 回退（#508）：9:2 贴月共振成员（近月高
+                # ~1500 km）在 phase=0.5 下两段独立打靶后 seam 失配
+                # ~10² km，合并层不收敛；改为单段 2 圈（无合并层）可收敛。
+                # 反之 phase=0 端点单段不收敛、原路径可收敛——两种策略
+                # 互补，按失败自动切换。仅限 n_rev=2（多圈单段长弧打靶
+                # 另有收敛风险，#473）。
+                if sel != "NRHO" or n_rev != 2 or revs_per_group >= n_rev:
+                    raise
+                t_patch_long, s_patch_long, max_residual = _design_apolune_segmented(
+                    forces_py,
+                    "EARTH",
+                    t_patch_j2000_n,
+                    state_patch_j2000_n,
+                    n_rev,
+                    per_rev,
+                    max_iter=50,
+                    tolerance=CORRECTION_TOL_KM,
+                    var_time=sel not in _FIXED_TIME_ORBIT_TYPES,
+                    verbose=verbose,
+                )
 
             # 逐段积分填满 et_grid（下沉 Rust propagate_segments_py 并发积分，
             # #400 性能修复）：每段从修正后节点初值积分到下一节点。中间段

--- a/tests/algorithm/design/test_nrho_ephemeris_correction.py
+++ b/tests/algorithm/design/test_nrho_ephemeris_correction.py
@@ -42,6 +42,11 @@ GUI_OUTPUT_STEP_SEC = 3600.0
 PHASE_ZERO_DURATION_SEC = 8 * 86400.0
 PHASE_ZERO_OUTPUT_STEP_SEC = 7200.0
 
+# #508：9:2 贴月共振成员（近月高 1500 km）略超一圈的 8 天弧。主路径
+# （1 圈/段 + 合并层）对该成员不收敛，须回退单段 2 圈。
+RESONANT_DURATION_SEC = 8 * 86400.0
+RESONANT_OUTPUT_STEP_SEC = 7200.0
+
 
 @pytest.fixture(scope="module")
 def nrho_tight_short_result():
@@ -94,6 +99,23 @@ def nrho_phase_zero_result():
     )
 
 
+@pytest.fixture(scope="module")
+def nrho_resonant_result():
+    """9:2 贴月共振成员 8 天弧——#508 回退链回归样本。"""
+    return design_orbit(
+        make_design_request(
+            orbit_type="NRHO",
+            collinear_point=2,
+            north_south=2,
+            perilune_height=1500.0,
+            phase=0.5,
+            duration=RESONANT_DURATION_SEC,
+            output_step=RESONANT_OUTPUT_STEP_SEC,
+            correction_method="segmented",
+        )
+    )
+
+
 def test_tight_short_nrho_converges(nrho_tight_short_result):
     """贴月短弧修正收敛：#463 场景在新默认策略下仍可用。"""
     res = nrho_tight_short_result
@@ -132,6 +154,18 @@ def test_nrho_phase_zero_converges(nrho_phase_zero_result):
     assert res.correction is not None
     assert res.correction.status is ConvergenceState.CONVERGED
     assert res.ephemeris is not None
+
+
+def test_resonant_slightly_over_one_rev_converges(nrho_resonant_result):
+    """略超一圈的 9:2 贴月成员收敛（#508：主路径不收敛须回退单段）。"""
+    res = nrho_resonant_result
+    assert res.correction is not None
+    assert res.correction.status is ConvergenceState.CONVERGED
+    assert res.correction.max_residual < 2e-2
+    eph = res.ephemeris
+    n_expected = int(RESONANT_DURATION_SEC / RESONANT_OUTPUT_STEP_SEC) + 1
+    assert eph is not None
+    assert len(eph) == n_expected
 
 
 def test_gui_default_nrho_converges(nrho_gui_default_result):


### PR DESCRIPTION
> *This was generated by AI during triage.*

## 关联 issue

Closes #508

## 改动摘要

9:2 贴月共振成员（近月高 ~1500 km）在 phase=0.5 下，两段独立打靶各自收敛后 seam 失配 ~10² km，合并层 LM 迭代跳不出残差盆地（主路径残差卡 9.4e2 km，容差 2e-2 km）；而 phase=0 端点恰好相反——单段两圈第 1 步不收敛、原路径可收敛。两种策略按相位互补，无单一策略通吃。

修复：主路径保持生产默认（1 圈/段 + 合并层，#473）；NRHO 且 n_rev=2 主路径 `DesignNotConvergedError` 时自动回退单段 2 圈（无合并层）重试。作用域严格限定 n_rev=2，不外推（多圈单段长弧另有收敛风险，#473）。

- `e2m2e/algorithm/design/design_orbit.py`：+13 行回退链；
- `tests/algorithm/design/test_nrho_ephemeris_correction.py`：新增 #508 回归用例。

实验中试过并放弃的方案（供参考）：全周期 tile（geo-nrho 口径）单独使用不解决合并层；单段锚定首节点更糟。

## 测试命令及结果

- `uv run --no-sync pytest tests/algorithm/design/test_nrho_ephemeris_correction.py`：**7 passed**（24 分钟，覆盖主路径三场景 + 回退场景 + 30 天 GUI 不变路径）；
- `uv run --no-sync ruff check .` / `ruff format --check` / `mypy e2m2e/`：全绿。

## 遗留

本修复不解决契约层的 duration 与修正圈数耦合（#508 讨论方向 1/3）：n_rev>2 的 9:2 成员更长弧未测，`correction_revolutions` 语义是否延伸到星历段待另行裁决。