### PR TITLE
fix(api): 信封层降级序列化修复族生成/catalog_get/promote，orbit_stability 标回 placeholder（#526 补全/#510 决策）

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ print(result.initial_state)
 **接口与工具**
 
 - Facade 任务级入口，统一对外调用面。
-- MCP 服务化封装：`create_server` 进程内服务器与 `e2m2e mcp-serve` 子命令，由 Facade 方法元数据派生工具清单（`[mcp]` extra）。
+- MCP 服务化封装：`create_server` 进程内服务器与 `e2m2e mcp-serve` 子命令（stdio 传输，`[mcp]` extra），由 Facade 方法元数据派生工具清单——轨道设计、站保仿真、转移设计、轨道预报、时空转换、轨道族生成与 7 个轨道库工具，产物自动入库、`record_id` 跨工具链式调用。接入配置与工具用法见文档「[通过 MCP 使用 e2m2e](https://cislunarspace.github.io/e2m2e/getting-started/mcp.html)」。
 
 ## 文档
 

--- a/docs/adr/0014-api-facade-mcp-cli.md
+++ b/docs/adr/0014-api-facade-mcp-cli.md
@@ -1,6 +1,6 @@
 # ADR 0014：接口层 Facade/MCP/CLI
 
-**状态**：已采纳（部分实施：Facade 已落地，MCP/CLI 占位）
+**状态**：已采纳（Facade 与 MCP 已落地；CLI 完整子命令仍占位）
 **日期**：2026-07-31
 **关联**：ADR 0011（五层架构）、README 愿景（LLM+Agent 可调用）
 

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -46,11 +46,12 @@ pip 安装
 
    pip install e2m2e
 
-可选依赖（标准形化简）：
+可选依赖：
 
 .. code-block:: bash
 
-   pip install e2m2e[normal-form]
+   pip install e2m2e[normal-form]   # 标准形化简
+   pip install "e2m2e[mcp]"         # MCP 服务器（e2m2e mcp-serve，见「通过 MCP 使用 e2m2e」）
 
 发布的 wheel 内嵌 CSPICE（静态链接，署名见仓库 NOTICE），STM 传播、打靶、
 第三体引力等 Rust 快速路径开箱即用。

--- a/docs/getting-started/mcp.rst
+++ b/docs/getting-started/mcp.rst
@@ -1,0 +1,184 @@
+通过 MCP 使用 e2m2e
+===================
+
+e2m2e 把任务级能力（轨道设计、站保仿真、转移设计、轨道库等）封装为
+MCP (Model Context Protocol) 工具，供 LLM Agent 直接调用（ADR 0014）。
+在支持 MCP 的客户端里，你不需要写代码或填参数表——用自然语言描述任务，
+模型会根据每个工具的 schema（含参数单位、默认值、取值域的中文描述）
+自行选工具、拼参数。
+
+接入
+----
+
+MCP 服务器随 ``[mcp]`` extra 分发，以 stdio 传输启动::
+
+   pip install "e2m2e[mcp]"        # 或 uv sync --extra mcp
+   e2m2e mcp-serve                 # stdio JSON-RPC，不监听端口
+
+在 MCP 客户端配置中注册（以 Claude Desktop / Cursor 的 ``mcpServers``
+格式为例）::
+
+   {
+     "mcpServers": {
+       "e2m2e": {
+         "command": "/path/to/.venv/Scripts/e2m2e.exe",
+         "args": ["mcp-serve"],
+         "cwd": "/path/to/e2m2e-repo"
+       }
+     }
+   }
+
+ZCode 工作区配置（``<repo>/.zcode/config.json``）同构，键为嵌套的
+``mcp.servers``::
+
+   {
+     "mcp": {
+       "servers": {
+         "e2m2e": {
+           "type": "stdio",
+           "command": "C:\\path\\to\\.venv\\Scripts\\e2m2e.exe",
+           "args": ["mcp-serve"],
+           "cwd": "C:\\path\\to\\e2m2e-repo"
+         }
+       }
+     }
+   }
+
+.. note::
+
+   ``cwd`` 建议钉在仓库根：SPICE 内核目录（``kernels``）与轨道库目录
+   （``catalog``）的默认值是相对路径。也可用环境变量
+   ``SPICE_KERNEL_DIR`` / ``E2M2E_CATALOG_DIR`` 显式指定绝对路径。
+
+统一信封
+--------
+
+所有工具的返回都是统一信封 ``{status, data, error, meta}``：成功时
+``status="ok"``、``data`` 为该工具的响应模型；失败时 ``status="error"``、
+``error`` 含结构化错误码与信息（如 ``INVALID_PARAMS``、
+``RECORD_NOT_FOUND``、``PROPAGATION_FAILED``），不泄漏 traceback。
+数值计算类工具的 ``data.status`` 另行报告算法收敛状态
+（converged / diverged / stagnated / max_iterations / …，ADR 0020 软失败
+语义：发散也是有效结果）。
+
+工具清单
+--------
+
+清单由 Facade 方法元数据纯派生，``placeholder`` 状态的不注册
+（实现后自动上线）。当前 13 个：
+
+.. list-table::
+   :header-rows: 1
+   :widths: 28 14 58
+
+   * - 工具
+     - 分档
+     - 用途与关键输入
+   * - ``design_orbit``
+     - 一档
+     - 任务轨道设计。``orbit_type`` 取 DRO/DPO/HALO/NRHO/LISSAJOUS/L4/L5/
+       AXIAL/SPO/LPO/HORSESHOE/ELFO 之一，另给各族形状参数（多数有默认值），
+       产出星历修正后的标称轨道并自动入库。
+   * - ``control_orbit``
+     - 一档
+     - 轨道保持（站保）蒙特卡洛仿真。输入二选一：``input_record_id``
+       引用库中记录，或 ``input_ephemeris`` 直接给星历；控制模式
+       1–6、测定轨/推力误差、力模型阶数等。
+   * - ``transfer_design``
+     - 一档
+     - 转移轨道设计。``transfer_type`` 取 HMN/LGA/WSB/low_thrust，
+       ``tli_epoch`` 为 TLI 历元；LGA/WSB 需 ``target_ephemeris``，
+       坐标系契约见下文注意事项。
+   * - ``orbit_propagation``
+     - 一档
+     - 轨道预报。GCRS 六维初态 + 历元 + 时长（秒）。
+   * - ``spacetime_transform``
+     - 一档
+     - 时空坐标转换：synodic↔J2000、GCRS↔EBCRS。会合系转换的
+       ``times`` 是无量纲会合时间 t_syn（0 = ``et0_jd`` 参考历元）；
+       GCRS↔EBCRS 用 JD_TDB 且需 ``ephemeris_path``。
+   * - ``orbit_family_generation``
+     - 二档
+     - 轨道族延拓生成（HALO/NRHO/AXIAL/LISSAJOUS/SPO/LPO/HORSESHOE/
+       DRO 八族），按族有振幅/延拓方向参数，族记录自动入库。
+   * - ``catalog_query``
+     - 库
+     - 多维过滤查询（族、平动点、Jacobi 区间、振幅区间、标签、收敛
+       状态），返回摘要列表。
+   * - ``catalog_get``
+     - 库
+     - 按 ``record_id`` 取完整记录（含 CR3BP 段与星历段数组）。
+   * - ``catalog_tag``
+     - 库
+     - 写教学标注：``tags`` 整体替换，``note`` 为自由文本。
+   * - ``catalog_promote``
+     - 库
+     - 把族成员（``member_index``）提升为独立记录，
+       ``source_record_id`` 指向所属族。
+   * - ``catalog_export``
+     - 库
+     - 按查询条件打包导出：``dest`` 以 ``.zip`` 结尾产出 zip 包，
+       否则产出目录；包可直接作为库打开。
+   * - ``catalog_sweep``
+     - 库
+     - 参数空间扫描批量生成并入库：族 × 平动点 × 振幅网格 / 能量
+       窗口 / LISSAJOUS 二维振幅网格。
+   * - ``catalog_delete``
+     - 库
+     - 按 ``record_id`` 删除记录（文件与索引条目），不可撤销。
+
+每个产物型工具成功后都会自动写入轨道库（ADR 0031），响应里带
+``record_id``——这是跨工具链式调用的句柄。
+
+典型工作流
+----------
+
+设计 → 站保 → 归档::
+
+   design_orbit(orbit_type="NRHO", north_south=2, perilune_height=3000)
+     └─ 得 record_id
+   control_orbit(input_record_id=<上一步>, control_mode=1)
+     └─ 站保产物自动指向该记录，谱系不断
+   catalog_tag(record_id=…, tags=["教学示例"], note="…")
+   catalog_export(orbit_family="nrho", dest="nrho.zip")
+
+族 → 挑成员 → 站保::
+
+   orbit_family_generation(orbit_type="HALO", libration_point=2, n_orbits=10)
+   catalog_query(orbit_family="halo")          # 浏览族记录
+   catalog_promote(record_id=…, member_index=3)  # 挑成员独立成记录
+   control_orbit(input_record_id=<提升产物>)
+
+批量填充轨道库::
+
+   catalog_sweep(orbit_types=["HALO","NRHO"], max_amplitudes_km=[…],
+                 jacobi_windows=[[3.0,3.2]])
+
+自然语言示例（在 MCP 客户端里直接说）::
+
+   设计一条 L2 南族 NRHO，近月点高度 3000 km，起始历元 2026-01-01，
+   然后对它做 100 次蒙特卡洛的站保仿真，最后打上"候选"标签。
+
+注意事项
+--------
+
+1. **``transfer_design`` 的 ``target_ephemeris`` 坐标系契约**：LGA/WSB
+   要求会合旋转系（synodic）物理单位（km, km/s）；``design_orbit`` /
+   ``orbit_propagation`` 产出的惯性系星历必须先经
+   ``spacetime_transform(j2000_to_synodic)`` 转换再传入，否则目标态
+   几何全错。HMN / low_thrust 按地心惯性系解释。
+2. **单位**：时长统一秒（``control_orbit`` 的间隔类参数是天）；角度用
+   度；历元可用 UTC ISO 字符串或 ``[年,月,日,时,分,秒]``；
+   ``spacetime_transform`` 的 JD_TDB 与无量纲 t_syn 按上文区分。
+3. **``catalog_delete`` 不可撤销**，删除前先用 ``catalog_get`` 确认。
+4. ``orbit_stability``（稳定性分析）需要带 period/system 绑定的
+   ``Orbit`` 对象入参，暂无法经 JSON 信封表达，未注册为 MCP 工具；
+   记录引用式入参落地后再开放。需要稳定性分析时用算法层 API
+   （:doc:`../algorithms/stability`）。
+
+下一步
+------
+
+- :doc:`installation`：安装与 ``[mcp]`` extra
+- :doc:`../api/e2m2e`：Facade / 模型 / MCP 模块的 API 参考
+- ``docs/adr/0014-api-facade-mcp-cli.md``：接口层设计决策（ADR，不入 Sphinx 构建）

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,7 @@ e2m2e (Earth to Moon, Moon to Earth) 面向地月空间任务规划，提供精�
 
    getting-started/installation
    getting-started/quickstart
+   getting-started/mcp
 
 .. toctree::
    :maxdepth: 2

--- a/e2m2e/api/facade.py
+++ b/e2m2e/api/facade.py
@@ -1061,9 +1061,14 @@ class Facade:
         )
         return response
 
