### PR TITLE
fix(transfer): LGA 搜索补面外维度并统一 max_total_dv 的 km/s 语义（#512）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **LGA 搜索面外维度缺失与 Δv 单位语义**（#512）：`transfer_orbit("LGA")` 在发射倾角 ≥ 20° 时一律 INFEASIBLE——出发速度网格只有面内角，无面外自由度，候选在 dv 筛选前就被近月高度窗口筛光。`LgaSearchParams` 新增面外角网格（`out_of_plane_halfwidth_deg`/`n_out_of_plane`，中心随出发轨道面倾角缓慢负移，实测倾角 0°–90° 覆盖）；`LgaCandidate` 记录 `out_of_plane_angle`。同时修复 `max_total_dv` 语义：阈值 km/s 换算为无量纲后比较，`LgaTransferDetails` 与 `delta_v` 统一按特征速度换算回 km/s；ThreeBodyLambert 精化劣于网格候选时保留网格解（修复精化后 Δv 远超阈值仍报 CONVERGED）。
+
 ## [5.8.3] - 2026-08-22
 
 ### Added

--- a/docs/transfer/lga.rst
+++ b/docs/transfer/lga.rst
@@ -40,7 +40,8 @@ LGA 转移分为三段：
        print(f"搜索未完成：{candidates.status.value}, {candidates.cause.value}: {candidates.message}")
 
    for c in candidates:
