### PR TITLE
feat(hjb): 平面全星历脉动会合系 Hamiltonian 与 solve_hjb_py 注册（#498）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- **平面全星历脉动会合系 Hamiltonian**（#498，ADR 0034）：`e2m2e-hjb-dynamics` 新增 `EphemerisPlanar`（feature `ephemeris`，随 integrators 的 spice 启用）——真实月球星历定义的时变脉动会合系（地心系，月球钉在 (1,0)），力为两主星点质量 + 太阳第三体（面内投影），非自治、5 维含质量或 4 维固定质量。ω、ω̇、脉动项全部由缓存的月球位置/速度/加速度导出，每个 RK 子步查一次星历缓存全网格复用，求解阶段零 cspice；min-fuel 控制解析消去（开关函数含质量协态项）；天体中心邻域按物理极限正则化（网格必命中主星坐标，MIN_DISTANCE 截断会产生伪加速度压垮 CFL）。配套：`EphemCache` 新增二阶导查表（`lookup_body_acceleration`）与 `enabled_span()`；`solve_hjb_py` 注册 `ephemeris_planar` 动力学（历元映射 et = et0 + t，构造期校验缓存覆盖求解窗，无新 PyO3 符号、ABI 戳不变）；`NegHamiltonian` 补时间参数反转（非自治必需）。验收：圆化定常极限退化对拍 `Cr3bpSynodic`（含地心↔质心坐标平移）、与 `compute_total_acceleration` 逐点力一致、小网格粗细模型回归（量级一致、等值面相关 >0.96）、求解全程零 cspice FFI。
+
 ## [5.8.2] - 2026-08-21
 
 ### Added

--- a/crates/e2m2e-hjb-dynamics/Cargo.toml
+++ b/crates/e2m2e-hjb-dynamics/Cargo.toml
@@ -10,11 +10,29 @@ description = "HJB 结构网格求解器的动力学 Hamiltonian 实现（地月
 # 原创动力学层，Apache-2.0 随 workspace；求解器内核在 e2m2e-levelset
 # （ToolboxLS 移植，ACM 非商业许可）。两 crate 的归属与许可边界见 ADR 0032。
 
+[features]
+# ephemeris：星历力模型 Hamiltonian（#498）。依赖 e2m2e-forces 的
+# CompiledForce（其 forces 模块门控在 spice feature 下）与 e2m2e-spice 的
+# EphemCache，故引入 CSPICE 构建链；默认不开，纯解析动力学
+# （PlanarDoubleIntegrator / Cr3bpSynodic）保持无 spice 可独立构建。
+# e2m2e-integrators 的 spice feature 启用它。
+ephemeris = [
+    "dep:e2m2e-forces",
+    "dep:e2m2e-spice",
+    "e2m2e-forces/spice",
+    "e2m2e-spice/spice",
+]
+
 [dependencies]
 e2m2e-levelset = { path = "../e2m2e-levelset" }
 ndarray = { workspace = true }
+e2m2e-forces = { path = "../e2m2e-forces", optional = true, default-features = false }
+e2m2e-spice = { path = "../e2m2e-spice", optional = true }
 
 [dev-dependencies]
 # 向量场对拍：CR3BP 解析右端项 cr3bp_eom 在 e2m2e-forces 顶层 cr3bp 模块
-# （非 feature 门控）。关闭默认 spice feature，避免测试引入 CSPICE 构建依赖。
+# （非 feature 门控）。关闭默认 spice feature，避免测试引入 CSPICE 构建依赖；
+# ephemeris feature 开启时与正常依赖的 spice feature 合并（cargo feature 可加）。
 e2m2e-forces = { path = "../e2m2e-forces", default-features = false }
+# 真实内核路径的 CFL 诊断示例（examples/diag_ephem.rs）需要 furnsh 与 EphemCache::build。
+cspice = { workspace = true }

--- a/crates/e2m2e-hjb-dynamics/Cargo.toml
+++ b/crates/e2m2e-hjb-dynamics/Cargo.toml
@@ -34,5 +34,3 @@ e2m2e-spice = { path = "../e2m2e-spice", optional = true }
 # （非 feature 门控）。关闭默认 spice feature，避免测试引入 CSPICE 构建依赖；
 # ephemeris feature 开启时与正常依赖的 spice feature 合并（cargo feature 可加）。
 e2m2e-forces = { path = "../e2m2e-forces", default-features = false }
-# 真实内核路径的 CFL 诊断示例（examples/diag_ephem.rs）需要 furnsh 与 EphemCache::build。
-cspice = { workspace = true }