-    @mcp_exposed
+    @mcp_exposed(status="placeholder")
     def orbit_stability(self, **params) -> Any:
-        """稳定性分析（二档）：薄封装 algorithm/stability。"""
+        """稳定性分析（二档）：薄封装 algorithm/stability。
+
+        需要带 period/system 绑定的 Orbit 对象入参，无法经 JSON 信封表达
+        （空参 schema 注册后 Agent 必然调用失败）；按 issue #510 决策不
+        注册，待记录引用式入参（如 input_record_id）落地后放开。
+        """
         from e2m2e.algorithm.stability import StabilityAnalysis
 
         orbit = params.get("orbit")

--- a/e2m2e/api/mcp/envelope.py
+++ b/e2m2e/api/mcp/envelope.py
@@ -14,9 +14,10 @@ from typing import Any
 import numpy as np
 from pydantic import BaseModel, ValidationError
 
+from e2m2e.data.types.orbit import Orbit
+
 from ..catalog_ingest import _finite_or_none
 from ..models import OrbitError
-from e2m2e.data.types.orbit import Orbit
 
 __all__ = ["Envelope", "ok_envelope", "error_envelope", "invoke_tool", "dispatch_tool"]
 

--- a/e2m2e/api/mcp/envelope.py
+++ b/e2m2e/api/mcp/envelope.py
@@ -11,9 +11,12 @@ from __future__ import annotations
 import json
 from typing import Any
 
