### PR TITLE
feat(api): serve-stdio 族生成映射补 period 与 mu (#525)

### DIFF
--- a/e2m2e/api/sidecar/__init__.py
+++ b/e2m2e/api/sidecar/__init__.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING, Any
 
+from ..catalog_ingest import _finite_or_none
 from ..mcp import envelope, tools
 from .frames import FrameError, encode_frame
 
@@ -58,6 +59,8 @@ def _family_binary_payload(result: Any, dtype: str) -> tuple[dict[str, Any], lis
 
     帧序 = ``data.orbits`` 成员序；每帧是该成员的 ``(n, 6)`` 状态数组。
     times 等小数组留在 JSON。``states`` 置 None 占位，帧是唯一真身。
+    成员级透传 ``period``、响应级透传 ``mu``（原值，归一化单位），供
+    消费端从 ``(1, 6)`` 初态重采样整条轨迹（issue #525）。
     """
     frames = [encode_frame(orbit.states, dtype) for orbit in result.orbits]
     data = {
@@ -65,11 +68,17 @@ def _family_binary_payload(result: Any, dtype: str) -> tuple[dict[str, Any], lis
         "cause": result.cause.value,
         "message": result.message,
         "family_type": result.family_type,
+        "mu": _finite_or_none(getattr(result.system, "mu", None)),
         "requested_members": result.requested_members,
         "generated_members": result.generated_members,
         "record_id": result.record_id,
         "orbits": [
-            {"states": None, "times": [float(t) for t in orbit.times]} for orbit in result.orbits
+            {
+                "states": None,
+                "times": [float(t) for t in orbit.times],
+                "period": _finite_or_none(orbit.period),
+            }
+            for orbit in result.orbits
         ],
     }
     return data, frames

--- a/tests/api/test_sidecar.py
+++ b/tests/api/test_sidecar.py
@@ -25,9 +25,17 @@ from e2m2e.data.types.orbit import Orbit  # noqa: E402
 _ARGS = {"orbit_type": "HALO", "libration_point": 1}  # 能过 FamilyGenerationRequest 校验的最小参数
 
 
-def _orbit(seed: float, n: int = 3) -> Orbit:
+def _orbit(seed: float, n: int = 3, period: float | None = None) -> Orbit:
     states = np.arange(n * 6, dtype=float).reshape(n, 6) + seed
-    return Orbit(states=states, times=np.linspace(0.0, 1.0, n))
+    orbit = Orbit(states=states, times=np.linspace(0.0, 1.0, n))
+    orbit.period = period
+    return orbit
+
+
+class _System:
+    """鸭子类型 system：仅供 sidecar 映射读取 mu。"""
+
+    mu = 1.215e-2
 
 
 @pytest.fixture
@@ -41,8 +49,9 @@ def facade(tmp_path, monkeypatch) -> Facade:
                 status=ConvergenceState.CONVERGED,
                 cause=FailureCause.NONE,
                 message="ok",
-                orbits=[_orbit(0.0), _orbit(10.0)],
+                orbits=[_orbit(0.0, period=2.5), _orbit(10.0)],
                 family_type="halo",
+                system=_System(),
                 requested_members=2,
                 generated_members=2,
             )
@@ -81,6 +90,10 @@ def test_family_generation_binary_roundtrip(facade):
     orbits = line["data"]["orbits"]
     assert [o["states"] for o in orbits] == [None, None]
     assert len(orbits[0]["times"]) == 3  # 小数组留 JSON
+    # 周期原值透传（归一化单位，issue #525）：成员缺失或非有限时为 null
+    assert [o["period"] for o in orbits] == [2.5, None]
+    # 重采样方程需要 mu：响应级原值透传
+    assert line["data"]["mu"] == pytest.approx(1.215e-2)
     # 帧内容 = 成员状态数组，dtype 按请求方声明
     arr0, dtype0, _ = decode_frame(frames[0])
     assert dtype0 == "f32"


### PR DESCRIPTION
## 关联 issue

Closes #525

## 改动

- `e2m2e/api/sidecar/__init__.py`：`_family_binary_payload` 的 `orbits[]` 每项补 `period`（原值透传，归一化单位；缺失/非有限为 null，不猜值），响应级补 `mu`（`getattr` 容错，照 `catalog_ingest` 范式）。不动二进制帧契约（ADR 0035）。
- `tests/api/test_sidecar.py`：roundtrip 测试补 `period`/`mu` 断言，含 period 为 None 的成员。

消费端（tod 画布）由此可从 `(1, 6)` 初态按 `period` 重采样出整条轨迹。

## 验证

- `pytest tests/api/test_sidecar.py tests/api/test_sidecar_frames.py` — 21 passed（TDD 红→绿）
- `ruff check .` / `ruff format --check .` / `mypy e2m2e/ --ignore-missing-imports` — 全过