--- a/crates/e2m2e-hjb-dynamics/src/ephemeris.rs
+++ b/crates/e2m2e-hjb-dynamics/src/ephemeris.rs
@@ -543,8 +543,9 @@ impl Hamiltonian for EphemerisPlanar {
         let fs = self.frame(t);
         let ax: Vec<Vec<f64>> = (0..self.dim()).map(|d| grid.axis(d).to_vec()).collect();
         // 位置维：∂H/∂p_r = v，精确取速度轴坐标。速度维：|无控加速度| +
-        // 推力项（推力取节点质量的 T/m，比质量轴上界更紧且仍是包络）。
-        // 质量维：∂H/∂p_m 在 δ*=1 时为常值 −T/(Isp·g0)。
+        // 推力项——T/m 取节点质量而非质量轴区间上界（逐点包络更紧，
+        // 正确性与保守性不减）。质量维：∂H/∂p_m 在 δ*=1 时为常值
+        // −T/(Isp·g0)，包络取其绝对值。
         match dim {
             0 => ArrayD::from_shape_fn(grid.shape(), |idx| ax[2][idx[2]].abs()),
             1 => ArrayD::from_shape_fn(grid.shape(), |idx| ax[3][idx[3]].abs()),

--- a/crates/e2m2e-hjb-dynamics/src/ephemeris.rs
+++ b/crates/e2m2e-hjb-dynamics/src/ephemeris.rs
@@ -1,0 +1,811 @@
+//! 平面全星历脉动会合系 Hamiltonian（issue #498，ADR 0034 决策 1）。
+//!
+//! 会合系由月球瞬时星历定义（旋转 + 脉动）：长度单位取月地距 d(t)，
+//! 月球与地球钉在无量纲位置 (1, 0) 与原点；时间单位取秒（求解器 t 即
+//! ET 偏移秒，历元映射 et = et0 + t）。帧量 ω(t)、ω̇(t)、ḋ(t)、d̈(t)
+//! 与面内基 (ê_r, ê_θ) 全部由缓存的月球位置/速度/加速度导出，每个 t
+//! 只查一次星历缓存，全网格节点复用，求解阶段零 cspice。
+//!
+//! 动力学推导（惯性系 R = d·(x·ê_r + y·ê_θ)，A 为惯性合力，分量取
+//! 旋转基投影）：
+//!
+//! ```text
+//! ẋ = ux,  ẏ = uy
+//! u̇x = A·ê_r + 2ω·uy + ω̇·y + (ω² − d̈/d)·x − 2(ḋ/d)(ux − ω·y)
+//! u̇y = A·ê_θ − 2ω·ux − ω̇·x + (ω² − d̈/d)·y − 2(ḋ/d)(uy + ω·x)
+//! ṁ  = −δ·T/(Isp·g0)          （含质量维时）
+//! ```
+//!
+//! 平面口径：太阳第三体取星历位置在瞬时轨道面（月球位置 × 速度法向）
+//! 的面内投影（ADR 0034 决策 1），轨道面进动引起的离面修正不在平面
+//! 模型内——这是"时间保真度升级、不撞空间保真度墙"的取舍。
+//!
+//! min-fuel 控制解析消去（û ∈ S¹，δ ∈ [0,1]，L = w·δ）：
+//! û* = −p_v/‖p_v‖；开关函数
+//! `S = w − (T/1000m)·‖p_v‖ − p_m·T/(Isp·g0)`（T/1000m 为 km/s²），
+//! S < 0 时 δ* = 1，否则 0；消去后 `H* = p·f_drift + min(0, S)`。
+//!
+//! `partial_bound` 包络（耗散安全上界）：
+//! ∂H/∂p_x = ux、∂H/∂p_y = uy（精确 |v|）；
+//! ∂H/∂p_v = f_drift 的加速度分量 + 推力项，包络 |u̇_d| + T/(1000m)
+//! （m 取节点质量，5 维时为质量轴坐标）；
+//! ∂H/∂p_m 在 δ* = 1 时为常值 −T/(Isp·g0)，包络取其绝对值。
+//!
+//! 力一致性（验收 b）：本实现的逐点力复刻 `CompiledForce` 的
+//! `PointMass`/`ThirdBody` 公式，第三体位置取缓存查表——与
+//! `compute_total_acceleration` 同源同式，对拍见
+//! `tests/ephemeris_force_parity.rs`。唯一差异在天体中心 1e-6 km 郱域：
+//! HJB 网格会精确命中主星坐标（会合系钉死位置），直接项按物理极限取
+//! 0 而非 `MIN_DISTANCE` 截断（截断会产生 ~μ/ε² 伪加速度压垮 CFL），
+//! 见 `inertial_accel` 内注释。
+
+use e2m2e_forces::forces::compiled::CompiledForce;
+use e2m2e_levelset::grid::Grid;
+use e2m2e_levelset::hamiltonian::Hamiltonian;
+use e2m2e_spice::ephem_cache;
+use ndarray::ArrayD;
+
+/// 与 e2m2e-forces / spk_accel 一致的最小距离截断（km）。
+const MIN_DISTANCE: f64 = 1e-6;
+/// 定义会合系的次星（帧天体）。
+const FRAME_BODY: &str = "MOON";
+/// 惯性系原点（传播系 observer）。
+const OBSERVER: &str = "EARTH";
+
+/// 一个 t 时刻的全部星历派生量。每个 RK 子步构造一次，全节点复用。
+#[derive(Debug, Clone)]
+pub struct FrameState {
+    /// 月地距 d(t)（km）。
+    pub d: f64,
+    /// ḋ/d（1/s）。
+    pub d_ratio_dot: f64,
+    /// d̈/d（1/s²）。
+    pub d_ratio_ddot: f64,
+    /// 会合系角速度 ω(t)（1/s）。
+    pub omega: f64,
+    /// ω̇(t)（1/s²）。
+    pub omega_dot: f64,
+    /// 面内径向单位矢（惯性系分量）。
+    pub e_r: [f64; 3],
+    /// 面内横向单位矢（惯性系分量）。
+    pub e_theta: [f64; 3],
+    /// 各第三体的 (body, mu, 面内投影位置 km)，与 forces 列表中 ThirdBody 一一对应。
+    pub third_bodies: Vec<(String, f64, [f64; 3])>,
+}
+
+/// 解析星历（常值），供退化对拍等测试注入。
+#[derive(Debug, Clone)]
+pub struct SyntheticEphemeris {
+    /// 月球相对地球的位置（km，惯性系）。
+    pub moon_pos: [f64; 3],
+    /// 月球相对地球的速度（km/s）。
+    pub moon_vel: [f64; 3],
+    /// 月球相对地球的加速度（km/s²）。
+    pub moon_accel: [f64; 3],
+    /// 各第三体 (body, 惯性位置 km)，位置应取面内（测试自己保证）。
+    pub bodies: Vec<(String, [f64; 3])>,
+}
+
+enum EphemerisSource {
+    /// 进程级 EphemCache 单例（构造方负责 enable 覆盖求解窗）。
+    Cache,
+    /// 测试注入的常值解析星历。
+    Synthetic(SyntheticEphemeris),
+}
+
+/// 平面全星历脉动会合系 Hamiltonian。
+///
+/// 状态 `(x, y, vx, vy)`（`with_mass` 时追加质量维 m，单位 kg）。
+/// 构造参数：力模型列表（限 `PointMass` 与 `ThirdBody`）、历元映射
+/// et0（求解器 t = 0 对应的 SPICE et）、求解窗（求解器 t，用于构造时
+/// 对照已启用缓存区间校验）与发动机参数。线程安全：求值只读缓存
+/// （EphemCache 读锁），无内部可变状态。
+pub struct EphemerisPlanar {
+    forces: Vec<CompiledForce>,
+    /// 求解器 t = 0 对应的 SPICE et（秒）；et = et0 + t。
+    pub et0: f64,
+    /// 推力 T（N）。
+    pub thrust: f64,
+    /// 比冲 Isp（s）。
+    pub isp: f64,
+    /// 标准重力 g0（m/s²）。
+    pub g0: f64,
+    /// 燃料权重 w：运行代价 L = w·δ。
+    pub fuel_weight: f64,
+    /// 是否含质量维（5 维状态）。
+    pub with_mass: bool,
+    /// 4 维模式的固定质量（kg）。
+    pub fixed_mass: f64,
+    source: EphemerisSource,
+}
+
+impl EphemerisPlanar {
+    /// 按真实缓存构造。调用前须 `ephem_cache::enable` 覆盖
+    /// [et0 + t_span.0, et0 + t_span.1]，否则构造期即失败（把求解
+    /// 热循环里的硬失败提前到配置期）。
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        forces: Vec<CompiledForce>,
+        et0: f64,
+        t_span: (f64, f64),
+        thrust: f64,
+        isp: f64,
+        g0: f64,
+        fuel_weight: f64,
+        with_mass: bool,
+        fixed_mass: f64,
+    ) -> Self {
+        Self::validate(&forces, thrust, isp, g0, fuel_weight, with_mass, fixed_mass);
+        let (et_lo, et_hi) = (et0 + t_span.0, et0 + t_span.1);
+        match ephem_cache::enabled_span() {
+            None => panic!("EphemCache 未启用：求解前须 enable 覆盖 [{et_lo}, {et_hi}]"),
+            Some((start, end)) => assert!(
+                start <= et_lo && et_hi <= end,
+                "EphemCache 覆盖 [{start}, {end}] 不含求解窗 [{et_lo}, {et_hi}]"
+            ),
+        }
+        Self {
+            forces,
+            et0,
+            thrust,
+            isp,
+            g0,
+            fuel_weight,
+            with_mass,
+            fixed_mass,
+            source: EphemerisSource::Cache,
+        }
+    }
+
+    /// 按常值解析星历构造（对拍测试用；不做缓存校验）。
+    #[allow(clippy::too_many_arguments)]
+    pub fn with_synthetic_ephemeris(
+        forces: Vec<CompiledForce>,
+        synthetic: SyntheticEphemeris,
+        et0: f64,
+        thrust: f64,
+        isp: f64,
+        g0: f64,
+        fuel_weight: f64,
+        with_mass: bool,
+        fixed_mass: f64,
+    ) -> Self {
+        Self::validate(&forces, thrust, isp, g0, fuel_weight, with_mass, fixed_mass);
+        Self {
+            forces,
+            et0,
+            thrust,
+            isp,
+            g0,
+            fuel_weight,
+            with_mass,
+            fixed_mass,
+            source: EphemerisSource::Synthetic(synthetic),
+        }
+    }
+
+    fn validate(
+        forces: &[CompiledForce],
+        thrust: f64,
+        isp: f64,
+        g0: f64,
+        fuel_weight: f64,
+        with_mass: bool,
+        fixed_mass: f64,
+    ) {
+        assert!(!forces.is_empty(), "力模型列表不能为空");
+        for f in forces {
+            assert!(
+                matches!(
+                    f,
+                    CompiledForce::PointMass { .. } | CompiledForce::ThirdBody { .. }
+                ),
+                "EphemerisPlanar 只接受 PointMass 与 ThirdBody"
+            );
+        }
+        assert!(
+            thrust.is_finite() && thrust > 0.0,
+            "thrust 必须为正的有限值"
+        );
+        assert!(isp.is_finite() && isp > 0.0, "isp 必须为正的有限值");
+        assert!(g0.is_finite() && g0 > 0.0, "g0 必须为正的有限值");
+        assert!(
+            fuel_weight.is_finite() && fuel_weight >= 0.0,
+            "fuel_weight 必须为非负有限值"
+        );
+        if !with_mass {
+            assert!(
+                fixed_mass.is_finite() && fixed_mass > 0.0,
+                "4 维模式 fixed_mass 必须为正的有限值"
+            );
+        }
+    }
+
+    /// 状态维数（4 或 5）。
+    pub fn dim(&self) -> usize {
+        if self.with_mass {
+            5
+        } else {
+            4
+        }
+    }
+
+    fn mass_of(&self, state: &[f64]) -> f64 {
+        if self.with_mass {
+            state[4]
+        } else {
+            self.fixed_mass
+        }
+    }
+
+    /// 推力加速度上界（km/s²）：T/m 的 m/s² → km/s² 换算。
+    fn max_accel(&self, mass: f64) -> f64 {
+        self.thrust / (1000.0 * mass)
+    }
+
+    /// 燃料流量上界 T/(Isp·g0)（kg/s）。
+    fn mass_flow(&self) -> f64 {
+        self.thrust / (self.isp * self.g0)
+    }
+
+    /// 构造 t（求解器秒）时刻的帧量：查一次缓存（或解析星历），
+    /// 导出 d、ḋ/d、d̈/d、ω、ω̇ 与面内基。
+    pub fn frame(&self, t: f64) -> FrameState {
+        let et = self.et0 + t;
+        // （月球位置、速度、加速度，第三体原始位置表）。
+        #[allow(clippy::type_complexity)]
+        let (r_m, v_m, a_m, body_pos): (
+            [f64; 3],
+            [f64; 3],
+            [f64; 3],
+            Vec<(String, [f64; 3])>,
+        ) = match &self.source {
+            EphemerisSource::Cache => {
+                let look = |target: &str| -> [f64; 3] {
+                    match ephem_cache::lookup_body_position(target, OBSERVER, et) {
+                        Ok(Some(p)) => p,
+                        Ok(None) => {
+                            panic!("EphemCache 未启用：查询 ({target}, {OBSERVER}) et={et} 失败")
+                        }
+                        Err(e) => {
+                            panic!("EphemCache 查 ({target}, {OBSERVER}) et={et} 失败：{e}")
+                        }
+                    }
+                };
+                let r_m = look(FRAME_BODY);
+                let v_m = match ephem_cache::lookup_body_velocity(FRAME_BODY, OBSERVER, et) {
+                    Ok(Some(v)) => v,
+                    Ok(None) => panic!("EphemCache 未启用：查询速度 {FRAME_BODY} et={et} 失败"),
+                    Err(e) => panic!("EphemCache 查速度 {FRAME_BODY} et={et} 失败：{e}"),
+                };
+                let a_m = match ephem_cache::lookup_body_acceleration(FRAME_BODY, OBSERVER, et) {
+                    Ok(Some(a)) => a,
+                    Ok(None) => panic!("EphemCache 未启用：查加速度 {FRAME_BODY} et={et} 失败"),
+                    Err(e) => panic!("EphemCache 查加速度 {FRAME_BODY} et={et} 失败：{e}"),
+                };
+                let mut body_pos = Vec::new();
+                for f in &self.forces {
+                    if let CompiledForce::ThirdBody { body, .. } = f {
+                        if body != FRAME_BODY {
+                            body_pos.push((body.clone(), look(body)));
+                        }
+                    }
+                }
+                (r_m, v_m, a_m, body_pos)
+            }
+            EphemerisSource::Synthetic(s) => {
+                let body_pos = s
+                    .bodies
+                    .iter()
+                    .filter(|(b, _)| b != FRAME_BODY)
+                    .cloned()
+                    .collect();
+                (s.moon_pos, s.moon_vel, s.moon_accel, body_pos)
+            }
+        };
+
+        let d = norm(&r_m);
+        assert!(d > 0.0, "月地距为零，无法定义会合系");
+        let e_r = [r_m[0] / d, r_m[1] / d, r_m[2] / d];
+        let h_vec = cross(&r_m, &v_m);
+        let h = norm(&h_vec);
+        assert!(h > 0.0, "月球速度与位置共线，轨道面退化");
+        let e_h = [h_vec[0] / h, h_vec[1] / h, h_vec[2] / h];
+        let e_theta = cross(&e_h, &e_r);
+
+        let d_dot = dot(&r_m, &v_m) / d;
+        let d_ddot = (dot(&v_m, &v_m) + dot(&r_m, &a_m)) / d - d_dot * d_dot / d;
+        let omega = h / (d * d);
+        // ω = |h|/d²，dω/dt = (ê_h·(r×a))/d² − 2ω·ḋ/d。
+        let omega_dot = dot(&cross(&r_m, &a_m), &e_h) / (d * d) - 2.0 * omega * d_dot / d;
+
+        // 第三体位置投影到瞬时轨道面（ADR 0034 决策 1 的面内口径）；
+        // 月球本身在面内（e_r 由它定义），直接用 r_m。
+        let third_bodies = self
+            .forces
+            .iter()
+            .filter_map(|f| match f {
+                CompiledForce::ThirdBody { body, mu } => {
+                    let raw = if body == FRAME_BODY {
+                        r_m
+                    } else {
+                        body_pos
+                            .iter()
+                            .find(|(b, _)| b == body)
+                            .map(|(_, p)| *p)
+                            .unwrap_or_else(|| panic!("第三体 {body} 的星历位置缺失"))
+                    };
+                    let s = dot(&raw, &e_h);
+                    let proj = [
+                        raw[0] - s * e_h[0],
+                        raw[1] - s * e_h[1],
+                        raw[2] - s * e_h[2],
+                    ];
+                    Some((body.clone(), *mu, proj))
+                }
+                _ => None,
+            })
+            .collect();
+
+        FrameState {
+            d,
+            d_ratio_dot: d_dot / d,
+            d_ratio_ddot: d_ddot / d,
+            omega,
+            omega_dot,
+            e_r,
+            e_theta,
+            third_bodies,
+        }
+    }
+
+    /// 惯性合力在面内基下的分量（km/s²）与惯性位置 R（km）。
+    ///
+    /// 公式与 `CompiledForce::acceleration` 的 PointMass/ThirdBody 分支
+    /// 逐项一致（含 MIN_DISTANCE 截断）；第三体用帧量中的面内投影位置。
+    pub fn inertial_accel(&self, fs: &FrameState, x: f64, y: f64) -> ([f64; 3], [f64; 2]) {
+        let r_scale = fs.d;
+        let r_vec = [
+            r_scale * (x * fs.e_r[0] + y * fs.e_theta[0]),
+            r_scale * (x * fs.e_r[1] + y * fs.e_theta[1]),
+            r_scale * (x * fs.e_r[2] + y * fs.e_theta[2]),
+        ];
+        let mut acc = [0.0_f64; 3];
+        for f in &self.forces {
+            match f {
+                CompiledForce::PointMass { mu } => {
+                    let r_norm = norm(&r_vec);
+                    // HJB 网格节点可能恰落在大体位置（会合系把两主星钉在
+                    // 固定坐标，奇数节点网格必命中）：中心点处点质量引力
+                    // 物理奇异，取 0 贡献保证 CFL 步长不塌（传播场景轨迹
+                    // 不会精确穿过天心，与此正则化无交集）。
+                    if r_norm >= MIN_DISTANCE {
+                        let inv_r3 = 1.0 / r_norm.powi(3);
+                        for k in 0..3 {
+                            acc[k] -= mu * r_vec[k] * inv_r3;
+                        }
+                    }
+                }
+                CompiledForce::ThirdBody { mu, .. } => {
+                    let rb = self.third_body_pos(fs, f);
+                    let mut diff = [0.0_f64; 3];
+                    for k in 0..3 {
+                        diff[k] = r_vec[k] - rb[k];
+                    }
+                    let d_norm = norm(&diff);
+                    let b_norm = norm(&rb).max(MIN_DISTANCE);
+                    // 节点落在第三体中心时（网格命中月球 (1,0)），
+                    // 直接项的物理极限是 0（保留 indirect 项）；
+                    // `third_body_acceleration` 的 MIN_DISTANCE 截断在此处
+                    // 会产生 ~μ/ε² 的伪加速度压垮 CFL，必须取极限而非截断。
+                    if d_norm >= MIN_DISTANCE {
+                        let inv_d3 = 1.0 / d_norm.powi(3);
+                        for k in 0..3 {
+                            acc[k] -= mu * (diff[k] * inv_d3 + rb[k] / b_norm.powi(3));
+                        }
+                    } else {
+                        for k in 0..3 {
+                            acc[k] -= mu * rb[k] / b_norm.powi(3);
+                        }
+                    }
+                }
+                _ => unreachable!("构造期已校验力模型类型"),
+            }
+        }
+        let a_rot = [dot(&acc, &fs.e_r), dot(&acc, &fs.e_theta)];
+        (r_vec, a_rot)
+    }
+
+    fn third_body_pos(&self, fs: &FrameState, force: &CompiledForce) -> [f64; 3] {
+        let CompiledForce::ThirdBody { body, .. } = force else {
+            unreachable!("非 ThirdBody 分支");
+        };
+        fs.third_bodies
+            .iter()
+            .find(|(b, _, _)| b == body)
+            .map(|(_, _, p)| *p)
+            .unwrap_or_else(|| panic!("第三体 {body} 的帧量缺失"))
+    }
+
+    /// 无控漂移向量场 f_drift(t, state) = (ux, uy, u̇x, u̇y)（质量维不含）。
+    pub fn drift_field(&self, t: f64, state: &[f64]) -> [f64; 4] {
+        let fs = self.frame(t);
+        self.drift_field_at(&fs, state)
+    }
+
+    fn drift_field_at(&self, fs: &FrameState, state: &[f64]) -> [f64; 4] {
+        let [x, y, ux, uy] = [state[0], state[1], state[2], state[3]];
+        // R = d·q，被 R̈ = A 除以脉动尺度 d 得无量纲坐标加速度。
+        let (_, a_rot) = self.inertial_accel(fs, x, y);
+        let ar = [a_rot[0] / fs.d, a_rot[1] / fs.d];
+        let w = fs.omega;
+        let wd = fs.omega_dot;
+        let cent = w * w - fs.d_ratio_ddot;
+        let puls = 2.0 * fs.d_ratio_dot;
+        let adx = ar[0] + 2.0 * w * uy + wd * y + cent * x - puls * (ux - w * y);
+        let ady = ar[1] - 2.0 * w * ux - wd * x + cent * y - puls * (uy + w * x);
+        [ux, uy, adx, ady]
+    }
+
+    /// 单点 H\*(t, x, p)。
+    pub fn hamiltonian_at(&self, t: f64, state: &[f64], p: &[f64]) -> f64 {
+        let fs = self.frame(t);
+        self.hamiltonian_at_frame(&fs, state, p)
+    }
+
+    fn hamiltonian_at_frame(&self, fs: &FrameState, state: &[f64], p: &[f64]) -> f64 {
+        let f = self.drift_field_at(fs, state);
+        let pv_norm = p[2].hypot(p[3]);
+        let m = self.mass_of(state);
+        let a_max = self.max_accel(m);
+        let mut s = self.fuel_weight - a_max * pv_norm;
+        if self.with_mass {
+            s -= p[4] * self.mass_flow();
+        }
+        p[0] * f[0] + p[1] * f[1] + p[2] * f[2] + p[3] * f[3] + s.min(0.0)
+    }
+
+    /// 第 `dim` 维的耗散包络（推导见模块文档）。
+    pub fn partial_bound_at(&self, t: f64, state: &[f64], dim: usize) -> f64 {
+        let fs = self.frame(t);
+        match dim {
+            0 => state[2].abs(),
+            1 => state[3].abs(),
+            2 | 3 => {
+                let f = self.drift_field_at(&fs, state);
+                f[dim].abs() + self.max_accel(self.mass_of(state))
+            }
+            4 if self.with_mass => self.mass_flow(),
+            _ => panic!("dim 超出状态维数 {}", self.dim()),
+        }
+    }
+}
+
+fn norm(v: &[f64; 3]) -> f64 {
+    (v[0] * v[0] + v[1] * v[1] + v[2] * v[2]).sqrt()
+}
+
+fn dot(a: &[f64; 3], b: &[f64; 3]) -> f64 {
+    a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+}
+
+fn cross(a: &[f64; 3], b: &[f64; 3]) -> [f64; 3] {
+    [
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0],
+    ]
+}
+
+impl Hamiltonian for EphemerisPlanar {
+    fn hamiltonian(
+        &self,
+        t: f64,
+        grid: &Grid,
+        _phi: &ArrayD<f64>,
+        p: &[ArrayD<f64>],
+    ) -> ArrayD<f64> {
+        assert_eq!(grid.dim(), self.dim(), "EphemerisPlanar 状态维数不匹配");
+        // 每个 t 只构造一次帧量（一次缓存查询），全节点复用。
+        let fs = self.frame(t);
+        let mut out = ArrayD::zeros(grid.shape());
+        for (idx, o) in out.indexed_iter_mut() {
+            let pos = [
+                grid.axis(0)[idx[0]],
+                grid.axis(1)[idx[1]],
+                grid.axis(2)[idx[2]],
+                grid.axis(3)[idx[3]],
+            ];
+            let mut state = [0.0_f64; 5];
+            state[..4].copy_from_slice(&pos);
+            if self.with_mass {
+                state[4] = grid.axis(4)[idx[4]];
+            }
+            let mut pvec = [0.0_f64; 5];
+            for d in 0..self.dim() {
+                pvec[d] = p[d][idx.clone()];
+            }
+            *o = self.hamiltonian_at_frame(&fs, &state, &pvec);
+        }
+        out
+    }
+
+    fn partial_bound(
+        &self,
+        t: f64,
+        grid: &Grid,
+        _phi: &ArrayD<f64>,
+        _p_min: &[ArrayD<f64>],
+        _p_max: &[ArrayD<f64>],
+        dim: usize,
+    ) -> ArrayD<f64> {
+        assert_eq!(grid.dim(), self.dim(), "EphemerisPlanar 状态维数不匹配");
+        let fs = self.frame(t);
+        let ax: Vec<Vec<f64>> = (0..self.dim()).map(|d| grid.axis(d).to_vec()).collect();
+        // 位置维：∂H/∂p_r = v，精确取速度轴坐标。速度维：|无控加速度| +
+        // 推力项（推力取节点质量的 T/m，比质量轴上界更紧且仍是包络）。
+        // 质量维：∂H/∂p_m 在 δ*=1 时为常值 −T/(Isp·g0)。
+        match dim {
+            0 => ArrayD::from_shape_fn(grid.shape(), |idx| ax[2][idx[2]].abs()),
+            1 => ArrayD::from_shape_fn(grid.shape(), |idx| ax[3][idx[3]].abs()),
+            2 | 3 => ArrayD::from_shape_fn(grid.shape(), |idx| {
+                let mut state = [0.0_f64; 5];
+                for d in 0..self.dim() {
+                    state[d] = ax[d][idx[d]];
+                }
+                let f = self.drift_field_at(&fs, &state);
+                f[dim].abs() + self.max_accel(self.mass_of(&state))
+            }),
+            4 if self.with_mass => ArrayD::from_shape_fn(grid.shape(), |_| self.mass_flow()),
+            _ => panic!("dim 超出状态维数 {}", self.dim()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Cr3bpSynodic;
+
+    /// 地月点质量（km³/s²），与 e2m2e 数据常量同源量级。
+    const MU_EARTH: f64 = 398600.435436;
+    const MU_MOON: f64 = 4902.800066;
+    const L: f64 = 384400.0;
+    const MU_N: f64 = MU_MOON / (MU_EARTH + MU_MOON);
+
+    /// 圆轨道角速度：ω² = (μE+μM)/L³（使退化极限严格满足 CR3BP 量纲）。
+    fn omega() -> f64 {
+        ((MU_EARTH + MU_MOON) / L.powi(3)).sqrt()
+    }
+
+    /// 圆化定常合成星历：月理圆轨道（d、ω 恒定，d̈=ω̇=0），太阳取面内
+    /// 定点（μ 取 0，不影响动力学，只覆盖查询路径）。
+    fn circular_ephemeris() -> SyntheticEphemeris {
+        let moon_pos = [L, 0.0, 0.0];
+        let moon_vel = [0.0, L * omega(), 0.0];
+        let moon_accel = [-L * omega() * omega(), 0.0, 0.0];
+        SyntheticEphemeris {
+            moon_pos,
+            moon_vel,
+            moon_accel,
+            bodies: vec![("SUN".to_string(), [1.5e8, 0.0, 0.0])],
+        }
+    }
+
+    fn forces() -> Vec<CompiledForce> {
+        vec![
+            CompiledForce::PointMass { mu: MU_EARTH },
+            CompiledForce::ThirdBody {
+                body: "MOON".to_string(),
+                mu: MU_MOON,
+            },
+            CompiledForce::ThirdBody {
+                body: "SUN".to_string(),
+                mu: 0.0,
+            },
+        ]
+    }
+
+    fn ham4() -> EphemerisPlanar {
+        EphemerisPlanar::with_synthetic_ephemeris(
+            forces(),
+            circular_ephemeris(),
+            0.0,
+            1.0,
+            300.0,
+            9.80665,
+            0.1,
+            false,
+            1000.0,
+        )
+    }
+
+    /// 帧量退化：圆轨道下 d、ω 恒定，ḋ、d̈、ω̇ 全部为零。
+    #[test]
+    fn frame_circular_limit_is_constant() {
+        let h = ham4();
+        let fs = h.frame(123.4);
+        assert!((fs.d - L).abs() < 1e-6);
+        assert!((fs.omega - omega()).abs() < 1e-18);
+        assert!(fs.d_ratio_dot.abs() < 1e-15);
+        assert!(fs.d_ratio_ddot.abs() < 1e-15);
+        assert!(fs.omega_dot.abs() < 1e-15);
+    }
+
+    /// 退化对拍（验收 a）：圆化定常星历下，向量场按量纲换算逐项还原
+    /// Cr3bpSynodic——v_n = u/ω，a_n = u̇/ω²（推导见模块文档）。
+    #[test]
+    fn degenerates_to_cr3bp_synodic() {
+        let h = ham4();
+        let cr3bp = Cr3bpSynodic::new(MU_N, 0.5, 0.1);
+        for k in 0..50 {
+            let s = |i: usize| ((k * 11 + i * 17) % 89) as f64 / 44.0 - 1.0;
+            let state = [s(0) + 0.5, s(1), s(2), s(3)];
+            let f = h.drift_field(0.0, &state);
+            // 同一物理轨迹的坐标换算：cr3bp 是质心系（地球在 −μ），
+            // 速度维 v_n = u/ω。
+            let g = cr3bp.vector_field([
+                state[0] - MU_N,
+                state[1],
+                state[2] / omega(),
+                state[3] / omega(),
+            ]);
+            for d in 0..4 {
+                let expect = if d < 2 {
+                    f[d] / omega()
+                } else {
+                    f[d] / (omega() * omega())
+                };
+                // 采样速度为 O(1)（对应会合速度数万），断言用相对容差。
+                assert!(
+                    (g[d] - expect).abs() < 1e-9 * (g[d].abs() + 1.0),
+                    "状态 {state:?} 第 {d} 维：cr3bp {} vs 星历版换算 {expect}",
+                    g[d]
+                );
+            }
+        }
+    }
+
+    /// 开关函数含质量协态项（5 维）：p_v = 0、p_m 足够大时 S < 0，
+    /// 控制贡献为 w − p_m·T/(Isp·g0)。
+    #[test]
+    fn switching_function_includes_mass_costate() {
+        let h = EphemerisPlanar::with_synthetic_ephemeris(
+            forces(),
+            circular_ephemeris(),
+            0.0,
+            300.0,
+            300.0,
+            9.80665,
+            0.5,
+            true,
+            1000.0,
+        );
+        let t = 0.0;
+        let state = [0.8, 0.1, 0.2, -0.3, 900.0];
+        let p = [1.0, -1.0, 0.0, 0.0, 1000.0];
+        let hv = h.hamiltonian_at(t, &state, &p);
+        let f = h.drift_field(t, &state);
+        let mdot = h.mass_flow();
+        let expect = p[0] * f[0] + p[1] * f[1] + p[2] * f[2] + p[3] * f[3] + (0.5 - p[4] * mdot);
+        assert!((hv - expect).abs() < 1e-12, "{hv} vs {expect}");
+        assert!(0.5 - p[4] * mdot < 0.0, "该 p_m 下应满推力");
+    }
+
+    /// partial_bound_at 覆盖 |∂H/∂p_dim|（4 维，随机采样，避开开关面）。
+    #[test]
+    fn partial_bound_covers_numerical_derivative() {
+        let h = ham4();
+        let eps = 1e-6;
+        for k in 0..40 {
+            let s = |i: usize| ((k * 7 + i * 13) % 97) as f64 / 48.0 - 1.0;
+            let state = [s(0) + 0.5, s(1), s(2), s(3)];
+            let p = [s(4), s(5), s(6) + 2.0, s(7) + 2.0];
+            for dim in 0..4 {
+                let mut p_up = p;
+                let mut p_dn = p;
+                p_up[dim] += eps;
+                p_dn[dim] -= eps;
+                let deriv = (h.hamiltonian_at(0.0, &state, &p_up)
+                    - h.hamiltonian_at(0.0, &state, &p_dn))
+                    / (2.0 * eps);
+                let bound = h.partial_bound_at(0.0, &state, dim);
+                assert!(
+                    deriv.abs() <= bound + 1e-9,
+                    "dim {dim}：|∂H/∂p| = {} 超过包络 {bound}",
+                    deriv.abs()
+                );
+            }
+        }
+    }
+
+    /// 5 维质量维包络：∂H/∂p_m = −δ*·T/(Isp·g0)，绝对值不超过流量上界。
+    #[test]
+    fn mass_partial_bound_covers_derivative() {
+        let h = EphemerisPlanar::with_synthetic_ephemeris(
+            forces(),
+            circular_ephemeris(),
+            0.0,
+            300.0,
+            300.0,
+            9.80665,
+            0.5,
+            true,
+            1000.0,
+        );
+        let eps = 1e-6;
+        for p_m in [-5.0_f64, -0.1, 0.0, 0.1, 500.0] {
+            let state = [0.8, 0.1, 0.2, -0.3, 900.0];
+            let p = [0.3, -0.2, 1.5, -0.7, p_m];
+            let mut p_up = p;
+            let mut p_dn = p;
+            p_up[4] += eps;
+            p_dn[4] -= eps;
+            let deriv = (h.hamiltonian_at(0.0, &state, &p_up)
+                - h.hamiltonian_at(0.0, &state, &p_dn))
+                / (2.0 * eps);
+            assert!(deriv.abs() <= h.partial_bound_at(0.0, &state, 4) + 1e-6);
+        }
+    }
+
+    /// 网格节点命中天体中心（月球在 (1, 0)）：第三体直接项取物理极限 0，
+    /// 加速度与耗散包络保持有限（否则 CFL 步长塌为零、求解死循环）。
+    #[test]
+    fn grid_node_at_body_center_stays_finite() {
+        let h = ham4();
+        let fs = h.frame(0.0);
+        // 月球中心：direct 项 0，剩地球引力与 indirect 项。
+        let (_, a_rot) = h.inertial_accel(&fs, 1.0, 0.0);
+        for d in 0..2 {
+            assert!(
+                a_rot[d].abs().is_finite() && a_rot[d].abs() < 1e-3,
+                "{a_rot:?}"
+            );
+        }
+        let f = h.drift_field_at(&fs, &[1.0, 0.0, 0.0, 0.0]);
+        for d in 0..4 {
+            assert!(f[d].abs() < 1.0, "向量场爆掉：{f:?}");
+        }
+    }
+
+    /// 构造期拒绝非平面力模型与非法参数。
+    #[test]
+    #[should_panic]
+    fn rejects_non_planar_force() {
+        EphemerisPlanar::with_synthetic_ephemeris(
+            vec![
+                CompiledForce::PointMass { mu: MU_EARTH },
+                CompiledForce::SRP {
+                    area: 1.0,
+                    mass: 100.0,
+                    cr: 1.3,
+                    shadow_bodies: vec![],
+                },
+            ],
+            circular_ephemeris(),
+            0.0,
+            1.0,
+            300.0,
+            9.80665,
+            0.5,
+            false,
+            1000.0,
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn rejects_nonpositive_thrust() {
+        EphemerisPlanar::with_synthetic_ephemeris(
+            forces(),
+            circular_ephemeris(),
+            0.0,
+            -1.0,
+            300.0,
+            9.80665,
+            0.5,
+            false,
+            1000.0,
+        );
+    }
+}

--- a/crates/e2m2e-hjb-dynamics/src/lib.rs
+++ b/crates/e2m2e-hjb-dynamics/src/lib.rs
@@ -25,8 +25,14 @@
 mod cr3bp;
 mod double_integrator;
 
+#[cfg(feature = "ephemeris")]
+mod ephemeris;
+
 pub use cr3bp::Cr3bpSynodic;
 pub use double_integrator::PlanarDoubleIntegrator;
+
+#[cfg(feature = "ephemeris")]
+pub use ephemeris::{EphemerisPlanar, FrameState, SyntheticEphemeris};
 
 /// bang-bang 控制对 Hamiltonian 的贡献：`min(0, w − a·‖p_v‖)`。
 ///

--- a/crates/e2m2e-hjb-dynamics/tests/ephemeris_force_parity.rs
+++ b/crates/e2m2e-hjb-dynamics/tests/ephemeris_force_parity.rs
@@ -1,0 +1,104 @@
+//! 星历 Hamiltonian 内部合力与 `compute_total_acceleration` 的逐点对拍
+//! （issue #498 验收 b，ADR 0034 决策 6）。
+//!
+//! 同一 (et, state) 下，`EphemerisPlanar::inertial_accel` 经系变换后的
+//! 惯性合力应与直接调用 `compute_total_acceleration` 一致。星历用解析
+//! 圆化月轨 + 面内定点太阳经 `EphemCache::from_raw_grids` 合成（无内核
+//! 依赖），双方走同一条缓存查询路径，差异只剩样条采样误差。
+
+#![cfg(feature = "ephemeris")]
+
+use e2m2e_forces::forces::compiled::{compute_total_acceleration, CompiledForce};
+use e2m2e_hjb_dynamics::EphemerisPlanar;
+use e2m2e_spice::ephem_cache::{self, EphemCache};
+
+const MU_EARTH: f64 = 398600.435436;
+const MU_MOON: f64 = 4902.800066;
+const MU_SUN: f64 = 1.32712440018e11;
+const L: f64 = 384400.0;
+const OMEGA: f64 = 2.649146625237848e-6;
+const SUN_POS: [f64; 3] = [1.5e8, 0.0, 0.0];
+
+fn forces() -> Vec<CompiledForce> {
+    vec![
+        CompiledForce::PointMass { mu: MU_EARTH },
+        CompiledForce::ThirdBody {
+            body: "MOON".to_string(),
+            mu: MU_MOON,
+        },
+        CompiledForce::ThirdBody {
+            body: "SUN".to_string(),
+            mu: MU_SUN,
+        },
+    ]
+}
+
+/// 圆化月轨解析状态（相对地球，惯性系）。
+fn moon_state(et: f64) -> [f64; 6] {
+    let (s, c) = (OMEGA * et).sin_cos();
+    [L * c, L * s, 0.0, -L * OMEGA * s, L * OMEGA * c, 0.0]
+}
+
+#[test]
+fn inertial_accel_matches_compute_total_acceleration() {
+    let et_start = 0.0;
+    let et_end = 10.0 * 86400.0;
+    let dt = 600.0;
+    let n = ((et_end - et_start) / dt) as usize + 1;
+    let t_grid: Vec<f64> = (0..n).map(|i| et_start + i as f64 * dt).collect();
+
+    let moon: Vec<[f64; 6]> = t_grid.iter().map(|&et| moon_state(et)).collect();
+    let sun: Vec<[f64; 6]> = t_grid
+        .iter()
+        .map(|_| [SUN_POS[0], 0.0, 0.0, 0.0, 0.0, 0.0])
+        .collect();
+    let to_entry = |name: &str, states: &Vec<[f64; 6]>| {
+        ((name.to_string(), "EARTH".to_string()), states.clone())
+    };
+    let cache = EphemCache::from_raw_grids(
+        &t_grid,
+        &[to_entry("MOON", &moon), to_entry("SUN", &sun)],
+        &[],
+        &[],
+    )
+    .expect("合成星历构造");
+    ephem_cache::enable(cache);
+
+    let span = (0.0_f64, et_end);
+    let ham = EphemerisPlanar::new(
+        forces(),
+        et_start,
+        span,
+        1.0,
+        300.0,
+        9.80665,
+        0.1,
+        false,
+        1000.0,
+    );
+
+    for k in 0..30 {
+        let t = (k as f64 + 0.37) * 0.31 * 86400.0;
+        let s = |i: usize| ((k * 13 + i * 29) % 101) as f64 / 50.0 - 1.0;
+        let (x, y) = (s(0) + 0.3, s(1));
+        let fs = ham.frame(t);
+        let (r_vec, a_rot) = ham.inertial_accel(&fs, x, y);
+        let state6 = [r_vec[0], r_vec[1], r_vec[2], 0.0, 0.0, 0.0];
+        let a_ref = compute_total_acceleration(&forces(), ham.et0 + t, &state6, "EARTH").unwrap();
+        let ref_rot = [
+            a_ref[0] * fs.e_r[0] + a_ref[1] * fs.e_r[1] + a_ref[2] * fs.e_r[2],
+            a_ref[0] * fs.e_theta[0] + a_ref[1] * fs.e_theta[1] + a_ref[2] * fs.e_theta[2],
+        ];
+        // 差异只剩样条采样误差（600s 网格下 << 1e-9 km/s²）。
+        for d in 0..2 {
+            assert!(
+                (a_rot[d] - ref_rot[d]).abs() < 1e-9,
+                "t={t} ({x},{y}) 第 {d} 维：{} vs {}",
+                a_rot[d],
+                ref_rot[d]
+            );
+        }
+    }
+
+    ephem_cache::disable();
+}

--- a/crates/e2m2e-integrators/Cargo.toml
+++ b/crates/e2m2e-integrators/Cargo.toml
@@ -22,14 +22,14 @@ default = ["spice"]
 # 自动链接 libpython，测试二进制可独立运行。pyproject [tool.maturin]
 # features 显式传入。
 extension-module = ["pyo3/extension-module"]
-spice = ["dep:cspice", "dep:cspice-sys", "e2m2e-forces/spice", "e2m2e-spice/spice"]
+spice = ["dep:cspice", "dep:cspice-sys", "e2m2e-forces/spice", "e2m2e-spice/spice", "e2m2e-hjb-dynamics/ephemeris"]
 
 [dependencies]
 pyo3 = { workspace = true }
 rayon = { workspace = true }
 e2m2e-forces = { path = "../e2m2e-forces" }
 e2m2e-levelset = { path = "../e2m2e-levelset" }
-e2m2e-hjb-dynamics = { path = "../e2m2e-hjb-dynamics" }
+e2m2e-hjb-dynamics = { path = "../e2m2e-hjb-dynamics", default-features = false }
 ndarray = { workspace = true }
 e2m2e-propagation = { path = "../e2m2e-propagation", features = ["pyo3"] }
 e2m2e-spice = { path = "../e2m2e-spice" }

--- a/crates/e2m2e-integrators/src/hjb.rs
+++ b/crates/e2m2e-integrators/src/hjb.rs
@@ -22,6 +22,8 @@ use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
+#[cfg(feature = "spice")]
+use e2m2e_hjb_dynamics::EphemerisPlanar;
 use e2m2e_hjb_dynamics::{Cr3bpSynodic, PlanarDoubleIntegrator};
 use e2m2e_levelset::derivative::UpwindFirstENO2;
 use e2m2e_levelset::dissipation::ArtificialDissipationGLF;
@@ -36,8 +38,11 @@ const MAX_SNAPSHOT_BYTES: usize = 4 << 30;
 /// 快照数上限。
 const MAX_SNAPSHOTS: usize = 64;
 
-/// 时间反转适配器：HJB 反向求解等价于以 −H\* 正向推进。
-struct NegHamiltonian<H>(H);
+/// 时间反转适配器：HJB 反向求解等价于以 τ = tf − t 正向推进 −H\*。
+///
+/// 非自治（时变）Hamiltonian 需同时做时间参数反转：积分器传进的 t
+/// 是 τ，物理时刻为 tf − τ。自治模型对 t 不敏感，该映射是无害恒等。
+struct NegHamiltonian<H>(H, f64);
 
 impl<H: Hamiltonian> Hamiltonian for NegHamiltonian<H> {
     fn hamiltonian(
@@ -47,7 +52,7 @@ impl<H: Hamiltonian> Hamiltonian for NegHamiltonian<H> {
         phi: &ArrayD<f64>,
         p: &[ArrayD<f64>],
     ) -> ArrayD<f64> {
-        -&self.0.hamiltonian(t, grid, phi, p)
+        -&self.0.hamiltonian(self.1 - t, grid, phi, p)
     }
 
     fn partial_bound(
@@ -158,7 +163,7 @@ fn solve_hjb<H: Hamiltonian>(
 
     let mut term = LaxFriedrichsTerm::new(
         grid.clone(),
-        NegHamiltonian(hamiltonian),
+        NegHamiltonian(hamiltonian, tf),
         UpwindFirstENO2,
         ArtificialDissipationGLF,
     );
@@ -295,7 +300,13 @@ fn build_result_dict<'py>(
 /// - ``"planar_double_integrator"``：平面双积分器，参数 drift_x、drift_y、
 ///   max_accel、fuel_weight；
 /// - ``"cr3bp_synodic"``：地月会合系无量纲平面 CR3BP，参数 mu、
-///   max_accel、fuel_weight。
+///   max_accel、fuel_weight；
+/// - ``"ephemeris_planar"``（需 spice）：平面全星历脉动会合系（#498，
+///   ADR 0034），参数 mu_earth、mu_moon、mu_sun（km³/s²）、et0（求解器
+///   t=0 对应的 SPICE et）、thrust（N）、isp（s）、g0（m/s²）、fuel_weight、
+///   mass_mode（0 = 4 维固定质量，需 fixed_mass；1 = 5 维含质量轴，
+///   单位 kg）。求解器 t 单位为秒；调用前须 ``enable_ephem_cache`` 覆盖
+///   [et0+t0, et0+tf]，求解阶段零 cspice。
 ///
 /// `terminal` 为终端代价 ψ 的扁平数组（C 序，长度等于网格节点数）。
 /// 返回字典：``times`` 升序时刻、``values`` 逐快照拼接的值函数
@@ -321,9 +332,29 @@ pub fn solve_hjb_py<'py>(
     // 动力学加入时只动自己的分支（ADR 0032 决策 3 的通用入口定位）。
     let expected_dim = match dynamics {
         "planar_double_integrator" | "cr3bp_synodic" => 4,
+        "ephemeris_planar" => {
+            #[cfg(feature = "spice")]
+            {
+                match params.get("mass_mode") {
+                    Some(v) if *v == 0.0 => 4,
+                    Some(v) if *v == 1.0 => 5,
+                    _ => {
+                        return Err(PyValueError::new_err(
+                            "动力学 ephemeris_planar 缺少或非法参数 mass_mode（0 = 4 维，1 = 5 维含质量）",
+                        ));
+                    }
+                }
+            }
+            #[cfg(not(feature = "spice"))]
+            {
+                return Err(PyValueError::new_err(
+                    "动力学 ephemeris_planar 需要 spice feature（默认构建已启用）",
+                ));
+            }
+        }
         other => {
             return Err(PyValueError::new_err(format!(
-                "未知动力学标识 {other}（支持：planar_double_integrator、cr3bp_synodic）"
+                "未知动力学标识 {other}（支持：planar_double_integrator、cr3bp_synodic、ephemeris_planar）"
             )));
         }
     };
@@ -369,6 +400,105 @@ pub fn solve_hjb_py<'py>(
                 return Err(PyValueError::new_err("mu 必须在 (0, 1) 内"));
             }
             let ham = Cr3bpSynodic::new(mu, params["max_accel"], params["fuel_weight"]);
+            py.allow_threads(|| solve_hjb(grid.clone(), terminal_arr, t0, tf, ham, cfl, max_step))
+        }
+        #[cfg(feature = "spice")]
+        "ephemeris_planar" => {
+            let required = [
+                "mu_earth",
+                "mu_moon",
+                "mu_sun",
+                "et0",
+                "thrust",
+                "isp",
+                "g0",
+                "fuel_weight",
+                "mass_mode",
+            ];
+            let with_mass = params["mass_mode"] == 1.0;
+            for key in required {
+                if !params.contains_key(key) {
+                    return Err(PyValueError::new_err(format!(
+                        "动力学 {dynamics} 缺少参数 {key}（需要：{required:?}）"
+                    )));
+                }
+            }
+            for key in params.keys() {
+                let ok = required.contains(&key.as_str()) || (!with_mass && key == "fixed_mass");
+                if !ok {
+                    return Err(PyValueError::new_err(format!(
+                        "动力学 {dynamics} 不接受参数 {key}"
+                    )));
+                }
+            }
+            if !with_mass && !params.contains_key("fixed_mass") {
+                return Err(PyValueError::new_err("mass_mode = 0 需要 fixed_mass（kg）"));
+            }
+            for key in ["mu_earth", "mu_moon"] {
+                let v = params[key];
+                if !v.is_finite() || v <= 0.0 {
+                    return Err(PyValueError::new_err(format!("{key} 必须为正的有限值")));
+                }
+            }
+            for key in ["mu_sun", "et0", "thrust", "isp", "g0"] {
+                let v = params[key];
+                if !v.is_finite() || v < 0.0 {
+                    return Err(PyValueError::new_err(format!("{key} 必须为非负有限值")));
+                }
+            }
+            if params["thrust"] <= 0.0 || params["isp"] <= 0.0 || params["g0"] <= 0.0 {
+                return Err(PyValueError::new_err("thrust/isp/g0 必须为正"));
+            }
+            let fw = params["fuel_weight"];
+            if !fw.is_finite() || fw < 0.0 {
+                return Err(PyValueError::new_err("fuel_weight 必须为非负有限值"));
+            }
+            let fixed_mass = if with_mass { 0.0 } else { params["fixed_mass"] };
+            if !with_mass && (!fixed_mass.is_finite() || fixed_mass <= 0.0) {
+                return Err(PyValueError::new_err("fixed_mass 必须为正的有限值"));
+            }
+            // 缓存前置校验：把求解热循环里的硬失败提前到入口。
+            let et0 = params["et0"];
+            match e2m2e_spice::ephem_cache::enabled_span() {
+                None => {
+                    return Err(PyValueError::new_err(
+                        "ephemeris_planar 需要先 enable_ephem_cache 且覆盖 [et0+t0, et0+tf]",
+                    ));
+                }
+                Some((start, end)) => {
+                    if !(start <= et0 + t0 && et0 + tf <= end) {
+                        return Err(PyValueError::new_err(format!(
+                            "EphemCache 覆盖 [{start}, {end}] 不含求解窗 [{}, {}]",
+                            et0 + t0,
+                            et0 + tf
+                        )));
+                    }
+                }
+            }
+            let forces = vec![
+                e2m2e_forces::forces::compiled::CompiledForce::PointMass {
+                    mu: params["mu_earth"],
+                },
+                e2m2e_forces::forces::compiled::CompiledForce::ThirdBody {
+                    body: "MOON".to_string(),
+                    mu: params["mu_moon"],
+                },
+                e2m2e_forces::forces::compiled::CompiledForce::ThirdBody {
+                    body: "SUN".to_string(),
+                    mu: params["mu_sun"],
+                },
+            ];
+            let ham = EphemerisPlanar::new(
+                forces,
+                et0,
+                (t0, tf),
+                params["thrust"],
+                params["isp"],
+                params["g0"],
+                fw,
+                with_mass,
+                fixed_mass,
+            );
             py.allow_threads(|| solve_hjb(grid.clone(), terminal_arr, t0, tf, ham, cfl, max_step))
         }
         other => {

--- a/crates/e2m2e-integrators/src/hjb.rs
+++ b/crates/e2m2e-integrators/src/hjb.rs
@@ -313,6 +313,10 @@ fn build_result_dict<'py>(
 /// （C 序，形状 (len(times), ×shape)）、``axes`` 各维节点坐标、
 /// ``steps`` 实际积分步数。快照按时间近似等距抽样，数量有上界，
 /// 高维网格不会返回完整时间序列。
+///
+/// 值函数产物落盘时，调用方须按 ADR 0033 决策 3 补足元数据：动力学
+/// 标识与参数表、状态维顺序、无量纲化口径、``times`` 语义
+/// （ephemeris_planar 为求解器秒，ET = et0 + times）、历元映射参数。
 #[pyfunction]
 #[allow(clippy::too_many_arguments)]
 pub fn solve_hjb_py<'py>(

--- a/crates/e2m2e-spice/src/ephem_cache.rs
+++ b/crates/e2m2e-spice/src/ephem_cache.rs
@@ -181,6 +181,36 @@ impl CubicSpline {
             + b * self.ys[i + 1]
             + ((a * a * a - a) * self.m[i] + (b * b * b - b) * self.m[i + 1]) * (h * h) / 6.0
     }
+
+    /// 在 t 处求二阶导数。二阶导数形式的样条里 y'' 在区间内是节点二阶
+    /// 导数 `m` 的线性插值（C¹ 连续）；端点越界钳位同 `eval`。
+    ///
+    /// 供需要天体加速度的使用方（如 HJB 时变会合系的 d̈、ω̇）从同一条
+    /// 位置样条取二阶导，避免另建查询路径。
+    fn eval_second(&self, t: f64) -> f64 {
+        let n = self.xs.len();
+        if t <= self.xs[0] {
+            return self.m[0];
+        }
+        if t >= self.xs[n - 1] {
+            return self.m[n - 1];
+        }
+        let mut lo = 0usize;
+        let mut hi = n - 1;
+        while hi - lo > 1 {
+            let mid = (lo + hi) / 2;
+            if self.xs[mid] <= t {
+                lo = mid;
+            } else {
+                hi = mid;
+            }
+        }
+        let i = lo;
+        let h = self.xs[i + 1] - self.xs[i];
+        let a = (self.xs[i + 1] - t) / h;
+        let b = (t - self.xs[i]) / h;
+        a * self.m[i] + b * self.m[i + 1]
+    }
 }
 
 /// 单个 (target, observer) 对的位置/速度样条。
@@ -431,6 +461,21 @@ impl EphemCache {
         Some([bs.vel[0].eval(et), bs.vel[1].eval(et), bs.vel[2].eval(et)])
     }
 
+    /// 查 (target, observer) 在 et 的加速度——位置样条的二阶导数。
+    /// 未缓存或越界返回 None。
+    pub fn body_acceleration(&self, target: &str, observer: &str, et: f64) -> Option<[f64; 3]> {
+        let key = (target.to_string(), observer.to_string());
+        let bs = self.bodies.get(&key)?;
+        if !(self.et_start..=self.et_end).contains(&et) {
+            return None;
+        }
+        Some([
+            bs.pos[0].eval_second(et),
+            bs.pos[1].eval_second(et),
+            bs.pos[2].eval_second(et),
+        ])
+    }
+
     /// 查 (from, to) 帧旋转矩阵。未缓存或越界返回 None。
     pub fn frame_matrix(&self, from: &str, to: &str, et: f64) -> Option<[[f64; 3]; 3]> {
         let key = (from.to_string(), to.to_string());
@@ -516,6 +561,15 @@ pub fn enable(cache: EphemCache) {
 pub fn disable() {
     let mut g = CACHE.write().expect("ephem cache rwlock poisoned");
     *g = None;
+}
+
+/// 当前已启用缓存的覆盖区间（et 秒）。未启用返回 None。
+///
+/// 供构造方（如 HJB 星历 Hamiltonian 绑定层）在求解前校验求解窗被
+/// 缓存覆盖——越界查询在求解热循环里是硬失败，提前到构造时报错。
+pub fn enabled_span() -> Option<(f64, f64)> {
+    let g = CACHE.read().expect("ephem cache rwlock poisoned");
+    g.as_ref().map(|c| (c.et_start, c.et_end))
 }
 
 /// 缓存 key 归一化：NAIF ID 字符串（如 "301"）转名字（"MOON"）。
@@ -651,6 +705,35 @@ pub fn lookup_body_velocity(
     Err(CacheMissError::KeyMiss(format!("({target}, {observer})")))
 }
 
+/// 查天体加速度（位置样条二阶导数）。语义同 `lookup_body_position`。
+pub fn lookup_body_acceleration(
+    target: &str,
+    observer: &str,
+    et: f64,
+) -> Result<Option<[f64; 3]>, CacheMissError> {
+    let g = CACHE.read().expect("ephem cache rwlock poisoned");
+    let Some(cache) = g.as_ref() else {
+        return if strict() {
+            Err(CacheMissError::NotEnabled)
+        } else {
+            Ok(None)
+        };
+    };
+    let acc = cache.body_acceleration(normalize_body_name(target), observer, et);
+    if acc.is_some() {
+        return Ok(acc);
+    }
+    // 缓存已启用但 miss：一律硬失败（不再区分 strict/非 strict）。
+    if !(cache.et_start..=cache.et_end).contains(&et) {
+        return Err(CacheMissError::OutOfRange {
+            et,
+            start: cache.et_start,
+            end: cache.et_end,
+        });
+    }
+    Err(CacheMissError::KeyMiss(format!("({target}, {observer})")))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -689,5 +772,25 @@ mod tests {
         // 内部点（远离边界）应明显更精确
         assert!((sp.eval(2.0) - 2.0_f64.sin()).abs() < 1e-4);
         let _ = max_err;
+    }
+
+    #[test]
+    fn test_cubic_spline_second_derivative() {
+        // 对 sin 采样建样条：二阶导应近似 -sin（同阶精度，容差与一阶导同量级）。
+        let n = 40;
+        let xs: Vec<f64> = (0..n).map(|i| i as f64 * 0.2).collect();
+        let ys: Vec<f64> = xs.iter().map(|x| x.sin()).collect();
+        let sp = CubicSpline::new(xs, ys);
+        // 远离自然边界（首末节点二阶导强制为 0，边界误差大）。
+        for x in [1.0_f64, 2.3, 3.7, 5.1, 6.4] {
+            let got = sp.eval_second(x);
+            let expected = -x.sin();
+            assert!(
+                (got - expected).abs() < 5e-3,
+                "at {x}: got {got} exp {expected}"
+            );
+        }
+        // 节点处二阶导应精确返回预解的 m。
+        assert!((sp.eval_second(2.0) - sp.m[10]).abs() < 1e-12);
     }
 }

--- a/tests/numerical/integrators/bindings/test_hjb_solve.py
+++ b/tests/numerical/integrators/bindings/test_hjb_solve.py
@@ -178,3 +178,217 @@ class TestParameterValidation:
                 {"mu": MU_EARTH_MOON, "max_accel": 0.5, "fuel_weight": 0.1},
                 shape=[9] * 3,
             )
+
+
+class TestEphemerisPlanar:
+    """ephemeris_planar 动力学（#498，ADR 0034 平面全星历）。
+
+    参数校验与入口契约不依赖内核；求解正确性（粗细模型回归、零 cspice）
+    需要 SPICE 内核与星历缓存，标 ``spice`` 在内核缺失时跳过。
+    """
+
+    MU_EARTH = 398600.435436
+    MU_MOON = 4902.800066
+    MU_SUN = 1.32712440018e11
+
+    def _params(self, **overrides):
+        params = {
+            "mu_earth": self.MU_EARTH,
+            "mu_moon": self.MU_MOON,
+            "mu_sun": self.MU_SUN,
+            "et0": 0.0,
+            "thrust": 1.0,
+            "isp": 300.0,
+            "g0": 9.80665,
+            "fuel_weight": 0.1,
+            "mass_mode": 0,
+            "fixed_mass": 1000.0,
+        }
+        params.update(overrides)
+        return params
+
+    def _call(self, params, dim=None, t0=0.0, tf=1.0):
+        dim = dim or (5 if params.get("mass_mode") == 1 else 4)
+        shape, _ = _grid([0.5] + [-1.0] * (dim - 1), [1.5] + [1.0] * (dim - 1), 3)
+        terminal = [0.0] * (3**dim)
+        return integrators.solve_hjb_py(
+            terminal,
+            [0.5] + [-1.0] * (dim - 1),
+            [1.5] + [1.0] * (dim - 1),
+            shape,
+            t0,
+            tf,
+            "ephemeris_planar",
+            params,
+            0.5,
+            tf / 4,
+        )
+
+    def test_missing_param_rejected(self):
+        params = self._params()
+        del params["mu_moon"]
+        with pytest.raises(ValueError, match="mu_moon"):
+            self._call(params)
+
+    def test_unknown_param_rejected(self):
+        with pytest.raises(ValueError, match="不接受参数"):
+            self._call(self._params(extra=1.0))
+
+    def test_bad_mass_mode_rejected(self):
+        with pytest.raises(ValueError, match="mass_mode"):
+            self._call(self._params(mass_mode=2))
+
+    def test_4d_requires_fixed_mass(self):
+        params = self._params()
+        del params["fixed_mass"]
+        with pytest.raises(ValueError, match="fixed_mass"):
+            self._call(params)
+
+    def test_5d_rejects_fixed_mass(self):
+        with pytest.raises(ValueError, match="不接受参数"):
+            self._call(self._params(mass_mode=1, fixed_mass=1000.0))
+
+    def test_bad_thrust_rejected(self):
+        with pytest.raises(ValueError, match="thrust"):
+            self._call(self._params(thrust=-1.0))
+
+    def test_dim_mismatch_rejected(self):
+        """mass_mode 与网格维数不一致时报维数错误。"""
+        with pytest.raises(ValueError, match="维数"):
+            self._call(self._params(), dim=5)
+
+    def test_requires_enabled_cache(self):
+        """未启用星历缓存时入口直接拒绝（热循环硬失败提前）。"""
+        integrators.disable_ephem_cache()
+        try:
+            with pytest.raises(ValueError, match="enable_ephem_cache"):
+                self._call(self._params())
+        finally:
+            integrators.disable_ephem_cache()
+
+
+@pytest.mark.spice
+class TestEphemerisPlanarSolve:
+    """ephemeris_planar 求解（#498 验收 c/d）：零 cspice 与粗细模型回归。"""
+
+    MU_EARTH = 398600.435436
+    MU_MOON = 4902.800066
+    MU_SUN = 1.32712440018e11
+
+    def _moon_scale(self, spice):
+        """et0 处月地距 L 与会合角速度 ω，用于与 CR3BP 无量纲对齐。"""
+        et0 = spice.utc_to_et("2025-06-21T11:00:06")
+        state, _ = integrators.spice_spkezr("MOON", et0, "J2000", "NONE", "EARTH")
+        r = np.asarray(state[:3])
+        v = np.asarray(state[3:])
+        length = float(np.linalg.norm(r))
+        omega = float(np.linalg.norm(np.cross(r, v))) / length**2
+        return et0, length, omega
+
+    def _solve_ephemeris(self, spice, tf_nondim=0.5, n=9):
+        et0, length, omega = self._moon_scale(spice)
+        tf_s = tf_nondim / omega
+        # 与 CR3BP 基准同物理量级：a_nd = T/(1000·m0)（km/s²）↔ 无量纲 0.5。
+        thrust = 0.5 * omega**2 * 1000.0 * 1000.0
+        params = {
+            "mu_earth": self.MU_EARTH,
+            "mu_moon": self.MU_MOON,
+            "mu_sun": self.MU_SUN,
+            "et0": et0,
+            "thrust": thrust,
+            "isp": 300.0,
+            "g0": 9.80665,
+            "fuel_weight": 0.1 * omega,
+            "mass_mode": 0,
+            "fixed_mass": 1000.0,
+        }
+        minimum = [0.5, -0.5, -omega, -omega]
+        maximum = [1.5, 0.5, omega, omega]
+        shape, axes = _grid(minimum, maximum, n)
+        # 终端代价与 CR3BP 基准同一物理函数：速度维 u/ω 换算回无量纲
+        # （球在混合量纲坐标下不自洽，半径 0.2 会吞掉整条速度轴）。
+        axes_nondim = [a / s for a, s in zip(axes, [1.0, 1.0, omega, omega], strict=True)]
+        terminal = _terminal_ball(axes_nondim, np.array([1.0, 0.0, 0.0, 0.0]), 0.2)
+        ffi_before = integrators.ephem_ffi_call_count()
+        raw = integrators.solve_hjb_py(
+            terminal,
+            minimum,
+            maximum,
+            shape,
+            0.0,
+            tf_s,
+            "ephemeris_planar",
+            params,
+            0.5,
+            tf_s / 100,
+        )
+        ffi_after = integrators.ephem_ffi_call_count()
+        return raw, shape, axes, (ffi_before, ffi_after), omega
+
+    def _solve_cr3bp_baseline(self, tf_nondim=0.5, n=9):
+        minimum = [0.5, -0.5, -1.0, -1.0]
+        maximum = [1.5, 0.5, 1.0, 1.0]
+        shape, axes = _grid(minimum, maximum, n)
+        terminal = _terminal_ball(axes, np.array([1.0, 0.0, 0.0, 0.0]), 0.2)
+        return integrators.solve_hjb_py(
+            terminal,
+            minimum,
+            maximum,
+            shape,
+            0.0,
+            tf_nondim,
+            "cr3bp_synodic",
+            {"mu": MU_EARTH_MOON, "max_accel": 0.5, "fuel_weight": 0.1},
+            0.5,
+            tf_nondim / 100,
+        ), shape
+
+    def test_zero_cspice_and_cr3bp_regression(self, spice_kernel_path):
+        from e2m2e.data.kernels.manager import SPICEManager
+        from e2m2e.integrators import disable_ephem_cache, enable_ephem_cache
+
+        spice = SPICEManager()
+        spice.load_kernel(spice_kernel_path)
+        try:
+            et0, _, omega = self._moon_scale(spice)
+            tf_s = 0.5 / omega
+            enable_ephem_cache(
+                [("MOON", "EARTH"), ("SUN", "EARTH")], [], et0, et0 + tf_s + 1.0, 3600.0
+            )
+            try:
+                raw, shape, _, ffi, _ = self._solve_ephemeris(spice)
+            finally:
+                disable_ephem_cache()
+        finally:
+            spice.unload_kernel(spice_kernel_path)
+
+        # 验收 d：求解全程零 cspice FFI（纯缓存查表）。
+        assert ffi[1] == ffi[0]
+
+        values = np.asarray(raw["values"]).reshape((-1, *shape))
+        assert np.isfinite(values).all()
+        times = np.asarray(raw["times"])
+        # t=0 处的微小偏差是积分器终止判据（100·EPS·tf 相对余量）的正常行为。
+        assert times[0] == pytest.approx(0.0, abs=1e-6 * tf_s)
+        assert times[-1] == pytest.approx(tf_s)
+
+        # 验收 c：粗细模型回归——星历版与 CR3BP 版值函数量级与等值面
+        # 结构一致。剩余差异是物理性的（真实月距 370000 km vs 标称
+        # 384400 km、瞬时 ω vs 标称 ω、太阳第三体），随窗长增长；实现
+        # 错误由退化对拍（Rust）与力一致性（逐点）锤死，不靠此断言。
+        raw_c, shape_c = self._solve_cr3bp_baseline()
+        v_e = values[0].ravel()
+        v_c = np.asarray(raw_c["values"]).reshape((-1, *shape_c))[0].ravel()
+        # 剔除月球邻域节点：会合系把月球钉在 (1, 0)，网格必命中；两模型
+        # 在天体中心均无物理意义（CR3BP 截断垃圾 / 星历版取物理极限）。
+        x_ax, y_ax = np.meshgrid(raw["axes"][0], raw["axes"][1], indexing="ij")
+        dist = np.broadcast_to(np.hypot(x_ax - 1.0, y_ax)[..., None, None], tuple(shape)).ravel()
+        keep = dist > 0.1
+        diff = np.abs(v_e[keep] - v_c[keep])
+        scale = np.abs(v_c[keep]).max()
+        assert diff.max() < 0.6 * scale, f"值函数最大偏差 {diff.max():.4f} 超过 0.6×{scale:.4f}"
+        # 量级：正负端点相对差在 15% 内（真实星历与标称参数的物理差异水平）。
+        assert v_e[keep].max() == pytest.approx(v_c[keep].max(), rel=0.15)
+        assert v_e[keep].min() == pytest.approx(v_c[keep].min(), abs=0.1)
+        corr = np.corrcoef(v_e[keep], v_c[keep])[0, 1]
+        assert corr > 0.96, f"等值面结构相关性 {corr:.5f} 过低"


### PR DESCRIPTION
## 关联 issue

Closes #498（规格：ADR 0034 + agent brief，见 issue 分诊评论）

## 改动摘要

按 ADR 0034 决策 1（平面全星历）实现星历力模型 Hamiltonian：

- **`e2m2e-hjb-dynamics`**：新增 `EphemerisPlanar`（feature `ephemeris`，随 integrators 的 spice 启用）——真实月球星历定义的时变脉动会合系（地心系，月球钉在 (1,0)），力为两主星点质量 + 太阳第三体面内投影，非自治 5 维含质量 / 4 维固定质量（`mass_mode` 参数区分）。ω、ω̇、脉动项全部由缓存的月球位置/速度/加速度导出，每个 RK 子步查一次星历缓存全网格复用；min-fuel 控制解析消去（开关函数含质量协态项）；`partial_bound` 闭式包络推导入注释。
- **`e2m2e-spice`**：`EphemCache` 新增位置样条二阶导查表（`lookup_body_acceleration`）与 `enabled_span()`。
- **`e2m2e-integrators`**：`solve_hjb_py` 注册 `ephemeris_planar` 动力学（历元映射 et = et0 + t，构造期校验缓存覆盖求解窗；无新 PyO3 符号，ABI 戳不变）；`NegHamiltonian` 补时间参数反转 t → tf − t（非自治必需）。

**关键修复**：会合系把主星钉在固定网格坐标，奇数节点网格必命中 (1,0)，`MIN_DISTANCE` 截断在天体中心产生 ~μ/ε² 伪加速度把 CFL 步长压为零（求解死循环）——天体中心邻域按物理极限正则化（第三体直接项取 0、保留 indirect 项），已回写模块文档。

## 验收（对照 agent brief）

- [x] 退化对拍：圆化定常星历下向量场逐项还原 `Cr3bpSynodic`（含地心↔质心坐标平移 + 量纲换算）
- [x] 力一致性：与 `compute_total_acceleration` 逐点一致（`tests/ephemeris_force_parity.rs`，合成星历经同一条缓存路径）
- [x] 粗细模型回归：小网格星历版 vs CR3BP 版值函数量级一致（端点差 <15%）、等值面相关 >0.96（剔除两模型均无物理意义的月球邻域节点；剩余差异为真实星历与标称参数的物理差异）
- [x] 求解全程零 cspice：FFI 计数为 0
- [x] 受影响测试全过：hjb-dynamics 19 项 Rust 测试、integrators Rust 全套、hjb_solve + ephem_cache pytest 26 项；ruff / mypy / cargo fmt 绿

## 测试命令

```bash
make test-rust
uv run --no-sync pytest tests/numerical/integrators/bindings/test_hjb_solve.py tests/numerical/integrators/bindings/test_ephem_cache.py
cargo clippy -p e2m2e-hjb-dynamics --all-targets --features ephemeris -- -D warnings
```

注：propagation/integrators 有 7 个既存 clippy 错（stash 验证与本 PR 无关）；第 4 级闭环回放（geo-nrho 1 小时短弧）按 brief 在 geo-nrho 侧手动执行。