### PR TITLE
fix(api): catalog_get 进二进制帧映射，信封化失败不再炸进程 (#526)

### DIFF
--- a/e2m2e/api/mcp/envelope.py
+++ b/e2m2e/api/mcp/envelope.py
@@ -84,4 +84,9 @@ def invoke_tool(method: Any, arguments: dict[str, Any]) -> Envelope:
     result, err = dispatch_tool(method, arguments)
     if err is not None:
         return err
-    return ok_envelope(result)
+    try:
+        return ok_envelope(result)
+    except Exception as exc:
+        # 结果含不可 JSON 化对象（如 ndarray，issue #526）：兑成结构化错误
+        # 而非炸穿传输层（MCP 与 sidecar 共用此处）。
+        return error_envelope("INTERNAL_ERROR", f"响应序列化失败（{type(exc).__name__}）")

--- a/e2m2e/api/sidecar/__init__.py
+++ b/e2m2e/api/sidecar/__init__.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING, Any
 
+import numpy as np
+
 from ..mcp import envelope, tools
 from .frames import FrameError, encode_frame
 
@@ -26,10 +28,56 @@ __all__ = ["handle_request", "run_loop"]
 # 请求方可声明的二进制 dtype（ADR 0035 决策 1：渲染 f32，复算量 f64）。
 _BINARY_DTYPES = ("f32", "f64")
 
-# 大数组走二进制帧的工具→响应字段映射。首个落地的画布契约：族生成响应的
-# 成员状态数组（Orbit 对象不可 JSON 化，本就必须走帧）。其余工具等消费端
-# （tod 阶段 2）出现真实需求再补，不预先铺开。
-_BINARY_TOOLS = frozenset({"orbit_family_generation"})
+
+# 大数组走二进制帧的工具→响应帧抽取函数映射（issue #526：catalog_get 入列）。
+# 首个落地的画布契约：族生成响应的成员状态数组（Orbit 对象不可 JSON 化，
+# 本就必须走帧）；catalog_get 的记录数组段同理。其余工具等消费端（tod）
+# 出现真实需求再补，不预先铺开。
+def _family_binary_payload(result: Any, dtype: str) -> tuple[dict[str, Any], list[bytes]]:
+    """族生成响应的画布契约：成员状态数组出帧，JSON 行留占位。
+
+    帧序 = ``data.orbits`` 成员序；每帧是该成员的 ``(n, 6)`` 状态数组。
+    times 等小数组留在 JSON。``states`` 置 None 占位，帧是唯一真身。
+    """
+    frames = [encode_frame(orbit.states, dtype) for orbit in result.orbits]
+    data = {
+        "status": result.status.value,
+        "cause": result.cause.value,
+        "message": result.message,
+        "family_type": result.family_type,
+        "requested_members": result.requested_members,
+        "generated_members": result.generated_members,
+        "record_id": result.record_id,
+        "orbits": [
+            {"states": None, "times": [float(t) for t in orbit.times]} for orbit in result.orbits
+        ],
+    }
+    return data, frames
+
+
+def _catalog_binary_payload(result: Any, dtype: str) -> tuple[dict[str, Any], list[bytes]]:
+    """catalog_get 响应的画布契约（issue #526）：数组段 ndarray 出帧。
+
+    帧序 = JSON 行 ``data.arrays`` 中 None 占位键的顺序；每帧是对应键的
+    数组。非数组值原样留 JSON。元数据、标量段、成员参数表不受影响。
+    """
+    frames = []
+    arrays: dict[str, Any] = {}
+    for key, value in result.arrays.items():
+        if isinstance(value, np.ndarray):
+            frames.append(encode_frame(value, dtype))
+            arrays[key] = None
+        else:
+            arrays[key] = value
+    data = result.model_dump(mode="json", exclude={"arrays"})
+    data["arrays"] = arrays
+    return data, frames
+
+
+_BINARY_TOOLS: dict[str, Any] = {
+    "orbit_family_generation": _family_binary_payload,
+    "catalog_get": _catalog_binary_payload,
+}
 
 
 def _line(payload: Any) -> bytes:
@@ -51,28 +99,6 @@ def _progress_line(job_id: Any, percent: float, message: str) -> bytes:
             "meta": {"job_id": job_id, "percent": percent, "message": message},
         }
     )
