### PR TITLE
fix(solver): 修正器迭代内容差可配并与 dynamics 研究级容差解耦（#534/#536）

### DIFF
--- a/e2m2e/algorithm/solver/differential_correction.py
+++ b/e2m2e/algorithm/solver/differential_correction.py
@@ -88,9 +88,7 @@ class DifferentialCorrection:
         # 可能因积分噪声停滞（由 stagnation_limit 兜底盘整为 MAX_ITERATIONS），
         # 需要更紧闭合时应同步调紧 integration_rtol。
         self.integration_rtol = (
-            integration_rtol
-            if integration_rtol is not None
-            else self.DEFAULT_INTEGRATION_TOLERANCE
+            integration_rtol if integration_rtol is not None else self.DEFAULT_INTEGRATION_TOLERANCE
         )
         self.integration_atol = (
             integration_atol if integration_atol is not None else self.integration_rtol

--- a/e2m2e/algorithm/solver/differential_correction.py
+++ b/e2m2e/algorithm/solver/differential_correction.py
@@ -51,6 +51,11 @@ class DifferentialCorrection:
     DEFAULT_TOLERANCE = 1e-12
     DEFAULT_MAX_ITERATIONS = 50
     DEFAULT_DAMPING_FACTOR = 1.0
+    # Newton 迭代内增广状态（6+36 STM）传播的筛选级容差（#536）。修正
+    # 闭环只需中间精度（残差评估/雅可比），研究级 1e-12 使单次 STM
+    # 传播成本不可接受；1e-10 对 1e-6 级闭合判据精度足够。最终轨道
+    # 编排（_create_corrected_orbit）仍用 dynamics 的研究级容差。
+    DEFAULT_INTEGRATION_TOLERANCE = 1e-10
     VALID_SETUP_TYPES = [
         "2D_symmetric_x_fixed_x0",
         "2D_symmetric_x_fixed_t",
@@ -70,11 +75,26 @@ class DifferentialCorrection:
         dynamic: CR3BP_Dynamics,
         target: dict[str, Any] | None = None,
         free_vars: list[str] | None = None,
+        integration_rtol: float | None = None,
+        integration_atol: float | None = None,
     ) -> None:
         self.dynamics = dynamic
         self.target_conditions = target or {}
         self.free_variables = free_vars or []
         self.tolerance = self.DEFAULT_TOLERANCE
+        # 迭代内积分容差：默认修正级 1e-10（DEFAULT_INTEGRATION_TOLERANCE），
+        # 与 dynamics.rtol（研究级 1e-12，影响最终轨迹编排）解耦；显式传入
+        # 时覆盖。收敛判据 self.tolerance 低于 100×integration_rtol 时 Newton
+        # 可能因积分噪声停滞（由 stagnation_limit 兜底盘整为 MAX_ITERATIONS），
+        # 需要更紧闭合时应同步调紧 integration_rtol。
+        self.integration_rtol = (
+            integration_rtol
+            if integration_rtol is not None
+            else self.DEFAULT_INTEGRATION_TOLERANCE
+        )
+        self.integration_atol = (
+            integration_atol if integration_atol is not None else self.integration_rtol
+        )
         self.max_iterations = self.DEFAULT_MAX_ITERATIONS
         self.damping_factor = self.DEFAULT_DAMPING_FACTOR
         self.convergence_history: list[dict[str, Any]] = []
@@ -241,8 +261,8 @@ class DifferentialCorrection:
             tolerance=self.tolerance,
             stagnation_limit=self.stagnation_limit,
             divergence_limit=self.divergence_limit,
-            rtol=dynamics.rtol,
-            atol=dynamics.atol,
+            rtol=self.integration_rtol,
+            atol=self.integration_atol,
             max_step=dynamics.max_step,
             sample_count=1000,
         )

--- a/tests/algorithm/solver/test_differential_correction.py
+++ b/tests/algorithm/solver/test_differential_correction.py
@@ -143,6 +143,57 @@ class TestSetup:
 
 
 # ============================================================
