### PR TITLE
fix: MCP 实测修复——预测 PCK 未来历元覆盖与信封枚举序列化 (#556, #557)

### DIFF
--- a/docs/getting-started/mcp.rst
+++ b/docs/getting-started/mcp.rst
@@ -45,6 +45,15 @@ nested key ``mcp.servers``::
      }
    }
 
+Claude Code registers the same binary with a one-liner::
+
+   claude mcp add e2m2e --cwd "C:\path\to\e2m2e-repo" -- .venv/Scripts/e2m2e.exe mcp-serve
+
+For wire-level debugging (list tools, inspect schemas, replay single calls),
+the MCP Inspector drives the server interactively::
+
+   npx @modelcontextprotocol/inspector .venv/Scripts/e2m2e.exe mcp-serve
+
 .. note::
 
    Pin ``cwd`` at the repo root: the SPICE kernel directory (``kernels``) and
@@ -162,6 +171,95 @@ Natural-language example (say this inside your MCP client)::
    2026-01-01, then run 100 Monte Carlo station-keeping simulations on it, and
    tag it "candidate".
 
+Interactive mission design (human-in-the-loop)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The intended operating mode is a reviewed conversation, not a fire-and-forget
+script: you state mission intent in natural language, the agent assembles tool
+calls from each tool's schema (units, defaults, value domains), and every
+result comes back as a unified envelope for you to check before the next step.
+Artifacts are auto-ingested into the orbit catalog, so the whole session is
+reproducible — each product carries a ``record_id`` and links back to its
+inputs via ``source_record_id``.
+
+A reviewed loop looks like this:
+
+1. **State intent** — e.g. "Design an L2 southern NRHO with 2000 km perilune
+   starting 2026-01-01."
+2. **Agent calls** ``design_orbit(...)`` → envelope ``status="ok"`` with
+   ``data.status="converged"`` and ``data.record_id=…`` (auto-ingested).
+3. **Review the envelope** — there are two status layers: the transport layer
+   (``status``: ok/error with structured ``error.code``) and the numerical
+   layer (``data.status``: converged / diverged / stagnated / …). Per the
+   soft-failure semantics (ADR 0020) a diverged run is a valid, inspectable
+   result — never chain downstream steps on a ``status="ok"`` envelope whose
+   ``data.status`` is not ``converged``.
+4. **Chain by reference** — "run station-keeping Monte Carlo on it" → the
+   agent passes the previous ``record_id`` as ``input_record_id``; the product
+   record points back automatically.
+5. **Annotate and package** — ``catalog_tag`` attaches review notes;
+   ``catalog_export`` bundles a tagged subset into a zip for handover.
+
+Verified end-to-end session (13 calls, ~1 minute on a release build)::
+
+   catalog_query({})                                  # 13 baseline records
+   design_orbit(orbit_type="NRHO", north_south=2, perilune_height=2000,
+                phase=0.5, epoch=[2026,1,1,0,0,0.0],
+                duration=691200.0, output_step=7200.0)    # converged, ~22 s
+   catalog_tag(record_id=…, tags=["candidate"], note="…")
+   orbit_family_generation(orbit_type="HALO", libration_point=2, n_orbits=5)
+   catalog_query(orbit_family="halo")
+   catalog_promote(record_id=…, member_index=2)        # member → standalone
+   design_orbit(orbit_type="DRO", amplitude=15000, phase=0.5001,
+                epoch=[2026,1,1,0,0,0.0],
+                duration=7776000.0, output_step=7200.0)   # converged, ~17 s
+   catalog_tag(record_id=…, tags=["evader"], note="…")
+   design_orbit(orbit_type="HALO", collinear_point=2, amplitude=30000,
+                phase=0.0, epoch=[2026,1,1,0,0,0.0], duration=3155760.0,
+                output_step=3600.0, perturbation={…})     # SK nominal
+   control_orbit(input_record_id=…, control_mode=1, control_interval=10.0,
+                 num_controls=2, num_monte_carlo=2, perturbation={…})
+   catalog_export(tags=["candidate"], dest="case.zip")
+
+Parameter cookbook (verified recipes)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Convergence is parameter- and epoch-sensitive. Prefer these measured recipes
+(release build, kernels as shipped) over ad-hoc scaling:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 42 12 28
+
+   * - Tool
+     - Recipe
+     - Runtime
+     - Notes
+   * - ``design_orbit`` NRHO
+     - L2 south, ``perilune_height=2000``, ``phase=0.5``, 8-day arc
+       (``duration=691200``, ``output_step=7200``)
+     - ~20–100 s
+     - Converges at epochs 2024 and 2026. A 30-day / 5000 km arc converges
+       at 2024 but not at 2026 (segmented shooting residual ~2e4 km), and
+       year-scale arcs do not converge either — do not scale ``duration``
+       blindly.
+   * - ``design_orbit`` DRO
+     - ``amplitude=15000``, ``phase=0.5001``, 90-day arc
+     - ~17 s
+     - The default ``amplitude=10000`` stalls the initial-guess differential
+       correction (80 iterations, 29 m residual). Pick amplitudes near
+       baseline-catalog members (``catalog_query(orbit_family="dro")``).
+   * - ``control_orbit``
+     - HALO L2 30000 km nominal (36.5-day arc) with the same perturbation
+       switches as the design; ``control_mode=1``, ``control_interval=10``,
+       ``num_controls=2``
+     - seconds
+     - Contract: control horizon + ``feedback_arc`` must fit inside the
+       nominal ephemeris span (the nominal view interpolates, it does not
+       extrapolate). Long-horizon station-keeping needs its own tuning —
+       a 9 × 7-day DRO setup was observed to diverge (per-burn Δv
+       0 → 3.5 → 6.0 → 86.5 m/s, breaching ``thrust_max``).
+
 Caveats
 ~~~~~~~
 
