### PR TITLE
fix: 清零测试代码的编译与 clippy 警告

### DIFF
--- a/crates/e2m2e-forces/src/bcr4bp.rs
+++ b/crates/e2m2e-forces/src/bcr4bp.rs
@@ -820,13 +820,13 @@ mod tests {
         assert_eq!(bwd.states.len(), 2);
         assert!((bwd.times[0] - 1.0).abs() < 1e-12);
         assert!(bwd.times[1].abs() < 1e-12);
-        for i in 0..6 {
+        for (i, (got, &want)) in bwd.states[1].iter().zip(state0.iter()).enumerate() {
             assert!(
-                (bwd.states[1][i] - state0[i]).abs() < 1e-7,
+                (got - want).abs() < 1e-7,
                 "backward roundtrip state[{}] = {} vs {}",
                 i,
-                bwd.states[1][i],
-                state0[i]
+                got,
+                want
             );
         }
     }

--- a/crates/e2m2e-forces/src/cr3bp.rs
+++ b/crates/e2m2e-forces/src/cr3bp.rs
@@ -660,13 +660,13 @@ mod tests {
         assert_eq!(bwd.states.len(), 2);
         assert!((bwd.times[0] - 1.0).abs() < 1e-12);
         assert!(bwd.times[1].abs() < 1e-12);
-        for i in 0..6 {
+        for (i, (got, &want)) in bwd.states[1].iter().zip(state0.iter()).enumerate() {
             assert!(
-                (bwd.states[1][i] - state0[i]).abs() < 1e-7,
+                (got - want).abs() < 1e-7,
                 "backward roundtrip state[{}] = {} vs {}",
                 i,
-                bwd.states[1][i],
-                state0[i]
+                got,
+                want
             );
         }
     }

--- a/crates/e2m2e-forces/src/forces/ecom.rs
+++ b/crates/e2m2e-forces/src/forces/ecom.rs
@@ -135,9 +135,9 @@ mod tests {
         let a0 = 1.0 * pressure * dyb[0] / KM_TO_M; // flux=1, u=0
         let d_comp = 1.0_f64; // dyb[1..9]=0, u=0
 
-        for i in 0..3 {
+        for (i, &dh) in d_hat.iter().enumerate() {
             assert!(
-                (a0 * d_comp * d_hat[i] - expected * d_hat[i]).abs() < 1e-30,
+                (a0 * d_comp * dh - expected * dh).abs() < 1e-30,
                 "ECOM degenerate mismatch at [{}]",
                 i
             );

--- a/crates/e2m2e-forces/src/forces/nbody_stm.rs
+++ b/crates/e2m2e-forces/src/forces/nbody_stm.rs
@@ -497,16 +497,6 @@ mod tests {
         has_spk
     }
 
-    /// 地月系配置：EARTH 为中心，MOON 为摄动体。
-    fn earth_moon_config() -> NBodyConfig {
-        NBodyConfig {
-            bodies: vec!["EARTH".to_string(), "MOON".to_string()],
-            origin: "EARTH".to_string(),
-            // GM 值（km³/s²）：JPL DE430
-            gm_values: vec![398600.435436, 4902.800066],
-        }
-    }
-
     /// 地月日配置。
     fn earth_moon_sun_config() -> NBodyConfig {
         NBodyConfig {

--- a/crates/e2m2e-forces/src/solid_tide.rs
+++ b/crates/e2m2e-forces/src/solid_tide.rs
@@ -384,13 +384,14 @@ mod tests {
 
     /// Step1 在地球 + Sun/Moon 扰动下应非零。
     #[test]
+    #[allow(clippy::approx_constant)] // K22 = 0.30102 是真实 Love 数，碰巧接近 LOG10_2
     fn test_step1_earth_sun_moon() {
         // 地球 Love 数（只填 n=2,3 的前几项）
         let mut k_love_flat = vec![0.0_f64; 25];
-        k_love_flat[2 * 5 + 0] = 0.30190; // K20
+        k_love_flat[2 * 5] = 0.30190; // K20
         k_love_flat[2 * 5 + 1] = 0.29830; // K21
         k_love_flat[2 * 5 + 2] = 0.30102; // K22
-        k_love_flat[3 * 5 + 0] = 0.093;
+        k_love_flat[3 * 5] = 0.093;
         k_love_flat[3 * 5 + 1] = 0.093;
         k_love_flat[3 * 5 + 2] = 0.093;
         k_love_flat[3 * 5 + 3] = 0.094;
@@ -418,7 +419,7 @@ mod tests {
         );
         assert_eq!(out.len(), 50);
         // (2,0) 应该有显著值
-        assert!(out[2 * 5 + 0].abs() > 1e-9);
+        assert!(out[2 * 5].abs() > 1e-9);
         // 所有项有限
         assert!(out.iter().all(|v| v.is_finite()));
     }

--- a/crates/e2m2e-integrators/src/multiple_shooting.rs
+++ b/crates/e2m2e-integrators/src/multiple_shooting.rs
@@ -848,12 +848,12 @@ mod tests {
         let f = build_residual(&final_states, &state_work, 2, 1.0);
         assert_eq!(f.len(), 12);
         // 第一段残差：final_states[0] - state_work[1] = [0, 0, 0, 0, 0, 0]
-        for i in 0..6 {
-            assert!((f[i] - 0.0).abs() < 1e-15);
+        for &v in &f[..6] {
+            assert!((v - 0.0).abs() < 1e-15);
         }
         // 第二段残差：final_states[1] - state_work[2] = [0, 0, 0, 0, 0, 0]
-        for i in 6..12 {
-            assert!((f[i] - 0.0).abs() < 1e-15);
+        for &v in &f[6..] {
+            assert!((v - 0.0).abs() < 1e-15);
         }
     }
 

--- a/crates/e2m2e-integrators/src/planar_pal.rs
+++ b/crates/e2m2e-integrators/src/planar_pal.rs
@@ -809,15 +809,13 @@ mod tests {
         let stm = result.stms.last().unwrap();
         let flow = cr3bp_eom(MU, &final_state);
 
-        for row in 0..4 {
-            let component = PLANAR[row];
+        for (row, &component) in PLANAR.iter().enumerate() {
             assert!(
                 (evaluation.closure[row] - (final_state[component] - state_from_q(&q)[component]))
                     .abs()
                     < 1e-12
             );
-            for col in 0..4 {
-                let variable = PLANAR[col];
+            for (col, &variable) in PLANAR.iter().enumerate() {
                 let expected = (stm[component * 6 + variable] - f64::from(component == variable))
                     * SCALES[col];
                 assert!((evaluation.jacobian[(row, col)] - expected).abs() < 1e-8);

--- a/crates/e2m2e-integrators/src/qf_cm.rs
+++ b/crates/e2m2e-integrators/src/qf_cm.rs
@@ -488,11 +488,12 @@ mod tests {
         let d = d_matrix();
         let inv = d_inv_matrix();
         // inv · D ≈ I
-        for i in 0..6 {
+        #[allow(clippy::needless_range_loop)] // j 同时用于索引与 i==j 判别，迭代器化反而绕
+        for (i, inv_row) in inv.iter().enumerate() {
             for j in 0..6 {
                 let mut acc = C64::ZERO;
                 for k in 0..6 {
-                    acc = acc.add(inv[i][k].mul(d[k][j]));
+                    acc = acc.add(inv_row[k].mul(d[k][j]));
                 }
                 let expect = if i == j { 1.0 } else { 0.0 };
                 assert!(
@@ -532,8 +533,8 @@ mod tests {
         let dx = hamilton_flow_rhs(&x, &poly);
         assert!((dx[0].re - 0.7).abs() < 1e-14);
         assert!((dx[0].im + 0.4).abs() < 1e-14);
-        for i in 1..6 {
-            assert!(dx[i].re.abs() < 1e-14 && dx[i].im.abs() < 1e-14);
+        for dx_v in &dx[1..] {
+            assert!(dx_v.re.abs() < 1e-14 && dx_v.im.abs() < 1e-14);
         }
     }
 

--- a/crates/e2m2e-integrators/src/qf_cm.rs
+++ b/crates/e2m2e-integrators/src/qf_cm.rs
@@ -488,8 +488,8 @@ mod tests {
         let d = d_matrix();
         let inv = d_inv_matrix();
         // inv · D ≈ I
-        #[allow(clippy::needless_range_loop)] // j 同时用于索引与 i==j 判别，迭代器化反而绕
         for (i, inv_row) in inv.iter().enumerate() {
+            #[allow(clippy::needless_range_loop)] // j 同时用于索引与 i==j 判别，迭代器化反而绕
             for j in 0..6 {
                 let mut acc = C64::ZERO;
                 for k in 0..6 {

--- a/crates/e2m2e-propagation/src/abm.rs
+++ b/crates/e2m2e-propagation/src/abm.rs
@@ -121,7 +121,7 @@ mod tests {
         let (y1, error, new_history) = abm_step(0.0, &[1.0, 0.0], h, &history, f).unwrap();
 
         // Exact solution at t = h: [cos h, -sin h].
-        let exact = vec![h.cos(), -h.sin()];
+        let exact = [h.cos(), -h.sin()];
         let num_err = y1
             .iter()
             .zip(exact.iter())

--- a/crates/e2m2e-propagation/src/pd45.rs
+++ b/crates/e2m2e-propagation/src/pd45.rs
@@ -106,7 +106,7 @@ mod tests {
         let (y1, error) = explicit_rk_step(&PD45_TABLE, 0.0, &y0, h, f, None).unwrap();
 
         // Analytic solution at t=h: cos(h), -sin(h).
-        let y_exact = vec![h.cos(), -h.sin()];
+        let y_exact = [h.cos(), -h.sin()];
         let num_err = y1
             .iter()
             .zip(y_exact.iter())

--- a/crates/e2m2e-propagation/src/pd78.rs
+++ b/crates/e2m2e-propagation/src/pd78.rs
@@ -199,7 +199,7 @@ mod tests {
 
         let (y1, error) = explicit_rk_step(&PD78_TABLE, 0.0, &y0, h, f, None).unwrap();
 
-        let y_exact = vec![h.cos(), -h.sin()];
+        let y_exact = [h.cos(), -h.sin()];
         let num_err = y1
             .iter()
             .zip(y_exact.iter())

--- a/crates/e2m2e-propagation/src/rk89.rs
+++ b/crates/e2m2e-propagation/src/rk89.rs
@@ -281,13 +281,9 @@ mod tests {
     #[test]
     fn ee_consistency() {
         // b - b_star must equal GMAT's ee literal (verifies b_star = cj - ee).
-        for i in 0..RK89_TABLE.stages {
-            let diff = RK89_TABLE.b[i] - RK89_TABLE.b_star[i];
-            assert!(
-                (diff - GMAT_EE[i]).abs() < 1e-12,
-                "b[{i}] - b_star[{i}] = {diff} != ee {}",
-                GMAT_EE[i]
-            );
+        for ((&b, &b_star), ee) in RK89_TABLE.b.iter().zip(RK89_TABLE.b_star).zip(GMAT_EE) {
+            let diff = b - b_star;
+            assert!((diff - ee).abs() < 1e-12, "b - b_star = {diff} != ee {ee}");
         }
     }
 
@@ -303,7 +299,7 @@ mod tests {
 
         let (y1, error) = explicit_rk_step(&RK89_TABLE, 0.0, &y0, h, f, None).unwrap();
 
-        let y_exact = vec![h.cos(), -h.sin()];
+        let y_exact = [h.cos(), -h.sin()];
         let num_err = y1
             .iter()
             .zip(y_exact.iter())

--- a/crates/e2m2e-propagation/src/rk89.rs
+++ b/crates/e2m2e-propagation/src/rk89.rs
@@ -281,9 +281,18 @@ mod tests {
     #[test]
     fn ee_consistency() {
         // b - b_star must equal GMAT's ee literal (verifies b_star = cj - ee).
-        for ((&b, &b_star), ee) in RK89_TABLE.b.iter().zip(RK89_TABLE.b_star).zip(GMAT_EE) {
+        for (i, ((&b, &b_star), ee)) in RK89_TABLE
+            .b
+            .iter()
+            .zip(RK89_TABLE.b_star)
+            .zip(GMAT_EE)
+            .enumerate()
+        {
             let diff = b - b_star;
-            assert!((diff - ee).abs() < 1e-12, "b - b_star = {diff} != ee {ee}");
+            assert!(
+                (diff - ee).abs() < 1e-12,
+                "b[{i}] - b_star[{i}] = {diff} != ee {ee}"
+            );
         }
     }
 

--- a/crates/e2m2e-propagation/src/solve_ivp.rs
+++ b/crates/e2m2e-propagation/src/solve_ivp.rs
@@ -482,8 +482,8 @@ mod tests {
         let y0 = vec![1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
 
         // 用 error_dim=None：STM 分量主导误差，步长很小，可能超时或步数耗尽
-        let sol_no_limit = solve_ivp_capped(
-            &f,
+        let _sol_no_limit = solve_ivp_capped(
+            f,
             (0.0, 5.0),
             &y0,
             &t_eval,
@@ -496,7 +496,7 @@ mod tests {
 
         // 用 error_dim=Some(2)：只统计前 2 维，步长正常
         let sol_with_dim = solve_ivp_capped(
-            &f,
+            f,
             (0.0, 5.0),
             &y0,
             &t_eval,

--- a/crates/e2m2e-spice/src/spice_ffi.rs
+++ b/crates/e2m2e-spice/src/spice_ffi.rs
@@ -457,11 +457,7 @@ mod tests {
         )
         .expect("easier_reader failed");
         let (state2, _lt2) = spkezr("MOON", et, "J2000", "NONE", "EARTH").expect("spkezr failed");
-        let expected_pos = [
-            state.position.x as f64,
-            state.position.y as f64,
-            state.position.z as f64,
-        ];
+        let expected_pos = [state.position.x, state.position.y, state.position.z];
         for k in 0..3 {
             let diff = (expected_pos[k] - state2[k]).abs();
             assert!(diff < 1e-9, "pos[{}] diff={}", k, diff);

--- a/crates/e2m2e-spice/tests/ephem_cache_correctness.rs
+++ b/crates/e2m2e-spice/tests/ephem_cache_correctness.rs
@@ -93,7 +93,7 @@ fn test_cubic_spline_exact_at_nodes() {
     let t_grid: Vec<f64> = (0..20).map(|i| i as f64 * 0.3).collect();
     let pos_fn = |t: f64| -> [f64; 3] { [t.sin(), t.cos(), t.powi(2)] };
     let vel_fn = |t: f64| -> [f64; 3] { [t.cos(), -t.sin(), 2.0 * t] };
-    let cache = build_body_cache(&t_grid, "ND", &pos_fn, &vel_fn);
+    let cache = build_body_cache(&t_grid, "ND", pos_fn, vel_fn);
     enable(cache);
 
     for &t in &t_grid {
@@ -121,7 +121,7 @@ fn test_cubic_spline_sin_interior_error_bound() {
     let t_grid: Vec<f64> = (0..=20).map(|i| i as f64 * 0.5).collect();
     let pos_fn = |t: f64| -> [f64; 3] { [t.sin(), 0.0, 0.0] };
     let vel_fn = |_t: f64| -> [f64; 3] { [0.0, 0.0, 0.0] };
-    let cache = build_body_cache(&t_grid, "SIN", &pos_fn, &vel_fn);
+    let cache = build_body_cache(&t_grid, "SIN", pos_fn, vel_fn);
     enable(cache);
 
     let h = 0.5;
@@ -147,7 +147,7 @@ fn test_cubic_spline_cos_interior_error_bound() {
     let t_grid: Vec<f64> = (0..=20).map(|i| i as f64 * 0.5).collect();
     let pos_fn = |t: f64| -> [f64; 3] { [0.0, t.cos(), 0.0] };
     let vel_fn = |_t: f64| -> [f64; 3] { [0.0, 0.0, 0.0] };
-    let cache = build_body_cache(&t_grid, "COS", &pos_fn, &vel_fn);
+    let cache = build_body_cache(&t_grid, "COS", pos_fn, vel_fn);
     enable(cache);
 
     let h = 0.5;
@@ -172,9 +172,9 @@ fn test_cubic_spline_cos_interior_error_bound() {
 fn test_cubic_spline_constant_exact() {
     let _guard = lock();
     let t_grid: Vec<f64> = (0..=20).map(|i| i as f64 * 0.5).collect();
-    let pos_fn = |_t: f64| -> [f64; 3] { [42.0, -7.0, 3.14] };
+    let pos_fn = |_t: f64| -> [f64; 3] { [42.0, -7.0, 2.5] };
     let vel_fn = |_t: f64| -> [f64; 3] { [0.0, 0.0, 0.0] };
-    let cache = build_body_cache(&t_grid, "CST", &pos_fn, &vel_fn);
+    let cache = build_body_cache(&t_grid, "CST", pos_fn, vel_fn);
     enable(cache);
 
     for &t in &t_grid {
@@ -183,7 +183,7 @@ fn test_cubic_spline_constant_exact() {
             .expect("cache miss");
         assert!((pos[0] - 42.0).abs() < 1e-14, "CST t={t}: x={}", pos[0]);
         assert!((pos[1] + 7.0).abs() < 1e-14, "CST t={t}: y={}", pos[1]);
-        assert!((pos[2] - 3.14).abs() < 1e-14, "CST t={t}: z={}", pos[2]);
+        assert!((pos[2] - 2.5).abs() < 1e-14, "CST t={t}: z={}", pos[2]);
     }
     disable();
 }
@@ -198,7 +198,7 @@ fn test_ephem_cache_position_roundtrip() {
     let t_grid: Vec<f64> = (0..50).map(|i| i as f64 * 100.0).collect();
     let pos_fn = |t: f64| -> [f64; 3] { [t * 1.5, t.sin() * 100.0, t.cos() * 100.0] };
     let vel_fn = |t: f64| -> [f64; 3] { [1.5, t.cos() * 100.0, -t.sin() * 100.0] };
-    let cache = build_body_cache(&t_grid, "RT", &pos_fn, &vel_fn);
+    let cache = build_body_cache(&t_grid, "RT", pos_fn, vel_fn);
     enable(cache);
 
     for &t in &t_grid {
@@ -224,7 +224,7 @@ fn test_ephem_cache_interpolation_accuracy() {
     let t_grid: Vec<f64> = (0..=20).map(|i| i as f64 * 0.5).collect();
     let pos_fn = |t: f64| -> [f64; 3] { [t.sin(), t.cos(), 0.0] };
     let vel_fn = |t: f64| -> [f64; 3] { [t.cos(), -t.sin(), 0.0] };
-    let cache = build_body_cache(&t_grid, "INT", &pos_fn, &vel_fn);
+    let cache = build_body_cache(&t_grid, "INT", pos_fn, vel_fn);
     enable(cache);
 
     let h = 0.5;
@@ -262,7 +262,7 @@ fn test_frame_orthogonality_at_nodes() {
             [0.0, 0.0, 1.0],
         ]
     };
-    let cache = build_frame_cache(&t_grid, &mat_fn);
+    let cache = build_frame_cache(&t_grid, mat_fn);
     enable(cache);
 
     for &t in &t_grid {
@@ -274,8 +274,8 @@ fn test_frame_orthogonality_at_nodes() {
         for i in 0..3 {
             for j in 0..3 {
                 let mut rtr = 0.0;
-                for k in 0..3 {
-                    rtr += r[k][i] * r[k][j];
+                for row in r {
+                    rtr += row[i] * row[j];
                 }
                 let expected = if i == j { 1.0 } else { 0.0 };
                 assert!(
@@ -310,7 +310,7 @@ fn test_frame_orthogonality_off_grid_bounded() {
             [0.0, 0.0, 1.0],
         ]
     };
-    let cache = build_frame_cache(&t_grid, &mat_fn);
+    let cache = build_frame_cache(&t_grid, mat_fn);
     enable(cache);
 
     // h=1，中间点处样条误差量级 ~h⁴ = 1 导致正交性偏离约 2e-2。
@@ -325,8 +325,8 @@ fn test_frame_orthogonality_off_grid_bounded() {
         for i in 0..3 {
             for j in 0..3 {
                 let mut rtr = 0.0;
-                for k in 0..3 {
-                    rtr += r[k][i] * r[k][j];
+                for row in r {
+                    rtr += row[i] * row[j];
                 }
                 let expected = if i == j { 1.0 } else { 0.0 };
                 assert!(
@@ -364,7 +364,7 @@ fn test_enabled_cache_miss_is_error() {
     let t_grid: Vec<f64> = (0..20).map(|i| i as f64 * 0.3).collect();
     let pos_fn = |t: f64| -> [f64; 3] { [t.sin(), t.cos(), t.powi(2)] };
     let vel_fn = |t: f64| -> [f64; 3] { [t.cos(), -t.sin(), 2.0 * t] };
-    let cache = build_body_cache(&t_grid, "ND", &pos_fn, &vel_fn);
+    let cache = build_body_cache(&t_grid, "ND", pos_fn, vel_fn);
     enable(cache);
 
     // 区间外 miss → Err


### PR DESCRIPTION
## 关联 issue

无（调研过程中新开 #520，为后续遗留项，本 PR 不解决）

## 改动摘要

清理 `cargo test --workspace --no-run` 与 `cargo clippy --workspace --all-targets` 的全部测试代码警告（atmosphere.rs 精度警告除外，见下）：

- **编译警告 2 条**：`solve_ivp.rs` 测试未用变量 `sol_no_limit` 加下划线前缀（调用本身验证不 panic，有意保留）；删除 `nbody_stm.rs` 零调用的死代码 `earth_moon_config()`
- **approx_constant（deny 级）2 处**：测试常数 `3.14`（碰巧像 π）改为 `2.5`；Love 数 K22 = 0.30102 是真实物理常数（碰巧像 LOG10_2），加 `#[allow]` 并注释
- **clippy 风格类**：`needless_range_loop` 改迭代器写法（9 处，其中 qf_cm 一处因 `j` 同时用于索引与 `i==j` 判别改为 `#[allow]`）；去掉冗余 `&`、`useless vec!`、同类型转换、无效果运算（`cargo clippy --fix` 自动 + 手工复核）
- **有意不动**：atmosphere.rs 39 条 `excessive_precision`——常量为 Python 侧 `%.17e` 全精度打印的对照值，保留文献原值便于逐位对照；是否加 `#[allow]` 见 #520（含 Rust 1.98 新特性调研结论：无相关改进）

## 测试

- `cargo test --workspace -- --test-threads=1`：全部通过（22 个测试目标全绿）。串行原因是既存的 SPICE 线程锁问题（nbody_stm 测试并行触发 `SPICE is already in use by another thread` panic），与本 PR 无关
- `cargo clippy --workspace --all-targets`：除 atmosphere.rs 精度警告外为零
- `cargo fmt --all -- --check`：通过