### PR TITLE
将 de430/de440s 行星星历内核纳入 git-lfs 跟踪

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -66,3 +66,4 @@ tests/ export-ignore
 docs/ export-ignore
 scripts/ export-ignore
 CHANGELOG.md export-ignore
+kernels/*.bsp filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -95,9 +95,8 @@ temp.py
 scripts/*.png
 examples/main_*.png
 
-# SPICE 内核大文件（超过 Gitee 100MB 限制）
-# 下载方式：https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/
-kernels/*.bsp
+# SPICE 行星星历内核大文件（de430.bsp 超 100MB，经 git-lfs 入库，见 .gitattributes）
+# 下载方式（不用 LFS 时可手动下载）：https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/
 # 本地 CSPICE 库与下载缓存（scripts/download_cspice.py 生成）
 # 只忽略仓库根目录的 cspice/（手动解压的 CSPICE 源码包），不动 crates/cspice/
 /cspice/

--- a/kernels/de430.bsp
+++ b/kernels/de430.bsp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e1b277c5f07135a84950604b83e56b736be696a7f3560bcddb1d4aeb944fca1
+size 119741440

--- a/kernels/de440s.bsp
+++ b/kernels/de440s.bsp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c1c7feeab882263fc493a9d5a5b2ddd71b54826cdf65d8d17a76126b260a49f2
+size 32726016


### PR DESCRIPTION
## 改动摘要

- `kernels/de430.bsp`（115MB）超过 GitHub 单文件 100MB 限制，普通 git 无法推送，改用 git-lfs 入库；`kernels/de440s.bsp`（32MB）一并跟踪。
- `.gitattributes` 新增 `kernels/*.bsp filter=lfs diff=lfs merge=lfs -text` 规则。
- `.gitignore` 移除 `kernels/*.bsp` 忽略规则，注释更新为说明改走 LFS，并保留 NAIF 手动下载地址。

## 关联 issue

无关联 issue。

## 验证

- `git lfs ls-files` 确认两个 bsp 已作为 LFS 对象跟踪。
- 推送时 LFS 对象上传成功（152MB，2/2）。

## 注意

- 协作者需安装 git-lfs（Ubuntu: `sudo apt install git-lfs && git lfs install`），clone 后 LFS 文件自动下载。
- Gitee 不支持 LFS，若仍需镜像推送 Gitee 会在大文件上失败。