-       print(f"总 Δv: {c.total_dv:.4f} km/s, 飞行时间: {c.tof_sec / 86400:.2f} 天, "
+       dv_km_s = c.total_dv * system.characteristic_velocity  # 无量纲 → km/s
+       print(f"总 Δv: {dv_km_s:.4f} km/s, 飞行时间: {c.tof_sec / 86400:.2f} 天, "
              f"近月点高度: {c.perilune_alt_km:.1f} km")
 
 参考文献

--- a/e2m2e/algorithm/transfer/__init__.py
+++ b/e2m2e/algorithm/transfer/__init__.py
@@ -494,8 +494,11 @@ def _transfer_orbit_lga(
     )
 
     params = search_params if search_params is not None else LgaSearchParams()
+    vu_km_s = system.characteristic_velocity
+    if vu_km_s is None or vu_km_s <= 0.0:
+        raise ValueError("system.characteristic_velocity must be set")
 
-    n_searched = params.n_departure_phase * params.n_tof
+    n_searched = params.n_departure_phase * params.n_tof * params.n_out_of_plane
     n_feasible = len(candidates)
 
     if not candidates:
@@ -556,8 +559,8 @@ def _transfer_orbit_lga(
         perilune_alt_km=refined.perilune_alt_km,
         perilune_vel_km_s=perilune_vel,
         perilune_state=perilune_phys,
-        dv_departure_km_s=refined.dv_departure,
-        dv_arrival_km_s=refined.dv_arrival,
+        dv_departure_km_s=refined.dv_departure * vu_km_s,
+        dv_arrival_km_s=refined.dv_arrival * vu_km_s,
         jacobi_departure=refined.jacobi_departure,
         jacobi_arrival=refined.jacobi_arrival,
         n_candidates_searched=n_searched,
@@ -570,7 +573,7 @@ def _transfer_orbit_lga(
 
     return TransferDesignResult(
         transfer_type="LGA",
-        delta_v=refined.total_dv,
+        delta_v=refined.total_dv * vu_km_s,
         trajectory=None,
         details=details,
         status=refined.status,

--- a/e2m2e/algorithm/transfer/lga.py
+++ b/e2m2e/algorithm/transfer/lga.py
@@ -34,22 +34,34 @@ R_MOON_KM: float = MOON.require_mean_radius_km()
 class LgaSearchParams:
     """LGA 弹道搜索参数。
 
-    搜索空间：出发相位角 x 飞行时间（TOF）。
+    出发速度大小固定为略超逃逸速度，方向由两个角度参数化：面内角
+    （departure_phase，在停泊轨道切向 × 径向平面内）与面外角
+    （out-of-plane，绕出发轨道面法向）。面外角网格覆盖经验可行带：
+    其中心随倾角缓慢负移（约 -0.08·δ，实测倾角 0°–90°），修复了
+    共面网格下发射倾角 ≥ 20° 时全部候选被近月高度筛掉的问题
+    （issue #512）。
+
     近月点高度由传播自然决定，不作为独立搜索变量，
     仅用于筛选可行候选（Parker & Anderson 2014 §3.4）。
 
     Attributes:
         departure_phase_range: 出发相位角范围 (min, max)，弧度，[0, 2pi)
         n_departure_phase: 出发相位角网格点数
+        out_of_plane_halfwidth_deg: 面外角网格半宽 (deg)，对称展开于经验可行带
+            中心（约 -0.08·出发轨道面倾角）两侧
+        n_out_of_plane: 面外角网格点数（1 退化为纯共面搜索）
         tof_range: 飞行时间范围 (min, max)，天（LGA 典型 15-45 天，Shi et al. 2025）
         n_tof: TOF 网格点数
         perilune_alt_min: 近月点高度下限 (km)，低于此值的候选丢弃（避免撞击月面）
         perilune_alt_max: 近月点高度上限 (km)，高于此值的候选丢弃（飞越不够近）
-        max_total_dv: 最大总 Δv 筛选阈值，km/s（超过的候选丢弃）
+        max_total_dv: 最大总 Δv 筛选阈值，km/s（超过的候选丢弃；
+            候选的 CR3BP 无量纲 Δv 按特征速度换算到 km/s 后比较）
     """
 
     departure_phase_range: tuple[float, float] = (0.0, 2.0 * math.pi)
     n_departure_phase: int = 50
+    out_of_plane_halfwidth_deg: float = 2.5
+    n_out_of_plane: int = 9
     tof_range: tuple[float, float] = (5.0, 45.0)
     n_tof: int = 50
     perilune_alt_min: float = 100.0
@@ -63,9 +75,13 @@ class LgaCandidate:
     """单个 LGA 候选解（无动力 LGA）。
 
     飞越段 Δv = 0（仅利用月球引力），总 Δv = 出发脉冲 + 到达脉冲。
+
+    dv 字段（dv_departure / dv_arrival / total_dv）均为 CR3BP 无量纲单位；
+    换算 km/s 需乘以 ``CR3BP_System.characteristic_velocity``。
     """
 
     departure_phase: float
+    out_of_plane_angle: float
     tof_sec: float
     departure_state: np.ndarray
     perilune_state: np.ndarray
@@ -109,21 +125,24 @@ def search_lga_trajectories(
 ) -> CandidateSearchResult[LgaCandidate]:
     """LGA 弹道网格搜索。
 
-    搜索空间：出发速度方向角 x 飞行时间（TOF）二维网格。
+    搜索空间：出发速度方向（面内角 × 面外角）× 飞行时间（TOF）三维网格。
 
-    出发态为 LEO 停泊轨道（圆轨道速度）。对每个 (angle, tof) 组合：
+    出发态为 LEO 停泊轨道（圆轨道速度）。对每个 (angle, b, tof) 组合：
 
-    1. 从停泊轨道出发，沿 angle 方向施加逃逸速度级的 TLI 脉冲
-       （``v_tli = v_escape * 1.01``，方向由 angle 参数化，确保超逃逸速度）
+    1. 从停泊轨道出发，沿方向施加逃逸速度级的 TLI 脉冲
+       （``v_tli = v_escape * 1.01``，方向由面内/面外角参数化，确保超逃逸速度）
     2. CR3BP 前向传播 tof 时间，检测近月点（PoincareSection.periapsis("moon")）
     3. 近月点高度在 perilune_alt_range 内的保留
     4. 继续传播，检测轨迹首次到达目标轨道距离（r_target）的时刻
     5. ``Δv_dep = |v_departure - v_parking|``
        ``Δv_arr = |v_at_target_distance - v_target|``
-    6. 总 Δv < max_total_dv 的保留为候选
+    6. 物理总 Δv（无量纲 Δv × 特征速度）< max_total_dv 的保留为候选
 
-    departure_phase_range 控制出发速度方向角范围（弧度）：
-    0 = 纯切向（沿 y 轴），pi/2 = 径向向外（沿 x 轴）。
+    departure_phase_range 控制出发速度面内方向角范围（弧度）：
+    0 = 纯切向（沿停泊轨道切向），pi/2 = 径向向外。
+    面外角网格覆盖经验可行带（中心约 -0.08·出发轨道面倾角，
+    ±out_of_plane_halfwidth_deg 对称展开，issue #512 实测倾角 0°–90°）。
+    共面出发态（倾角 0）的网格对称于 0，纯共面行为是共面候选的子集。
 
     Args:
         departure_state: CR3BP 无量纲出发态 (6,)，LEO 停泊轨道
@@ -162,7 +181,7 @@ def search_lga_trajectories(
     # TLI 速度：略高于逃逸速度（+1%），确保超逃逸速度
     v_tli = v_esc * 1.01
 
-    # 出发速度方向角网格
+    # 出发速度面内方向角网格
     angle_grid = np.linspace(
         params.departure_phase_range[0],
         params.departure_phase_range[1],
@@ -182,92 +201,115 @@ def search_lga_trajectories(
 
     r_hat = r0 / r0_norm if r0_norm > 1e-12 else np.array([1.0, 0.0, 0.0])
 
+    # 面外角网格：以出发轨道面与月球平面的夹角 δ 为中心对称展开。
+    # 出发轨道面法向 = r_hat × v_hat（v_hat 取停泊轨道切向）；δ = acos(|n_z|)。
+    # 可行面外角带的经验中心（issue #512 实测，倾角 0°–90°）：
+    # b ≈ -0.08·δ，带宽约 2°–3°。可行解的出发方向近径向（沿地月连线），
+    # 所需面外角由到达几何决定，随倾角缓慢负移，而非把转移面转回月球平面。
+    n_hat = np.cross(r_hat, v_hat)
+    n_norm = np.linalg.norm(n_hat)
+    n_hat = n_hat / n_norm if n_norm > 1e-12 else np.array([0.0, 0.0, 1.0])
+    incl_dep_deg = math.degrees(math.acos(min(1.0, abs(n_hat[2]))))
+    b_center = math.radians(-0.08 * incl_dep_deg)
+    halfwidth = math.radians(params.out_of_plane_halfwidth_deg)
+    b_grid = np.linspace(b_center - halfwidth, b_center + halfwidth, params.n_out_of_plane)
+
+    # max_total_dv 语义为 km/s：候选 Δv 为无量纲，阈值按特征速度换算
+    vu_km_s = system.characteristic_velocity
+    if vu_km_s is None or vu_km_s <= 0.0:
+        raise ValueError("system.characteristic_velocity must be set")
+    max_total_dv_dim = params.max_total_dv / vu_km_s
+
     n_samples = params.n_propagation_samples
     candidates: list[LgaCandidate] = []
     n_propagation_failures = 0
+    n_grid_points = len(angle_grid) * len(b_grid) * len(tof_grid_dim)
 
-    for angle in angle_grid:
-        cos_a, sin_a = math.cos(angle), math.sin(angle)
-        v_dir = cos_a * v_hat + sin_a * r_hat
-        v_dep = v_dir * v_tli
-        x0 = np.concatenate([r0, v_dep])
-        dv_dep = float(np.linalg.norm(v_dep - v_park))
+    for b in b_grid:
+        cos_b, sin_b = math.cos(b), math.sin(b)
+        for angle in angle_grid:
+            cos_a, sin_a = math.cos(angle), math.sin(angle)
+            v_inplane = cos_a * v_hat + sin_a * r_hat
+            v_dep = (cos_b * v_inplane + sin_b * n_hat) * v_tli
+            x0 = np.concatenate([r0, v_dep])
+            dv_dep = float(np.linalg.norm(v_dep - v_park))
 
-        for tof_dim in tof_grid_dim:
-            # 1. 传播 tof 时间，检测近月点
-            t_eval = np.linspace(0.0, tof_dim, n_samples)
-            try:
-                result = dynamics.propagate(x0, (0.0, tof_dim), t_eval=t_eval)
-            except PropagationFailure:
-                n_propagation_failures += 1
-                logger.debug("传播失败：angle=%.3f rad, tof=%.2f", angle, tof_dim)
-                continue
+            for tof_dim in tof_grid_dim:
+                # 1. 传播 tof 时间，检测近月点
+                t_eval = np.linspace(0.0, tof_dim, n_samples)
+                try:
+                    result = dynamics.propagate(x0, (0.0, tof_dim), t_eval=t_eval)
+                except PropagationFailure:
+                    n_propagation_failures += 1
+                    logger.debug("传播失败：angle=%.3f rad, tof=%.2f", angle, tof_dim)
+                    continue
 
-            times = result["time"]
-            states = result["states"]
+                times = result["time"]
+                states = result["states"]
 
-            crossings = detect_crossings(times, states, periapsis_section)
-            if not crossings:
-                continue
+                crossings = detect_crossings(times, states, periapsis_section)
+                if not crossings:
+                    continue
 
-            # 取首次近月点
-            t_peri, state_peri, idx_peri = crossings[0]
-            r_peri_rel = np.linalg.norm(state_peri[:3] - moon_pos)
-            alt_km = float(r_peri_rel * du_km - R_MOON_KM)
+                # 取首次近月点
+                t_peri, state_peri, idx_peri = crossings[0]
+                r_peri_rel = np.linalg.norm(state_peri[:3] - moon_pos)
+                alt_km = float(r_peri_rel * du_km - R_MOON_KM)
 
-            if alt_km < params.perilune_alt_min or alt_km > params.perilune_alt_max:
-                continue
+                if alt_km < params.perilune_alt_min or alt_km > params.perilune_alt_max:
+                    continue
 
-            # 2. 检测轨迹到达目标轨道距离的时刻
-            #    从近月点之后开始搜索
-            r_traj = np.linalg.norm(states[:, :3], axis=1)
-            arrival_state = None
-            arrival_time_dim = tof_dim
-            for k in range(idx_peri, len(r_traj) - 1):
-                r1, r2 = r_traj[k], r_traj[k + 1]
-                if (r1 <= r_target <= r2) or (r2 <= r_target <= r1):
-                    frac = (r_target - r1) / (r2 - r1) if abs(r2 - r1) > 1e-12 else 0.5
-                    arrival_state = states[k] + frac * (states[k + 1] - states[k])
-                    arrival_time_dim = times[k] + frac * (times[k + 1] - times[k])
-                    break
+                # 2. 检测轨迹到达目标轨道距离的时刻
+                #    从近月点之后开始搜索
+                r_traj = np.linalg.norm(states[:, :3], axis=1)
+                arrival_state = None
+                arrival_time_dim = tof_dim
+                for k in range(idx_peri, len(r_traj) - 1):
+                    r1, r2 = r_traj[k], r_traj[k + 1]
+                    if (r1 <= r_target <= r2) or (r2 <= r_target <= r1):
+                        frac = (r_target - r1) / (r2 - r1) if abs(r2 - r1) > 1e-12 else 0.5
+                        arrival_state = states[k] + frac * (states[k + 1] - states[k])
+                        arrival_time_dim = times[k] + frac * (times[k + 1] - times[k])
+                        break
 
-            if arrival_state is None:
-                # 未到达目标距离：用轨迹末态作为近似
-                arrival_state = states[-1]
+                if arrival_state is None:
+                    # 未到达目标距离：用轨迹末态作为近似
+                    arrival_state = states[-1]
 
-            tof_sec = float(arrival_time_dim * char_time)
+                tof_sec = float(arrival_time_dim * char_time)
 
-            # Δv 计算
-            dv_arr = float(np.linalg.norm(arrival_state[3:] - target_state[3:]))
-            total_dv = dv_dep + dv_arr
+                # Δv 计算
+                dv_arr = float(np.linalg.norm(arrival_state[3:] - target_state[3:]))
+                total_dv = dv_dep + dv_arr
 
-            if total_dv > params.max_total_dv:
-                continue
+                if total_dv > max_total_dv_dim:
+                    continue
 
-            # Jacobi 常数
-            jac_dep = _compute_jacobi(x0, mu)
-            jac_arr = _compute_jacobi(arrival_state, mu)
+                # Jacobi 常数
+                jac_dep = _compute_jacobi(x0, mu)
+                jac_arr = _compute_jacobi(arrival_state, mu)
 
-            candidates.append(
-                LgaCandidate(
-                    departure_phase=float(angle),
-                    tof_sec=tof_sec,
-                    departure_state=x0.copy(),
-                    perilune_state=state_peri.copy(),
-                    perilune_alt_km=alt_km,
-                    perilune_time_dim=float(t_peri),
-                    arrival_state=arrival_state.copy(),
-                    dv_departure=dv_dep,
-                    dv_arrival=dv_arr,
-                    total_dv=total_dv,
-                    jacobi_departure=jac_dep,
-                    jacobi_arrival=jac_arr,
-                    arrival_time_dim=arrival_time_dim,
-                    status=ConvergenceState.CONVERGED,
-                    cause=FailureCause.NONE,
-                    message="找到 LGA 候选",
+                candidates.append(
+                    LgaCandidate(
+                        departure_phase=float(angle),
+                        out_of_plane_angle=float(b),
+                        tof_sec=tof_sec,
+                        departure_state=x0.copy(),
+                        perilune_state=state_peri.copy(),
+                        perilune_alt_km=alt_km,
+                        perilune_time_dim=float(t_peri),
+                        arrival_state=arrival_state.copy(),
+                        dv_departure=dv_dep,
+                        dv_arrival=dv_arr,
+                        total_dv=total_dv,
+                        jacobi_departure=jac_dep,
+                        jacobi_arrival=jac_arr,
+                        arrival_time_dim=arrival_time_dim,
+                        status=ConvergenceState.CONVERGED,
+                        cause=FailureCause.NONE,
+                        message="找到 LGA 候选",
+                    )
                 )
-            )
 
     candidates.sort(key=lambda c: c.total_dv)
     if candidates:
@@ -277,7 +319,7 @@ def search_lga_trajectories(
             FailureCause.NONE,
             "找到 LGA 候选",
         )
-    if n_propagation_failures == len(angle_grid) * len(tof_grid_dim):
+    if n_propagation_failures == n_grid_points:
         return CandidateSearchResult(
             (),
             ConvergenceState.DIVERGED,
@@ -304,7 +346,7 @@ def _refine_lga_candidate(
     1. 到达段：perilune → target（ThreeBodyLambert 打靶修正到达速度）
     2. 打靶后的到达速度更新 Δv 计算。
 
-    如果打靶未达到收敛状态，返回原始候选。
+    如果打靶未收敛、或打靶解的总 Δv 劣于网格候选，返回原始候选。
     """
     from .terminal import StateTerminal
     from .three_body_lambert import ThreeBodyLambert
@@ -335,13 +377,27 @@ def _refine_lga_candidate(
         )
 
         if arrival_leg.status is ConvergenceState.CONVERGED:
-            # 更新 Δv
+            # 更新 Δv：ThreeBodyLambert 解为物理单位 (km/s)，换算回无量纲
             v_arrival_shot = arrival_leg.arcs[-1].states[-1][3:]
             v_target_phys = target_phys[3:]
-            dv_arr = float(np.linalg.norm(v_arrival_shot - v_target_phys))
+            vu_km_s = system.characteristic_velocity
+            if vu_km_s is None or vu_km_s <= 0.0:
+                raise ValueError("system.characteristic_velocity must be set")
+            dv_arr = float(np.linalg.norm(v_arrival_shot - v_target_phys)) / vu_km_s
+
+            # 精化未带来改进时保留网格候选（打靶解可能劣于网格解，
+            # 此时采纳会让结果超出 max_total_dv，issue #512）
+            if candidate.dv_departure + dv_arr > candidate.total_dv:
+                logger.debug(
+                    "ThreeBodyLambert 精化未改进 Δv（%.4f → %.4f），保留网格候选",
+                    candidate.total_dv,
+                    candidate.dv_departure + dv_arr,
+                )
+                return candidate
 
             return LgaCandidate(
                 departure_phase=candidate.departure_phase,
+                out_of_plane_angle=candidate.out_of_plane_angle,
                 tof_sec=candidate.tof_sec,
                 departure_state=candidate.departure_state,
                 perilune_state=candidate.perilune_state,
@@ -364,6 +420,7 @@ def _refine_lga_candidate(
     # 打靶失败，返回原始候选
     return LgaCandidate(
         departure_phase=candidate.departure_phase,
+        out_of_plane_angle=candidate.out_of_plane_angle,
         tof_sec=candidate.tof_sec,
         departure_state=candidate.departure_state,
         perilune_state=candidate.perilune_state,

--- a/tests/algorithm/transfer/test_lga.py
+++ b/tests/algorithm/transfer/test_lga.py
@@ -445,3 +445,192 @@ class TestLgaTransferOrbit:
 
         with pytest.raises(ValueError, match="target_ephemeris"):
             transfer_orbit("LGA", tli_params=TliParams(parking_alt_km=200.0, inclination_deg=0.0))
+
+
+# ---------------------------------------------------------------------------
+# TestLgaOutOfPlane：面外搜索维度（issue #512）
+# ---------------------------------------------------------------------------
+
+
+class TestLgaOutOfPlane:
+    """非零出发倾角下 LGA 搜索应通过面外角维度找到可行候选（issue #512）。"""
+
+    @pytest.fixture
+    def inclined_setup(self):
+        """20°/28.5° 倾角出发态（经 construct_departure_state → 无量纲）。"""
+        from e2m2e.algorithm.transfer.hohmann import construct_departure_state
+
+        system, dynamics = _make_cr3bp_system()
+        tgt_state = _make_target_state(system)
+        dep_states = {}
+        for incl in (20.0, 28.5):
+            r0, v0 = construct_departure_state(
+                TliParams(parking_alt_km=200.0, inclination_deg=incl)
+            )
+            dep_states[incl] = system.physical_to_dimensionless(np.concatenate([r0, v0]))
+        return system, dynamics, dep_states, tgt_state
+
+    def test_search_inclined_departure_finds_candidates(self, inclined_setup):
+        """倾角 20° 与 28.5° 的搜索都应返回非空候选（修复前 INFEASIBLE）。"""
+        system, dynamics, dep_states, tgt_state = inclined_setup
+        for incl, dep_state in dep_states.items():
+            candidates = search_lga_trajectories(
+                dep_state, tgt_state, system, dynamics, _SEARCH_PARAMS
+            )
+            assert len(candidates) > 0, f"倾角 {incl}° 应找到可行候选（issue #512）"
+
+    def test_out_of_plane_grid_centered_keeps_coplanar_candidates(self, inclined_setup):
+        """共面出发态（倾角 0）在默认面外网格下仍找到候选，且不劣于纯共面网格。"""
+        system, dynamics, _, tgt_state = inclined_setup
+        dep_state = _make_departure_state(system)
+        candidates = search_lga_trajectories(dep_state, tgt_state, system, dynamics, _SEARCH_PARAMS)
+        assert len(candidates) > 0, "共面出发态不应因面外网格退化"
+
+
+# ---------------------------------------------------------------------------
+# TestLgaMaxTotalDvUnits：max_total_dv 的 km/s 语义（issue #512）
+# ---------------------------------------------------------------------------
+
+
+class TestLgaMaxTotalDvUnits:
+    """max_total_dv 以 km/s 语义参与筛选（修复前与无量纲值直接比较）。"""
+
+    @pytest.fixture
+    def cr3bp_setup(self):
+        system, dynamics = _make_cr3bp_system()
+        dep_state = _make_departure_state(system)
+        tgt_state = _make_target_state(system)
+        return system, dynamics, dep_state, tgt_state
+
+    def test_candidates_physical_dv_within_limit(self, cr3bp_setup):
+        """所有候选的物理总 Δv（total_dv × 特征速度）≤ max_total_dv (km/s)。"""
+        system, dynamics, dep_state, tgt_state = cr3bp_setup
+        vu = system.characteristic_velocity
+        candidates = search_lga_trajectories(dep_state, tgt_state, system, dynamics, _SEARCH_PARAMS)
+        for c in candidates:
+            assert c.total_dv * vu <= _SEARCH_PARAMS.max_total_dv + 1e-9, (
+                f"物理总 Δv {c.total_dv * vu:.3f} km/s 超过 max_total_dv="
+                f"{_SEARCH_PARAMS.max_total_dv} km/s"
+            )
+
+    def test_tighter_dv_limit_reduces_candidates(self, cr3bp_setup):
+        """把 max_total_dv 压到最优候选物理 Δv 之下，搜索应无候选。"""
+        system, dynamics, dep_state, tgt_state = cr3bp_setup
+        vu = system.characteristic_velocity
+        baseline = search_lga_trajectories(dep_state, tgt_state, system, dynamics, _SEARCH_PARAMS)
+        assert len(baseline) > 0
+        best_physical_km_s = baseline[0].total_dv * vu
+        tight = LgaSearchParams(
+            n_departure_phase=_SEARCH_PARAMS.n_departure_phase,
+            n_tof=_SEARCH_PARAMS.n_tof,
+            max_total_dv=best_physical_km_s - 0.1,
+            perilune_alt_min=_SEARCH_PARAMS.perilune_alt_min,
+            perilune_alt_max=_SEARCH_PARAMS.perilune_alt_max,
+        )
+        reduced = search_lga_trajectories(dep_state, tgt_state, system, dynamics, tight)
+        assert len(reduced) == 0, (
+            f"max_total_dv={best_physical_km_s - 0.1:.3f} km/s 应滤掉全部候选"
+            f"（最优物理 Δv={best_physical_km_s:.3f} km/s），实际剩 {len(reduced)} 个"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestLgaInclinedEndToEnd：transfer_orbit("LGA") 非零倾角端到端（issue #512）
+# ---------------------------------------------------------------------------
+
+
+class TestLgaInclinedEndToEnd:
+    """issue #512 复现场景：发射倾角 28.5°（文昌纬度）端到端收敛。"""
+
+    def test_transfer_orbit_inclination_28_5_converges(self):
+        """incl=28.5° 时 transfer_orbit("LGA") 应 CONVERGED 且候选 > 0。"""
+        import warnings
+
+        system, _ = _make_cr3bp_system()
+        target_state = _make_target_state(system)
+        du, vu = system.characteristic_length, system.characteristic_velocity
+        target_ephemeris = np.array(
+            [
+                target_state[0] * du,
+                0.0,
+                0.0,
+                0.0,
+                target_state[4] * vu,
+                0.0,
+            ]
+        ).reshape(1, 6)
+        params = LgaSearchParams(
+            n_departure_phase=120,
+            n_tof=5,
+            max_total_dv=25.0,
+            perilune_alt_min=100.0,
+            perilune_alt_max=10000.0,
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            result = transfer_orbit(
+                "LGA",
+                tli_params=TliParams(parking_alt_km=200.0, inclination_deg=28.5),
+                target_ephemeris=target_ephemeris,
+                lga_search_params=params,
+            )
+        assert result.status is ConvergenceState.CONVERGED, (
+            f"28.5° 倾角应收敛（issue #512），实际 {result.status}: {result.message}"
+        )
+        assert result.details.n_candidates_feasible > 0
+        assert result.delta_v <= params.max_total_dv + 1e-6
+
+    def test_low_inclination_dv_not_degraded(self):
+        """倾角 0°/5°/10°/20° 端到端收敛且 Δv ≤ max_total_dv（issue #512 验收）。
+
+        修复前低倾角基线（精化后）总 Δv 为 50~70 km/s；修复后应低于
+        max_total_dv=25 km/s，满足"不劣于基线 5%"（基线×1.05 ≈ 52~74）。
+        """
+        import warnings
+
+        system, _ = _make_cr3bp_system()
+        target_state = _make_target_state(system)
+        du, vu = system.characteristic_length, system.characteristic_velocity
+        target_ephemeris = np.array(
+            [
+                target_state[0] * du,
+                0.0,
+                0.0,
+                0.0,
+                target_state[4] * vu,
+                0.0,
+            ]
+        ).reshape(1, 6)
+        params = LgaSearchParams(
+            n_departure_phase=120,
+            n_tof=5,
+            max_total_dv=25.0,
+            perilune_alt_min=100.0,
+            perilune_alt_max=10000.0,
+        )
+        for incl in (0.0, 5.0, 10.0, 20.0):
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                result = transfer_orbit(
+                    "LGA",
+                    tli_params=TliParams(parking_alt_km=200.0, inclination_deg=incl),
+                    target_ephemeris=target_ephemeris,
+                    lga_search_params=params,
+                )
+            assert result.status is ConvergenceState.CONVERGED, (
+                f"倾角 {incl}° 应收敛，实际 {result.status}: {result.message}"
+            )
+            assert result.delta_v <= params.max_total_dv + 1e-6, (
+                f"倾角 {incl}° 总 Δv {result.delta_v:.3f} km/s 超过 max_total_dv=25"
+            )
+
+    def test_search_high_inclination_iss_finds_candidates(self):
+        """大倾角 51.6°（ISS 倾角）搜索层应找到可行候选（经验面外带覆盖 0°–90°）。"""
+        from e2m2e.algorithm.transfer.hohmann import construct_departure_state
+
+        system, dynamics = _make_cr3bp_system()
+        tgt_state = _make_target_state(system)
+        r0, v0 = construct_departure_state(TliParams(parking_alt_km=200.0, inclination_deg=51.6))
+        dep_state = system.physical_to_dimensionless(np.concatenate([r0, v0]))
+        candidates = search_lga_trajectories(dep_state, tgt_state, system, dynamics, _SEARCH_PARAMS)
+        assert len(candidates) > 0, "倾角 51.6° 应找到可行候选（面外带覆盖 0°–90°）"


### PR DESCRIPTION
> *关联 issue:* #512（agent brief 见 issue 评论）

## 改动摘要

**根因（两个叠加）：**
1. LGA 出发速度网格只有面内角一维方向，无面外自由度。倾角 ≥ 20° 时所有网格点的近月高度都落在 [100, 10000] km 窗口外，候选在 Δv 筛选前就被清空——这是放宽 `max_total_dv` 无效的原因。
2. `max_total_dv` 声称 km/s 却与无量纲 Δv 直接比较，过滤形同虚设；且 ThreeBodyLambert 精化劣于网格解时原样采纳，把到达 Δv 从 ~8 恶化到 ~74 km/s 仍报 CONVERGED。

**修复：**
- `LgaSearchParams` 新增面外角网格（`out_of_plane_halfwidth_deg` / `n_out_of_plane`），中心随出发轨道面倾角缓慢负移（实测倾角 0°–90° 可行带中心 ≈ -0.08·δ）；共面出发态网格对称于 0
- `LgaCandidate` 记录 `out_of_plane_angle`
- `max_total_dv` 先按特征速度换算为无量纲再比较；`LgaTransferDetails` 与 `delta_v` 统一换算回 km/s
- 精化劣于网格候选时保留网格解（brief 未列出的必要新行为：否则精化会击穿 Δv 阈值）

## 测试

- issue 复现脚本五档倾角（0/5/10/20/28.5°）全部 CONVERGED，总 Δv 20.6~20.7 km/s ≤ 25（修复前 20°/28.5° INFEASIBLE，低倾角精化后 50~70 km/s）
- 51.6°（ISS 倾角）搜索层可行
- `tests/algorithm/transfer/test_lga.py` 27 项通过（新增面外搜索、Δv 单位语义、端到端回归三个测试类）；`test_hohmann.py` 31 项、`tests/api/test_facade_responses.py` 8 项通过
- `ruff check` / `ruff format --check` / `mypy` 全过

## 已知取舍

- 面外带中心 `-0.08·δ` 来自本 issue 任务剖面（200 km 停泊轨道、近月 2000 km 目标）的实测，换剖面后失准可调 `out_of_plane_halfwidth_deg` 放宽
- 默认面外网格 9 点，搜索量约 ×9；`n_out_of_plane=1` 可退回纯共面