### PR TITLE
feat(transfer): 转移收敛响应新增 state_frame 数据系标注（ADR 0040 增补）

### DIFF
--- a/docs/adr/0040-transfer-trajectory-contract.md
+++ b/docs/adr/0040-transfer-trajectory-contract.md
@@ -82,6 +82,40 @@ requires `spacetime_transform` with real epochs — out of scope by design.
 - `_refine_lga_candidate` / `_refine_wsb_candidate` now return
   `(candidate, arrival_arc | None)`; tests calling them unpack accordingly.
 
+## Amendment (2026-08-30): `state_frame` data-frame label
+
+### Context
+
+Consumers drawing trajectories had to *guess* which frame the numbers live
+in — the root cause of tod #421 (GCRS-km propagation output drawn as
+dimensionless). No response self-describes its frame. tod's ADR 0013 already
+uses "frame" for the *view* frame (the user's synodic/inertial display
+choice), so the data-side label needs its own name.
+
+### Decision
+
+`TransferDesignResult` / `TransferDesignResponse` gains a top-level
+`state_frame` field (string enum), emitted on every converged response:
+
+- `synodic_barycentric_km` — the §1 contract (HMN/LGA/WSB trajectories).
+- `force_model_state` — low_thrust trajectories (the §2 known inconsistency,
+  named honestly rather than papered over).
+
+The vocabulary is the canonical data-frame enum going forward; later batches
+add `gcrs_km` and `synodic_barycentric_nd` when other responses (propagation,
+design) adopt the field. `state_frame` is data-side and travels with the
+numbers; tod's `view_frame` (ADR 0013) stays user-side — the two must not be
+conflated. This branch is unreleased, so the field is mandatory (no `None`
+default).
+
+### Consequences
+
+- tod renders by label instead of per-tool hardcoding; the interim hardcoded
+  fix for propagation stays until that response adopts the field.
+- MCP consumers (LLM agents) get frame semantics machine-readably.
+- low_thrust's inconsistency becomes machine-readable: a future unification
+  changes the enum value, not the contract shape.
+
 ## Consequences
 
 - MCP and sidecar consumers get the trajectory inline as JSON (transfer tools

--- a/e2m2e/algorithm/transfer/__init__.py
+++ b/e2m2e/algorithm/transfer/__init__.py
@@ -152,12 +152,26 @@ __all__ = [
     "WsbSearchParams",
     "WsbCandidate",
     "LowThrustTransferDetails",
+    "STATE_FRAME_SYNODIC_BARYCENTRIC_KM",
+    "STATE_FRAME_FORCE_MODEL_STATE",
     "transfer_orbit",
 ]
 
 
 _DEFAULT_TOF_GRID_POINTS: int = 50
 _G0: float = G0_MPS2  # m/s²，标准重力；以 thrust_arcs.G0_MPS2 为准
+
+# ADR 0040 增补：state_frame 数据系标签的转移管线取值。语义全集后续由其他
+# 响应（propagation/design）扩充 gcrs_km / synodic_barycentric_nd。
+STATE_FRAME_SYNODIC_BARYCENTRIC_KM = "synodic_barycentric_km"
+STATE_FRAME_FORCE_MODEL_STATE = "force_model_state"
+
+_STATE_FRAME_BY_TRANSFER_TYPE: dict[str, str] = {
+    "HMN": STATE_FRAME_SYNODIC_BARYCENTRIC_KM,
+    "LGA": STATE_FRAME_SYNODIC_BARYCENTRIC_KM,
+    "WSB": STATE_FRAME_SYNODIC_BARYCENTRIC_KM,
+    "low_thrust": STATE_FRAME_FORCE_MODEL_STATE,
+}
 
 
 @dataclass
@@ -172,6 +186,8 @@ class TransferDesignResult:
             low_thrust 暂为力模型状态系的已知不一致）。
         trajectory_times: 轨迹时刻 (n,) 秒，TLI 起算（t=0 为出发脉冲），
             与 trajectory 逐行对齐。
+        state_frame: trajectory 的数据系标签（ADR 0040 增补）。缺省按
+            transfer_type 派生，显式传值可覆盖。
         details: 设计细节（弹道参数汇总）。
         stages: 搜索、精化和打靶等可选阶段的执行记录。
         status: 任务最终状态。
@@ -183,6 +199,7 @@ class TransferDesignResult:
     delta_v: float
     trajectory: Any
     trajectory_times: Any = None
+    state_frame: str = ""
     details: (
         HmnTransferDetails
         | LgaTransferDetails
@@ -197,6 +214,13 @@ class TransferDesignResult:
 
     def __post_init__(self) -> None:
         ResultStatus(self.status, self.cause, self.message)
+        if not self.state_frame:
+            derived = _STATE_FRAME_BY_TRANSFER_TYPE.get(self.transfer_type)
+            if derived is None:
+                raise ValueError(
+                    f"transfer_type {self.transfer_type!r} 无 state_frame 派生规则，须显式指定"
+                )
+            self.state_frame = derived
 
 
 @dataclass

--- a/e2m2e/api/facade.py
+++ b/e2m2e/api/facade.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 
 import dataclasses
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 import numpy as np
 
@@ -823,6 +823,12 @@ class Facade:
                 delta_v=result.delta_v,
                 trajectory=trajectory,
                 trajectory_times=trajectory_times,
+                # __post_init__ 派生保证取值在 Literal 集内；显式覆盖属 ADR 0040
+                # 扩展路径，越界值由响应构造期的 pydantic 校验兜底。
+                state_frame=cast(
+                    Literal["synodic_barycentric_km", "force_model_state"],
+                    result.state_frame,
+                ),
                 details=_details_to_dict(result.details),
             )
         except OrbitError:

--- a/e2m2e/api/models.py
+++ b/e2m2e/api/models.py
@@ -12,7 +12,7 @@ import warnings
 from collections.abc import Mapping
 from dataclasses import dataclass
 from types import MappingProxyType
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -734,6 +734,16 @@ class TransferDesignResponse(ResultResponse):
     trajectory_times: list[float] | None = Field(
         default=None,
         description="轨迹时刻 (n,) 秒，TLI 起算（t=0 为出发脉冲），与 trajectory 逐行对齐",
+    )
+    # 字面量与 e2m2e/algorithm/transfer 的 STATE_FRAME_* 常量同源，改动须两侧同步；
+    # 此处不导入以保持 models 层轻依赖（schema 出口）。
+    state_frame: Literal["synodic_barycentric_km", "force_model_state"] = Field(
+        description=(
+            "trajectory 的数据系标签（ADR 0040 增补）：synodic_barycentric_km"
+            " = 地月会合旋转系质心原点物理 km/km/s（HMN/LGA/WSB）；"
+            "force_model_state = 力模型状态系（low_thrust，已知不一致）。"
+            "语义全集后续批次扩充 gcrs_km / synodic_barycentric_nd"
+        ),
     )
     details: dict[str, Any]
 

--- a/tests/algorithm/transfer/test_hohmann.py
+++ b/tests/algorithm/transfer/test_hohmann.py
@@ -8,6 +8,8 @@ import numpy as np
 import pytest
 
 from e2m2e.algorithm.transfer import (
+    STATE_FRAME_FORCE_MODEL_STATE,
+    STATE_FRAME_SYNODIC_BARYCENTRIC_KM,
     HmnTransferDetails,
     TransferDesignResult,
     transfer_orbit,
@@ -226,6 +228,7 @@ class TestTransferOrbitHmn:
         r2 = 384400.0
         result = transfer_orbit("HMN", tli_params=params, target_orbit_radius_km=r2)
         assert result.trajectory is not None
+        assert result.state_frame == STATE_FRAME_SYNODIC_BARYCENTRIC_KM
         traj = np.asarray(result.trajectory)
         times = np.asarray(result.trajectory_times)
         assert traj.shape == (200, 6)
@@ -265,6 +268,38 @@ class TestTransferOrbitHmn:
         """transfer_orbit("low_thrust") without engine_config 抛出 ValueError。"""
         with pytest.raises(ValueError, match="low_thrust"):
             transfer_orbit("low_thrust")
+
+    def test_state_frame_derivation(self):
+        """state_frame 按 transfer_type 派生（ADR 0040 增补），可显式覆盖。"""
+        assert (
+            TransferDesignResult(transfer_type="HMN", delta_v=1.0, trajectory=None).state_frame
+            == STATE_FRAME_SYNODIC_BARYCENTRIC_KM
+        )
+        assert (
+            TransferDesignResult(transfer_type="LGA", delta_v=1.0, trajectory=None).state_frame
+            == STATE_FRAME_SYNODIC_BARYCENTRIC_KM
+        )
+        assert (
+            TransferDesignResult(transfer_type="WSB", delta_v=1.0, trajectory=None).state_frame
+            == STATE_FRAME_SYNODIC_BARYCENTRIC_KM
+        )
+        assert (
+            TransferDesignResult(
+                transfer_type="low_thrust", delta_v=1.0, trajectory=None
+            ).state_frame
+            == STATE_FRAME_FORCE_MODEL_STATE
+        )
+        assert (
+            TransferDesignResult(
+                transfer_type="HMN",
+                delta_v=1.0,
+                trajectory=None,
+                state_frame="gcrs_km",
+            ).state_frame
+            == "gcrs_km"
+        )
+        with pytest.raises(ValueError, match="state_frame"):
+            TransferDesignResult(transfer_type="bogus", delta_v=1.0, trajectory=None)
 
 
 class TestHmnTransferPhysics:

--- a/tests/algorithm/transfer/test_lga.py
+++ b/tests/algorithm/transfer/test_lga.py
@@ -389,6 +389,7 @@ class TestLgaTransferOrbit:
             assert times[0] == 0.0
             assert np.all(np.diff(times) > 0)
             assert 0.0 < times[-1] <= result.details.tof_sec * 1.3
+            assert result.state_frame == "synodic_barycentric_km"
         assert [stage.name for stage in result.stages] == ["search", "refinement", "shooting"]
         assert result.stages[0].applicable and result.stages[0].executed
         assert result.stages[0].result_status in (

--- a/tests/api/test_facade.py
+++ b/tests/api/test_facade.py
@@ -95,6 +95,7 @@ class TestFacadeDelegation:
                 delta_v=1.0,
                 trajectory=None,
                 trajectory_times=None,
+                state_frame="force_model_state",
                 details={},
             )
 
@@ -182,6 +183,8 @@ class TestFacadeCallChains:
         assert len(response.trajectory[0]) == 6
         assert response.trajectory_times is not None
         assert len(response.trajectory_times) == len(response.trajectory)
+        # ADR 0040 增补：数据系标签随响应下发
+        assert response.state_frame == "synodic_barycentric_km"
 
     def test_unknown_transfer_type_is_not_implemented_error(self):
         with pytest.raises(OrbitError, match="NOT_IMPLEMENTED"):

--- a/tests/api/test_facade_responses.py
+++ b/tests/api/test_facade_responses.py
@@ -85,6 +85,7 @@ class TestTransferResponse:
                 delta_v=3.1,
                 trajectory=np.array([[1.0] * 6]),
                 trajectory_times=np.array([0.0]),
+                state_frame="synodic_barycentric_km",
                 details={
                     "array": np.array([1.0, 2.0]),
                     "nested": {"tuple": (np.array([3.0]), 4.0)},
@@ -100,6 +101,7 @@ class TestTransferResponse:
 
         assert response.trajectory == [[1.0] * 6]
         assert response.trajectory_times == [0.0]
+        assert response.state_frame == "synodic_barycentric_km"
         assert response.details == {"array": [1.0, 2.0], "nested": {"tuple": [[3.0], 4.0]}}
 
     def test_serializes_dataclass_details(self, monkeypatch):
@@ -114,6 +116,7 @@ class TestTransferResponse:
                 delta_v=3.1,
                 trajectory=None,
                 trajectory_times=None,
+                state_frame="synodic_barycentric_km",
                 details=ManeuverTable(mjd_tdb=np.array([60000.0]), delta_v_mps=np.array([1.0])),
             )
 


### PR DESCRIPTION
## 内容

ADR 0040 增补（2026-08-30）：转移收敛响应新增 `state_frame` 数据系标签，让 LLM/GUI 无需猜测轨迹数据所在坐标系。

- `TransferDesignResult.state_frame`：经 `__post_init__` 按 transfer 类型派生——HMN/LGA/WSB → `synodic_barycentric_km`（会合系物理 km，ADR 0040 契约），low_thrust → `force_model_state`（力模型状态系，已知不一致，ADR 已记录）；未知类型无派生规则时 `ValueError` 提示显式指定。六个构造点零改动。
- `TransferDesignResponse.state_frame`：`Literal["synodic_barycentric_km", "force_model_state"]`，注释约束与算法层常量同源（models 层保持轻依赖不反向导入）；MCP/sidecar schema 同步获得该字段。
- facade 透传；ADR 0040 追加增补节（字段随合入版本 5.8.10 直接落地，无过渡期）。

## 测试

- 派生规则（4 类型）/显式覆盖（`gcrs_km` 预留）/未知类型报错
- facade HMN 断言 + 序列化透传（本地 110 passed；HMN/LGA 优化用例约 32 min，debug 扩展）

下游：tod 双层画布 PR 将在发版后 bump pin ≥5.8.10。