+# 迭代内积分容差配置（#536）
+# ============================================================
+class TestIntegrationTolerance:
+    """迭代内 STM 传播容差与 dynamics 研究级容差解耦（#536）。"""
+
+    def test_default_is_correction_level(self, dro_dynamics):
+        """默认修正级 1e-10，不跟随 dynamics.rtol（研究级 1e-12）。"""
+        corrector = DifferentialCorrection(dro_dynamics)
+        assert corrector.integration_rtol == 1e-10
+        assert corrector.integration_atol == 1e-10
+        assert dro_dynamics.rtol == 1e-12
+
+    def test_explicit_override(self, dro_dynamics):
+        corrector = DifferentialCorrection(
+            dro_dynamics, integration_rtol=1e-9, integration_atol=1e-11
+        )
+        assert corrector.integration_rtol == 1e-9
+        assert corrector.integration_atol == 1e-11
+
+    def test_iterate_uses_integration_tolerance(self, dro_dynamics, monkeypatch):
+        """_iterate_rust 传给 Rust 内核的容差是修正级容差，而非 dynamics.rtol。"""
+        captured = {}
+
+        import e2m2e.algorithm.solver.differential_correction as dc_module
+
+        def fake_kernel(**kwargs):
+            captured.update(kwargs)
+            return {
+                "error_history": [],
+                "correction_history": [],
+                "iterations": 0,
+                "residual": None,
+                "state_history": [],
+                "time_history": [],
+                "final_state_history": [],
+                "status": "max_iterations",
+                "cause": "max_iterations_reached",
+                "message": "mock",
+            }
+
+        monkeypatch.setattr(dc_module, "differential_correction_cr3bp_py", fake_kernel)
+        corrector = DifferentialCorrection(dro_dynamics, integration_rtol=1e-9)
+        corrector.setup_2D_symmetric_x_fixed_t(t_half=2.5)
+        seed = np.zeros(6)
+        seed[0] = 0.8
+        corrector._iterate_rust(seed, 2.5, full_period=False, verbose=False, callback=None)
+        assert captured["rtol"] == 1e-9
+        assert captured["atol"] == 1e-9
+
+
+# ============================================================
 # 微分修正收敛测试
 # ============================================================
 class TestIterateCorrection:

--- a/tests/algorithm/transfer/test_lga.py
+++ b/tests/algorithm/transfer/test_lga.py
@@ -629,11 +629,16 @@ class TestLgaInclinedEndToEnd:
 
     def test_search_high_inclination_iss_finds_candidates(self):
         """大倾角 51.6°（ISS 倾角）搜索层应找到可行候选（经验面外带覆盖 0°~90°）。"""
+        import dataclasses
+
         from e2m2e.algorithm.transfer.hohmann import construct_departure_state
 
         system, dynamics = _make_cr3bp_system()
         tgt_state = _make_target_state(system)
         r0, v0 = construct_departure_state(TliParams(parking_alt_km=200.0, inclination_deg=51.6))
         dep_state = system.physical_to_dimensionless(np.concatenate([r0, v0]))
-        candidates = search_lga_trajectories(dep_state, tgt_state, system, dynamics, _SEARCH_PARAMS)
+        # 大倾角候选的命中瓶颈在出发相位网格密度（面外加宽不补），
+        # 90 点漏检；120 点 + n_tof=2 实测 8 候选 / 7s（ADR 0037 预算内）
+        params = dataclasses.replace(_SEARCH_PARAMS, n_departure_phase=120, n_tof=2)
+        candidates = search_lga_trajectories(dep_state, tgt_state, system, dynamics, params)
         assert len(candidates) > 0, "倾角 51.6° 应找到可行候选（面外带覆盖 0°~90°）"


### PR DESCRIPTION
## 关联 issue
- #534：归因收尾。全量 pytest（2074 用例）仅剩的 1 个失败 `test_search_high_inclination_iss_finds_candidates` 系 #538 把 LGA 出发相位网格 360→90 降密度引入，与 #531 WSB 合并无关。本 PR 修复（测试局部参数 120 相位 + n_tof=2，实测 8 候选 7.3s，ADR 0037 预算内）。
- #536：落地方向 1（修正器可配容差）。**实测发现**：修正器已全走 Rust 内核，issue 所述 scipy STM 传播根因不复存在；rtol 1e-12 vs 1e-10、max_step 0.01 vs 0.2 对 NRHO 设计耗时与闭合误差无显著影响（3.5s / 9.05e-15）。原 35 分钟耗时本质是测试数量 × 固有迭代成本，已由 #538 的端到端测试移除 + ADR 0037 缓解。本 PR 提供契约性配置能力（默认修正级 1e-10），建议据此更新/关闭 #536。

## 改动摘要
- `DifferentialCorrection(integration_rtol=, integration_atol=)`：Newton 迭代内 STM 传播容差，默认 1e-10，与 dynamics.rtol 解耦；最终轨迹编排仍用研究级 1e-12
- `test_lga.py`：大倾角 ISS 测试局部网格参数修复
- `test_differential_correction.py`：新增 3 个单元测试钉住默认值/覆盖/转发

## 测试
- `pytest tests/algorithm/design tests/algorithm/solver -n auto`：336 passed, 1 skipped
- `pytest tests/algorithm/transfer/test_lga.py`：27 passed
- `pytest tests/algorithm/solver/test_differential_correction.py`：35 passed