### PR TITLE
feat(transfer): 补齐 transfer_design 收敛轨迹与 trajectory_times——统一会合系契约 (#568, ADR 0040)

### DIFF
--- a/docs/adr/0040-transfer-trajectory-contract.md
+++ b/docs/adr/0040-transfer-trajectory-contract.md
@@ -1,0 +1,94 @@
+# ADR 0040: transfer_design converged trajectory — unified synodic-frame contract
+
+**Status**: Adopted (implemented)
+**Date**: 2026-08-29
+**Related Issue**: #568
+**Related**: ADR 0015 (nominal-orbit coordinate contract), ADR 0031 (orbit
+catalog — transfer products deliberately out of scope), transfer-orbit-design
+ADR 0013 (four-slot visualization contract)
+
+## Context
+
+`transfer_design` converged for HMN/LGA/WSB yet returned `trajectory=None`
+(only low_thrust filled it). Consumers (tod GUI canvas, MCP sidebar) got Δv
+numbers but no geometry, so a designed transfer could not be drawn. Meanwhile
+the internals already propagated the geometry and threw it away:
+
+- HMN's trajectory-bearing path sits behind a `dynamics` parameter the Facade
+  never passes; the geometric two-body path returned nothing.
+- LGA/WSB refinement (`_refine_*_candidate`) runs `ThreeBodyLambert.solve()`,
+  which re-propagates the full arrival leg (200 points, synodic rotating frame,
+  physical km via `dimensionless_to_physical`), then keeps only the terminal
+  velocity for the Δv update.
+
+The `trajectory` field existed in the response model all along — the contract
+was there, the producers were not wired.
+
+## Decision
+
+### 1. Unified trajectory contract
+
+`TransferDesignResult.trajectory` / `TransferDesignResponse.trajectory` is
+(n, 6) states in the **Earth-Moon synodic rotating frame, barycenter origin,
+physical units km / km/s**; new sibling `trajectory_times` is (n,) seconds
+since TLI (t=0 is the departure pulse), row-aligned. This matches the
+`target_ephemeris` input contract (synodic physical, e2m2e#516) on the output
+side, and is the frame tod's canvas natively renders (after ÷DU).
+
+### 2. Producers per transfer type
+
+- **HMN**: sample the two-body arc with `multi_impulse.propagate_two_body`
+  (new public wrapper) from the post-TLI state — Lambert solution when
+  `tof_range` is given, else the Hohmann tangential scaling of the parking
+  velocity — then convert via `hohmann.eci_to_synodic_display`.
+- **LGA**: departure leg (LEO→perilune) re-propagated in CR3BP from the
+  candidate's departure state; arrival leg is the refinement's
+  `ThreeBodyLambert` arc, now returned alongside the refined candidate.
+  Refinement fallback (shooting failed or no improvement): the grid candidate
+  is a single free-flight solution, re-propagated whole.
+- **WSB**: same assembly, but the departure leg is re-propagated in BCR4BP
+  with the candidate's `sun_phase0` (solar perturbation is the point of WSB);
+  the arrival leg remains the CR3BP-refined arc.
+- **low_thrust**: unchanged (its `trajectory` is the force-model state
+  system — a known inconsistency, tracked separately).
+
+Trajectory assembly failures (PropagationFailure) degrade to
+`trajectory=None` with a warning; numeric results (Δv, details) still return.
+
+### 3. HMN display convention (phase alignment)
+
+`eci_to_synodic_display` rotates the ECI two-body scene by Rz(−θ) so the
+arrival direction lands in the +x half-plane (z preserved), then translates
+positions by −[μ·DU, 0, 0] (geocentric → barycentric). Velocities rotate but
+get **no ω×r transport term**. This is a *display convention*, not an
+ephemeris-consistent transformation: HMN's geometric path has no real epoch
+semantics (epoch is record-keeping only). A truly consistent frame conversion
+requires `spacetime_transform` with real epochs — out of scope by design.
+
+### 4. Seam notes
+
+- Join at perilune: positions are continuous (guarded by test, <10 km
+  tolerance from integrator/interpolation error); the **velocity kink** is the
+  refinement's implicit correction impulse, which the Δv accounting does not
+  include — recorded, not asserted.
+- WSB legs use their own systems' scales (BCR4BP DU=384405 vs CR3BP
+  DU=384400, a pre-existing 1.3e-5 DU split); each converts with its own
+  characteristic quantities, the canvas normalizes by 384400 — invisible, not
+  fixed.
+- No catalog ingestion: ADR 0031 scoped auto-ingestion to orbit products;
+  transfer records (departure/arrival, Δv events, no period/family) need their
+  own record type — deliberately deferred again, tracked in tod's discovery
+  notes.
+- `_refine_lga_candidate` / `_refine_wsb_candidate` now return
+  `(candidate, arrival_arc | None)`; tests calling them unpack accordingly.
+
+## Consequences
+
+- MCP and sidecar consumers get the trajectory inline as JSON (transfer tools
+  are not in the sidecar `_BINARY_TOOLS` frame map; 200-point arrays are small
+  enough — the frame map stays demand-driven per ADR 0035).
+- tod's GUI can draw the arc after a run by scaling positions by 1/DU_KM and
+  feeding `trajectory_times` to the timeline.
+- HMN visuals are textbook-style demos (arrival on the +x/Moon side); anyone
+  needing ephemeris-grade transfers should use the LGA/WSB paths or wire
+  `dynamics`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -110,3 +110,4 @@ ADRs.
 | 0037 | Test suite time budget, minimal real-call coverage, and e2e test boundaries | Adopted |
 | 0038 | IAS15 integrator and force-model parametric variational equations (ASSIST-derived); MERCURIUS not adopted | Adopted |
 | 0039 | Shared-kernel leaf modules at the package root | Adopted (implemented) |
+| 0040 | transfer_design converged trajectory: unified synodic-frame contract with trajectory_times | Adopted (implemented) |

--- a/e2m2e/algorithm/transfer/__init__.py
+++ b/e2m2e/algorithm/transfer/__init__.py
@@ -22,6 +22,7 @@ from numpy.typing import NDArray
 
 from ...data.constants import SECONDS_PER_DAY
 from ...data.templates import ConvergenceState, FailureCause
+from ...exceptions import PropagationFailure
 from ..forces import PointMassGravity
 from ..results import CandidateSearchResult, ResultStatus, StageRecord
 from .config import (
@@ -35,9 +36,11 @@ from .hohmann import (
     R_EARTH,
     TliParams,
     construct_departure_state,
+    eci_to_synodic_display,
     ephemeris_shoot_transfer,
     hohmann_delta_v,
     hohmann_tof,
+    hohmann_transfer_states,
     scan_lambert_delta_v,
 )
 from .lambert import LambertSolution, solve_lambert, solve_lambert_batch
@@ -164,7 +167,11 @@ class TransferDesignResult:
     Attributes:
         transfer_type: 转移类型（"HMN"/"LGA"/"WSB"/"low_thrust"）。
         delta_v: 总 Δv（km/s）。
-        trajectory: 转移轨迹。
+        trajectory: 转移轨迹 (n, 6)，地月会合旋转系、质心原点、物理单位
+            km / km/s（ADR 0040；HMN 为两体几何的相位对齐显示约定，
+            low_thrust 暂为力模型状态系的已知不一致）。
+        trajectory_times: 轨迹时刻 (n,) 秒，TLI 起算（t=0 为出发脉冲），
+            与 trajectory 逐行对齐。
         details: 设计细节（弹道参数汇总）。
         stages: 搜索、精化和打靶等可选阶段的执行记录。
         status: 任务最终状态。
@@ -175,6 +182,7 @@ class TransferDesignResult:
     transfer_type: str
     delta_v: float
     trajectory: Any
+    trajectory_times: Any = None
     details: (
         HmnTransferDetails
         | LgaTransferDetails
@@ -459,6 +467,59 @@ def _extract_target_state(target_ephemeris: Any) -> tuple[NDArray[np.float64], N
     )
 
 
+def _propagate_synodic_leg(
+    dynamics: Any,
+    system: Any,
+    x0_dim: np.ndarray,
+    t_end_dim: float,
+    n_samples: int = 200,
+) -> tuple[np.ndarray, np.ndarray]:
+    """会合系无量纲传播一段弧 → 物理单位 + 秒（ADR 0040 轨迹契约）。
+
+    LGA/WSB 拼接轨迹的出发段采样：``dynamics.propagate`` 在无量纲会合
+    系积分，输出经特征量换算（位置 ×DU、速度 ×VU、时间 ×TU），时刻
+    从 0 起算。
+
+    Args:
+        dynamics: 会合系动力学（CR3BP 或 BCR4BP）。
+        system: 对应系统（提供特征尺度）。
+        x0_dim: 出发状态 (6,)，无量纲会合系。
+        t_end_dim: 弧段时长（无量纲时间）。
+        n_samples: 采样点数。
+
+    Returns:
+        ((n, 6) 状态 km / km/s，(n,) 时刻秒)。
+    """
+    du = system.characteristic_length
+    tu = system.characteristic_time
+    vu = system.characteristic_velocity
+    if du is None or tu is None or vu is None:
+        raise ValueError("system 必须设置特征尺度（长度/时间/速度）")
+    t_end = float(t_end_dim)
+    t_eval = np.linspace(0.0, t_end, int(n_samples))
+    result = dynamics.propagate(np.asarray(x0_dim, dtype=float), (0.0, t_end), t_eval=t_eval)
+    states = np.asarray(result["states"], dtype=float)
+    times = np.asarray(result["time"], dtype=float)
+    states_km = np.column_stack([states[:, :3] * du, states[:, 3:] * vu])
+    return states_km, times * tu
+
+
+def _join_transfer_legs(
+    dep_states: np.ndarray,
+    dep_times: np.ndarray,
+    arr_states: np.ndarray,
+    arr_times: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    """拼接出发段与到达段（去重衔接点），到达段时刻偏移到出发段时间轴。"""
+    dep_states = np.asarray(dep_states, dtype=float)
+    arr_states = np.asarray(arr_states, dtype=float)
+    dep_times = np.asarray(dep_times, dtype=float)
+    arr_times = np.asarray(arr_times, dtype=float)
+    states = np.vstack([dep_states, arr_states[1:]])
+    times = np.concatenate([dep_times, arr_times[1:] + dep_times[-1]])
+    return states, times
+
+
 def _transfer_orbit_lga(
     tli_params: TliParams | None,
     target_ephemeris: Any,
@@ -557,7 +618,28 @@ def _transfer_orbit_lga(
     # 5. ThreeBodyLambert 打靶精化
     from .lga import _refine_lga_candidate
 
-    refined = _refine_lga_candidate(best, system, cr3bp_dynamics, target_dim)
+    refined, arrival_arc = _refine_lga_candidate(best, system, cr3bp_dynamics, target_dim)
+
+    # 轨迹组装（ADR 0040）：出发段（LEO→perilune）CR3BP 重传播 + 精化
+    # 到达弧拼接（近月点速度折点是精化的隐式修正脉冲，位置连续由测试
+    # 守护）；精化回退时网格候选是单条自由飞行解，整段重传播即可。
+    trajectory: Any = None
+    trajectory_times: Any = None
+    try:
+        if arrival_arc is not None:
+            dep_states, dep_times = _propagate_synodic_leg(
+                cr3bp_dynamics, system, refined.departure_state, refined.perilune_time_dim
+            )
+            trajectory, trajectory_times = _join_transfer_legs(
+                dep_states, dep_times, arrival_arc.states, arrival_arc.times
+            )
+        else:
+            trajectory, trajectory_times = _propagate_synodic_leg(
+                cr3bp_dynamics, system, refined.departure_state, refined.arrival_time_dim
+            )
+    except PropagationFailure:
+        warnings.warn("LGA 轨迹组装传播失败，返回无轨迹结果", stacklevel=2)
+        trajectory, trajectory_times = None, None
 
     # 6. 物理单位换算
     perilune_phys = system.dimensionless_to_physical(refined.perilune_state)
@@ -584,7 +666,8 @@ def _transfer_orbit_lga(
     return TransferDesignResult(
         transfer_type="LGA",
         delta_v=refined.total_dv * vu_km_s,
-        trajectory=None,
+        trajectory=trajectory,
+        trajectory_times=trajectory_times,
         details=details,
         status=refined.status,
         cause=refined.cause,
@@ -631,7 +714,7 @@ def _transfer_orbit_wsb(
     if target_ephemeris is None:
         raise ValueError("WSB 转移需要 target_ephemeris")
 
-    from ..dynamics import CR3BP_Dynamics, CR3BP_System
+    from ..dynamics import BCR4BP_Dynamics, CR3BP_Dynamics, CR3BP_System
     from ..dynamics.bcr4bp_system import BCR4BPSystem
     from .wsb import _refine_wsb_candidate
 
@@ -706,7 +789,32 @@ def _transfer_orbit_wsb(
     # 5. ThreeBodyLambert 打靶精化（CR3BP 到达段）
     cr3bp_system = CR3BP_System(mu=MU_EM, primary="Earth", secondary="Moon")._with_default_scales()
     cr3bp_dynamics = CR3BP_Dynamics(cr3bp_system)
-    refined = _refine_wsb_candidate(best, cr3bp_system, cr3bp_dynamics, target_dim)
+    refined, arrival_arc = _refine_wsb_candidate(best, cr3bp_system, cr3bp_dynamics, target_dim)
+
+    # 轨迹组装（ADR 0040）：出发段必须用 BCR4BP 重传播（太阳摄动是 WSB
+    # 本体，sun_phase0 对齐候选；研究级默认容差，只为取轨迹），到达段用
+    # CR3BP 精化弧拼接；精化回退时候选整段都是 BCR4BP 搜索解，整段重传播。
+    # 两段特征尺度分属 BCR4BP（DU=384405 km）与 CR3BP（DU=384400 km），
+    # 差 1.3e-5 DU 在画布不可见，不修。
+    trajectory: Any = None
+    trajectory_times: Any = None
+    try:
+        dep_system = BCR4BPSystem.earth_moon(sun_phase0=refined.sun_phase0)
+        dep_dynamics = BCR4BP_Dynamics(dep_system)
+        if arrival_arc is not None:
+            dep_states, dep_times = _propagate_synodic_leg(
+                dep_dynamics, dep_system, refined.departure_state, refined.perilune_time_dim
+            )
+            trajectory, trajectory_times = _join_transfer_legs(
+                dep_states, dep_times, arrival_arc.states, arrival_arc.times
+            )
+        else:
+            trajectory, trajectory_times = _propagate_synodic_leg(
+                dep_dynamics, dep_system, refined.departure_state, refined.arrival_time_dim
+            )
+    except PropagationFailure:
+        warnings.warn("WSB 轨迹组装传播失败，返回无轨迹结果", stacklevel=2)
+        trajectory, trajectory_times = None, None
 
     # 6. 物理单位换算
     # WsbCandidate dv 字段全无量纲（#566）：dv_departure 恒产自 BCR4BP 搜索，
@@ -744,7 +852,8 @@ def _transfer_orbit_wsb(
     return TransferDesignResult(
         transfer_type="WSB",
         delta_v=dv_departure_km_s + dv_arrival_km_s,
-        trajectory=None,
+        trajectory=trajectory,
+        trajectory_times=trajectory_times,
         details=details,
         status=refined.status,
         cause=refined.cause,
@@ -994,6 +1103,7 @@ def _transfer_orbit_hmn(
 
     # 当 dynamics 提供时，用 ephemeris 打靶修正 Lambert 初猜
     trajectory: Any = None
+    trajectory_times: Any = None
     if dynamics is not None:
         t0 = 0.0  # 动力学模型的时间基准（秒）
         shoot_result = ephemeris_shoot_transfer(
@@ -1009,15 +1119,26 @@ def _transfer_orbit_hmn(
             dv1 = float(np.linalg.norm(v0_shot - v0))
             departure_state = shoot_result.state_patch[0].copy()
             trajectory = shoot_result.state_patch
+            trajectory_times = np.linspace(0.0, float(tof), int(shoot_result.state_patch.shape[0]))
         else:
             warnings.warn(
                 "ephemeris_shoot_transfer 未收敛，回退到 Lambert 解",
                 stacklevel=2,
             )
             departure_state = np.concatenate([r0, v0])
-            trajectory = None
     else:
         departure_state = np.concatenate([r0, v0])
+
+    if trajectory is None:
+        # 两体弧采样（dynamics 缺省，或打靶未收敛回退到 Lambert/霍曼解，
+        # ADR 0040）：出发速度取 Lambert 解（tof_range 路径）或停泊速度的
+        # 霍曼切向缩放（纯霍曼路径），方向不变。
+        v_dep = v0_lambert if tof_range is not None else v0 * np.sqrt(2.0 * r2 / (r1 + r2))
+        trajectory, trajectory_times = hohmann_transfer_states(r0, v_dep, tof)
+
+    # 统一显示契约（ADR 0040）：ECI 两体几何 → 会合系相位对齐显示坐标；
+    # 参考方向取转移弧末行位置（到达点落入 +x 半平面，即画布月球方向）
+    trajectory = eci_to_synodic_display(trajectory, np.asarray(trajectory, dtype=float)[-1, :3])
 
     details = HmnTransferDetails(
         tli_epoch=tli_params.epoch,
@@ -1043,6 +1164,7 @@ def _transfer_orbit_hmn(
         transfer_type="HMN",
         delta_v=dv1 + dv2,
         trajectory=trajectory,
+        trajectory_times=trajectory_times,
         details=details,
         status=status,
         cause=cause,

--- a/e2m2e/algorithm/transfer/hohmann.py
+++ b/e2m2e/algorithm/transfer/hohmann.py
@@ -250,6 +250,75 @@ def scan_lambert_delta_v(
     )
 
 
+def hohmann_transfer_states(
+    r0: NDArray[np.float64],
+    v0_dep: NDArray[np.float64],
+    tof_sec: float,
+    mu: float = MU_EARTH,
+    n_samples: int = 200,
+) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+    """沿两体转移弧采样状态（HMN 轨迹合成，ADR 0040）。
+
+    用 :func:`~e2m2e.algorithm.transfer.multi_impulse.propagate_two_body`
+    从 TLI 后出发态 ``(r0, v0_dep)`` 在 ``[0, tof_sec]`` 均匀采样。
+
+    Args:
+        r0: 出发位置 (3,) km（地心惯性系）。
+        v0_dep: 出发速度 (3,) km/s（TLI 脉冲后）。
+        tof_sec: 飞行时间（秒）。
+        mu: 中心天体引力参数 (km³/s²)。
+        n_samples: 采样点数。
+
+    Returns:
+        ((n, 6) 状态, (n,) 时刻秒)，地心惯性系。
+    """
+    from .multi_impulse import propagate_two_body
+
+    state0 = np.concatenate([np.asarray(r0, dtype=float), np.asarray(v0_dep, dtype=float)])
+    t_eval = np.linspace(0.0, float(tof_sec), int(n_samples))
+    out = propagate_two_body(state0, t_eval, mu)
+    return np.asarray(out["states"], dtype=float), np.asarray(out["time"], dtype=float)
+
+
+def eci_to_synodic_display(
+    states_eci: NDArray[np.float64],
+    r_ref_eci: NDArray[np.float64],
+    *,
+    mu_em: float = 1.21506683e-2,
+    du_km: float = 384400.0,
+) -> NDArray[np.float64]:
+    """ECI 两体几何 → 会合系显示坐标（HMN 轨迹显示约定，ADR 0040）。
+
+    相位对齐：绕 z 轴旋转 −θ（θ 为参考方向经度）使参考方向（转移弧
+    到达点）落入 +x 半平面（z 分量保留，倾斜转移的展宽不抹平）；随后
+    位置平移 −[μ·DU, 0, 0]（地心 → 地月质心）。速度同旋转、不受平移
+    影响，不加 ω×r 牵连项——真星历一致的转换需要真实历元语义，HMN
+    简化路径（几何搜索，epoch 仅记录）不支持，此处只是显示约定。
+
+    Args:
+        states_eci: (n, 6) 地心惯性系 km / km/s。
+        r_ref_eci: (3,) 相位对齐参考方向（取转移弧末行位置）。
+        mu_em: 地月质量比 μ。
+        du_km: 特征长度 (km)。
+
+    Returns:
+        (n, 6) 会合系显示坐标（地月质心原点，km / km/s）。
+    """
+    arr = np.asarray(states_eci, dtype=float)
+    ref = np.asarray(r_ref_eci, dtype=float)
+    theta = math.atan2(float(ref[1]), float(ref[0]))
+    c, s = math.cos(-theta), math.sin(-theta)
+    rot = np.array(
+        [[c, -s, 0.0], [s, c, 0.0], [0.0, 0.0, 1.0]],
+        dtype=float,
+    )
+    out = arr.copy()
+    out[:, :3] = arr[:, :3] @ rot.T
+    out[:, 3:] = arr[:, 3:] @ rot.T
+    out[:, 0] -= mu_em * du_km
+    return out
+
+
 def ephemeris_shoot_transfer(
     dynamics: Any,
     t0: float,

--- a/e2m2e/algorithm/transfer/lga.py
+++ b/e2m2e/algorithm/transfer/lga.py
@@ -23,6 +23,7 @@ from ...exceptions import PropagationFailure
 from ..dynamics import CR3BP_Dynamics, CR3BP_System
 from ..manifold.sections import PoincareSection, detect_crossings
 from ..results import CandidateSearchResult, ResultStatus
+from .config import TransferArc
 
 logger = logging.getLogger(__name__)
 
@@ -338,14 +339,18 @@ def _refine_lga_candidate(
     system: CR3BP_System,
     dynamics: CR3BP_Dynamics,
     target_state: np.ndarray,
-) -> LgaCandidate:
+) -> tuple[LgaCandidate, TransferArc | None]:
     """用 ThreeBodyLambert 打靶精化 LGA 候选。
 
     分两段打靶：
     1. 到达段：perilune → target（ThreeBodyLambert 打靶修正到达速度）
     2. 打靶后的到达速度更新 Δv 计算。
 
-    如果打靶未收敛、或打靶解的总 Δv 劣于网格候选，返回原始候选。
+    Returns:
+        (精化候选, 到达段弧)。精化成功时弧为打靶重传播的整段
+        (200, 6) 会合系物理 km / km/s + 秒（ADR 0040 轨迹契约）；
+        打靶未收敛或未带来改进时弧为 None（此时轨迹应由网格候选
+        的自由飞行解整段重传播得到）。
     """
     from .terminal import StateTerminal
     from .three_body_lambert import ThreeBodyLambert
@@ -392,26 +397,29 @@ def _refine_lga_candidate(
                     candidate.total_dv,
                     candidate.dv_departure + dv_arr,
                 )
-                return candidate
+                return candidate, None
 
-            return LgaCandidate(
-                departure_phase=candidate.departure_phase,
-                out_of_plane_angle=candidate.out_of_plane_angle,
-                tof_sec=candidate.tof_sec,
-                departure_state=candidate.departure_state,
-                perilune_state=candidate.perilune_state,
-                perilune_alt_km=candidate.perilune_alt_km,
-                perilune_time_dim=candidate.perilune_time_dim,
-                arrival_state=candidate.arrival_state,
-                dv_departure=candidate.dv_departure,
-                dv_arrival=dv_arr,
-                total_dv=candidate.dv_departure + dv_arr,
-                jacobi_departure=candidate.jacobi_departure,
-                jacobi_arrival=candidate.jacobi_arrival,
-                arrival_time_dim=candidate.arrival_time_dim,
-                status=ConvergenceState.CONVERGED,
-                cause=FailureCause.NONE,
-                message="找到 LGA 候选",
+            return (
+                LgaCandidate(
+                    departure_phase=candidate.departure_phase,
+                    out_of_plane_angle=candidate.out_of_plane_angle,
+                    tof_sec=candidate.tof_sec,
+                    departure_state=candidate.departure_state,
+                    perilune_state=candidate.perilune_state,
+                    perilune_alt_km=candidate.perilune_alt_km,
+                    perilune_time_dim=candidate.perilune_time_dim,
+                    arrival_state=candidate.arrival_state,
+                    dv_departure=candidate.dv_departure,
+                    dv_arrival=dv_arr,
+                    total_dv=candidate.dv_departure + dv_arr,
+                    jacobi_departure=candidate.jacobi_departure,
+                    jacobi_arrival=candidate.jacobi_arrival,
+                    arrival_time_dim=candidate.arrival_time_dim,
+                    status=ConvergenceState.CONVERGED,
+                    cause=FailureCause.NONE,
+                    message="找到 LGA 候选",
+                ),
+                arrival_leg.arcs[0],
             )
     except (RuntimeError, ValueError, np.linalg.LinAlgError, PropagationFailure):
         # PropagationFailure：打靶内部传播失败（退化候选几何可触发），
@@ -419,22 +427,25 @@ def _refine_lga_candidate(
         logger.debug("ThreeBodyLambert 打靶失败，保留原始候选", exc_info=True)
 
     # 打靶失败，返回原始候选
-    return LgaCandidate(
-        departure_phase=candidate.departure_phase,
-        out_of_plane_angle=candidate.out_of_plane_angle,
-        tof_sec=candidate.tof_sec,
-        departure_state=candidate.departure_state,
-        perilune_state=candidate.perilune_state,
-        perilune_alt_km=candidate.perilune_alt_km,
-        perilune_time_dim=candidate.perilune_time_dim,
-        arrival_state=candidate.arrival_state,
-        dv_departure=candidate.dv_departure,
-        dv_arrival=candidate.dv_arrival,
-        total_dv=candidate.total_dv,
-        jacobi_departure=candidate.jacobi_departure,
-        jacobi_arrival=candidate.jacobi_arrival,
-        arrival_time_dim=candidate.arrival_time_dim,
-        status=ConvergenceState.MAX_ITERATIONS,
-        cause=FailureCause.MAX_ITERATIONS_REACHED,
-        message="LGA 候选精化未收敛",
+    return (
+        LgaCandidate(
+            departure_phase=candidate.departure_phase,
+            out_of_plane_angle=candidate.out_of_plane_angle,
+            tof_sec=candidate.tof_sec,
+            departure_state=candidate.departure_state,
+            perilune_state=candidate.perilune_state,
+            perilune_alt_km=candidate.perilune_alt_km,
+            perilune_time_dim=candidate.perilune_time_dim,
+            arrival_state=candidate.arrival_state,
+            dv_departure=candidate.dv_departure,
+            dv_arrival=candidate.dv_arrival,
+            total_dv=candidate.total_dv,
+            jacobi_departure=candidate.jacobi_departure,
+            jacobi_arrival=candidate.jacobi_arrival,
+            arrival_time_dim=candidate.arrival_time_dim,
+            status=ConvergenceState.MAX_ITERATIONS,
+            cause=FailureCause.MAX_ITERATIONS_REACHED,
+            message="LGA 候选精化未收敛",
+        ),
+        None,
     )

--- a/e2m2e/algorithm/transfer/multi_impulse.py
+++ b/e2m2e/algorithm/transfer/multi_impulse.py
@@ -183,6 +183,24 @@ def _propagate_two_body(
     return out
 
 
+def propagate_two_body(
+    state0: npt.ArrayLike,
+    t_eval: npt.ArrayLike,
+    mu: float,
+) -> dict[str, np.ndarray]:
+    """二体数值传播（公开封装，HMN 转移弧采样用）。
+
+    Args:
+        state0: 出发状态 (6,)，km / km/s，与中心天体固连的惯性系。
+        t_eval: 采样时刻（秒，单调）；首末时刻定义积分区间。
+        mu: 中心天体 GM，km³/s²。
+
+    Returns:
+        ``{"time": (n,), "states": (n, 6)}``（DOP853，同内部精度常量）。
+    """
+    return _propagate_two_body(state0, t_eval, mu, with_stm=False)
+
+
 class MultiImpulseTransfer:
     """固定端点间的多脉冲转移规划器。
 

--- a/e2m2e/algorithm/transfer/wsb.py
+++ b/e2m2e/algorithm/transfer/wsb.py
@@ -37,6 +37,7 @@ from ...exceptions import PropagationFailure
 from ..dynamics import BCR4BP_Dynamics, BCR4BPSystem, CR3BP_Dynamics, CR3BP_System
 from ..manifold.sections import PoincareSection, detect_crossings
 from ..results import CandidateSearchResult, ResultStatus
+from .config import TransferArc
 
 logger = logging.getLogger(__name__)
 
@@ -600,11 +601,15 @@ def _refine_wsb_candidate(
     system: CR3BP_System,
     dynamics: CR3BP_Dynamics,
     target_state: np.ndarray,
-) -> WsbCandidate:
+) -> tuple[WsbCandidate, TransferArc | None]:
     """用 ThreeBodyLambert 打靶精化 WSB 候选。
 
     到达段（perilune → target）用 ThreeBodyLambert 修正到达速度。
-    打靶未达到收敛状态时返回原始候选。
+
+    Returns:
+        (精化候选, 到达段弧)。精化成功时弧为打靶重传播的整段
+        (200, 6) 会合系物理 km / km/s + 秒（ADR 0040 轨迹契约）；
+        打靶未收敛时弧为 None。
     """
     from .terminal import StateTerminal
     from .three_body_lambert import ThreeBodyLambert
@@ -643,44 +648,50 @@ def _refine_wsb_candidate(
                 raise ValueError("system.characteristic_velocity must be set")
             dv_arr = float(np.linalg.norm(v_arrival_shot - v_target_phys)) / vu_km_s
 
-            return WsbCandidate(
-                sun_phase0=candidate.sun_phase0,
-                departure_phase=candidate.departure_phase,
-                tof_sec=candidate.tof_sec,
-                departure_state=candidate.departure_state,
-                perilune_state=candidate.perilune_state,
-                perilune_alt_km=candidate.perilune_alt_km,
-                perilune_time_dim=candidate.perilune_time_dim,
-                arrival_state=candidate.arrival_state,
-                h2_kepler=candidate.h2_kepler,
-                dv_departure=candidate.dv_departure,
-                dv_arrival=dv_arr,
-                total_dv=candidate.dv_departure + dv_arr,
-                arrival_time_dim=candidate.arrival_time_dim,
-                status=ConvergenceState.CONVERGED,
-                cause=FailureCause.NONE,
-                message="找到 WSB 候选",
+            return (
+                WsbCandidate(
+                    sun_phase0=candidate.sun_phase0,
+                    departure_phase=candidate.departure_phase,
+                    tof_sec=candidate.tof_sec,
+                    departure_state=candidate.departure_state,
+                    perilune_state=candidate.perilune_state,
+                    perilune_alt_km=candidate.perilune_alt_km,
+                    perilune_time_dim=candidate.perilune_time_dim,
+                    arrival_state=candidate.arrival_state,
+                    h2_kepler=candidate.h2_kepler,
+                    dv_departure=candidate.dv_departure,
+                    dv_arrival=dv_arr,
+                    total_dv=candidate.dv_departure + dv_arr,
+                    arrival_time_dim=candidate.arrival_time_dim,
+                    status=ConvergenceState.CONVERGED,
+                    cause=FailureCause.NONE,
+                    message="找到 WSB 候选",
+                ),
+                arrival_leg.arcs[0],
             )
     except (RuntimeError, ValueError, np.linalg.LinAlgError, PropagationFailure):
         # PropagationFailure：打靶内部传播失败（退化候选几何可触发），
         # 与其他打靶失败同义——保留原始候选，不让编排器崩（#566）。
         logger.debug("ThreeBodyLambert 打靶失败，保留原始候选", exc_info=True)
 
-    return WsbCandidate(
-        sun_phase0=candidate.sun_phase0,
-        departure_phase=candidate.departure_phase,
-        tof_sec=candidate.tof_sec,
-        departure_state=candidate.departure_state,
-        perilune_state=candidate.perilune_state,
-        perilune_alt_km=candidate.perilune_alt_km,
-        perilune_time_dim=candidate.perilune_time_dim,
-        arrival_state=candidate.arrival_state,
-        h2_kepler=candidate.h2_kepler,
-        dv_departure=candidate.dv_departure,
-        dv_arrival=candidate.dv_arrival,
-        total_dv=candidate.total_dv,
-        arrival_time_dim=candidate.arrival_time_dim,
-        status=ConvergenceState.MAX_ITERATIONS,
-        cause=FailureCause.MAX_ITERATIONS_REACHED,
-        message="WSB 候选精化未收敛",
+    return (
+        WsbCandidate(
+            sun_phase0=candidate.sun_phase0,
+            departure_phase=candidate.departure_phase,
+            tof_sec=candidate.tof_sec,
+            departure_state=candidate.departure_state,
+            perilune_state=candidate.perilune_state,
+            perilune_alt_km=candidate.perilune_alt_km,
+            perilune_time_dim=candidate.perilune_time_dim,
+            arrival_state=candidate.arrival_state,
+            h2_kepler=candidate.h2_kepler,
+            dv_departure=candidate.dv_departure,
+            dv_arrival=candidate.dv_arrival,
+            total_dv=candidate.total_dv,
+            arrival_time_dim=candidate.arrival_time_dim,
+            status=ConvergenceState.MAX_ITERATIONS,
+            cause=FailureCause.MAX_ITERATIONS_REACHED,
+            message="WSB 候选精化未收敛",
+        ),
+        None,
     )

--- a/e2m2e/api/facade.py
+++ b/e2m2e/api/facade.py
@@ -808,6 +808,12 @@ class Facade:
                 if result.trajectory is not None and isinstance(result.trajectory, np.ndarray)
                 else result.trajectory
             )
+            trajectory_times = (
+                result.trajectory_times.tolist()
+                if result.trajectory_times is not None
+                and isinstance(result.trajectory_times, np.ndarray)
+                else result.trajectory_times
+            )
             status, cause, message = _result_triplet(result)
             return TransferDesignResponse(
                 status=status,
@@ -816,6 +822,7 @@ class Facade:
                 transfer_type=result.transfer_type,
                 delta_v=result.delta_v,
                 trajectory=trajectory,
+                trajectory_times=trajectory_times,
                 details=_details_to_dict(result.details),
             )
         except OrbitError:

--- a/e2m2e/api/models.py
+++ b/e2m2e/api/models.py
@@ -674,7 +674,12 @@ class TransferDesignRequest(_ApiModel):
         ),
     )
     target_orbit_radius_km: float | None = Field(
-        default=None, gt=0.0, description="目标轨道半径 (km)，HMN 必需"
+        default=None,
+        gt=0.0,
+        description=(
+            "目标轨道半径 (km)，HMN 必需；地心距——从地心量起的圆轨道半径，"
+            "非月心高度（环月取 ≈384400）"
+        ),
     )
     tof_range: list[float] | None = Field(default=None, description="飞行时间范围 [min, max]（天）")
     lga_search_params: Any = Field(default=None, description="LGA 搜索参数（LgaSearchParams 实例）")
@@ -718,7 +723,18 @@ class TransferDesignResponse(ResultResponse):
 
     transfer_type: str
     delta_v: float
-    trajectory: list[list[float]] | None
+    trajectory: list[list[float]] | None = Field(
+        default=None,
+        description=(
+            "转移轨迹 (n, 6)：地月会合旋转系、质心原点、物理单位 km / km/s"
+            "（ADR 0040；HMN 为两体几何的相位对齐显示约定，low_thrust 暂为"
+            "力模型状态系的已知不一致）"
+        ),
+    )
+    trajectory_times: list[float] | None = Field(
+        default=None,
+        description="轨迹时刻 (n,) 秒，TLI 起算（t=0 为出发脉冲），与 trajectory 逐行对齐",
+    )
     details: dict[str, Any]
 
 

--- a/tests/algorithm/transfer/test_hohmann.py
+++ b/tests/algorithm/transfer/test_hohmann.py
@@ -18,9 +18,11 @@ from e2m2e.algorithm.transfer.hohmann import (
     TliParams,
     _rotation_matrix,
     construct_departure_state,
+    eci_to_synodic_display,
     ephemeris_shoot_transfer,
     hohmann_delta_v,
     hohmann_tof,
+    hohmann_transfer_states,
     keplerian_to_cartesian,
     scan_lambert_delta_v,
 )
@@ -217,6 +219,47 @@ class TestTransferOrbitHmn:
         expected_tof = hohmann_tof(r1, r2)
         assert isinstance(result.details, HmnTransferDetails)
         assert abs(result.details.tof_sec - expected_tof) < 1e-10
+
+    def test_trajectory_pure_hohmann(self):
+        """纯霍曼路径（无 tof_range）返回会合系显示轨迹（ADR 0040）。"""
+        params = TliParams(parking_alt_km=200.0, inclination_deg=28.5)
+        r2 = 384400.0
+        result = transfer_orbit("HMN", tli_params=params, target_orbit_radius_km=r2)
+        assert result.trajectory is not None
+        traj = np.asarray(result.trajectory)
+        times = np.asarray(result.trajectory_times)
+        assert traj.shape == (200, 6)
+        assert times.shape == (200,)
+        assert times[0] == 0.0
+        r1 = R_EARTH + 200.0
+        assert times[-1] == pytest.approx(hohmann_tof(r1, r2), rel=1e-9)
+        assert np.all(np.diff(times) > 0)
+        # 相位对齐（显示约定）：到达点落在 +x 半平面，端点距地球显示
+        # 位置（−μ·DU）分别为 r1（LEO）与 r2（目标半径）
+        earth = np.array([-1.21506683e-2 * 384400.0, 0.0, 0.0])
+        departure = traj[0, :3] - earth
+        arrival = traj[-1, :3] - earth
+        assert arrival[0] > 0
+        assert np.linalg.norm(departure) == pytest.approx(r1, rel=1e-5)
+        assert np.linalg.norm(arrival) == pytest.approx(r2, rel=1e-5)
+
+    def test_trajectory_lambert_scan_path(self):
+        """tof_range Lambert 路径同样返回轨迹与时刻，端点距地球 ≈ r2。"""
+        params = TliParams(parking_alt_km=200.0, inclination_deg=0.0)
+        r2 = 42164.0  # GEO；霍曼 tof≈0.22 天，扫描范围须覆盖
+        result = transfer_orbit(
+            "HMN", tli_params=params, target_orbit_radius_km=r2, tof_range=(0.1, 0.5)
+        )
+        assert result.trajectory is not None
+        traj = np.asarray(result.trajectory)
+        times = np.asarray(result.trajectory_times)
+        assert traj.ndim == 2 and traj.shape[1] == 6
+        assert times.shape == (traj.shape[0],)
+        assert np.all(np.diff(times) > 0)
+        earth = np.array([-1.21506683e-2 * 384400.0, 0.0, 0.0])
+        arrival = traj[-1, :3] - earth
+        assert arrival[0] > 0
+        assert np.linalg.norm(arrival) == pytest.approx(r2, rel=1e-3)
 
     def test_unsupported_type_raises(self):
         """transfer_orbit("low_thrust") without engine_config 抛出 ValueError。"""
@@ -518,3 +561,64 @@ class TestEphemerisShooting:
         assert result.trajectory is not None
         assert result.trajectory.ndim == 2
         assert result.trajectory.shape[1] == 6
+        assert result.trajectory_times is not None
+        assert len(result.trajectory_times) == result.trajectory.shape[0]
+
+
+class TestHohmannTransferStates:
+    """hohmann_transfer_states + eci_to_synodic_display（ADR 0040）。"""
+
+    def test_arc_endpoint_and_times(self):
+        """两体弧采样：端点半径 r1→r2、时刻 0..tof 单调。"""
+        r1 = R_EARTH + 200.0
+        r2 = 384405.0
+        r0 = np.array([r1, 0.0, 0.0])
+        v_park = math.sqrt(MU_EARTH / r1)
+        v_dep = np.array([0.0, v_park * math.sqrt(2.0 * r2 / (r1 + r2)), 0.0])
+        tof = hohmann_tof(r1, r2)
+        states, times = hohmann_transfer_states(r0, v_dep, tof)
+        assert states.shape == (200, 6)
+        assert times.shape == (200,)
+        assert times[0] == 0.0
+        assert times[-1] == pytest.approx(tof)
+        assert np.all(np.diff(times) > 0)
+        radii = np.linalg.norm(states[:, :3], axis=1)
+        assert radii[0] == pytest.approx(r1, rel=1e-6)
+        assert radii[-1] == pytest.approx(r2, rel=1e-6)
+
+    def test_display_invariants(self):
+        """显示转换不变量：|r|/|v|/z 不变，参考方向入 +x 半平面。"""
+        mu_em, du_km = 1.21506683e-2, 384400.0
+        shift = np.array([mu_em * du_km, 0.0, 0.0])
+        states = np.array(
+            [
+                [7000.0, 0.0, 500.0, 0.0, 7.0, 1.0],
+                [-20000.0, 30000.0, -500.0, 1.0, -6.0, 0.5],
+            ]
+        )
+        ref = states[-1, :3].copy()
+        out = eci_to_synodic_display(states, ref, mu_em=mu_em, du_km=du_km)
+        # 旋转+平移不改模长与速度大小；z 不变
+        assert np.allclose(
+            np.linalg.norm(out[:, :3] + shift, axis=1),
+            np.linalg.norm(states[:, :3], axis=1),
+            rtol=1e-12,
+        )
+        assert np.allclose(
+            np.linalg.norm(out[:, 3:], axis=1),
+            np.linalg.norm(states[:, 3:], axis=1),
+            rtol=1e-12,
+        )
+        assert np.allclose(out[:, 2], states[:, 2])
+        # 参考方向（末行位置，平移前）映射到 +x 半平面且 y=0
+        ref_out = out[-1, :3] + shift
+        assert ref_out[0] > 0
+        assert ref_out[1] == pytest.approx(0.0, abs=1e-9)
+
+    def test_earth_mapped_to_minus_mu_du(self):
+        """地心（ECI 原点）映射到会合系 (−μ·DU, 0, 0)。"""
+        states = np.array([[0.0, 0.0, 0.0, 0.0, 0.0, 0.0]])
+        out = eci_to_synodic_display(states, np.array([1.0, 0.0, 0.0]))
+        assert out[0, 0] == pytest.approx(-1.21506683e-2 * 384400.0)
+        assert out[0, 1] == 0.0
+        assert out[0, 2] == 0.0

--- a/tests/algorithm/transfer/test_lga.py
+++ b/tests/algorithm/transfer/test_lga.py
@@ -210,11 +210,18 @@ class TestLgaRefine:
             pytest.skip("无可行候选，跳过精化测试")
 
         best = candidates[0]
-        refined = _refine_lga_candidate(best, system, dynamics, tgt_state)
+        refined, arrival_arc = _refine_lga_candidate(best, system, dynamics, tgt_state)
         tof_arr = (best.arrival_time_dim - best.perilune_time_dim) * system.characteristic_time
         assert refined.status is ConvergenceState.CONVERGED, (
             f"精化应收敛：best.total_dv={best.total_dv:.4f}, tof_arrival={tof_arr:.2f}s"
         )
+        # ADR 0040 契约：精化成功伴随到达段弧（(200, 6) 会合系 km + 秒，
+        # 时刻从 0 起算、末值 ≈ (arrival−perilune)×TU）；未带来改进的回退
+        # 允许弧为 None（此时轨迹由编排器整段重传播）。
+        if arrival_arc is not None:
+            assert arrival_arc.states.shape == (200, 6)
+            assert arrival_arc.times[0] == 0.0
+            assert arrival_arc.times[-1] == pytest.approx(tof_arr, rel=0.01)
 
     def test_refine_tof_arrival_correct(self, cr3bp_setup):
         """精化使用的 tof_arrival = (arrival - perilune) * char_time，而非总 TOF。"""
@@ -371,6 +378,17 @@ class TestLgaTransferOrbit:
 
         assert isinstance(result, TransferDesignResult)
         assert result.transfer_type == "LGA"
+        # ADR 0040：收敛时轨迹（会合系物理 km）与时刻（TLI 起算秒）逐行
+        # 对齐下发，时刻从 0 起单调，总时长与 details.tof_sec 一致量级
+        if result.status is ConvergenceState.CONVERGED:
+            assert result.trajectory is not None
+            traj = np.asarray(result.trajectory)
+            times = np.asarray(result.trajectory_times)
+            assert traj.ndim == 2 and traj.shape[1] == 6
+            assert times.shape == (traj.shape[0],)
+            assert times[0] == 0.0
+            assert np.all(np.diff(times) > 0)
+            assert 0.0 < times[-1] <= result.details.tof_sec * 1.3
         assert [stage.name for stage in result.stages] == ["search", "refinement", "shooting"]
         assert result.stages[0].applicable and result.stages[0].executed
         assert result.stages[0].result_status in (
@@ -642,3 +660,43 @@ class TestLgaInclinedEndToEnd:
         params = dataclasses.replace(_SEARCH_PARAMS, n_departure_phase=120, n_tof=2)
         candidates = search_lga_trajectories(dep_state, tgt_state, system, dynamics, params)
         assert len(candidates) > 0, "倾角 51.6° 应找到可行候选（面外带覆盖 0°~90°）"
+
+
+class TestTransferLegHelpers:
+    """_propagate_synodic_leg + _join_transfer_legs（ADR 0040 拼接契约）。"""
+
+    def test_leg_units_and_join_continuity(self):
+        """弧段输出为会合系物理 km + 秒；拼接去重衔接点、时刻偏移、位置连续。"""
+        from e2m2e.algorithm.transfer import _join_transfer_legs, _propagate_synodic_leg
+
+        system, dynamics = _make_cr3bp_system()
+        du = system.characteristic_length
+        vu = system.characteristic_velocity
+        tu = system.characteristic_time
+        x0 = _make_target_state(system)
+
+        t_dep = 0.25
+        dep_states, dep_times = _propagate_synodic_leg(dynamics, system, x0, t_dep, n_samples=50)
+        # 出发段终点的真值状态（无量纲）作为到达段初值，模拟拼接语义
+        full = dynamics.propagate(x0, (0.0, t_dep), t_eval=np.array([t_dep]))
+        x_mid = np.asarray(full["states"][-1], dtype=float)
+        arr_states, arr_times = _propagate_synodic_leg(dynamics, system, x_mid, 0.5, n_samples=100)
+
+        # 单位换算：位置 ×DU、时刻 ×TU，从 0 起算
+        assert dep_states.shape == (50, 6)
+        assert np.allclose(dep_states[0, :3], x0[:3] * du, rtol=1e-9)
+        assert np.allclose(dep_states[0, 3:], x0[3:] * vu, rtol=1e-9)
+        assert dep_times[0] == 0.0
+        assert dep_times[-1] == pytest.approx(t_dep * tu, rel=1e-9)
+
+        joined, joined_times = _join_transfer_legs(dep_states, dep_times, arr_states, arr_times)
+        assert joined.shape == (50 + 100 - 1, 6)
+        assert joined_times.shape == (joined.shape[0],)
+        # 到达段整体偏移到出发段时间轴，衔接点无重复时刻
+        assert joined_times[49] == pytest.approx(dep_times[-1])
+        assert joined_times[50] > joined_times[49]
+        assert joined_times[50] == pytest.approx(dep_times[-1] + arr_times[1])
+        # 拼接处位置连续：出发段末行与被去重的到达段首行是同一时刻的
+        # 同一状态（出发段 t_eval 采样 vs dense 输出重传播），差在容差内
+        seam_km = float(np.linalg.norm(dep_states[-1, :3] - arr_states[0, :3]))
+        assert seam_km < 10.0, f"拼接位置跳变 {seam_km:.3f} km 超过 10 km"

--- a/tests/algorithm/transfer/test_wsb.py
+++ b/tests/algorithm/transfer/test_wsb.py
@@ -686,7 +686,7 @@ class TestWsbDvUnits:
         )
         monkeypatch.setattr(
             "e2m2e.algorithm.transfer.wsb._refine_wsb_candidate",
-            lambda *args, **kwargs: refined,
+            lambda *args, **kwargs: (refined, None),
         )
 
         target_phys = system.dimensionless_to_physical(_make_target_state(system))

--- a/tests/api/test_facade.py
+++ b/tests/api/test_facade.py
@@ -94,6 +94,7 @@ class TestFacadeDelegation:
                 transfer_type="low_thrust",
                 delta_v=1.0,
                 trajectory=None,
+                trajectory_times=None,
                 details={},
             )
 
@@ -176,6 +177,11 @@ class TestFacadeCallChains:
         assert response.status is ConvergenceState.CONVERGED
         assert response.cause is FailureCause.NONE
         assert response.message == "霍曼转移完成"
+        # ADR 0040：收敛轨迹与会合系时刻随响应下发
+        assert response.trajectory is not None
+        assert len(response.trajectory[0]) == 6
+        assert response.trajectory_times is not None
+        assert len(response.trajectory_times) == len(response.trajectory)
 
     def test_unknown_transfer_type_is_not_implemented_error(self):
         with pytest.raises(OrbitError, match="NOT_IMPLEMENTED"):

--- a/tests/api/test_facade_responses.py
+++ b/tests/api/test_facade_responses.py
@@ -84,6 +84,7 @@ class TestTransferResponse:
                 transfer_type="HMN",
                 delta_v=3.1,
                 trajectory=np.array([[1.0] * 6]),
+                trajectory_times=np.array([0.0]),
                 details={
                     "array": np.array([1.0, 2.0]),
                     "nested": {"tuple": (np.array([3.0]), 4.0)},
@@ -98,6 +99,7 @@ class TestTransferResponse:
         )
 
         assert response.trajectory == [[1.0] * 6]
+        assert response.trajectory_times == [0.0]
         assert response.details == {"array": [1.0, 2.0], "nested": {"tuple": [[3.0], 4.0]}}
 
     def test_serializes_dataclass_details(self, monkeypatch):
@@ -111,6 +113,7 @@ class TestTransferResponse:
                 transfer_type="HMN",
                 delta_v=3.1,
                 trajectory=None,
+                trajectory_times=None,
                 details=ManeuverTable(mjd_tdb=np.array([60000.0]), delta_v_mps=np.array([1.0])),
             )
 


### PR DESCRIPTION
Closes #568
替代因 base 分支随 #567 合并删除而被自动关闭的 #569（同一内容 rebase 到新 master，PR-1 改动已识别为已应用）。

## 统一契约（ADR 0040）

`trajectory`：(n,6) 地月会合旋转系、质心原点、物理 km/km/s；`trajectory_times`：(n,) 秒，TLI 起算。与 `target_ephemeris` 输入契约（会合系物理，#516）对称；tod 画布 ÷DU_KM 即画。

## 改动

- **HMN**：纯霍曼/Lambert 两路径沿弧采样 200 点（`multi_impulse.propagate_two_body` 公开封装），`eci_to_synodic_display` 相位对齐显示转换（到达方向入 +x 半平面、地心→质心平移；显示约定非星历一致）；dynamics 收敛路径 state_patch 同过转换。
- **LGA**：`_refine_lga_candidate` 改返回 `(候选, 到达段弧|None)`——ThreeBodyLambert 已重传播的 (200,6) 会合系 km 弧不再丢弃；出发段 CR3BP 重传播 + 拼接；精化回退时候选整段自由飞行重传播。
- **WSB**：同构；出发段 BCR4BP 重传播（sun_phase0 对齐）。两段 DU 差 5 km（1.3e-5 DU）注释记录不修。
- 组装传播失败 → warn + trajectory=None 软失败。
- 响应模型/Facade 透传 `trajectory_times`；`target_orbit_radius_km` 描述补**地心距**语义。MCP/sidecar JSON 内联（不动 `_BINARY_TOOLS`）。
- low_thrust 维持现状（力模型状态系，已知不一致记入 ADR 0040）。

## 测试

HMN 两路径轨迹端点/时刻/显示不变量；LGA 端到端追加轨迹断言（组装实测 0.0s）；拼接 helper 单测（位置连续 <10 km）；facade 序列化含 trajectory_times；`make check` 全绿。已获用户合并授权（发版 5.8.9 流程）。