-
-
-def _family_binary_payload(result: Any, dtype: str) -> tuple[dict[str, Any], list[bytes]]:
-    """族生成响应的画布契约：成员状态数组出帧，JSON 行留占位。
-
-    帧序 = ``data.orbits`` 成员序；每帧是该成员的 ``(n, 6)`` 状态数组。
-    times 等小数组留在 JSON。``states`` 置 None 占位，帧是唯一真身。
-    """
-    frames = [encode_frame(orbit.states, dtype) for orbit in result.orbits]
-    data = {
-        "status": result.status.value,
-        "cause": result.cause.value,
-        "message": result.message,
-        "family_type": result.family_type,
-        "requested_members": result.requested_members,
-        "generated_members": result.generated_members,
-        "record_id": result.record_id,
-        "orbits": [
-            {"states": None, "times": [float(t) for t in orbit.times]} for orbit in result.orbits
-        ],
-    }
-    return data, frames
 
 
 def handle_request(facade: Facade, request: Any) -> list[bytes]:
@@ -104,10 +130,11 @@ def handle_request(facade: Facade, request: Any) -> list[bytes]:
     started = _progress_line(job_id, 0.0, f"开始 {tool}")
     chunks = [started]
 
-    if tool in _BINARY_TOOLS:
+    payload_fn = _BINARY_TOOLS.get(tool)
+    if payload_fn is not None:
         if dtype is None:
