### PR TITLE
fix(transfer): WSB Δv 单位混用——阈值与汇总按特征速度换算 km/s (#566)

### DIFF
--- a/crates/e2m2e-forces/src/wsb.rs
+++ b/crates/e2m2e-forces/src/wsb.rs
@@ -219,6 +219,10 @@ fn evaluate_task(
     let tof_dim = tof_sec / params.characteristic_time_sec;
     let t_eval = linspace_inclusive(0.0, tof_dim, params.n_propagation_samples);
     let moon_x = 1.0 - mu;
+    // max_total_dv 语义为 km/s（Python 侧 WsbSearchParams 文档）：候选 Δv 为
+    // 无量纲，阈值按特征速度换算到无量纲域再比较（与 Python 参照后端对齐，#566）。
+    let max_total_dv_dim =
+        params.max_total_dv * params.characteristic_time_sec / params.characteristic_length_km;
     let mut candidates = Vec::new();
     let mut n_propagation_failures = 0;
     let mut n_perilune_in_window = 0;
@@ -318,7 +322,7 @@ fn evaluate_task(
         let tof_sec_actual = arrival_time_dim * params.characteristic_time_sec;
         let dv_arrival = distance3(&arrival_state[3..], &target_state[3..]);
         let total_dv = dv_departure + dv_arrival;
-        if total_dv > params.max_total_dv {
+        if total_dv > max_total_dv_dim {
             continue;
         }
 

--- a/e2m2e/algorithm/transfer/__init__.py
+++ b/e2m2e/algorithm/transfer/__init__.py
@@ -709,6 +709,18 @@ def _transfer_orbit_wsb(
     refined = _refine_wsb_candidate(best, cr3bp_system, cr3bp_dynamics, target_dim)
 
     # 6. 物理单位换算
+    # WsbCandidate dv 字段全无量纲（#566）：dv_departure 恒产自 BCR4BP 搜索，
+    # dv_arrival 在精化成功时产自 CR3BP 打靶、回退时产自 BCR4BP 搜索——按
+    # 来源乘各自特征速度（两 vu 相差约 0.13%）。精化回退分支的 status 不是
+    # CONVERGED（见 _refine_wsb_candidate）。
+    vu_bcr4 = bcr4bp_system.characteristic_velocity
+    vu_cr3 = cr3bp_system.characteristic_velocity
+    if vu_bcr4 is None or vu_cr3 is None:
+        raise ValueError("两个系统都必须设置 characteristic_velocity")
+    dv_departure_km_s = refined.dv_departure * vu_bcr4
+    dv_arrival_km_s = refined.dv_arrival * (
+        vu_cr3 if refined.status is ConvergenceState.CONVERGED else vu_bcr4
+    )
     perilune_phys = bcr4bp_system.dimensionless_to_physical(refined.perilune_state)
     perilune_vel = float(np.linalg.norm(perilune_phys[3:]))
 
@@ -719,8 +731,8 @@ def _transfer_orbit_wsb(
         perilune_vel_km_s=perilune_vel,
         perilune_state=perilune_phys,
         h2_kepler=refined.h2_kepler,
-        dv_departure_km_s=refined.dv_departure,
-        dv_arrival_km_s=refined.dv_arrival,
+        dv_departure_km_s=dv_departure_km_s,
+        dv_arrival_km_s=dv_arrival_km_s,
         n_candidates_searched=n_searched,
         n_candidates_feasible=n_feasible,
         status=refined.status,
@@ -731,7 +743,7 @@ def _transfer_orbit_wsb(
 
     return TransferDesignResult(
         transfer_type="WSB",
-        delta_v=refined.total_dv,
+        delta_v=dv_departure_km_s + dv_arrival_km_s,
         trajectory=None,
         details=details,
         status=refined.status,

--- a/e2m2e/algorithm/transfer/lga.py
+++ b/e2m2e/algorithm/transfer/lga.py
@@ -413,7 +413,9 @@ def _refine_lga_candidate(
                 cause=FailureCause.NONE,
                 message="找到 LGA 候选",
             )
-    except (RuntimeError, ValueError, np.linalg.LinAlgError):
+    except (RuntimeError, ValueError, np.linalg.LinAlgError, PropagationFailure):
+        # PropagationFailure：打靶内部传播失败（退化候选几何可触发），
+        # 与其他打靶失败同义——保留原始候选，不让编排器崩（#566）。
         logger.debug("ThreeBodyLambert 打靶失败，保留原始候选", exc_info=True)
 
     # 打靶失败，返回原始候选

--- a/e2m2e/algorithm/transfer/wsb.py
+++ b/e2m2e/algorithm/transfer/wsb.py
@@ -116,6 +116,8 @@ class WsbCandidate:
     """单个 WSB 候选解（无动力月球飞越 + BCR4BP 太阳摄动）。
 
     飞越段 Δv = 0，总 Δv = 出发脉冲 + 到达脉冲。
+    ``dv_departure`` / ``dv_arrival`` / ``total_dv`` 均为无量纲
+    （× 系统特征速度得 km/s；产自 BCR4BP 搜索）。
     """
 
     sun_phase0: float
@@ -502,6 +504,9 @@ def _wsb_worker(
     )
     n_samples = params.n_propagation_samples
     tof_dim = tof_sec / char_time
+    # max_total_dv 语义为 km/s（WsbSearchParams 文档）：候选 Δv 为无量纲，
+    # 阈值按特征速度换算到无量纲域再比较（对齐 LGA，lga._search 的做法）。
+    max_total_dv_dim = params.max_total_dv / (du_km / char_time)
     candidates: list[WsbCandidate] = []
     n_propagation_failures = 0
 
@@ -563,7 +568,7 @@ def _wsb_worker(
         dv_arr = float(np.linalg.norm(arrival_state[3:] - target_state[3:]))
         total_dv = dv_dep + dv_arr
 
-        if total_dv > params.max_total_dv:
+        if total_dv > max_total_dv_dim:
             continue
 
         candidates.append(
@@ -631,7 +636,12 @@ def _refine_wsb_candidate(
         if arrival_leg.status is ConvergenceState.CONVERGED:
             v_arrival_shot = arrival_leg.arcs[-1].states[-1][3:]
             v_target_phys = target_phys[3:]
-            dv_arr = float(np.linalg.norm(v_arrival_shot - v_target_phys))
+            # ThreeBodyLambert 解为物理单位 (km/s)：换算回无量纲，
+            # 保持 WsbCandidate dv 字段全无量纲语义（对齐 LGA 精化）。
+            vu_km_s = system.characteristic_velocity
+            if vu_km_s is None or vu_km_s <= 0.0:
+                raise ValueError("system.characteristic_velocity must be set")
+            dv_arr = float(np.linalg.norm(v_arrival_shot - v_target_phys)) / vu_km_s
 
             return WsbCandidate(
                 sun_phase0=candidate.sun_phase0,
@@ -651,7 +661,9 @@ def _refine_wsb_candidate(
                 cause=FailureCause.NONE,
                 message="找到 WSB 候选",
             )
-    except (RuntimeError, ValueError, np.linalg.LinAlgError):
+    except (RuntimeError, ValueError, np.linalg.LinAlgError, PropagationFailure):
+        # PropagationFailure：打靶内部传播失败（退化候选几何可触发），
+        # 与其他打靶失败同义——保留原始候选，不让编排器崩（#566）。
         logger.debug("ThreeBodyLambert 打靶失败，保留原始候选", exc_info=True)
 
     return WsbCandidate(

--- a/tests/algorithm/transfer/test_wsb.py
+++ b/tests/algorithm/transfer/test_wsb.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import functools
 import math
+from dataclasses import replace
 
 import numpy as np
 import pytest
@@ -499,8 +500,11 @@ class TestWsbAcceptance:
         dv_hmn1, dv_hmn2 = hohmann_delta_v(r1, r2)
         dv_hohmann = dv_hmn1 + dv_hmn2
 
-        assert best.total_dv < dv_hohmann, (
-            f"WSB 总 Δv ({best.total_dv:.3f}) 应 < Hohmann Δv ({dv_hohmann:.3f})"
+        # 单位对齐（#566）：候选 total_dv 为无量纲，× 特征速度后与
+        # km/s 语义的 Hohmann Δv 比较。
+        best_dv_km_s = best.total_dv * _make_bcr4bp_system().characteristic_velocity
+        assert best_dv_km_s < dv_hohmann, (
+            f"WSB 总 Δv ({best_dv_km_s:.3f} km/s) 应 < Hohmann Δv ({dv_hohmann:.3f} km/s)"
         )
 
     def test_perilune_detection_precision(self):
@@ -546,3 +550,157 @@ class TestWsbAcceptance:
                 assert normalized_rv < 1e-6, (
                     f"近月点检测 r·v 归一化残差应 < 1e-6，得到 {normalized_rv}"
                 )
+
+
+class TestWsbDvUnits:
+    """#566 单位一致性回归：候选 Δv 全程无量纲，阈值与汇总按特征速度换算 km/s。
+
+    两处验证都打桩避免真实网格搜索（快，且不依赖参数空间有解）：
+    - 阈值域：stub 传播器给 _wsb_worker 喂一条确定轨迹，直接验证换算比较；
+    - 汇总：stub 搜索与精化，验证编排器 delta_v 与 details 分量的换算来源。
+    """
+
+    @staticmethod
+    def _synthetic_candidate(system):
+        """手造候选（几何数值只为通过流程，无物理意义）；dv 无量纲 2.0/1.0。"""
+        from e2m2e.algorithm.transfer import WsbCandidate
+
+        return WsbCandidate(
+            sun_phase0=0.0,
+            departure_phase=0.0,
+            tof_sec=1.0e6,
+            departure_state=np.zeros(6),
+            perilune_state=np.zeros(6),
+            perilune_alt_km=100.0,
+            perilune_time_dim=1.0,
+            arrival_state=np.zeros(6),
+            h2_kepler=-1.0,
+            dv_departure=2.0,
+            dv_arrival=1.0,
+            total_dv=3.0,
+            arrival_time_dim=2.0,
+            status=ConvergenceState.CONVERGED,
+            cause=FailureCause.NONE,
+            message="synthetic",
+        )
+
+    def test_worker_max_total_dv_threshold_in_km_s_domain(self, monkeypatch):
+        """max_total_dv 是 km/s 语义：阈值取候选物理总 Δv 的 99% 应过滤，
+        修复前按无量纲比较（有效阈值偏松 × 特征速度）会漏过。"""
+        from e2m2e.algorithm.transfer import wsb as wsb_module
+
+        system = _make_bcr4bp_system()
+
+        # 直线匀速轨迹：在月球近旁过拱点（r·v 变号），半径先降后升穿 r_target
+        n = 40
+        s = np.linspace(0.0, 1.0, n)
+        p0 = np.array([0.05, 0.06, 0.0])
+        d = np.array([1.2, 0.12, 0.0])
+        pos = p0[None, :] + s[:, None] * d[None, :]
+        vel = np.tile(d * 0.5, (n, 1))
+        states = np.hstack([pos, vel])
+        tof_sec = 10.0 * 86400.0
+        times = s * (tof_sec / system.characteristic_time)
+
+        class _StubDynamics:  # noqa: ANN204 -- 打桩 propagate，忽略动力学构造
+            def __init__(self, *args, **kwargs):
+                pass
+
+            rtol = 1.0
+            atol = 1.0
+            max_step = 1.0
+
+            def propagate(self, x0, t_span, t_eval=None):
+                return {"time": times, "states": states}
+
+        monkeypatch.setattr(wsb_module, "BCR4BP_Dynamics", _StubDynamics)
+
+        r0 = np.array([0.05, 0.06, 0.0])
+        v_park = np.array([0.0, 0.5, 0.0])
+        v_tli = 1.1
+        target_state = _make_target_state(system)
+        r_target = float(np.linalg.norm(target_state[:3]))
+        kwargs = dict(
+            departure_state=np.concatenate([r0, v_park]),
+            r0=r0,
+            v_park=v_park,
+            v_tli=v_tli,
+            target_state=target_state,
+            r_target=r_target,
+            mu=system.mu,
+            du_km=system.characteristic_length,
+            char_time=system.characteristic_time,
+            sun_mass=system.sun_mass,
+            sun_distance=system.sun_distance,
+            sun_angular_rate=system.sun_angular_rate,
+            sun_phase0=0.0,
+            tof_sec=tof_sec,
+        )
+        loose = WsbSearchParams(
+            n_departure_phase=2,
+            perilune_alt_min=-1_000_000.0,
+            perilune_alt_max=1_000_000.0,
+            max_total_dv=1_000_000.0,
+            h2_energy_threshold=1_000_000.0,
+        )
+        candidates, _ = wsb_module._wsb_worker(loose, **kwargs)
+        assert len(candidates) == 2, "stub 轨迹应在每个出发相位各产生一个候选"
+        best_physical_km_s = candidates[0].total_dv * system.characteristic_velocity
+
+        tight = replace(loose, max_total_dv=0.99 * best_physical_km_s)
+        candidates_tight, _ = wsb_module._wsb_worker(tight, **kwargs)
+        assert candidates_tight == [], (
+            f"阈值 0.99×物理 Δv（{0.99 * best_physical_km_s:.3f} km/s）应过滤该候选"
+        )
+
+    @pytest.mark.parametrize(
+        ("refine_status", "refine_cause"),
+        [
+            (ConvergenceState.CONVERGED, FailureCause.NONE),
+            (ConvergenceState.MAX_ITERATIONS, FailureCause.MAX_ITERATIONS_REACHED),
+        ],
+        ids=["refined", "refine-fallback"],
+    )
+    def test_transfer_orbit_delta_v_matches_details_km_s_components(
+        self, monkeypatch, refine_status, refine_cause
+    ):
+        """编排器汇总一致性：delta_v ≈ dv_departure_km_s + dv_arrival_km_s。
+        dv_departure 恒 ×BCR4BP 特征速度；dv_arrival 按精化来源取 CR3BP
+        （成功）或 BCR4BP（回退）特征速度。修复前是无量纲混合值。"""
+        import e2m2e.algorithm.transfer as transfer_pkg
+
+        system = _make_bcr4bp_system()
+        cr3bp_system, _ = _make_cr3bp_system()
+        vu_bcr4 = system.characteristic_velocity
+        vu_cr3 = cr3bp_system.characteristic_velocity
+
+        candidate = self._synthetic_candidate(system)
+        refined = replace(candidate, status=refine_status, cause=refine_cause)
+
+        monkeypatch.setattr(
+            transfer_pkg,
+            "search_wsb_trajectories",
+            lambda *args, **kwargs: CandidateSearchResult(
+                (candidate,), ConvergenceState.CONVERGED, FailureCause.NONE, "synthetic"
+            ),
+        )
+        monkeypatch.setattr(
+            "e2m2e.algorithm.transfer.wsb._refine_wsb_candidate",
+            lambda *args, **kwargs: refined,
+        )
+
+        target_phys = system.dimensionless_to_physical(_make_target_state(system))
+        result = transfer_orbit(
+            "WSB",
+            tli_params=TliParams(parking_alt_km=200.0, inclination_deg=0.0),
+            target_ephemeris=target_phys.reshape(1, 6),
+        )
+        details = result.details
+        expected_arrival_km_s = refined.dv_arrival * (
+            vu_cr3 if refine_status is ConvergenceState.CONVERGED else vu_bcr4
+        )
+        assert details.dv_departure_km_s == pytest.approx(refined.dv_departure * vu_bcr4, rel=1e-12)
+        assert details.dv_arrival_km_s == pytest.approx(expected_arrival_km_s, rel=1e-12)
+        assert result.delta_v == pytest.approx(
+            details.dv_departure_km_s + details.dv_arrival_km_s, rel=1e-12
+        )


### PR DESCRIPTION
Closes #566

## 改动

- **搜索层阈值**（Python `_wsb_worker` + Rust `evaluate_task` 同步）：候选 `total_dv` 无量纲与 km/s 语义的 `max_total_dv` 直接比较 → 仿 LGA（`lga.py:216-220`）先换算 `max_total_dv / vu` 再比较；rust/python 逐位对齐测试保持全绿。
- **精化返回值**：`_refine_wsb_candidate` 成功分支 `dv_arr` 除以 CR3BP 特征速度回无量纲（此前 km/s 写进无量纲语义字段，与失败分支并存两种语义——bug 根源）。
- **编排器汇总**：`dv_departure_km_s` 恒乘 BCR4BP 特征速度（出发 Δv 产自搜索）；`dv_arrival_km_s` 按精化来源乘 CR3BP（成功）/ BCR4BP（回退）特征速度；`delta_v` = 两 km/s 分量之和。
- **顺带**：两个精化函数 except 补接 `PropagationFailure`（退化候选几何会让打靶崩穿编排器，测试实测触发）；SI4 对比改同单位。

## 测试

新增 `TestWsbDvUnits`（打桩驱动，毫秒级，不依赖参数空间有解）：
- 阈值域：stub 传播器喂确定轨迹，0.99×物理 Δv 阈值应全滤（修复前按无量纲比较会漏过）；
- 汇总一致性：stub 搜索/精化，参数化精化成功/回退两分支断言 `delta_v ≈ dv_departure_km_s + dv_arrival_km_s` 与换算来源。

`test_wsb.py` + `test_wsb_contract.py` 29 passed / 2 skipped（原 SI1/SI4 小网格空解跳过为既存行为）；rust/python 对齐 8 passed；`make check`（ruff/format/mypy/cargo fmt/clippy）全绿。

## 影响量级

默认阈值 5.0 km/s 下修复前有效阈值 ≈5.12 km/s（偏松 2.3%）；`delta_v` 修复前是无量纲混合值（约偏小 2.4%）。