### PR TITLE
fix(api): dispatch_tool 用 exclude_unset 回传，未提供字段不再变显式 None

### DIFF
--- a/e2m2e/api/mcp/envelope.py
+++ b/e2m2e/api/mcp/envelope.py
@@ -54,7 +54,7 @@ def dispatch_tool(method: Any, arguments: dict[str, Any]) -> tuple[Any, Envelope
     try:
         if request_model is not None:
             request = request_model.model_validate(arguments)
-            result = method(**request.model_dump())
+            result = method(**request.model_dump(exclude_unset=True))
         else:
             result = method(**arguments)
     except OrbitError as exc:

--- a/tests/api/test_mcp.py
+++ b/tests/api/test_mcp.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 
 import pytest
+from pydantic import BaseModel
 
 pytestmark = [pytest.mark.interface]
 
@@ -140,6 +141,27 @@ def test_create_server_binds_facade(facade):
     listing = anyio.run(run)
     listed = listing.tools if hasattr(listing, "tools") else listing
     assert [t.name for t in listed] == [t.name for t in handle_list_tools(facade)]
+
+
+def test_dispatch_tool_omits_unset_fields():
+    """issue #522：未提供的字段不得变成显式 None 传给工具方法。"""
+
+    class Req(BaseModel):
+        a: int
+        b: str | None = None
+
+    seen: dict = {}
+
+    class Tool:
+        request_model = Req
+
+        def __call__(self, **kwargs):
+            seen.update(kwargs)
+            return "ok"
+
+    result, err = envelope.dispatch_tool(Tool(), {"a": 1})
+    assert err is None and result == "ok"
+    assert seen == {"a": 1}
 
 
 def test_invoke_tool_internal_error():


### PR DESCRIPTION
## 关联 issue

关闭 #522

## 改动摘要

- `e2m2e/api/mcp/envelope.py`：`dispatch_tool` 中 `request.model_dump()` 改为 `model_dump(exclude_unset=True)`。此前全字段往返会把未提供的可选字段输出为显式 `None` 传给工具方法，导致所有带 `request_model` 的工具在 serve-stdio 与 MCP 两条路径上被拒。
- `tests/api/test_mcp.py`：新增回归测试 `test_dispatch_tool_omits_unset_fields`，验证未提供字段不进入工具方法的 kwargs。

## 测试

- `uv run --no-sync pytest tests/api/test_mcp.py tests/api/test_sidecar.py -q` → 20 passed
- `uv run --no-sync ruff check .` / `ruff format --check .` / `mypy e2m2e/ --ignore-missing-imports` → 全部通过