@@ -179,6 +277,36 @@ Caveats
    expressible through the JSON envelope yet, so unregistered; revisit once
    record-reference inputs land. Use the algorithm-layer API meanwhile
    (:doc:`../algorithms/stability`).
+5. ``control_orbit`` reads the referenced record's ephemeris segment as the
+   nominal and only interpolates within its span: the control horizon
+   ``(num_controls-1) * control_interval`` plus ``feedback_arc`` must fit
+   inside the designed arc, so design the nominal with enough ``duration``
+   headroom.
+6. Long-arc CR3BP ephemeris correction is parameter- and epoch-sensitive
+   (see the cookbook above); a request that converges at one epoch may fail
+   at another. Failed corrections surface as ``DESIGN_FAILED`` with the
+   residual in the message — not as a crash.
+
+Troubleshooting
+~~~~~~~~~~~~~~~
+
+- ``DESIGN_FAILED … SPICE(FRAMEDATANOTFOUND)`` (ITRF93) at future epochs:
+  the body-fixed kernel list must load the predictive PCK
+  ``SPICEEarthPredictedKernel.bpc`` *before* the historical
+  ``earth_latest_high_prec.bpc`` (overlap prefers the later-loaded,
+  higher-accuracy historical data; the predictive file extends coverage to
+  ~2037). Fixed in the current tree (issue #556); on older checkouts keep
+  epochs inside the historical file's coverage.
+- ``data.status`` renders as ``"<ConvergenceState>"`` instead of a value like
+  ``"converged"``: envelope enum degradation on the fallback serialization
+  path (family / catalog_get / catalog_promote responses), fixed in the
+  current tree (issue #557).
+- A fresh catalog answers ``catalog_query({})`` with 13 records: the packaged
+  CR3BP baseline dataset auto-imports on first open (ADR 0036) — that is
+  intentional, not leftover state.
+- ``pytest tests/api/test_mcp.py`` reports the whole file as skipped: the
+  ``[mcp]`` extra is missing (the module uses ``importorskip``). Install with
+  ``uv sync --extra mcp`` and re-run.
 
 Next steps
 ~~~~~~~~~~

--- a/e2m2e/algorithm/design/design_orbit.py
+++ b/e2m2e/algorithm/design/design_orbit.py
@@ -149,8 +149,12 @@ _PATCH_SAMPLING_DROP_NEAR_PERILUNE = "drop_near_perilune"
 #: 固定时间后两种修正方法均在约 10 s 内收敛到容差内。
 _FIXED_TIME_ORBIT_TYPES = frozenset({"HALO", "NRHO", "DPO", "LISSAJOUS", "L4", "L5", "AXIAL"})
 
-#: body-fixed 帧（ITRF93 / MOON_PA）所需内核文件名，与 tests/kernel_helpers.py 一致
+#: body-fixed 帧（ITRF93 / MOON_PA）所需内核文件名，与 tests/kernel_helpers.py 一致。
+#: 预测 PCK 必须先于历史 PCK 加载：SPICE 对重叠覆盖段取后加载者，历史
+#: 重构数据（高精度）因此在过去时段优先，未来时段由预测数据补齐
+#: （历史文件覆盖有终点，超出即 FRAMEDATANOTFOUND）。
 _BODY_FIXED_KERNELS = [
+    "SPICEEarthPredictedKernel.bpc",
     "earth_latest_high_prec.bpc",
     "pck00010.tpc",
     "SPICELunaCurrentKernel.bpc",

--- a/e2m2e/algorithm/station_keeping/monte_carlo.py
+++ b/e2m2e/algorithm/station_keeping/monte_carlo.py
@@ -616,9 +616,13 @@ def _kernel_paths(kernel_dir: str | None = None) -> list[str]:
         "SPICE_KERNEL_DIR", str(Path(__file__).resolve().parents[3] / "kernels")
     )
     paths = []
+    # SPICEEarthPredictedKernel.bpc 在 earth_latest_high_prec.bpc 之前加载：
+    # 历史 PCK 覆盖终点之外的时段（未来历元）由预测数据补齐，重叠段仍取
+    # 后加载的历史高精度数据（对齐 design_orbit._BODY_FIXED_KERNELS）。
     for name in [
         "de440s.bsp",
         "de430.bsp",
+        "SPICEEarthPredictedKernel.bpc",
         "earth_latest_high_prec.bpc",
         "pck00010.tpc",
         "SPICELunaCurrentKernel.bpc",

--- a/e2m2e/api/mcp/envelope.py
+++ b/e2m2e/api/mcp/envelope.py
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
+import enum
 import json
 from typing import Any
 
@@ -51,6 +52,11 @@ def _to_jsonable(value: Any) -> Any:
         return {k: _to_jsonable(v) for k, v in value.items()}
     if isinstance(value, (list, tuple)):
         return [_to_jsonable(v) for v in value]
+    # 纯 Enum（ConvergenceState/FailureCause 等）须显式取值，否则落入
+    # ``<类型名>`` 占位——族生成/catalog_get 响应走本降级路径，枚举值
+    # （converged 等）是软失败语义（ADR 0020）对外契约的一部分。
+    if isinstance(value, enum.Enum):
+        return _to_jsonable(value.value)
     if isinstance(value, (str, int, float, bool)) or value is None:
         return value
     mu = getattr(value, "mu", None)

--- a/tests/algorithm/design/test_kernel_future_coverage.py
+++ b/tests/algorithm/design/test_kernel_future_coverage.py
@@ -1,0 +1,47 @@
+"""回归：body-fixed 内核清单须覆盖未来历元（预测 PCK 先于历史 PCK 加载）。
+
+历史 PCK（``earth_latest_high_prec.bpc``）覆盖终点随仓库快照日期固定
+（约 2026 年中）；设计/站保流水线只装历史 PCK 时，起始历元加默认年尺度
+传播一旦越过终点，Rust 星历缓存构建即 SPICE FRAMEDATANOTFOUND
+（``design_orbit`` 经 MCP/CLI 暴露后未来历元是真实使用路径）。修复：
+``SPICEEarthPredictedKernel.bpc`` 先于历史 PCK 加载——SPICE 对重叠覆盖段
+取后加载者，过去时段仍取历史高精度数据，未来时段由预测数据补齐。
+"""
+
+from __future__ import annotations
+
+import pytest
+from kernel_helpers import SPICE_KERNEL_DIR, requires_spice
+
+from e2m2e.algorithm.design.design_orbit import (
+    _BODY_FIXED_KERNELS,
+    load_design_kernels,
+)
+from e2m2e.algorithm.station_keeping import monte_carlo
+from e2m2e.data.kernels.manager import SPICEManager
+
+pytestmark = [pytest.mark.interface, pytest.mark.spice, requires_spice]
+
+_PREDICT = "SPICEEarthPredictedKernel.bpc"
+_HISTORICAL = "earth_latest_high_prec.bpc"
+#: 历史 PCK 覆盖终点（随快照更新只会后移）与预测 PCK 终点（约 2037-04）之间。
+_FUTURE_EPOCH_UTC = "2030-01-01"
+
+
+def test_predict_pck_precedes_historical() -> None:
+    """设计/站保两条内核清单都含预测 PCK，且加载顺序在历史 PCK 之前。"""
+    assert _PREDICT in _BODY_FIXED_KERNELS
+    assert _BODY_FIXED_KERNELS.index(_PREDICT) < _BODY_FIXED_KERNELS.index(_HISTORICAL)
+
+    mc_names = [p.rsplit("\\", 1)[-1].rsplit("/", 1)[-1] for p in monte_carlo._kernel_paths()]
+    assert _PREDICT in mc_names
+    assert mc_names.index(_PREDICT) < mc_names.index(_HISTORICAL)
+
+
+def test_itrf93_orientation_available_at_future_epoch() -> None:
+    """经生产加载路径后，超出历史 PCK 覆盖的历元 ITRF93 旋转可用。"""
+    spice = SPICEManager()
+    loaded = load_design_kernels(spice, kernel_dir=SPICE_KERNEL_DIR)
+    assert any(p.endswith(_PREDICT) for p in loaded)
+    matrix = spice.pxform("J2000", "ITRF93", spice.utc_to_et(_FUTURE_EPOCH_UTC))
+    assert matrix.shape == (3, 3)

--- a/tests/api/test_mcp.py
+++ b/tests/api/test_mcp.py
@@ -212,6 +212,9 @@ def test_family_response_serializes_orbit_members():
     env = envelope.invoke_tool(FamTool(), {})
     assert env["status"] == "ok"
     json.dumps(env)  # MCP 传输层直接 dumps 信封（server._to_result）
+    # 降级序列化路径（Orbit/ndarray 触发）枚举须取值而非 <ConvergenceState> 占位
+    assert env["data"]["status"] == "converged"
+    assert env["data"]["cause"] == "none"
     member = env["data"]["orbits"][0]
     assert member["states"][0] == [1.0, 0.0, 0.0, 0.0, 0.0, 0.0]
     assert member["times"][0] == 0.0

--- a/tests/kernel_helpers.py
+++ b/tests/kernel_helpers.py
@@ -32,10 +32,12 @@ requires_spice = pytest.mark.skipif(
 
 
 # 定义 body-fixed 帧所需的 SPICE 内核文件名：
-# 地球 ITRF93 需要二进制 PCK（earth_latest_high_prec.bpc），
-# 月球 MOON_PA 需要文本 PCK（pck00010.tpc）、二进制 PCK（SPICELunaCurrentKernel.bpc）
-# 与帧内核（SPICELunaFrameKernel.tf）。
+# 地球 ITRF93 需要二进制 PCK（earth_latest_high_prec.bpc），未来历元段由
+# 预测 PCK（SPICEEarthPredictedKernel.bpc，须先加载，使重叠段取历史高精度
+# 数据）补齐；月球 MOON_PA 需要文本 PCK（pck00010.tpc）、二进制 PCK
+# （SPICELunaCurrentKernel.bpc）与帧内核（SPICELunaFrameKernel.tf）。
 BODY_FIXED_KERNELS = [
+    "SPICEEarthPredictedKernel.bpc",
     "earth_latest_high_prec.bpc",
     "pck00010.tpc",
     "SPICELunaCurrentKernel.bpc",


### PR DESCRIPTION
## 关联 issue

- Fixes #556（已随提交关闭）
- Fixes #557（已随提交关闭）

## 改动摘要

MCP stdio 端到端实测（5 案例 14 步）发现并修复两个 bug，附带 mcp.rst 指南扩充：

1. **fix(design) `53f8477`**：body-fixed 内核清单（`design_orbit.py` / `monte_carlo.py` / `tests/kernel_helpers.py`）补装 `SPICEEarthPredictedKernel.bpc` 并置于历史 PCK 之前——overlap 时段优先后装的高精度历史数据，预测文件把覆盖延伸至 ~2037，修复未来历元设计/站保报 `SPICE(FRAMEDATANOTFOUND)`（ITRF93）。新增 `tests/algorithm/design/test_kernel_future_coverage.py` 回归（清单顺序契约 + 2030 历元 ITRF93 探针）。
2. **fix(api) `310e961`**：MCP 信封降级序列化路径 `_to_jsonable` 增加 `enum.Enum` 分支取 `.value`，修复族生成/查询/提升响应中 `data.status` 渲染为 `"<ConvergenceState>"` 占位、软失败语义对外不可读；`test_mcp.py` 增补 `status=="converged"` / `cause=="none"` 断言。
3. **docs `4beef7b`**：`docs/getting-started/mcp.rst` 补 Setup（Claude Code / Inspector）、人机交互闭环设计流程、实测收敛参数配方表、Caveats 5–6、Troubleshooting（含上述两 bug 的临时规避）。

## 测试

- `uv run --no-sync pytest tests/api/` + 新回归：**202 passed**
- `uv run --no-sync pytest tests/algorithm/design/test_kernel_future_coverage.py`：2 passed
- ruff check / format：6 个改动文件全过
- Sphinx 全量构建：零 warning
- MCP stdio 端到端（scratchpad 案例运行器）：5 案例 14 步全绿，~53 s