-            # 协议约定（非参数校验）：响应含 Orbit 对象不可 JSON 化（MCP
-            # 传输层同此限制），该工具必须走帧，缺省 dtype 视为协议用法
+            # 协议约定（非参数校验）：响应含 ndarray/Orbit 对象不可 JSON 化
+            # （MCP 传输层同此限制），该工具必须走帧，缺省 dtype 视为协议用法
             # 错误，借用 INVALID_PARAMS 错误码。
             return [
                 _line(
@@ -121,7 +148,7 @@ def handle_request(facade: Facade, request: Any) -> list[bytes]:
         if err is not None:
             return [started, _line(err)]
         try:
-            data, frames = _family_binary_payload(result, dtype)
+            data, frames = payload_fn(result, dtype)
         except FrameError as exc:
             return [started, _line(envelope.error_envelope("INTERNAL_ERROR", f"帧编码失败：{exc}"))]
         response = envelope.ok_envelope(data)
@@ -134,7 +161,9 @@ def handle_request(facade: Facade, request: Any) -> list[bytes]:
 def run_loop(facade: Facade, stdin: BinaryIO, stdout: BinaryIO) -> None:
     """std io 主循环：逐行读请求 JSON，写出进度/响应行与二进制帧。
 
-    坏 JSON 行返回错误信封并继续，不中断循环。
+    坏 JSON 行返回错误信封并继续，不中断循环。请求处理的任何未预期
+    异常（含响应信封化失败，issue #526）同样兑成 INTERNAL_ERROR 信封：
+    字节块在 handle_request 返回前不落盘，故不存在半写出的帧污染流。
     """
     for raw in stdin:
         if not raw.strip():
@@ -144,7 +173,17 @@ def run_loop(facade: Facade, stdin: BinaryIO, stdout: BinaryIO) -> None:
         except (UnicodeDecodeError, json.JSONDecodeError):
             chunks = [_line(envelope.error_envelope("INVALID_PARAMS", "请求行不是合法 JSON"))]
         else:
-            chunks = handle_request(facade, request)
+            try:
+                chunks = handle_request(facade, request)
+            except Exception as exc:
+                chunks = [
+                    _line(
+                        envelope.error_envelope(
+                            "INTERNAL_ERROR",
+                            f"响应处理失败（{type(exc).__name__}）",
+                        )
+                    )
+                ]
         for chunk in chunks:
             stdout.write(chunk)
         stdout.flush()

--- a/e2m2e/api/sidecar/__init__.py
+++ b/e2m2e/api/sidecar/__init__.py
@@ -60,6 +60,8 @@ def _catalog_binary_payload(result: Any, dtype: str) -> tuple[dict[str, Any], li
 
     帧序 = JSON 行 ``data.arrays`` 中 None 占位键的顺序；每帧是对应键的
     数组。非数组值原样留 JSON。元数据、标量段、成员参数表不受影响。
+    #525 落地 period/mu 标量补齐后，本函数与族生成的帧抽取共用字段
+    抽取逻辑（当前各自独立，待第二个消费点出现再收拢）。
     """
     frames = []
     arrays: dict[str, Any] = {}

--- a/tests/api/test_sidecar.py
+++ b/tests/api/test_sidecar.py
@@ -16,7 +16,13 @@ pytestmark = [pytest.mark.interface]
 
 from e2m2e.api.config import Config  # noqa: E402
 from e2m2e.api.facade import Facade, mcp_exposed  # noqa: E402
-from e2m2e.api.models import FamilyGenerationRequest, FamilyGenerationResponse  # noqa: E402
+from e2m2e.api.mcp import envelope  # noqa: E402
+from e2m2e.api.models import (  # noqa: E402
+    CatalogGetRequest,
+    CatalogRecordResponse,
+    FamilyGenerationRequest,
+    FamilyGenerationResponse,
+)
 from e2m2e.api.sidecar import handle_request, run_loop  # noqa: E402
 from e2m2e.api.sidecar.frames import decode_frame  # noqa: E402
 from e2m2e.data.templates import ConvergenceState, FailureCause  # noqa: E402
@@ -47,7 +53,44 @@ def facade(tmp_path, monkeypatch) -> Facade:
                 generated_members=2,
             )
 
+        @mcp_exposed(request_model=CatalogGetRequest)
+        def catalog_get(self, **params) -> CatalogRecordResponse:
+            if getattr(self, "_broken_response", False):
+                rec = _record()
+                object.__setattr__(rec, "scalars", object())  # 不可 JSON 化的标量段
+                return rec
+            return _record()
+
     return _StubFacade(Config())
+
+
+def _record() -> CatalogRecordResponse:
+    """含 ndarray 数组段的族记录（catalog_get 响应形状，issue #526）。"""
+    return CatalogRecordResponse(
+        record_id="r1",
+        created_at="2026-01-01T00:00:00Z",
+        source_tool="orbit_family_generation",
+        source_record_id=None,
+        orbit_family="halo_n",
+        libration_point=1,
+        jacobi=None,
+        amplitude=None,
+        has_cr3bp=True,
+        has_ephemeris=False,
+        status=ConvergenceState.CONVERGED,
+        cause=FailureCause.NONE,
+        message="ok",
+        member_count=2,
+        tags=[],
+        note="",
+        scalars={"mu": 0.1},
+        request={"orbit_type": "HALO"},
+        members=[{"index": 0}, {"index": 1}],
+        arrays={
+            "cr3bp/members/0/states": np.arange(18.0).reshape(3, 6),
+            "cr3bp/members/1/states": np.arange(18.0).reshape(3, 6) + 10.0,
+        },
+    )
 
 
 def _lines_and_frames(chunks: list[bytes]):
@@ -161,3 +204,95 @@ def test_cli_serve_stdio_registered(capsys):
         main(["serve-stdio", "--help"])
     assert exc_info.value.code == 0
     assert "serve-stdio" in capsys.readouterr().out
+
+
+def test_catalog_get_binary_roundtrip(facade):
+    """issue #526：记录数组段的 ndarray 出帧，JSON 行 null 占位，帧序=占位序。"""
+    chunks = handle_request(
+        facade,
+        {"tool": "catalog_get", "arguments": {"record_id": "r1"}, "binary_dtype": "f32"},
+    )
+    (progress, _), (line, frames) = _lines_and_frames(chunks)
+    assert progress["status"] == "progress"
+    assert line["status"] == "ok"
+    assert line["binary_frames"] == 2
+    arrays = line["data"]["arrays"]
+    assert arrays == {"cr3bp/members/0/states": None, "cr3bp/members/1/states": None}
+    assert line["data"]["scalars"] == {"mu": 0.1}  # 非数组段留 JSON
+    arr1, dtype, _ = decode_frame(frames[1])
+    assert dtype == "f32"
+    np.testing.assert_allclose(arr1, (np.arange(18.0).reshape(3, 6) + 10.0).astype(np.float32))
+
+
+def test_catalog_get_requires_binary_dtype(facade):
+    """未声明 binary_dtype 时结构化错误而非 PydanticSerializationError 崩溃。"""
+    chunks = handle_request(facade, {"tool": "catalog_get", "arguments": {"record_id": "r1"}})
+    [line] = [json.loads(c) for c in chunks]
+    assert line["status"] == "error"
+    assert line["error"]["code"] == "INVALID_PARAMS"
+
+
+def test_run_loop_survives_envelope_serialization_failure(facade):
+    """issue #526：信封化异常不得炸进程——返回 INTERNAL_ERROR 信封并继续循环。"""
+    facade._broken_response = True
+    try:
+        requests = (
+            b'{"tool": "catalog_get", "arguments": {"record_id": "r1"}, '
+            b'"binary_dtype": "f32"}\n'
+            b'{"tool": "orbit_family_generation", "arguments": {"orbit_type": "HALO", '
+            b'"libration_point": 1}, "binary_dtype": "f32"}\n'
+        )
+        stdout = io.BytesIO()
+        run_loop(facade, io.BytesIO(requests), stdout)  # 不应抛异常
+        lines = _lines_and_frames([stdout.getvalue()])
+        # 坏请求兑成 INTERNAL_ERROR 信封（进度行随失败丢弃），循环存活
+        assert lines[0][0]["status"] == "error"
+        assert lines[0][0]["error"]["code"] == "INTERNAL_ERROR"
+        # 第二个请求正常处理：进度行 + ok 响应 + 帧
+        assert lines[1][0]["status"] == "progress"
+        assert lines[2][0]["status"] == "ok" and lines[2][0]["binary_frames"] == 2
+    finally:
+        facade._broken_response = False
+
+
+def test_invoke_tool_serialization_failure_translated():
+    """issue #526：结果含不可 JSON 化对象时兑成 INTERNAL_ERROR 信封，不炸传输层。"""
+    import numpy as np
+
+    from e2m2e.api.models import CatalogRecordResponse
+    from e2m2e.data.templates import ConvergenceState, FailureCause
+
+    record = CatalogRecordResponse(
+        record_id="r",
+        created_at="2026-01-01T00:00:00Z",
+        source_tool="t",
+        source_record_id=None,
+        orbit_family=None,
+        libration_point=1,
+        jacobi=None,
+        amplitude=None,
+        has_cr3bp=True,
+        has_ephemeris=False,
+        status=ConvergenceState.CONVERGED,
+        cause=FailureCause.NONE,
+        message="",
+        member_count=1,
+        tags=[],
+        note="",
+        scalars={},
+        request={},
+        members=[],
+        arrays={"cr3bp/states": np.zeros((3, 6))},
+    )
+
+    class _Method:
+        request_model = None
+
+        def __call__(self, **kw):
+            return record
+
+    env = envelope.invoke_tool(_Method(), {})
+    assert env["status"] == "error"
+    assert env["error"]["code"] == "INTERNAL_ERROR"
+    assert "序列化" in env["error"]["message"]
+    assert "Traceback" not in env["error"]["message"]

--- a/tests/api/test_sidecar.py
+++ b/tests/api/test_sidecar.py
@@ -19,6 +19,8 @@ from e2m2e.api.facade import Facade, mcp_exposed  # noqa: E402
 from e2m2e.api.mcp import envelope  # noqa: E402
 from e2m2e.api.models import (  # noqa: E402
     CatalogGetRequest,
+    CatalogQueryRequest,
+    CatalogQueryResponse,
     CatalogRecordResponse,
     FamilyGenerationRequest,
     FamilyGenerationResponse,
@@ -51,6 +53,15 @@ def facade(tmp_path, monkeypatch) -> Facade:
                 family_type="halo",
                 requested_members=2,
                 generated_members=2,
+            )
+
+        @mcp_exposed(request_model=CatalogQueryRequest)
+        def catalog_query(self, **params) -> CatalogQueryResponse:
+            return CatalogQueryResponse(
+                status=ConvergenceState.CONVERGED,
+                cause=FailureCause.NONE,
+                message="查询完成：0 条记录",
+                records=[],
             )
 
         @mcp_exposed(request_model=CatalogGetRequest)
@@ -257,8 +268,6 @@ def test_run_loop_survives_envelope_serialization_failure(facade):
 
 def test_invoke_tool_serialization_failure_translated():
     """issue #526：结果含不可 JSON 化对象时兑成 INTERNAL_ERROR 信封，不炸传输层。"""
-    import numpy as np
-
     from e2m2e.api.models import CatalogRecordResponse
     from e2m2e.data.templates import ConvergenceState, FailureCause
 
@@ -296,3 +305,14 @@ def test_invoke_tool_serialization_failure_translated():
     assert env["error"]["code"] == "INTERNAL_ERROR"
     assert "序列化" in env["error"]["message"]
     assert "Traceback" not in env["error"]["message"]
+
+
+def test_catalog_query_unchanged_by_binary_mapping(facade):
+    """issue #526 验收：不进帧映射的工具走原信封化路径，无帧、无 binary_frames。"""
+    chunks = handle_request(facade, {"tool": "catalog_query", "arguments": {}})
+    lines = [json.loads(c) for c in chunks]
+    assert len(lines) == 2  # 进度行 + 响应行，无帧
+    assert lines[0]["status"] == "progress"
+    assert lines[1]["status"] == "ok"
+    assert "binary_frames" not in lines[1]
+    assert lines[1]["data"]["message"] == "查询完成：0 条记录"


### PR DESCRIPTION
关联 issue：#526（agent brief 见 issue 评论）

## 改动摘要

- **sidecar 帧映射**：`_BINARY_TOOLS` 从 frozenset 改为 tool→帧抽取函数映射，新增 `catalog_get`——记录数组段 `arrays` 中的 ndarray 全部出二进制帧，JSON 行同键置 `null` 占位，帧序 = 占位键序；非数组值原样留 JSON。未声明 `binary_dtype` 时返回 `INVALID_PARAMS`（与族生成工具同规则）
- **信封层兜底**：`invoke_tool` 对结果序列化失败兑成 `INTERNAL_ERROR` 结构化错误信封——MCP 与 sidecar 两条传输路径共用此接缝
- **run_loop 兜底**：请求处理的未预期异常不再炸进程，返回 `INTERNAL_ERROR` 信封并继续循环；字节块在 `handle_request` 返回前不落盘，不存在半写帧污染协议流

## 测试

- TDD：新增测试先复现 `PydanticSerializationError` 炸穿（与 issue 报告同串）后修复转绿
- `uv run --no-sync pytest tests/api -q`：179 passed, 1 skipped
- ruff check / format、mypy 全绿

## 验收对照（brief 验收标准）

- [x] `catalog_get` + `binary_dtype` 对族记录返回成功信封 + 帧，进程存活
- [x] 不声明 `binary_dtype` 返回 `INVALID_PARAMS`，进程存活
- [x] 信封化必然失败的工具调用返回 `INTERNAL_ERROR` 且主循环继续
- [x] `catalog_query` 等不含 ndarray 的工具行为不变（回归测试）
- [x] sidecar 测试覆盖全部场景（帧序与占位约定）

Out of scope（按 brief）：#525 的 period/mu 标量补齐、星历记录帧映射。