### PR TITLE
perf(hjb-dynamics): 热路径 powi 改为乘法链，vector_field 提速约 37%

### DIFF
--- a/crates/e2m2e-hjb-dynamics/src/cr3bp.rs
+++ b/crates/e2m2e-hjb-dynamics/src/cr3bp.rs
@@ -63,7 +63,7 @@ impl Cr3bpSynodic {
         let r2 = r2sq.sqrt().max(MIN_DISTANCE);
         let inv_r1_3 = 1.0 / (r1 * r1 * r1);
         let inv_r2_3 = 1.0 / (r2 * r2 * r2);
-        let ax = 2.0 * vy + x - (1.0 - mu) * (x + mu) * inv_r1_3 - mu * (x - 1.0 + mu) * inv_r2_3;
+        let ax = 2.0 * vy + x - (1.0 - mu) * x1 * inv_r1_3 - mu * x2 * inv_r2_3;
         let ay = -2.0 * vx + y - (1.0 - mu) * y * inv_r1_3 - mu * y * inv_r2_3;
         [vx, vy, ax, ay]
     }

--- a/crates/e2m2e-hjb-dynamics/src/cr3bp.rs
+++ b/crates/e2m2e-hjb-dynamics/src/cr3bp.rs
@@ -55,10 +55,14 @@ impl Cr3bpSynodic {
     pub fn vector_field(&self, state: [f64; 4]) -> [f64; 4] {
         let [x, y, vx, vy] = state;
         let mu = self.mu;
-        let r1 = ((x + mu).powi(2) + y * y).sqrt().max(MIN_DISTANCE);
-        let r2 = ((x - 1.0 + mu).powi(2) + y * y).sqrt().max(MIN_DISTANCE);
-        let inv_r1_3 = 1.0 / r1.powi(3);
-        let inv_r2_3 = 1.0 / r2.powi(3);
+        let x1 = x + mu;
+        let x2 = x - 1.0 + mu;
+        let r1sq = x1 * x1 + y * y;
+        let r2sq = x2 * x2 + y * y;
+        let r1 = r1sq.sqrt().max(MIN_DISTANCE);
+        let r2 = r2sq.sqrt().max(MIN_DISTANCE);
+        let inv_r1_3 = 1.0 / (r1 * r1 * r1);
+        let inv_r2_3 = 1.0 / (r2 * r2 * r2);
         let ax = 2.0 * vy + x - (1.0 - mu) * (x + mu) * inv_r1_3 - mu * (x - 1.0 + mu) * inv_r2_3;
         let ay = -2.0 * vx + y - (1.0 - mu) * y * inv_r1_3 - mu * y * inv_r2_3;
         [vx, vy, ax, ay]

--- a/crates/e2m2e-hjb-dynamics/src/ephemeris.rs
+++ b/crates/e2m2e-hjb-dynamics/src/ephemeris.rs
@@ -380,7 +380,7 @@ impl EphemerisPlanar {
                     // 物理奇异，取 0 贡献保证 CFL 步长不塌（传播场景轨迹
                     // 不会精确穿过天心，与此正则化无交集）。
                     if r_norm >= MIN_DISTANCE {
-                        let inv_r3 = 1.0 / r_norm.powi(3);
+                        let inv_r3 = 1.0 / (r_norm * r_norm * r_norm);
                         for k in 0..3 {
                             acc[k] -= mu * r_vec[k] * inv_r3;
                         }
@@ -398,14 +398,15 @@ impl EphemerisPlanar {
                     // 直接项的物理极限是 0（保留 indirect 项）；
                     // `third_body_acceleration` 的 MIN_DISTANCE 截断在此处
                     // 会产生 ~μ/ε² 的伪加速度压垮 CFL，必须取极限而非截断。
+                    let b3 = b_norm * b_norm * b_norm;
                     if d_norm >= MIN_DISTANCE {
-                        let inv_d3 = 1.0 / d_norm.powi(3);
+                        let inv_d3 = 1.0 / (d_norm * d_norm * d_norm);
                         for k in 0..3 {
-                            acc[k] -= mu * (diff[k] * inv_d3 + rb[k] / b_norm.powi(3));
+                            acc[k] -= mu * (diff[k] * inv_d3 + rb[k] / b3);
                         }
                     } else {
                         for k in 0..3 {
-                            acc[k] -= mu * rb[k] / b_norm.powi(3);
+                            acc[k] -= mu * rb[k] / b3;
                         }
                     }
                 }

--- a/crates/e2m2e-integrators/src/planar_pal.rs
+++ b/crates/e2m2e-integrators/src/planar_pal.rs
@@ -410,8 +410,10 @@ fn step_system(
 
 fn jacobi_constant(mu: f64, state: &[f64; 6]) -> f64 {
     let (x, y, z, vx, vy, vz) = (state[0], state[1], state[2], state[3], state[4], state[5]);
-    let r1 = ((x + mu).powi(2) + y * y + z * z).sqrt().max(1e-10);
-    let r2 = ((x - 1.0 + mu).powi(2) + y * y + z * z).sqrt().max(1e-10);
+    let x1 = x + mu;
+    let x2 = x - 1.0 + mu;
+    let r1 = (x1 * x1 + y * y + z * z).sqrt().max(1e-10);
+    let r2 = (x2 * x2 + y * y + z * z).sqrt().max(1e-10);
     x * x + y * y + 2.0 * (1.0 - mu) / r1 + 2.0 * mu / r2 - (vx * vx + vy * vy + vz * vz)
 }
 


### PR DESCRIPTION
## 关联 issue

无关联 issue。

## 改动摘要

评估 Rust 1.98.0 新特性对项目的影响：更新日志中仅浮点代数方法（algebraic_*）与本项目相关，但会牺牲数值可复现性，未采用。转而完成无代价的热路径优化：把 cr3bp / ephemeris / planar_pal 中的 powi(2)/powi(3) 距离平方与立方倒数改为乘法链，逐位结果不变。

## 测试

- 临时 benchmark（50M 次 vector_field 调用）：4.1 → 2.6 ns/次，提速约 37%，累加结果逐位相同
- cargo test（e2m2e-hjb-dynamics，默认 + ephemeris feature）：15 + 4 个测试通过
- cargo test（e2m2e-integrators）：56 个测试通过
- cargo fmt --check、cargo clippy --workspace -D warnings：通过