+import numpy as np
 from pydantic import BaseModel, ValidationError
 
+from ..catalog_ingest import _finite_or_none
 from ..models import OrbitError
+from e2m2e.data.types.orbit import Orbit
 
 __all__ = ["Envelope", "ok_envelope", "error_envelope", "invoke_tool", "dispatch_tool"]
 
@@ -21,10 +24,50 @@ __all__ = ["Envelope", "ok_envelope", "error_envelope", "invoke_tool", "dispatch
 Envelope = dict[str, Any]
 
 
+def _to_jsonable(value: Any) -> Any:
+    """把 ``model_dump(mode="python")`` 输出里的不可 JSON 化值降级转换。
+
+    MCP 是纯文本通道（sidecar 的大数组走二进制帧，ADR 0035）：Any/
+    任意类型字段携带的 ndarray 转嵌套 list；Orbit 成员取画布契约字段
+    （states/times/period/family_type，与 sidecar 帧契约同款）；System
+    鸭子类型只透传 ``mu`` 标量；其余未知对象以 ``<类型名>`` 占位。总线
+    保证结果可 JSON 序列化，不向传输层抛异常。
+    """
+    if isinstance(value, BaseModel):
+        return _jsonify(value)
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, Orbit):
+        return {
+            "states": _to_jsonable(value.states),
+            "times": _to_jsonable(value.times),
+            "period": _finite_or_none(value.period),
+            "family_type": value.family_type,
+        }
+    if isinstance(value, dict):
+        return {k: _to_jsonable(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_to_jsonable(v) for v in value]
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    mu = getattr(value, "mu", None)
+    if mu is not None:
+        return {"mu": _finite_or_none(mu)}
+    return f"<{type(value).__name__}>"
+
+
 def _jsonify(data: Any) -> Any:
     """把 Response 模型/普通对象转成可 JSON 序列化的结构。"""
     if isinstance(data, BaseModel):
-        return data.model_dump(mode="json")
+        try:
+            return data.model_dump(mode="json")
+        except Exception:
+            # issue #526 补全：Any/任意类型字段携带 ndarray/Orbit/System
+            # （族生成、catalog_get/promote）时 mode="json" 失败，降级为
+            # python 模式转储 + 逐值转换。
+            return _to_jsonable(data.model_dump(mode="python"))
     return data
 
 

--- a/e2m2e/api/models.py
+++ b/e2m2e/api/models.py
@@ -754,7 +754,10 @@ class SpacetimeTransformRequest(_ApiModel):
     """时空坐标转换输入。"""
 
     states: list[list[float]] = Field(description="状态列表，每项 [x,y,z,vx,vy,vz]")
-    times: list[float] = Field(description="每个状态的 JD_TDB 时间值")
+    times: list[float] = Field(
+        description="每个状态的时间值：GCRS↔EBCRS 用 JD_TDB；会合系转换用"
+        "无量纲会合时间 t_syn（0 = et0_jd 参考历元）"
+    )
     transform_type: str = Field(
         description="synodic_to_j2000/j2000_to_synodic/gcrs_to_ebcrs/ebcrs_to_gcrs"
     )

--- a/e2m2e/api/sidecar/__init__.py
+++ b/e2m2e/api/sidecar/__init__.py
@@ -144,9 +144,9 @@ def handle_request(facade: Facade, request: Any) -> list[bytes]:
     payload_fn = _BINARY_TOOLS.get(tool)
     if payload_fn is not None:
         if dtype is None:
-            # 协议约定（非参数校验）：响应含 ndarray/Orbit 对象不可 JSON 化
-            # （MCP 传输层同此限制），该工具必须走帧，缺省 dtype 视为协议用法
-            # 错误，借用 INVALID_PARAMS 错误码。
+            # 协议约定（非参数校验）：响应含 ndarray/Orbit 对象，本协议要求
+            # 走帧（MCP 传输层由 envelope 降级内联 JSON，帧仍是首选通道），
+            # 缺省 dtype 视为协议用法错误，借用 INVALID_PARAMS 错误码。
             return [
                 _line(
                     envelope.error_envelope(

--- a/tests/api/test_facade.py
+++ b/tests/api/test_facade.py
@@ -445,6 +445,8 @@ class TestFacadeToolInventory:
             "orbit_family_generation": FamilyGenerationRequest,
         }
         placeholders = {
+            # 需 Orbit 对象入参，无法经 JSON 信封表达；记录引用式入参落地前不注册
+            "orbit_stability",
             "transfer_search",
             "low_thrust_design",
             "manifold_analysis",
@@ -455,5 +457,3 @@ class TestFacadeToolInventory:
         assert all(by_name[name].request_model is model for name, model in implemented.items())
         assert all(by_name[name].status == "placeholder" for name in placeholders)
         assert all(by_name[name].request_model is None for name in placeholders)
-        assert by_name["orbit_stability"].status == "implemented"
-        assert by_name["orbit_stability"].request_model is None

--- a/tests/api/test_mcp.py
+++ b/tests/api/test_mcp.py
@@ -178,6 +178,100 @@ def test_invoke_tool_internal_error():
     assert "RuntimeError" in env["error"]["message"]
 
 
+def test_family_response_serializes_orbit_members():
+    """族生成响应（Orbit 成员）不再兑成 INTERNAL_ERROR（issue #526 补全）。
+
+    降级契约与 sidecar 帧契约同款：成员留 states/times/period/family_type，
+    System 鸭子类型透传 mu。
+    """
+    import numpy as np
+
+    from e2m2e.api.models import FamilyGenerationResponse
+    from e2m2e.data.templates import ConvergenceState, FailureCause
+    from e2m2e.data.types.orbit import Orbit
+
+    orbit = Orbit(states=np.eye(6, 6), times=np.linspace(0.0, 1.0, 6))
+
+    class SystemStub:
+        mu = 1.21506683e-2
+
+    class FamTool:
+        request_model = None
+
+        def __call__(self, **kwargs):
+            return FamilyGenerationResponse(
+                status=ConvergenceState.CONVERGED,
+                cause=FailureCause.NONE,
+                message="族生成完成",
+                orbits=[orbit],
+                system=SystemStub(),
+                requested_members=1,
+                generated_members=1,
+            )
+
+    env = envelope.invoke_tool(FamTool(), {})
+    assert env["status"] == "ok"
+    json.dumps(env)  # MCP 传输层直接 dumps 信封（server._to_result）
+    member = env["data"]["orbits"][0]
+    assert member["states"][0] == [1.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    assert member["times"][0] == 0.0
+    assert member["period"] is None  # eye(6) 非周期轨迹，x 零交叉检测不到周期
+    assert env["data"]["system"] == {"mu": pytest.approx(1.21506683e-2)}
+
+
+def test_catalog_record_response_serializes_arrays():
+    """catalog_get/promote 响应的数组段（ndarray）内联为嵌套 list。"""
+    import numpy as np
+
+    from e2m2e.api.models import CatalogRecordResponse
+    from e2m2e.data.templates import ConvergenceState, FailureCause
+
+    record = CatalogRecordResponse(
+        record_id="r1",
+        created_at="2026-08-25T00:00:00+00:00",
+        source_tool="design_orbit",
+        source_record_id=None,
+        orbit_family="dro",
+        libration_point=None,
+        jacobi=None,
+        amplitude=None,
+        has_cr3bp=True,
+        has_ephemeris=False,
+        status=ConvergenceState.CONVERGED,
+        cause=FailureCause.NONE,
+        message="ok",
+        member_count=1,
+        tags=[],
+        note="",
+        scalars={"mu": 1.21506683e-2},
+        request={},
+        members=[],
+        arrays={"cr3bp/states": np.zeros((2, 6)), "cr3bp/times": np.array([0.0, 1.0])},
+    )
+    env = envelope.ok_envelope(record)
+    assert env["status"] == "ok"
+    json.dumps(env)
+    assert env["data"]["arrays"]["cr3bp/states"] == [[0.0] * 6, [0.0] * 6]
+    assert env["data"]["arrays"]["cr3bp/times"] == [0.0, 1.0]
+
+
+def test_orbit_stability_placeholder_not_registered(facade):
+    """orbit_stability 需 Orbit 对象入参，无法经 JSON 信封表达：不注册（回归）。"""
+    assert "orbit_stability" not in {s.name for s in tool_specs(facade)}
+    result = handle_call_tool(facade, "orbit_stability", {})
+    env = json.loads(result.content[0].text)
+    assert env["error"]["code"] == "TOOL_NOT_FOUND"
+
+
+def test_spacetime_times_description_states_dual_units():
+    """times 字段描述须写明双单位契约（会合系是 t_syn 而非 JD_TDB）。"""
+    from e2m2e.api.models import SpacetimeTransformRequest
+
+    desc = SpacetimeTransformRequest.model_json_schema()["properties"]["times"]["description"]
+    assert "JD_TDB" in desc
+    assert "t_syn" in desc
+
+
 def test_cli_parser_has_mcp_serve():
     from e2m2e.api.cli.main import build_parser
 

--- a/tests/api/test_sidecar.py
+++ b/tests/api/test_sidecar.py
@@ -279,8 +279,10 @@ def test_run_loop_survives_envelope_serialization_failure(facade):
         facade._broken_response = False
 
 
-def test_invoke_tool_serialization_failure_translated():
-    """issue #526：结果含不可 JSON 化对象时兑成 INTERNAL_ERROR 信封，不炸传输层。"""
+def test_invoke_tool_serializes_ndarray_inline():
+    """issue #526 演进：结果含 ndarray 时信封层降级内联为嵌套 list，
+    不再兑成 INTERNAL_ERROR（sidecar 大数组仍首选二进制帧，见帧映射）。
+    """
     from e2m2e.api.models import CatalogRecordResponse
     from e2m2e.data.templates import ConvergenceState, FailureCause
 
@@ -314,10 +316,9 @@ def test_invoke_tool_serialization_failure_translated():
             return record
 
     env = envelope.invoke_tool(_Method(), {})
-    assert env["status"] == "error"
-    assert env["error"]["code"] == "INTERNAL_ERROR"
-    assert "序列化" in env["error"]["message"]
-    assert "Traceback" not in env["error"]["message"]
+    assert env["status"] == "ok"
+    assert env["data"]["arrays"]["cr3bp/states"] == [[0.0] * 6] * 3
+    assert "Traceback" not in json.dumps(env)
 
 
 def test_catalog_query_unchanged_by_binary_mapping(facade):


### PR DESCRIPTION
## 关联 issue

无直接关联 issue（测试中发现）。修复点为 issue #526 的漏网情形，orbit_stability 下架依据 issue #510 决策。

## 背景

对 MCP 服务做 14 工具全量协议测试时发现 4 个缺陷：`orbit_family_generation` / `catalog_get` / `catalog_promote` 的响应含 ndarray/Orbit 对象，`model_dump(mode="json")` 抛 `PydanticSerializationError` 被 envelope 兜底成 `INTERNAL_ERROR`，调用方拿不到任何结果（计算本身成功、记录已入库）；`orbit_stability` 空参 schema 却要求 Orbit 对象入参，Agent 必然调用失败。

## 改动

**代码修复（envelope.py）**：`_jsonify` 失败时降级为 python 模式转储 + numpy/Orbit 感知递归转换——ndarray 转嵌套 list，Orbit 取画布契约字段（states/times/period/family_type，与 sidecar 帧契约同款），System 鸭子类型透传 mu，未知对象以 `<类型名>` 占位。sidecar 二进制帧通道不受影响（共用 dispatch_tool）。

**orbit_stability**：标回 `status="placeholder"` 不注册，docstring 写明待记录引用式入参（input_record_id）落地后放开。

**models.py**：`SpacetimeTransformRequest.times` 字段描述由误导性的"JD_TDB 时间值"改为双单位契约（GCRS↔EBCRS 用 JD_TDB；会合系转换用无量纲 t_syn）。

**文档**：新增 `docs/getting-started/mcp.rst`「通过 MCP 使用 e2m2e」用户指南（接入配置、统一信封、13 工具速查、典型工作流、注意事项），挂进快速开始导航；README/installation/ADR 0014 状态行同步勘正。Sphinx 全量构建零警告。

## 测试

- `pytest tests/api/ -q` → **200 passed**（新增 4 个回归测试：族响应序列化、记录数组序列化、stability 不注册、times 描述双单位；更新 test_sidecar 旧断言与 test_facade inventory 断言）
- 端到端 stdio JSON-RPC 复测：族生成 ok 且 3 成员内联（含 period/system.mu）、catalog_get 数组段全 list 化、catalog_promote 返回完整新记录、orbit_stability 下架（tools/list 现为 13 个）、轨道库基线 13 条完好