### PR TITLE
feat(taxonomy): 轨道分类学 42 标签内核 + 入库打标 + 响应富化（#581 / ADR 0042）

### DIFF
--- a/docs/adr/0042-orbit-taxonomy-classification.md
+++ b/docs/adr/0042-orbit-taxonomy-classification.md
@@ -1,0 +1,157 @@
+# ADR 0042: orbit taxonomy — 42-label classification of CR3BP periodic orbits
+
+**Status**: Adopted (implemented)
+**Date**: 2026-08-30
+**Related**: ADR 0012 (layering), ADR 0014 (facade tiers), ADR 0031 (catalog
+records), ADR 0036 (baseline dataset), ADR 0040 (state_frame), ADR 0041
+(spatiography — the sibling single-state partition axis); issue #581.
+
+## Context
+
+e2m2e labels an orbit's family only at design time: the differential corrector
+echoes its correction setup, and catalog ingest copies the design-side family
+name into `classification.orbit_family`. Nothing can answer the reverse
+question — "given a trajectory, which family is it?". The spatiography
+classifier (ADR 0041) answers a different question (single state → spatial
+province).
+
+Issue #581 adopts a three-tier orbit taxonomy of 42 labels. The vocabulary
+comes verbatim from the STK **CODE** (Cislunar Orbit Designer) component,
+which is unreleased: there is no citable source for the labels' *semantics*
+and no published classification algorithm. As with ADR 0041's MEGNO
+thresholds (Primer §7 left them unspecified), the criteria below are
+e2m2e's own analytic definitions, calibrated against the packaged baseline
+dataset (ADR 0036) and recorded here in full.
+
+## Decision
+
+### 1. Taxonomy and label vocabulary
+
+42 labels = 27 libration-point + 4 moon-centered + 11 resonant (the issue
+list, verbatim). Each label carries a structured form — category
+(`libration_point` / `moon_centered` / `resonant`), family, libration point
+(1–5 or null), hemisphere (`northern` / `southern` / `eastern` / `western`
+or null), resonance (p:q or null) — plus a snake_case canonical string
+(`halo_l2_northern`, `low_prograde_eastern`, `resonant_2_1`). The canonical
+string is the serialization key everywhere (MCP responses, catalog records);
+the structured form is restored by parsing (labels legend).
+
+### 2. Classifier contract
+
+`classify_orbit(states, times=None, *, period=None, mu=None,
+periodicity="periodic") -> TaxonomyResult` in
+`e2m2e/algorithm/orbit_taxonomy/`. The result carries the status triplet,
+ordered labels (primary first), an `unclassified_reason`, and per-criterion
+diagnostics. Two input forms share one criteria path:
+
+- a full one-period closed trajectory (consumed as given), or
+- the minimal form — a single crossing state + period (the repository's
+  family-member storage form) — propagated one period internally.
+
+`unclassified` is a legal converged outcome (empty labels + reason:
+`non_periodic`, `quasi_periodic`, `no_matching_label`), not a failure;
+invalid input and minimal-form propagation failure are FAILED states.
+
+### 3. Criteria cascade (order is precedence; all quantities nondimensional
+synodic)
+
+1. `periodicity` gate: quasi-periodic → unclassified.
+2. **Moon-centered**: planar (max |z| ≤ 1e-7), net winding about the Moon
+   ≥ 1.5π, and ρ_max ≤ μ^(2/5) (Chebotarev SOI, Primer §5.4.2 — the extent
+   gate that keeps deep-perilune NRHO members in the libration branch).
+   Retrograde (moon-centered h_z < 0) → `distant_retrograde`; prograde
+   splits at ρ_max = 0.031 (≈12 000 km, the repository's low-lunar-orbit
+   parameter ceiling) into `distant_prograde` and
+   `low_prograde_{eastern,western}` (east = perilune direction in the +y
+   half-plane, the direction of lunar orbital motion).
+3. **L4/L5**: planar, winding about L4 or L5, localization ≤ 0.15;
+   T/T☾ > 2 → `longperiod_l{4,5}`, else `shortperiod_l{4,5}`.
+4. **Collinear points**: winding about an L, or (the no-winding fallback for
+   deep-perilune members) 3D with perpendicular x-z-plane crossings and
+   orbit-to-point distance ≤ 0.25. Side: time-mean x relative to the Moon —
+   < −0.5 → L3, < 0 → L1, > 0 → L2 (the four baseline halo/NRHO families
+   separate with zero overlap). Family by crossing geometry: 2 / 4 / 6
+   perpendicular y = 0 crossings per period → halo / butterfly / dragonfly
+   (hemisphere = sign of z at the vy < 0 crossing); 3D with non-perpendicular
+   y = 0 crossings → axial (the axial seed carries vz ≠ 0); 3D with
+   perpendicular z = 0 crossings only → vertical; planar with perpendicular
+   crossings → lyapunov.
+5. **Resonant**: net winding about the barycenter ≥ 1.5π and
+   |T/T☾ − q/p| < 0.01 → `resonant_p_q` (p:q = satellite:moon,
+   T/T☾ = q/p — same orientation as the ADR 0041 resonance ladders).
+6. Otherwise `no_matching_label`.
+
+Multi-label: a moon-centered or L4/L5 hit whose period is also commensurate
+appends the resonant label (primary stays the moon/libration family).
+
+### 4. Verification status per label
+
+Baseline-verified with real trajectories (all members): `halo_l1/l2`
+northern+southern, `axial_l1/l2`, `distant_retrograde`, `distant_prograde`,
+`low_prograde_*`, `longperiod_l4`, `shortperiod_l4`. Criteria-level synthetic
+coverage only (no design capability yet): `lyapunov_l1–l3`, `axial_l3–l5`,
+`vertical_l1–l5`, `butterfly_*`, `dragonfly_*`, all `resonant_*`,
+`longperiod_l5` / `shortperiod_l5`, `halo_l3_*`. The synthetic curves verify
+the crossing/winding geometry criteria, not dynamical solutions.
+
+### 5. Wiring (no new MCP tool)
+
+The maintainer's principle: expose only the highest-level Facade; the tool
+count stays 22.
+
+- **Ingest stamps measured labels**: `classification.taxonomy_labels`
+  (record-level deduplicated set) and `members[].taxonomy_label` (member
+  primary); the design-side family label remains as provenance. Conflict
+  against the design-side expectation map logs a warning and never fails.
+  Families outside the taxonomy (quasi-periodic lissajous, horseshoe, elfo)
+  are stamped empty without running the classifier.
+- **Index**: a `taxonomy_labels` column (schema-reset rebuild per ADR 0031
+  decision 5); `promote_member` inherits the member's measured label — the
+  data layer never imports the classifier.
+- **Response enrichment**: `design_orbit`, `orbit_family_generation`,
+  `catalog_query` / `catalog_get` responses carry `taxonomy_labels`.
+  `orbit_propagation` is deliberately NOT enriched: it is the force-model
+  ephemeris tool and would carry a permanent unclassified field — the same
+  noise argument that excluded the transfer tools (a deviation from the
+  issue brief, recorded here).
+- **Backfill**: `scripts/backfill_baseline_taxonomy.py` stamps the packaged
+  baseline through the same ingest path.
+
+### 6. Conventions
+
+p:q counts satellite revolutions per lunar revolution (T/T☾ = q/p; 2:1 is
+interior). Northern/southern = sign of z at the vy < 0 crossing (the same
+geometry the design side encodes as `halo_class`). Eastern/western =
+perilune half-plane in the moon-centered synodic frame. NRHO folds into
+halo (same family, high-amplitude near-rectilinear arc).
+
+## Reproduction notes
+
+- **dpo baseline members 0–3 are retrograde.** The design-side family walk
+  started on the retrograde branch; geometrically they are small retrograde
+  lunar orbits → `distant_retrograde`, and the backfill logs four conflicts
+  against the prograde expectation. Measured labels win; design labels stay
+  as provenance.
+- **nrho-l2's record class disagrees with its geometry.** The baseline
+  records `halo_class=1` (south) while every seed has z0 > 0 at the vy < 0
+  crossing → the taxonomy says `halo_l2_northern`. The taxonomy follows
+  trajectory geometry; the design-side label is preserved unchanged.
+- **The horseshoe family overlaps lpo.** Its endpoint members are identical
+  to lpo-l4's largest (large-amplitude tadpoles, libration ≲ 50°). Per the
+  mapping they ingest as empty labels, but a bare classifier call on such a
+  trajectory returns `longperiod_l4` — the taxonomy simply has no horseshoe
+  label.
+- **Deep-perilune NRHO members wind the Moon** (ρ_min down to 2 700 km).
+  Winding alone would misroute them to moon-centered; the ρ_SOI extent gate
+  is what keeps them in the halo branch.
+
+## Consequences
+
+Classification is deterministic, explainable (full criteria diagnostics in
+every result), and anchored to real trajectories for every family the
+repository can generate. Labels whose families lack design capability rest
+on self-defined geometry; when those pipelines land, the baseline-anchored
+tests should be extended to replace the synthetic ones. The expectation map
+in `catalog_ingest` is the single place design-side vocabulary and taxonomy
+meet; a future vocabulary change (e.g. STK CODE publishing its semantics)
+is a one-map edit plus an ADR amendment.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -112,3 +112,4 @@ ADRs.
 | 0039 | Shared-kernel leaf modules at the package root | Adopted (implemented) |
 | 0040 | transfer_design converged trajectory: unified synodic-frame contract with trajectory_times | Adopted (implemented) |
 | 0041 | spatiography — cislunar partition (Primer) analytic core: five-province taxonomy, [primer] constants, scales/classify/boundaries tools | Adopted (implemented) |
+| 0042 | orbit taxonomy — 42-label classification of CR3BP periodic orbits: STK CODE vocabulary, self-defined analytic criteria, ingest stamping and response enrichment | Adopted (implemented) |

--- a/docs/reference/glossary.rst
+++ b/docs/reference/glossary.rst
@@ -213,3 +213,35 @@ Spatiography terms
       Adjacent partition zones intentionally overlap near their edges
       (Primer Table 4 note); classifiers therefore return ordered
       multi-labels instead of one exclusive zone.
+
+Orbit taxonomy terms
+~~~~~~~~~~~~~~~~~~~~
+
+.. glossary::
+
+   Orbit taxonomy
+      The 42-label classification of CR3BP periodic orbits (ADR 0042):
+      27 libration-point + 4 moon-centered + 11 resonant labels, adopted
+      verbatim from the unreleased STK CODE (Cislunar Orbit Designer)
+      component. Criteria are e2m2e's own analytic definitions.
+
+   Taxonomy label
+      Structured label (category / family / libration point / hemisphere /
+      resonance) with a snake_case canonical string such as
+      ``halo_l2_northern`` as the serialization key. Classification is
+      measured from the trajectory — never copied from design-side family
+      names, which remain as provenance.
+
+   Unclassified
+      A legal converged classification outcome (empty label list + reason:
+      non-periodic, quasi-periodic, or no matching label) — not an error.
+
+   Resonance ratio p:q
+      p satellite revolutions per q lunar revolutions, T/T☾ = q/p (2:1 is
+      interior) — the same orientation as the spatiography resonance
+      ladders' k:k_b.
+
+   Measured stamping
+      Catalog ingest runs the classifier on member trajectories and stores
+      ``taxonomy_labels`` alongside the design-side family label; a mismatch
+      logs a warning and never fails (ADR 0042 decision 5).

--- a/e2m2e/algorithm/orbit_taxonomy/__init__.py
+++ b/e2m2e/algorithm/orbit_taxonomy/__init__.py
@@ -1,0 +1,29 @@
+"""轨道分类学内核（orbit taxonomy）：42 标签词汇与周期轨道分类器。
+
+词汇与判据的权威记录是 ADR 0042；本包只做实现。分类是"给一条轨迹
+推断族标签"，与设计侧的 ``OrbitFamilyType``（生成时已知族）是两个
+方向的问题，两者经 ADR 0042 映射表对齐。
+"""
+
+from .classify import TaxonomyResult, classify_orbit
+from .labels import (
+    TAXONOMY,
+    TAXONOMY_BY_CANONICAL,
+    Hemisphere,
+    TaxonomyCategory,
+    TaxonomyLabel,
+    label_legend,
+    parse_taxonomy_label,
+)
+
+__all__ = [
+    "TAXONOMY",
+    "TAXONOMY_BY_CANONICAL",
+    "Hemisphere",
+    "TaxonomyCategory",
+    "TaxonomyLabel",
+    "TaxonomyResult",
+    "classify_orbit",
+    "label_legend",
+    "parse_taxonomy_label",
+]

--- a/e2m2e/algorithm/orbit_taxonomy/classify.py
+++ b/e2m2e/algorithm/orbit_taxonomy/classify.py
@@ -1,0 +1,488 @@
+"""轨道分类学分类器（orbit taxonomy classify）。
+
+42 标签词汇见 ``labels.py``；本模块实现"给一条 CR3BP 会合系周期轨迹
+推断族标签"的解析判据。词汇采自 STK 未发布 CODE 组件，**判据为
+e2m2e 自定**——无公开出处可抄，全部阈值与级联顺序的权威记录是
+ADR 0042，测试以随包 baseline 数据集为回归锚点。
+
+输入两种形态（ADR 0042 决策 2）：
+
+- 整条周期轨迹（``states`` n≥2，覆盖一个周期、首末闭合）——按输入
+  原样消费，不重传播；
+- 最小形态（``states`` (1,6) + ``period``——轨道族成员的仓库存储
+  形态）——内部传播一个周期物化轨迹后统一处理。
+
+判据级联（顺序即优先序，ADR 0042 决策 3）：
+
+1. ``periodicity="quasi-periodic"`` → unclassified（合法输出非失败）。
+2. **月心分支**：平面轨道（z 恒为零）、绕月净卷绕 ≈ ±2π、月心最大
+   半径 ≤ ρ_SOI = μ^(2/5)（Chebotarev 口径，Primer §5.4.2）。SOI
+   展布闸把深近月 NRHO 端成员（绕月但展布超 SOI）留给平动点分支。
+   逆行 → distant_retrograde；顺行按 ρ_max 分 distant_prograde /
+   low_prograde（东西 = 月心会合系近月点方向半平面，+y 朝月球公转
+   方向为东）。
+3. **L4/L5 分支**：平面轨道绕 L4 或 L5 净卷绕 ≈ ±2π：T/T☾ > 2 →
+   longperiod_l{4,5}，否则 shortperiod_l{4,5}。
+4. **共线平动点分支**：绕某共线 L 净卷绕，或（深近月端成员不卷绕
+   任何 L 的回退路径）三维且有 x-z 面垂直穿越、距共线 L 足够近。
+   侧别（L1/L2/L3）由轨迹时间平均 x 相对月球的符号定（L3 另加
+   x̄ < -0.5 闸）。族形态按穿越几何：
+
+   - x-z 面垂直穿越（穿越处 vx≈vz≈0）每周期 2/4/6 次 → halo /
+     butterfly / dragonfly（南北 = vy<0 穿越处的 z 符号）；
+   - 三维、有 x-z 面穿越但非垂直（axial 族种子 vz≠0）→ axial；
+   - 三维、无垂直 x-z 穿越但有垂直 z=0 面穿越 → vertical；
+   - 平面且垂直穿越 → lyapunov。
+
+5. **共振分支**：绕质心净卷绕 ≈ ±2π 且 T/T☾ 与 11 个比值的 q/p
+   通约（容差 0.01）→ resonant_p_q。
+6. 其余 → unclassified("no_matching_label")。
+
+多标签：月心/L4/L5 命中且周期同时通约 → 追加 resonant 标签
+（primary 取月心/L4/L5 族）。设计侧族 ↔ 分类标签的映射与入库
+冲突策略见 ADR 0042 映射表，落在 catalog_ingest 模块。
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from functools import lru_cache
+
+import numpy as np
+
+from ...data.constants import Datum
+from ...status import ConvergenceState, FailureCause, ResultStatus
+from ..dynamics import CR3BP_Dynamics
+from ..dynamics.cr3bp_system import CR3BP_System
+from .labels import TAXONOMY_BY_CANONICAL, Hemisphere, TaxonomyLabel
+
+__all__ = ["TaxonomyResult", "classify_orbit"]
+
+#: 绕天体/平动点净卷绕判据：|Δθ| ≥ 1.5π 视为环绕一周。
+_WINDING_GATE = 1.5 * math.pi
+
+#: 月心分支的展布闸指数：ρ_max ≤ μ^(2/5)（Chebotarev SOI）。
+_SOI_EXPONENT = 0.4
+
+#: 顺行月心族的 low/distant 分界（无量纲 ≈12000 km）：仓库低月轨道
+#: 参数域（近月高度 ≤10000 km）上缘加月半径的量级。
+_LOW_PROGRADE_RHO_MAX = 0.031
+
+#: L4/L5 长短周期分界：T/T☾ > 2 为长周期（baseline：spo≈1.05、lpo≈3.36）。
+_LONGPERIOD_T_RATIO = 2.0
+
+#: 平面判据：全程 |z| 最大值（平面族是会合系不变流形，传播后严格为 0；
+#: 三维族最小 z 振幅 ≈6.5e-4）。
+_PLANAR_Z_MAX = 1e-7
+
+#: 垂直穿越判据：穿越处横向速度 |vx|、|vz|（y=0 面）或 |vx|、|vy|
+#: （z=0 面）。halo/lyapunov 穿越处理论为 0；axial 族种子 vz ≥ 1e-3。
+_PERP_V_GATE = 5e-4
+
+#: 共振通约容差：|T/T☾ − q/p| < 0.01。
+_RESONANCE_TOL = 0.01
+
+#: L1/L3 侧别闸：时间平均 x < -0.5 归 L3（L1 族 x̄ ≥ -0.15）。
+_L3_MEAN_X_GATE = -0.5
+
+#: L4/L5 分支的局域化闸：轨道到三角平动点的最小距离（spo/lpo 实测
+#: ≤0.095；远距绕地圆虽把 L4 圈在内但距离 ≥0.6，不得误入）。
+_TRIANGULAR_EXTENT_GATE = 0.15
+
+#: 共线分支的轨道-共线 L 最小距离闸（卷绕与回退路径共用；深近月
+#: NRHO 端 ≈0.17，远距绕地圆 ≥0.6 不得误入）。
+_COLLINEAR_EXTENT_GATE = 0.25
+
+#: 最小形态内部传播的每周期采样点数。
+_N_SAMPLES = 720
+
+#: 轨迹闭合判据（首末状态差的相对范数）。
+_CLOSURE_TOL = 1e-5
+
+#: 11 个共振比 (p, q)，p:q = 卫星:月球，T/T☾ = q/p。
+_RESONANCES: tuple[tuple[int, int], ...] = (
+    (1, 1),
+    (1, 2),
+    (1, 3),
+    (1, 4),
+    (2, 1),
+    (3, 1),
+    (3, 2),
+    (3, 4),
+    (2, 3),
+    (4, 1),
+    (4, 3),
+)
+
+
+@dataclass(frozen=True)
+class TaxonomyResult:
+    """分类结果（状态契约：status/cause/message 三元组）。
+
+    unclassified 是合法输出（labels 为空 + unclassified_reason），
+    不是失败；失败（非法输入、最小形态传播失败）走 FAILED 状态。
+    """
+
+    status: ConvergenceState
+    cause: FailureCause
+    message: str
+    labels: tuple[TaxonomyLabel, ...] = ()
+    unclassified_reason: str | None = None
+    diagnostics: dict[str, float | int | str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        ResultStatus(self.status, self.cause, self.message)
+
+    @property
+    def primary(self) -> TaxonomyLabel | None:
+        """主标签（多标签时取第一项）。"""
+        return self.labels[0] if self.labels else None
+
+    @property
+    def canonical_labels(self) -> tuple[str, ...]:
+        """规范字符串形式的标签序列（序列化键，MCP/catalog 用）。"""
+        return tuple(label.canonical for label in self.labels)
+
+
+@lru_cache(maxsize=4)
+def _default_dynamics(mu: float) -> CR3BP_Dynamics:
+    """按 μ 缓存的默认地月 CR3BP 动力学（最小形态传播用）。"""
+    return CR3BP_Dynamics(CR3BP_System(mu=mu, primary="earth", secondary="moon"))
+
+
+@lru_cache(maxsize=4)
+def _libration_points(mu: float) -> dict[int, np.ndarray]:
+    """五平动点位置（解析求根并按 μ 缓存）。"""
+    system = CR3BP_System(mu=mu, primary="earth", secondary="moon")
+    points = system.compute_libration_points()
+    return {int(point.name[1]): np.asarray(pos, dtype=float) for point, pos in points.items()}
+
+
+def _resonance_label(t_ratio: float) -> TaxonomyLabel | None:
+    """T/T☾ 与 11 个比值通约时返回 resonant 标签（取最近者）。"""
+    best: tuple[float, tuple[int, int]] | None = None
+    for p, q in _RESONANCES:
+        gap = abs(t_ratio - q / p)
+        if gap < _RESONANCE_TOL and (best is None or gap < best[0]):
+            best = (gap, (p, q))
+    if best is None:
+        return None
+    return TAXONOMY_BY_CANONICAL[f"resonant_{best[1][0]}_{best[1][1]}"]
+
+
+@dataclass
+class _Features:
+    """一个周期轨迹的分类特征（全部无量纲会合系量）。"""
+
+    t_ratio: float
+    winding_moon: float
+    winding_earth: float
+    windings_l: dict[int, float]
+    rho_max: float
+    z_abs_max: float
+    mean_x_rel_moon: float
+    moon_prograde: bool | None  # None = 近月点处 h_z≈0（不判月心顺逆）
+    perilune_azimuth: float  # 月心会合系近月点方向角（弧度，(-π, π]）
+    crossings_y0: list[np.ndarray]  # y=0 面穿越状态（线性内插）
+    perp_y0: list[np.ndarray]  # 其中垂直穿越（|vx|、|vz| 均小于门）的子集
+    perp_z0: list[np.ndarray]  # z=0 面垂直穿越（|vx|、|vy| 均小于门）
+    min_collinear_dist: float
+    min_triangular_dist: float
+
+
+def _winding(pos: np.ndarray, center_x: float, center_y: float) -> float:
+    """绕 (center_x, center_y) 的净方位角变化（解卷绕）。"""
+    theta = np.unwrap(np.arctan2(pos[:, 1] - center_y, pos[:, 0] - center_x))
+    return float(theta[-1] - theta[0])
+
+
+def _crossings(states: np.ndarray, axis: int) -> list[np.ndarray]:
+    """``axis`` 分量变号处的线性内插穿越状态。
+
+    ``axis=1`` 为 y=0（x-z 面）穿越；``axis=2`` 为 z=0（轨道面）穿越。
+    周期轨迹首末点重复落在同一穿越上（如 halo 种子 y(0)=y(T)=0），
+    末段（内插分数 >0.999）按周期重复丢弃，避免重复计数。
+    """
+    values = states[:, axis]
+    crossed: list[np.ndarray] = []
+    for k in np.where(np.diff(np.sign(values)) != 0)[0]:
+        frac = -values[k] / (values[k + 1] - values[k])
+        if frac > 0.999:
+            continue
+        crossed.append(states[k] + frac * (states[k + 1] - states[k]))
+    return crossed
+
+
+def _extract_features(states: np.ndarray, period: float, mu: float) -> _Features:
+    pos = states[:, :3]
+    moon_x = 1.0 - mu
+    rel = pos - np.array([moon_x, 0.0, 0.0])
+    rho = np.linalg.norm(rel, axis=1)
+    l_positions = _libration_points(mu)
+
+    perilune = int(np.argmin(rho))
+    h_z = float(rel[perilune, 0] * states[perilune, 4] - rel[perilune, 1] * states[perilune, 3])
+    crossings_y0 = _crossings(states, 1)
+    perp_y0 = [s for s in crossings_y0 if abs(s[3]) < _PERP_V_GATE and abs(s[5]) < _PERP_V_GATE]
+    perp_z0 = [
+        s for s in _crossings(states, 2) if abs(s[3]) < _PERP_V_GATE and abs(s[4]) < _PERP_V_GATE
+    ]
+    return _Features(
+        t_ratio=period / (2.0 * math.pi),
+        winding_moon=_winding(pos, moon_x, 0.0),
+        winding_earth=_winding(pos, 0.0, 0.0),
+        windings_l={point: _winding(pos, lp[0], lp[1]) for point, lp in l_positions.items()},
+        rho_max=float(rho.max()),
+        z_abs_max=float(np.abs(pos[:, 2]).max()),
+        mean_x_rel_moon=float(np.mean(pos[:, 0]) - moon_x),
+        moon_prograde=(None if abs(h_z) < 1e-12 else h_z > 0.0),
+        perilune_azimuth=float(np.arctan2(rel[perilune, 1], rel[perilune, 0])),
+        crossings_y0=crossings_y0,
+        perp_y0=perp_y0,
+        perp_z0=perp_z0,
+        min_collinear_dist=min(
+            float(np.min(np.linalg.norm(pos - l_positions[point], axis=1))) for point in (1, 2, 3)
+        ),
+        min_triangular_dist=min(
+            float(np.min(np.linalg.norm(pos - l_positions[point], axis=1))) for point in (4, 5)
+        ),
+    )
+
+
+def _diagnostics(f: _Features, mu: float, reason: str | None) -> dict[str, float | int | str]:
+    diag: dict[str, float | int | str] = {
+        "t_over_t_moon": round(f.t_ratio, 6),
+        "winding_moon": round(f.winding_moon, 3),
+        "winding_earth": round(f.winding_earth, 3),
+        "rho_max": round(f.rho_max, 6),
+        "soi_moon": round(mu**_SOI_EXPONENT, 6),
+        "z_abs_max": float(f.z_abs_max),
+        "mean_x_rel_moon": round(f.mean_x_rel_moon, 6),
+        "n_crossings_y0": len(f.crossings_y0),
+        "n_perp_crossings_y0": len(f.perp_y0),
+        "n_perp_crossings_z0": len(f.perp_z0),
+    }
+    if reason is not None:
+        diag["unclassified_reason"] = reason
+    return diag
+
+
+def _ok(labels: list[TaxonomyLabel], f: _Features, mu: float) -> TaxonomyResult:
+    return TaxonomyResult(
+        ConvergenceState.CONVERGED,
+        FailureCause.NONE,
+        "ok",
+        labels=tuple(labels),
+        diagnostics=_diagnostics(f, mu, None),
+    )
+
+
+def _unclassified(reason: str, f: _Features, mu: float) -> TaxonomyResult:
+    return TaxonomyResult(
+        ConvergenceState.CONVERGED,
+        FailureCause.NONE,
+        "ok",
+        unclassified_reason=reason,
+        diagnostics=_diagnostics(f, mu, reason),
+    )
+
+
+def _classify_features(f: _Features, mu: float) -> TaxonomyResult:
+    """对已提取特征执行判据级联。"""
+    planar = f.z_abs_max <= _PLANAR_Z_MAX
+    soi = mu**_SOI_EXPONENT
+    wind_moon = abs(f.winding_moon) >= _WINDING_GATE
+
+    # 2. 月心分支：平面、绕月、展布在 SOI 内；顺逆不可判（近月点 h_z≈0
+    #    的退化轨迹）时不强贴月心标签，落到后续分支。
+    if planar and wind_moon and f.rho_max <= soi and f.moon_prograde is not None:
+        labels: list[TaxonomyLabel] = []
+        if f.moon_prograde is False:
+            labels.append(TAXONOMY_BY_CANONICAL["distant_retrograde"])
+        else:
+            if f.rho_max > _LOW_PROGRADE_RHO_MAX:
+                labels.append(TAXONOMY_BY_CANONICAL["distant_prograde"])
+            else:
+                east = 0.0 < f.perilune_azimuth < math.pi
+                labels.append(
+                    TAXONOMY_BY_CANONICAL[
+                        "low_prograde_eastern" if east else "low_prograde_western"
+                    ]
+                )
+        resonance = _resonance_label(f.t_ratio)
+        if resonance is not None:
+            labels.append(resonance)
+        return _ok(labels, f, mu)
+
+    # 3. L4/L5 分支：平面、绕三角平动点一周且局域在其邻域内。
+    if planar:
+        for point in (4, 5):
+            if (
+                abs(f.windings_l[point]) >= _WINDING_GATE
+                and f.min_triangular_dist <= _TRIANGULAR_EXTENT_GATE
+            ):
+                family = "longperiod" if f.t_ratio > _LONGPERIOD_T_RATIO else "shortperiod"
+                labels = [TAXONOMY_BY_CANONICAL[f"{family}_l{point}"]]
+                resonance = _resonance_label(f.t_ratio)
+                if resonance is not None:
+                    labels.append(resonance)
+                return _ok(labels, f, mu)
+
+    # 4. 共线平动点分支：卷绕或（三维垂直穿越形态的）回退路径，都要求
+    # 轨道局域在共线点邻域内（远距绕地圆把共线点圈在内也不得误入）。
+    wound = [point for point in (1, 2, 3) if abs(f.windings_l[point]) >= _WINDING_GATE]
+    spatial = not planar
+    halo_like = spatial and len(f.perp_y0) >= 2
+    vertical_like = spatial and len(f.perp_z0) >= 2
+    near_collinear = f.min_collinear_dist <= _COLLINEAR_EXTENT_GATE
+    if near_collinear and (wound or halo_like or vertical_like):
+        label = _collinear_family(f, _collinear_side(f, wound), spatial)
+        if label is not None:
+            return _ok([label], f, mu)
+
+    # 5. 共振分支：绕质心环绕且周期通约。
+    if abs(f.winding_earth) >= _WINDING_GATE:
+        resonance = _resonance_label(f.t_ratio)
+        if resonance is not None:
+            return _ok([resonance], f, mu)
+
+    return _unclassified("no_matching_label", f, mu)
+
+
+def _collinear_side(f: _Features, wound: list[int]) -> int:
+    """共线侧别：卷绕命中者优先；未卷绕（深近月端回退路径）由时间
+    平均 x 相对月球的符号定（L1 族全体 x̄<0、L2 族全体 x̄>0，零重叠）。"""
+    if wound:
+        if len(wound) > 1:
+            return min(wound)  # 横跨多点的极端振幅取靠地侧（ADR 0042）
+        return wound[0]
+    if f.mean_x_rel_moon < _L3_MEAN_X_GATE:
+        return 3
+    return 1 if f.mean_x_rel_moon < 0.0 else 2
+
+
+def _hemisphere(crossings: list[np.ndarray]) -> Hemisphere:
+    """南北：vy<0 的垂直穿越处 z 符号（与设计侧 halo_class 同源的几何量）。"""
+    for state in crossings:
+        if state[4] < 0.0:
+            return Hemisphere.NORTHERN if state[2] > 0.0 else Hemisphere.SOUTHERN
+    return Hemisphere.NORTHERN if crossings[0][2] > 0.0 else Hemisphere.SOUTHERN
+
+
+def _collinear_family(f: _Features, point: int, spatial: bool) -> TaxonomyLabel | None:
+    """共线平动点族形态判定（穿越几何，ADR 0042 决策 3）。"""
+    if spatial:
+        by_count = {2: "halo", 4: "butterfly", 6: "dragonfly"}
+        family = by_count.get(len(f.perp_y0))
+        if family is not None:
+            hemisphere = _hemisphere(f.perp_y0)
+            if family == "halo":
+                return TAXONOMY_BY_CANONICAL[f"halo_l{point}_{hemisphere.value}"]
+            return TAXONOMY_BY_CANONICAL[f"{family}_{hemisphere.value}"]
+        if f.crossings_y0:
+            # 三维且有 x-z 面穿越但非垂直（axial 族种子 vz≠0）。
+            return TAXONOMY_BY_CANONICAL[f"axial_l{point}"]
+        if f.perp_z0:
+            return TAXONOMY_BY_CANONICAL[f"vertical_l{point}"]
+        return None
+    if f.perp_y0:
+        return TAXONOMY_BY_CANONICAL[f"lyapunov_l{point}"]
+    return None
+
+
+def classify_orbit(
+    states: np.ndarray,
+    times: np.ndarray | None = None,
+    *,
+    period: float | None = None,
+    mu: float | None = None,
+    periodicity: str = "periodic",
+) -> TaxonomyResult:
+    """对一条 CR3BP 会合系周期轨迹做轨道分类学判定。
+
+    Args:
+        states: 状态序列 (n, 6)（无量纲会合系）。n=1 为最小形态（须给
+            ``period``，内部传播一个周期）；n≥2 按输入原样消费，须覆盖
+            一个周期且首末闭合。
+        times: 时间序列（无量纲），``period`` 缺省时取首末跨度并校验闭合。
+        period: 周期（无量纲）。
+        mu: CR3BP 质量比；缺省取 DE421 地月值。
+        periodicity: 族元数据的周期性标注；非 periodic 取值（如
+            quasi-periodic）直接判 unclassified。
+
+    Returns:
+        :class:`TaxonomyResult`；unclassified 是合法输出（labels 空 +
+        原因），非法输入/最小形态传播失败为 FAILED 状态。
+    """
+    array = np.asarray(states, dtype=float)
+    if array.ndim != 2 or array.shape[1] != 6 or array.shape[0] == 0:
+        return TaxonomyResult(
+            ConvergenceState.FAILED,
+            FailureCause.INVALID_INPUT,
+            f"states 须为 (n, 6)，当前 {array.shape}",
+        )
+    if not np.all(np.isfinite(array)):
+        return TaxonomyResult(
+            ConvergenceState.FAILED, FailureCause.INVALID_INPUT, "states 含非有限值"
+        )
+    if periodicity != "periodic":
+        return TaxonomyResult(
+            ConvergenceState.CONVERGED,
+            FailureCause.NONE,
+            "ok",
+            unclassified_reason="quasi_periodic",
+            diagnostics={"periodicity": periodicity},
+        )
+
+    mu_value = Datum.DE421.mu if mu is None else float(mu)
+    if period is None and array.shape[0] >= 2 and times is not None:
+        time_array = np.asarray(times, dtype=float)
+        if time_array.shape[0] != array.shape[0]:
+            return TaxonomyResult(
+                ConvergenceState.FAILED,
+                FailureCause.INVALID_INPUT,
+                "states 与 times 长度不一致",
+            )
+        period = float(time_array[-1] - time_array[0])
+    if period is None:
+        return TaxonomyResult(
+            ConvergenceState.FAILED,
+            FailureCause.INVALID_INPUT,
+            "最小形态（单状态）必须提供 period",
+        )
+    if not math.isfinite(period) or period <= 0.0:
+        return TaxonomyResult(
+            ConvergenceState.FAILED,
+            FailureCause.INVALID_INPUT,
+            f"period 须为正有限值，当前 {period}",
+        )
+
+    if array.shape[0] == 1:
+        try:
+            propagated = _default_dynamics(mu_value).propagate(
+                array[0], (0.0, period), t_eval=np.linspace(0.0, period, _N_SAMPLES)
+            )
+        except Exception as exc:  # 最小形态传播失败按积分失败契约上报
+            return TaxonomyResult(
+                ConvergenceState.FAILED,
+                FailureCause.INTEGRATION_FAILED,
+                f"周期传播失败：{exc}",
+            )
+        trajectory = np.asarray(propagated["states"], dtype=float)
+    else:
+        trajectory = array
+
+    closure = float(np.linalg.norm(trajectory[-1] - trajectory[0]))
+    scale = max(1.0, float(np.linalg.norm(trajectory[0])))
+    if closure > _CLOSURE_TOL * scale:
+        return TaxonomyResult(
+            ConvergenceState.CONVERGED,
+            FailureCause.NONE,
+            "ok",
+            unclassified_reason="non_periodic",
+            diagnostics={"closure_error": closure},
+        )
+
+    features = _extract_features(trajectory, period, mu_value)
+    return _classify_features(features, mu_value)

--- a/e2m2e/algorithm/orbit_taxonomy/labels.py
+++ b/e2m2e/algorithm/orbit_taxonomy/labels.py
@@ -1,0 +1,164 @@
+"""轨道分类学 42 标签词汇（orbit taxonomy labels）。
+
+三层分类学（issue #581，ADR 0042）：平动点轨道 27 + 月心轨道 4 + 共振
+轨道 11，标签措辞逐字采自 STK 未发布 CODE（Cislunar Orbit Designer）
+组件；判定判据无公开出处，为 e2m2e 自定解析判据（见 classify 模块）。
+
+命名约定：
+
+- 规范字符串为 snake_case，如 ``halo_l2_northern``、``low_prograde_eastern``；
+  它是序列化键（MCP 响应、catalog 记录），结构化字段是语义载荷。
+- 共振比 p:q = 卫星:月球：卫星 p 圈 per 月球 q 圈，T/T☾ = q/p
+  （2:1 内共振、1:2 外共振），与 spatiography 共振梯子的 k:k_b 同向。
+- 南北（northern/southern）由轨迹 z 极值符号定义，东西
+  （eastern/western）由月心会合系近月点方向定义（ADR 0042 判据）。
+"""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass
+
+__all__ = [
+    "TAXONOMY",
+    "TAXONOMY_BY_CANONICAL",
+    "Hemisphere",
+    "TaxonomyCategory",
+    "TaxonomyLabel",
+    "label_legend",
+    "parse_taxonomy_label",
+]
+
+
+class TaxonomyCategory(enum.Enum):
+    """标签顶层类别。"""
+
+    LIBRATION_POINT = "libration_point"
+    MOON_CENTERED = "moon_centered"
+    RESONANT = "resonant"
+
+
+class Hemisphere(enum.Enum):
+    """半球/朝向修饰词。"""
+
+    NORTHERN = "northern"
+    SOUTHERN = "southern"
+    EASTERN = "eastern"
+    WESTERN = "western"
+
+
+@dataclass(frozen=True)
+class TaxonomyLabel:
+    """单个分类标签：类别 + 族 + 平动点/半球/共振比修饰。
+
+    ``canonical`` 是序列化键；结构化字段描述语义（catalog 记录与 MCP
+    响应只落规范字符串，结构经 :func:`label_legend` 或
+    :func:`parse_taxonomy_label` 还原）。
+    """
+
+    category: TaxonomyCategory
+    family: str
+    libration_point: int | None = None
+    hemisphere: Hemisphere | None = None
+    resonance: tuple[int, int] | None = None
+
+    @property
+    def canonical(self) -> str:
+        parts = [self.family]
+        if self.resonance is not None:
+            parts.append(f"{self.resonance[0]}_{self.resonance[1]}")
+        elif self.libration_point is not None:
+            parts.append(f"l{self.libration_point}")
+        if self.hemisphere is not None:
+            parts.append(self.hemisphere.value)
+        return "_".join(parts)
+
+
+def _collinear_l(name: str, family: str) -> TaxonomyLabel:
+    point = int(name[-1])
+    return TaxonomyLabel(TaxonomyCategory.LIBRATION_POINT, family, libration_point=point)
+
+
+def _hemis_pair() -> tuple[Hemisphere, Hemisphere]:
+    return (Hemisphere.NORTHERN, Hemisphere.SOUTHERN)
+
+
+def _hemispheric(family: str, point: int | None, hemisphere: Hemisphere) -> TaxonomyLabel:
+    return TaxonomyLabel(
+        TaxonomyCategory.LIBRATION_POINT, family, libration_point=point, hemisphere=hemisphere
+    )
+
+
+#: 42 标签全集，顺序即 issue #581 清单顺序。
+TAXONOMY: tuple[TaxonomyLabel, ...] = tuple(
+    [
+        # 平动点轨道（Libration Point Orbits）
+        *(_collinear_l(f"lyapunov_l{i}", "lyapunov") for i in (1, 2, 3)),
+        *(
+            _hemispheric("halo", point, hemisphere)
+            for point in (1, 2, 3)
+            for hemisphere in (Hemisphere.NORTHERN, Hemisphere.SOUTHERN)
+        ),
+        *(_collinear_l(f"axial_l{i}", "axial") for i in (1, 2, 3, 4, 5)),
+        *(_collinear_l(f"vertical_l{i}", "vertical") for i in (1, 2, 3, 4, 5)),
+        *(_collinear_l(f"longperiod_l{i}", "longperiod") for i in (4, 5)),
+        *(_collinear_l(f"shortperiod_l{i}", "shortperiod") for i in (4, 5)),
+        *(_hemispheric("butterfly", None, hemisphere) for hemisphere in _hemis_pair()),
+        *(_hemispheric("dragonfly", None, hemisphere) for hemisphere in _hemis_pair()),
+        # 月球中心轨道（Moon Centered Orbits）
+        TaxonomyLabel(TaxonomyCategory.MOON_CENTERED, "distant_retrograde"),
+        TaxonomyLabel(TaxonomyCategory.MOON_CENTERED, "distant_prograde"),
+        TaxonomyLabel(
+            TaxonomyCategory.MOON_CENTERED,
+            "low_prograde",
+            hemisphere=Hemisphere.EASTERN,
+        ),
+        TaxonomyLabel(
+            TaxonomyCategory.MOON_CENTERED,
+            "low_prograde",
+            hemisphere=Hemisphere.WESTERN,
+        ),
+        # 共振轨道（Resonant Orbits），p:q = 卫星:月球
+        *(
+            TaxonomyLabel(TaxonomyCategory.RESONANT, "resonant", resonance=(p, q))
+            for (p, q) in (
+                (1, 1),
+                (1, 2),
+                (1, 3),
+                (1, 4),
+                (2, 1),
+                (3, 1),
+                (3, 2),
+                (3, 4),
+                (2, 3),
+                (4, 1),
+                (4, 3),
+            )
+        ),
+    ]
+)
+
+TAXONOMY_BY_CANONICAL: dict[str, TaxonomyLabel] = {label.canonical: label for label in TAXONOMY}
+
+
+def parse_taxonomy_label(canonical: str) -> TaxonomyLabel:
+    """规范字符串 → 标签；不在词汇表内时抛 ``ValueError``。"""
+    try:
+        return TAXONOMY_BY_CANONICAL[canonical]
+    except KeyError as exc:
+        raise ValueError(f"未知的轨道分类学标签：{canonical!r}") from exc
+
+
+def label_legend() -> dict[str, dict[str, object]]:
+    """规范字符串 → 结构化字段的图例（MCP legend / 文档用）。"""
+    legend: dict[str, dict[str, object]] = {}
+    for label in TAXONOMY:
+        legend[label.canonical] = {
+            "category": label.category.value,
+            "family": label.family,
+            "libration_point": label.libration_point,
+            "hemisphere": None if label.hemisphere is None else label.hemisphere.value,
+            "resonance_p": None if label.resonance is None else label.resonance[0],
+            "resonance_q": None if label.resonance is None else label.resonance[1],
+        }
+    return legend

--- a/e2m2e/api/catalog_ingest.py
+++ b/e2m2e/api/catalog_ingest.py
@@ -5,6 +5,11 @@
 （CR3BP 段位置三分量半极差最大值 × 特征长度，km）；各族定义不一的
 参数振幅保留在 ``request`` 快照中，不进分类字段。
 
+分类学标签（ADR 0042）是**实测**：``taxonomy_labels`` 由分类器对轨迹
+判定写入，设计侧族标签保留为 provenance；两者冲突记 warning 不失败。
+不在分类学内的族（拟周期 lissajous、horseshoe、星历冻结 elfo）按映射
+表置空标签，不跑分类器。
+
 无产物时不建记录（返回 ``None``）：族零成员、站保全样本失败（受控
 星历缺失）、转移无轨迹（组装失败或搜索零结果）都不产生记录。
 """
@@ -12,11 +17,14 @@
 from __future__ import annotations
 
 import dataclasses
+import logging
 import math
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from e2m2e.algorithm.orbit_taxonomy import classify_orbit
 from e2m2e.data.catalog import (
     cr3bp_segment_arrays,
     ephemeris_segment_arrays,
@@ -36,7 +44,10 @@ __all__ = [
     "build_design_record",
     "build_family_record",
     "build_transfer_record",
+    "stamp_taxonomy_labels",
 ]
+
+_LOGGER = logging.getLogger(__name__)
 
 #: design_orbit 的 orbit_type → (orbit_family, libration_point)。
 #: HALO/NRHO/LISSAJOUS/AXIAL 的平动点取请求的 collinear_point，不在此表。
@@ -53,6 +64,85 @@ _DESIGN_FAMILY_POINT: dict[str, tuple[str, int | None]] = {
     "L5_HORSESHOE": ("horseshoe", 5),
     "ELFO": ("elfo", None),
 }
+
+#: 设计侧 orbit_family → 分类学期望标签（ADR 0042 映射表）。NRHO 折叠
+#: 进 halo（同族高振幅近直线段）；空集 = 该族不在分类学内（拟周期
+#: lissajous、horseshoe、星历冻结 elfo、tadpole），入库直接置空标签。
+#: dpo 期望不含 distant_retrograde——baseline dpo 前 4 成员实测逆行
+#: （设计侧族行走的另一支，ADR 0042 复现注记），会触发冲突告警并按
+#: 实测值入库。
+_DESIGN_TAXONOMY_EXPECTATIONS: dict[str, set[str]] = {
+    "halo": {
+        "halo_l1_northern",
+        "halo_l1_southern",
+        "halo_l2_northern",
+        "halo_l2_southern",
+        "halo_l3_northern",
+        "halo_l3_southern",
+    },
+    "nrho": {
+        "halo_l1_northern",
+        "halo_l1_southern",
+        "halo_l2_northern",
+        "halo_l2_southern",
+    },
+    "axial": {"axial_l1", "axial_l2", "axial_l3", "axial_l4", "axial_l5"},
+    "dro": {"distant_retrograde"},
+    "dpo": {"distant_prograde", "low_prograde_eastern", "low_prograde_western"},
+    "spo": {"shortperiod_l4", "shortperiod_l5"},
+    "lpo": {"longperiod_l4", "longperiod_l5"},
+    "lissajous": set(),
+    "horseshoe": set(),
+    "elfo": set(),
+    "tadpole": set(),
+}
+
+
+def stamp_taxonomy_labels(
+    orbit_family: str | None,
+    orbits: Sequence[Any],
+    *,
+    periodicity: str = "periodic",
+    context: str = "",
+) -> tuple[list[str], list[str | None]]:
+    """对轨道成员做分类学实测打标（ADR 0042 决策 4）。
+
+    期望集为空的族不跑分类器、全体置空；成员 states 为单点时按最小
+    形态（须有 period）传播一个周期后分类。实测 primary 不在期望集 →
+    记 warning 不失败（两边都保留，设计侧标签是 provenance）。
+
+    Returns:
+        （记录级去重排序标签列表，成员级 primary 标签列表——无标签
+        成员为 ``None``）。
+    """
+    expected = _DESIGN_TAXONOMY_EXPECTATIONS.get(orbit_family or "")
+    if expected is not None and not expected:
+        return [], [None] * len(orbits)
+    record_labels: set[str] = set()
+    member_labels: list[str | None] = []
+    for index, orbit in enumerate(orbits):
+        mu = getattr(getattr(orbit, "system", None), "mu", None)
+        result = classify_orbit(
+            orbit.states,
+            orbit.times,
+            period=getattr(orbit, "period", None),
+            mu=mu,
+            periodicity=periodicity,
+        )
+        label = None if result.primary is None else result.primary.canonical
+        if label is not None:
+            record_labels.add(label)
+            if expected is not None and label not in expected:
+                _LOGGER.warning(
+                    "分类学冲突（%s 成员 %d）：设计侧族 %r 期望 %s，实测 %s",
+                    context or orbit_family or "?",
+                    index,
+                    orbit_family,
+                    sorted(expected),
+                    label,
+                )
+        member_labels.append(label)
+    return sorted(record_labels), member_labels
 
 
 def build_design_record(request: Any, result: Any) -> tuple[dict, dict[str, np.ndarray]] | None:
@@ -86,6 +176,11 @@ def build_design_record(request: Any, result: Any) -> tuple[dict, dict[str, np.n
 
     jacobi = _finite_or_none(result.cr3bp_jacobi)
     correction = result.correction
+    taxonomy_labels: list[str] = []
+    if cr3bp_orbit is not None:
+        taxonomy_labels, _ = stamp_taxonomy_labels(
+            orbit_family, [cr3bp_orbit], context="design_orbit"
+        )
     meta = _base_meta(
         source_tool="design_orbit",
         source_record_id=None,
@@ -96,6 +191,7 @@ def build_design_record(request: Any, result: Any) -> tuple[dict, dict[str, np.n
             "amplitude": amplitude,
             "has_cr3bp": cr3bp_orbit is not None,
             "has_ephemeris": result.ephemeris is not None,
+            "taxonomy_labels": taxonomy_labels,
         },
         status=result.status,
         cause=result.cause,
@@ -141,6 +237,10 @@ def build_family_record(
     system = family.system
     char_length_km = getattr(system, "characteristic_length", None)
     mu = getattr(system, "mu", None)
+    periodicity = family.metadata.get("periodicity", "periodic")
+    taxonomy_labels, member_labels = stamp_taxonomy_labels(
+        family.family_type, members, periodicity=periodicity, context="orbit_family_generation"
+    )
 
     arrays: dict[str, np.ndarray] = {}
     member_metas: list[dict[str, Any]] = []
@@ -164,6 +264,7 @@ def build_family_record(
                 "amplitude_km": amplitude_km,
                 "amplitudes": _sanitize_value(getattr(orbit, "amplitudes", {})),
                 "parameters": _sanitize_value(getattr(orbit, "parameters", {})),
+                "taxonomy_label": member_labels[index],
             }
         )
 
@@ -177,6 +278,7 @@ def build_family_record(
             "amplitude": _envelope(amplitudes),
             "has_cr3bp": True,
             "has_ephemeris": False,
+            "taxonomy_labels": taxonomy_labels,
         },
         status=status,
         cause=cause,
@@ -185,7 +287,7 @@ def build_family_record(
             "member_count": len(members),
             "requested_members": requested_members,
             "generated_members": generated_members,
-            "periodicity": family.metadata.get("periodicity", "periodic"),
+            "periodicity": periodicity,
             "mu": mu,
             "char_length_km": char_length_km,
         },

--- a/e2m2e/api/facade.py
+++ b/e2m2e/api/facade.py
@@ -149,7 +149,13 @@ def _family_generation_payload(
     *,
     requested_members: int | None = None,
 ) -> FamilyGenerationResponse:
-    """把算法层成功或软失败统一投影为 Facade 专属响应。"""
+    """把算法层成功或软失败统一投影为 Facade 专属响应。
+
+    分类学标签（#581，ADR 0042）对全体成员实测打标后去重；拟周期
+    （lissajous）与不在分类学内的族按映射表为空表。
+    """
+    from .catalog_ingest import stamp_taxonomy_labels
+
     if isinstance(result, FamilyGenerationResult):
         family = result.family
         status = result.status
@@ -164,6 +170,12 @@ def _family_generation_payload(
         message = "轨道族生成完成"
         requested_members = requested_members or len(family)
         generated_members = len(family)
+    taxonomy_labels, _ = stamp_taxonomy_labels(
+        family.family_type,
+        family.orbits,
+        periodicity=family.metadata.get("periodicity", "periodic"),
+        context="orbit_family_generation",
+    )
     return FamilyGenerationResponse(
         status=status,
         cause=cause,
@@ -172,6 +184,7 @@ def _family_generation_payload(
         family_type=family.family_type,
         system=family.system,
         metadata=family.metadata,
+        taxonomy_labels=taxonomy_labels,
         requested_members=requested_members,
         generated_members=generated_members,
     )
@@ -294,14 +307,21 @@ def _design_result_to_response(result: OrbitDesignResult) -> DesignOrbitResponse
     纯翻译、无副作用、不依赖 SPICE。ELFO 场景下 ``cr3bp_orbit`` /
     ``correction`` 为 None，对应字段输出默认值（mu=None、states/times 空、
     correction_iterations=0）。CR3BP 场景下从 ``cr3bp_orbit`` 提取
-    ``states`` / ``times`` / ``mu``。
+    ``states`` / ``times`` / ``mu``，并对参考周期轨道做分类学实测打标
+    （#581，ADR 0042；整条轨迹消费，无额外传播）。
     """
+    from e2m2e.algorithm.orbit_taxonomy import classify_orbit
+
     cr3bp_orbit = result.cr3bp_orbit
     correction = result.correction
+    taxonomy_labels: list[str] = []
     if cr3bp_orbit is not None:
         mu = getattr(cr3bp_orbit.system, "mu", None)
         states = cr3bp_orbit.states.tolist()
         times = cr3bp_orbit.times.tolist()
+        taxonomy_labels = list(
+            classify_orbit(cr3bp_orbit.states, cr3bp_orbit.times, mu=mu).canonical_labels
+        )
     else:
         mu = None
         states = []
@@ -321,6 +341,7 @@ def _design_result_to_response(result: OrbitDesignResult) -> DesignOrbitResponse
         mu=mu,
         states=states,
         times=times,
+        taxonomy_labels=taxonomy_labels,
         ephemeris=_ephemeris_to_dict(result.ephemeris),
         drift_e=result.drift_e,
         drift_aop_deg=result.drift_aop_deg,
@@ -418,6 +439,7 @@ def _summary_kwargs(
 
     transfer 维度（#574）两种来源都归一在 identity 顶层：索引行直接带
     列值；记录元数据经 ``_summary_from_meta`` 从 ``scalars`` 提取后合入。
+    分类学标签（#581）随 ``classification`` 走，未打标记录为 None。
     """
     return {
         "record_id": identity["record_id"],
@@ -430,6 +452,7 @@ def _summary_kwargs(
         "amplitude": classification["amplitude"],
         "has_cr3bp": classification["has_cr3bp"],
         "has_ephemeris": classification["has_ephemeris"],
+        "taxonomy_labels": classification.get("taxonomy_labels"),
         "transfer_type": identity.get("transfer_type"),
         "delta_v_km_s": identity.get("delta_v_km_s"),
         "tli_epoch": identity.get("tli_epoch"),

--- a/e2m2e/api/models.py
+++ b/e2m2e/api/models.py
@@ -417,6 +417,11 @@ class FamilyGenerationResponse(_ApiModel, OrbitFamily):
     family_type: str | None = None
     system: Any = None
     metadata: dict[str, Any] = Field(default_factory=dict)
+    taxonomy_labels: list[str] = Field(
+        default_factory=list,
+        description="分类学标签（ADR 0042）：全体成员实测 primary 标签的去重集合"
+        "（规范字符串）；lissajous 等不在分类学内的族为空表",
+    )
     requested_members: int
     generated_members: int
     record_id: str | None = Field(
@@ -467,6 +472,11 @@ class DesignOrbitResponse(ResultResponse):
     states: list[list[float]] = Field(
         default_factory=list,
         description="CR3BP 参考周期轨道状态序列 (n,6)，无量纲会合系",
+    )
+    taxonomy_labels: list[str] = Field(
+        default_factory=list,
+        description="分类学标签（ADR 0042）：对 CR3BP 参考轨道的实测多标签"
+        "（规范字符串，如 halo_l2_northern）；ELFO 等无 CR3BP 场景为空表",
     )
     times: list[float] = Field(
         default_factory=list,
@@ -1311,6 +1321,10 @@ class CatalogRecordSummary(_ApiModel):
     )
     has_cr3bp: bool
     has_ephemeris: bool
+    taxonomy_labels: list[str] | None = Field(
+        default=None,
+        description="分类学标签（ADR 0042，多标签规范字符串）；未打标为 None",
+    )
     transfer_type: str | None = Field(
         default=None, description="转移类型（HMN/LGA/WSB/low_thrust）；非 transfer 记录为 None"
     )

--- a/e2m2e/data/catalog/index.py
+++ b/e2m2e/data/catalog/index.py
@@ -33,6 +33,7 @@ CREATE TABLE records (
     amplitude_max REAL,
     has_cr3bp INTEGER NOT NULL,
     has_ephemeris INTEGER NOT NULL,
+    taxonomy_labels TEXT,
     transfer_type TEXT,
     delta_v REAL,
     tli_epoch REAL,
@@ -45,9 +46,10 @@ CREATE TABLE records (
 )
 """
 
-#: 表结构完备性检查列集：存量库缺任一列（如 #574 新增 transfer 维度）
-#: 时整个表废弃重建——索引是派生物（ADR 0031 决策 5），重建由
-#: ``CatalogStore`` 依据 :attr:`CatalogIndex.schema_reset` 标记触发。
+#: 表结构完备性检查列集：存量库缺任一列（如 #574 新增 transfer 维度、
+#: #581 新增分类学标签维度）时整个表废弃重建——索引是派生物（ADR 0031
+#: 决策 5），重建由 ``CatalogStore`` 依据 :attr:`CatalogIndex.schema_reset`
+#: 标记触发。
 _REQUIRED_COLUMNS = frozenset(
     {
         "record_id",
@@ -62,6 +64,7 @@ _REQUIRED_COLUMNS = frozenset(
         "amplitude_max",
         "has_cr3bp",
         "has_ephemeris",
+        "taxonomy_labels",
         "transfer_type",
         "delta_v",
         "tli_epoch",
@@ -143,6 +146,7 @@ class CatalogIndex:
         transfer_type = scalars.get("transfer_type")
         delta_v = numeric_or_none(scalars.get("delta_v_km_s"))
         tli_epoch = numeric_or_none(scalars.get("tli_epoch"))
+        taxonomy_labels = classification.get("taxonomy_labels")
         with self._lock:
             self._conn.execute(
                 """
@@ -150,9 +154,9 @@ class CatalogIndex:
                     record_id, created_at, source_tool, source_record_id,
                     orbit_family, libration_point, jacobi_min, jacobi_max,
                     amplitude_min, amplitude_max, has_cr3bp, has_ephemeris,
-                    transfer_type, delta_v, tli_epoch,
+                    taxonomy_labels, transfer_type, delta_v, tli_epoch,
                     status, cause, message, member_count, tags, note
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     meta["record_id"],
@@ -167,6 +171,7 @@ class CatalogIndex:
                     None if amplitude is None else float(amplitude[1]),
                     1 if classification["has_cr3bp"] else 0,
                     1 if classification["has_ephemeris"] else 0,
+                    None if not taxonomy_labels else ",".join(taxonomy_labels),
                     transfer_type,
                     delta_v,
                     tli_epoch,
@@ -266,6 +271,7 @@ class CatalogIndex:
         amplitude = (
             None if row["amplitude_min"] is None else [row["amplitude_min"], row["amplitude_max"]]
         )
+        taxonomy_text = row["taxonomy_labels"]
         return {
             "record_id": row["record_id"],
             "created_at": row["created_at"],
@@ -278,6 +284,7 @@ class CatalogIndex:
                 "amplitude": amplitude,
                 "has_cr3bp": bool(row["has_cr3bp"]),
                 "has_ephemeris": bool(row["has_ephemeris"]),
+                "taxonomy_labels": None if not taxonomy_text else taxonomy_text.split(","),
             },
             "transfer_type": row["transfer_type"],
             "delta_v_km_s": row["delta_v"],

--- a/e2m2e/data/catalog/store.py
+++ b/e2m2e/data/catalog/store.py
@@ -179,6 +179,7 @@ class CatalogStore:
         char_length = family.meta["scalars"].get("char_length_km")
         jacobi = member.get("jacobi")
         family_classification = family.meta["classification"]
+        taxonomy_label = member.get("taxonomy_label")
         classification = {
             "orbit_family": family_classification["orbit_family"],
             "libration_point": family_classification["libration_point"],
@@ -186,6 +187,8 @@ class CatalogStore:
             "amplitude": point_interval(geometric_amplitude_km(states, char_length)),
             "has_cr3bp": True,
             "has_ephemeris": False,
+            # 分类学标签继承成员实测标签（数据层不 import 算法层分类器）
+            "taxonomy_labels": [taxonomy_label] if taxonomy_label else [],
         }
         meta: dict[str, Any] = {
             "source_tool": "catalog_promote",

--- a/e2m2e/data/catalog_baseline/baseline-axial-l1.json
+++ b/e2m2e/data/catalog_baseline/baseline-axial-l1.json
@@ -13,7 +13,10 @@
       0.0
     ],
     "has_cr3bp": true,
-    "has_ephemeris": false
+    "has_ephemeris": false,
+    "taxonomy_labels": [
+      "axial_l1"
+    ]
   },
   "status": "converged",
   "cause": "none",
@@ -62,7 +65,8 @@
       "parameters": {
         "libration_point": 1,
         "amplitude_z_km": 249.8150497804224
-      }
+      },
+      "taxonomy_label": "axial_l1"
     },
     {
       "index": 1,
@@ -78,7 +82,8 @@
       "parameters": {
         "libration_point": 1,
         "amplitude_z_km": 1498.875311880193
-      }
+      },
+      "taxonomy_label": "axial_l1"
     },
     {
       "index": 2,
@@ -94,7 +99,8 @@
       "parameters": {
         "libration_point": 1,
         "amplitude_z_km": 2747.8713002230024
-      }
+      },
+      "taxonomy_label": "axial_l1"
     },
     {
       "index": 3,
@@ -110,7 +116,8 @@
       "parameters": {
         "libration_point": 1,
         "amplitude_z_km": 3996.7492673631596
-      }
+      },
+      "taxonomy_label": "axial_l1"
     },
     {
       "index": 4,
@@ -126,7 +133,8 @@
       "parameters": {
         "libration_point": 1,
         "amplitude_z_km": 5245.455137112774
-      }
+      },
+      "taxonomy_label": "axial_l1"
     },
     {
       "index": 5,
@@ -142,7 +150,8 @@
       "parameters": {
         "libration_point": 1,
         "amplitude_z_km": 6493.934353884484
-      }
+      },
+      "taxonomy_label": "axial_l1"
     },
     {
       "index": 6,
@@ -158,7 +167,8 @@
       "parameters": {
         "libration_point": 1,
         "amplitude_z_km": 7742.131730663573
-      }
+      },
+      "taxonomy_label": "axial_l1"
     },
     {
       "index": 7,
@@ -174,7 +184,8 @@
       "parameters": {
         "libration_point": 1,
         "amplitude_z_km": 8989.991295171545
-      }
+      },
+      "taxonomy_label": "axial_l1"
     }
   ],
   "tags": [

--- a/e2m2e/data/catalog_baseline/baseline-axial-l2.json
+++ b/e2m2e/data/catalog_baseline/baseline-axial-l2.json
@@ -13,7 +13,10 @@
       0.0
     ],
     "has_cr3bp": true,
-    "has_ephemeris": false
+    "has_ephemeris": false,
+    "taxonomy_labels": [
+      "axial_l2"
+    ]
   },
   "status": "converged",
   "cause": "none",
@@ -62,7 +65,8 @@
       "parameters": {
         "libration_point": 2,
         "amplitude_z_km": 86.72552181634713
-      }
+      },
+      "taxonomy_label": "axial_l2"
     },
     {
       "index": 1,
@@ -78,7 +82,8 @@
       "parameters": {
         "libration_point": 2,
         "amplitude_z_km": 520.3642309813532
-      }
+      },
+      "taxonomy_label": "axial_l2"
     },
     {
       "index": 2,
@@ -94,7 +99,8 @@
       "parameters": {
         "libration_point": 2,
         "amplitude_z_km": 954.0505205479208
-      }
+      },
+      "taxonomy_label": "axial_l2"
     },
     {
       "index": 3,
@@ -110,7 +116,8 @@
       "parameters": {
         "libration_point": 2,
         "amplitude_z_km": 1387.8240767568957
-      }
+      },
+      "taxonomy_label": "axial_l2"
     },
     {
       "index": 4,
@@ -126,7 +133,8 @@
       "parameters": {
         "libration_point": 2,
         "amplitude_z_km": 1821.7246493000403
-      }
+      },
+      "taxonomy_label": "axial_l2"
     },
     {
       "index": 5,
@@ -142,7 +150,8 @@
       "parameters": {
         "libration_point": 2,
         "amplitude_z_km": 2255.7920803122797
-      }
+      },
+      "taxonomy_label": "axial_l2"
     },
     {
       "index": 6,
@@ -158,7 +167,8 @@
       "parameters": {
         "libration_point": 2,
         "amplitude_z_km": 2690.0663335764693
-      }
+      },
+      "taxonomy_label": "axial_l2"
     },
     {
       "index": 7,
@@ -174,7 +184,8 @@
       "parameters": {
         "libration_point": 2,
         "amplitude_z_km": 3124.5875239606403
-      }
+      },
+      "taxonomy_label": "axial_l2"
     },
     {
       "index": 8,
@@ -190,7 +201,8 @@
       "parameters": {
         "libration_point": 2,
         "amplitude_z_km": 3559.395947167571
-      }
+      },
+      "taxonomy_label": "axial_l2"
     },
     {
       "index": 9,
@@ -206,7 +218,8 @@
       "parameters": {
         "libration_point": 2,
         "amplitude_z_km": 3994.532109843325
-      }
+      },
+      "taxonomy_label": "axial_l2"
     },
     {
       "index": 10,
@@ -222,7 +235,8 @@
       "parameters": {
         "libration_point": 2,
         "amplitude_z_km": 4430.0367601503785
-      }
+      },
+      "taxonomy_label": "axial_l2"
     },
     {
       "index": 11,
@@ -238,7 +252,8 @@
       "parameters": {
         "libration_point": 2,
         "amplitude_z_km": 4865.950918799685
-      }
+      },
+      "taxonomy_label": "axial_l2"
     },
     {
       "index": 12,
@@ -254,7 +269,8 @@
       "parameters": {
         "libration_point": 2,
         "amplitude_z_km": 5302.3159106499825
-      }
+      },
+      "taxonomy_label": "axial_l2"
     },
     {
       "index": 13,
@@ -270,7 +286,8 @@
       "parameters": {
         "libration_point": 2,
         "amplitude_z_km": 5739.173397035163
-      }
+      },
+      "taxonomy_label": "axial_l2"
     },
     {
       "index": 14,
@@ -286,7 +303,8 @@
       "parameters": {
         "libration_point": 2,
         "amplitude_z_km": 6176.565408610146
-      }
+      },
+      "taxonomy_label": "axial_l2"
     },
     {
       "index": 15,
@@ -302,7 +320,8 @@
       "parameters": {
         "libration_point": 2,
         "amplitude_z_km": 6614.534379204944
-      }
+      },
+      "taxonomy_label": "axial_l2"
     },
     {
       "index": 16,
@@ -318,7 +337,8 @@
       "parameters": {
         "libration_point": 2,
         "amplitude_z_km": 7053.1231803419805
-      }
+      },
+      "taxonomy_label": "axial_l2"
     },
     {
       "index": 17,
@@ -334,7 +354,8 @@
       "parameters": {
         "libration_point": 2,
         "amplitude_z_km": 7492.375156845118
-      }
+      },
+      "taxonomy_label": "axial_l2"
     },
     {
       "index": 18,
@@ -350,7 +371,8 @@
       "parameters": {
         "libration_point": 2,
         "amplitude_z_km": 7932.334163373896
-      }
+      },
+      "taxonomy_label": "axial_l2"
     },
     {
       "index": 19,
@@ -366,7 +388,8 @@
       "parameters": {
         "libration_point": 2,
         "amplitude_z_km": 8373.044602164224
-      }
+      },
+      "taxonomy_label": "axial_l2"
     },
     {
       "index": 20,
@@ -382,7 +405,8 @@
       "parameters": {
         "libration_point": 2,
         "amplitude_z_km": 8814.551461913967
-      }
+      },
+      "taxonomy_label": "axial_l2"
     },
     {
       "index": 21,
@@ -398,7 +422,8 @@
       "parameters": {
         "libration_point": 2,
         "amplitude_z_km": 9256.900358021807
-      }
+      },
+      "taxonomy_label": "axial_l2"
     },
     {
       "index": 22,
@@ -414,7 +439,8 @@
       "parameters": {
         "libration_point": 2,
         "amplitude_z_km": 9700.137574279684
-      }
+      },
+      "taxonomy_label": "axial_l2"
     }
   ],
   "tags": [

--- a/e2m2e/data/catalog_baseline/baseline-dpo.json
+++ b/e2m2e/data/catalog_baseline/baseline-dpo.json
@@ -13,7 +13,13 @@
       21010.34247344452
     ],
     "has_cr3bp": true,
-    "has_ephemeris": false
+    "has_ephemeris": false,
+    "taxonomy_labels": [
+      "distant_prograde",
+      "distant_retrograde",
+      "low_prograde_eastern",
+      "low_prograde_western"
+    ]
   },
   "status": "converged",
   "cause": "none",
@@ -52,7 +58,8 @@
       },
       "parameters": {
         "amplitude_target_km": 3421.8397535985523
-      }
+      },
+      "taxonomy_label": "distant_retrograde"
     },
     {
       "index": 1,
@@ -67,7 +74,8 @@
       },
       "parameters": {
         "amplitude_target_km": 4092.6338446629707
-      }
+      },
+      "taxonomy_label": "distant_retrograde"
     },
     {
       "index": 2,
@@ -82,7 +90,8 @@
       },
       "parameters": {
         "amplitude_target_km": 4894.9258272150755
-      }
+      },
+      "taxonomy_label": "distant_retrograde"
     },
     {
       "index": 3,
@@ -97,7 +106,8 @@
       },
       "parameters": {
         "amplitude_target_km": 5854.4936496537
-      }
+      },
+      "taxonomy_label": "distant_retrograde"
     },
     {
       "index": 4,
@@ -112,7 +122,8 @@
       },
       "parameters": {
         "amplitude_target_km": 7002.168593295316
-      }
+      },
+      "taxonomy_label": "low_prograde_western"
     },
     {
       "index": 5,
@@ -127,7 +138,8 @@
       },
       "parameters": {
         "amplitude_target_km": 8374.825893240402
-      }
+      },
+      "taxonomy_label": "low_prograde_eastern"
     },
     {
       "index": 6,
@@ -142,7 +154,8 @@
       },
       "parameters": {
         "amplitude_target_km": 10016.569553787642
-      }
+      },
+      "taxonomy_label": "low_prograde_eastern"
     },
     {
       "index": 7,
@@ -157,7 +170,8 @@
       },
       "parameters": {
         "amplitude_target_km": 11980.149426968594
-      }
+      },
+      "taxonomy_label": "distant_prograde"
     },
     {
       "index": 8,
@@ -172,7 +186,8 @@
       },
       "parameters": {
         "amplitude_target_km": 14328.65608547827
-      }
+      },
+      "taxonomy_label": "distant_prograde"
     },
     {
       "index": 9,
@@ -187,7 +202,8 @@
       },
       "parameters": {
         "amplitude_target_km": 17137.547946917748
-      }
+      },
+      "taxonomy_label": "distant_prograde"
     },
     {
       "index": 10,
@@ -202,7 +218,8 @@
       },
       "parameters": {
         "amplitude_target_km": 20497.075781626
-      }
+      },
+      "taxonomy_label": "distant_prograde"
     }
   ],
   "tags": [

--- a/e2m2e/data/catalog_baseline/baseline-dro.json
+++ b/e2m2e/data/catalog_baseline/baseline-dro.json
@@ -13,7 +13,10 @@
       0.0
     ],
     "has_cr3bp": true,
-    "has_ephemeris": false
+    "has_ephemeris": false,
+    "taxonomy_labels": [
+      "distant_retrograde"
+    ]
   },
   "status": "converged",
   "cause": "none",
@@ -61,7 +64,8 @@
       },
       "parameters": {
         "amplitude_km": 2052.2991743752677
-      }
+      },
+      "taxonomy_label": "distant_retrograde"
     },
     {
       "index": 1,
@@ -76,7 +80,8 @@
       },
       "parameters": {
         "amplitude_km": 2172.43497529402
-      }
+      },
+      "taxonomy_label": "distant_retrograde"
     },
     {
       "index": 2,
@@ -91,7 +96,8 @@
       },
       "parameters": {
         "amplitude_km": 2292.5725424469633
-      }
+      },
+      "taxonomy_label": "distant_retrograde"
     },
     {
       "index": 3,
@@ -106,7 +112,8 @@
       },
       "parameters": {
         "amplitude_km": 3253.7591555169056
-      }
+      },
+      "taxonomy_label": "distant_retrograde"
     },
     {
       "index": 4,
@@ -121,7 +128,8 @@
       },
       "parameters": {
         "amplitude_km": 3494.0873437317837
-      }
+      },
+      "taxonomy_label": "distant_retrograde"
     },
     {
       "index": 5,
@@ -136,7 +144,8 @@
       },
       "parameters": {
         "amplitude_km": 3734.431813647434
-      }
+      },
+      "taxonomy_label": "distant_retrograde"
     },
     {
       "index": 6,
@@ -151,7 +160,8 @@
       },
       "parameters": {
         "amplitude_km": 3974.7945739877596
-      }
+      },
+      "taxonomy_label": "distant_retrograde"
     },
     {
       "index": 7,
@@ -166,7 +176,8 @@
       },
       "parameters": {
         "amplitude_km": 4215.17772860281
-      }
+      },
+      "taxonomy_label": "distant_retrograde"
     },
     {
       "index": 8,
@@ -181,7 +192,8 @@
       },
       "parameters": {
         "amplitude_km": 4455.583472875093
-      }
+      },
+      "taxonomy_label": "distant_retrograde"
     },
     {
       "index": 9,
@@ -196,7 +208,8 @@
       },
       "parameters": {
         "amplitude_km": 4936.471957220186
-      }
+      },
+      "taxonomy_label": "distant_retrograde"
     },
     {
       "index": 10,
@@ -211,7 +224,8 @@
       },
       "parameters": {
         "amplitude_km": 5898.626151472615
-      }
+      },
+      "taxonomy_label": "distant_retrograde"
     },
     {
       "index": 11,
@@ -226,7 +240,8 @@
       },
       "parameters": {
         "amplitude_km": 7825.060322026189
-      }
+      },
+      "taxonomy_label": "distant_retrograde"
     },
     {
       "index": 12,
@@ -241,7 +256,8 @@
       },
       "parameters": {
         "amplitude_km": 8066.122478895534
-      }
+      },
+      "taxonomy_label": "distant_retrograde"
     },
     {
       "index": 13,
@@ -256,7 +272,8 @@
       },
       "parameters": {
         "amplitude_km": 8548.454202802193
-      }
+      },
+      "taxonomy_label": "distant_retrograde"
     },
     {
       "index": 14,
@@ -271,7 +288,8 @@
       },
       "parameters": {
         "amplitude_km": 9514.042958257725
-      }
+      },
+      "taxonomy_label": "distant_retrograde"
     },
     {
       "index": 15,
@@ -286,7 +304,8 @@
       },
       "parameters": {
         "amplitude_km": 10481.05406223705
-      }
+      },
+      "taxonomy_label": "distant_retrograde"
     },
     {
       "index": 16,
@@ -301,7 +320,8 @@
       },
       "parameters": {
         "amplitude_km": 11449.72239974983
-      }
+      },
+      "taxonomy_label": "distant_retrograde"
     },
     {
       "index": 17,
@@ -316,7 +336,8 @@
       },
       "parameters": {
         "amplitude_km": 12420.291187376804
-      }
+      },
+      "taxonomy_label": "distant_retrograde"
     },
     {
       "index": 18,
@@ -331,7 +352,8 @@
       },
       "parameters": {
         "amplitude_km": 13393.010482472473
-      }
+      },
+      "taxonomy_label": "distant_retrograde"
     },
     {
       "index": 19,
@@ -346,7 +368,8 @@
       },
       "parameters": {
         "amplitude_km": 13880.256230528039
-      }
+      },
+      "taxonomy_label": "distant_retrograde"
     },
     {
       "index": 20,
@@ -361,7 +384,8 @@
       },
       "parameters": {
         "amplitude_km": 14368.135799169002
-      }
+      },
+      "taxonomy_label": "distant_retrograde"
     },
     {
       "index": 21,
@@ -376,7 +400,8 @@
       },
       "parameters": {
         "amplitude_km": 14856.681805546963
-      }
+      },
+      "taxonomy_label": "distant_retrograde"
     },
     {
       "index": 22,
@@ -391,7 +416,8 @@
       },
       "parameters": {
         "amplitude_km": 15835.904577829531
-      }
+      },
+      "taxonomy_label": "distant_retrograde"
     },
     {
       "index": 23,
@@ -406,7 +432,8 @@
       },
       "parameters": {
         "amplitude_km": 17803.8016569041
-      }
+      },
+      "taxonomy_label": "distant_retrograde"
     },
     {
       "index": 24,
@@ -421,7 +448,8 @@
       },
       "parameters": {
         "amplitude_km": 19786.082551575935
-      }
+      },
+      "taxonomy_label": "distant_retrograde"
     },
     {
       "index": 25,
@@ -436,7 +464,8 @@
       },
       "parameters": {
         "amplitude_km": 21784.890777298482
-      }
+      },
+      "taxonomy_label": "distant_retrograde"
     },
     {
       "index": 26,
@@ -451,7 +480,8 @@
       },
       "parameters": {
         "amplitude_km": 23802.35943272533
-      }
+      },
+      "taxonomy_label": "distant_retrograde"
     },
     {
       "index": 27,
@@ -466,7 +496,8 @@
       },
       "parameters": {
         "amplitude_km": 25840.595687354944
-      }
+      },
+      "taxonomy_label": "distant_retrograde"
     },
     {
       "index": 28,
@@ -481,7 +512,8 @@
       },
       "parameters": {
         "amplitude_km": 27901.66655919834
-      }
+      },
+      "taxonomy_label": "distant_retrograde"
     },
     {
       "index": 29,
@@ -496,7 +528,8 @@
       },
       "parameters": {
         "amplitude_km": 29987.588903663105
-      }
+      },
+      "taxonomy_label": "distant_retrograde"
     },
     {
       "index": 30,
@@ -511,7 +544,8 @@
       },
       "parameters": {
         "amplitude_km": 32100.31568673152
-      }
+      },
+      "taxonomy_label": "distant_retrograde"
     },
     {
       "index": 31,
@@ -526,7 +560,8 @@
       },
       "parameters": {
         "amplitude_km": 34241.727118165865
-      }
+      },
+      "taxonomy_label": "distant_retrograde"
     },
     {
       "index": 32,
@@ -541,7 +576,8 @@
       },
       "parameters": {
         "amplitude_km": 36413.62001304373
-      }
+      },
+      "taxonomy_label": "distant_retrograde"
     },
     {
       "index": 33,
@@ -556,7 +592,8 @@
       },
       "parameters": {
         "amplitude_km": 38617.69551570995
-      }
+      },
+      "taxonomy_label": "distant_retrograde"
     },
     {
       "index": 34,
@@ -571,7 +608,8 @@
       },
       "parameters": {
         "amplitude_km": 40855.54778837567
-      }
+      },
+      "taxonomy_label": "distant_retrograde"
     },
     {
       "index": 35,
@@ -586,7 +624,8 @@
       },
       "parameters": {
         "amplitude_km": 43128.655745113625
-      }
+      },
+      "taxonomy_label": "distant_retrograde"
     },
     {
       "index": 36,
@@ -601,7 +640,8 @@
       },
       "parameters": {
         "amplitude_km": 45438.36689837621
-      }
+      },
+      "taxonomy_label": "distant_retrograde"
     },
     {
       "index": 37,
@@ -616,7 +656,8 @@
       },
       "parameters": {
         "amplitude_km": 47785.887370355864
-      }
+      },
+      "taxonomy_label": "distant_retrograde"
     },
     {
       "index": 38,
@@ -631,7 +672,8 @@
       },
       "parameters": {
         "amplitude_km": 50172.27174590672
-      }
+      },
+      "taxonomy_label": "distant_retrograde"
     },
     {
       "index": 39,
@@ -646,7 +688,8 @@
       },
       "parameters": {
         "amplitude_km": 52598.41069485299
-      }
+      },
+      "taxonomy_label": "distant_retrograde"
     },
     {
       "index": 40,
@@ -661,7 +704,8 @@
       },
       "parameters": {
         "amplitude_km": 55065.02083054533
-      }
+      },
+      "taxonomy_label": "distant_retrograde"
     },
     {
       "index": 41,
@@ -676,7 +720,8 @@
       },
       "parameters": {
         "amplitude_km": 57572.63360806718
-      }
+      },
+      "taxonomy_label": "distant_retrograde"
     }
   ],
   "tags": [

--- a/e2m2e/data/catalog_baseline/baseline-halo-l1.json
+++ b/e2m2e/data/catalog_baseline/baseline-halo-l1.json
@@ -13,7 +13,10 @@
       0.0
     ],
     "has_cr3bp": true,
-    "has_ephemeris": false
+    "has_ephemeris": false,
+    "taxonomy_labels": [
+      "halo_l1_northern"
+    ]
   },
   "status": "converged",
   "cause": "none",
@@ -63,7 +66,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.001
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 1,
@@ -80,7 +84,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.002
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 2,
@@ -97,7 +102,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.003
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 3,
@@ -114,7 +120,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.004
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 4,
@@ -131,7 +138,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.005
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 5,
@@ -148,7 +156,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.006
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 6,
@@ -165,7 +174,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.007
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 7,
@@ -182,7 +192,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.008
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 8,
@@ -199,7 +210,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.009000000000000001
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 9,
@@ -216,7 +228,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.010000000000000002
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 10,
@@ -233,7 +246,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.011000000000000003
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 11,
@@ -250,7 +264,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.012000000000000004
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 12,
@@ -267,7 +282,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.013000000000000005
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 13,
@@ -284,7 +300,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.014000000000000005
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 14,
@@ -301,7 +318,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.015000000000000006
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 15,
@@ -318,7 +336,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.016000000000000007
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 16,
@@ -335,7 +354,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.017000000000000008
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 17,
@@ -352,7 +372,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.01800000000000001
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 18,
@@ -369,7 +390,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.01900000000000001
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 19,
@@ -386,7 +408,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.02000000000000001
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 20,
@@ -403,7 +426,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.02100000000000001
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 21,
@@ -420,7 +444,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.022000000000000013
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 22,
@@ -437,7 +462,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.023000000000000013
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 23,
@@ -454,7 +480,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.024000000000000014
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 24,
@@ -471,7 +498,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.025000000000000015
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 25,
@@ -488,7 +516,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.026000000000000016
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 26,
@@ -505,7 +534,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.027000000000000017
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 27,
@@ -522,7 +552,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.028000000000000018
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 28,
@@ -539,7 +570,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.02900000000000002
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 29,
@@ -556,7 +588,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.03000000000000002
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 30,
@@ -573,7 +606,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.03100000000000002
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 31,
@@ -590,7 +624,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.03200000000000002
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 32,
@@ -607,7 +642,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.03300000000000002
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 33,
@@ -624,7 +660,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.03400000000000002
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 34,
@@ -641,7 +678,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.035000000000000024
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 35,
@@ -658,7 +696,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.036000000000000025
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 36,
@@ -675,7 +714,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.037000000000000026
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 37,
@@ -692,7 +732,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.03800000000000003
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 38,
@@ -709,7 +750,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.03900000000000003
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 39,
@@ -726,7 +768,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.04000000000000003
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 40,
@@ -743,7 +786,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.04100000000000003
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 41,
@@ -760,7 +804,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.04200000000000003
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 42,
@@ -777,7 +822,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.04300000000000003
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 43,
@@ -794,7 +840,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.04400000000000003
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 44,
@@ -811,7 +858,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.04500000000000003
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 45,
@@ -828,7 +876,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.046000000000000034
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 46,
@@ -845,7 +894,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.047000000000000035
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 47,
@@ -862,7 +912,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.048000000000000036
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 48,
@@ -879,7 +930,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.04900000000000004
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 49,
@@ -896,7 +948,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.05000000000000004
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 50,
@@ -913,7 +966,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.05100000000000004
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 51,
@@ -930,7 +984,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.05200000000000004
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 52,
@@ -947,7 +1002,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.05300000000000004
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 53,
@@ -964,7 +1020,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.05400000000000004
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 54,
@@ -981,7 +1038,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.05500000000000004
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 55,
@@ -998,7 +1056,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.05600000000000004
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 56,
@@ -1015,7 +1074,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.057000000000000044
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 57,
@@ -1032,7 +1092,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.058000000000000045
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 58,
@@ -1049,7 +1110,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.059000000000000045
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 59,
@@ -1066,7 +1128,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.060000000000000046
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 60,
@@ -1083,7 +1146,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.06100000000000005
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 61,
@@ -1100,7 +1164,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.06200000000000005
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 62,
@@ -1117,7 +1182,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.06300000000000004
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 63,
@@ -1134,7 +1200,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.06400000000000004
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 64,
@@ -1151,7 +1218,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.06500000000000004
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     },
     {
       "index": 65,
@@ -1168,7 +1236,8 @@
         "libration_point": 1,
         "halo_class": 0,
         "amplitude_z": 0.06503642039542143
-      }
+      },
+      "taxonomy_label": "halo_l1_northern"
     }
   ],
   "tags": [

--- a/e2m2e/data/catalog_baseline/baseline-halo-l2.json
+++ b/e2m2e/data/catalog_baseline/baseline-halo-l2.json
@@ -13,7 +13,10 @@
       0.0
     ],
     "has_cr3bp": true,
-    "has_ephemeris": false
+    "has_ephemeris": false,
+    "taxonomy_labels": [
+      "halo_l2_northern"
+    ]
   },
   "status": "converged",
   "cause": "none",
@@ -63,7 +66,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.001
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 1,
@@ -80,7 +84,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.002
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 2,
@@ -97,7 +102,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.003
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 3,
@@ -114,7 +120,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.004
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 4,
@@ -131,7 +138,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.005
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 5,
@@ -148,7 +156,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.006
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 6,
@@ -165,7 +174,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.007
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 7,
@@ -182,7 +192,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.008
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 8,
@@ -199,7 +210,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.009000000000000001
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 9,
@@ -216,7 +228,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.010000000000000002
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 10,
@@ -233,7 +246,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.011000000000000003
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 11,
@@ -250,7 +264,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.012000000000000004
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 12,
@@ -267,7 +282,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.013000000000000005
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 13,
@@ -284,7 +300,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.014000000000000005
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 14,
@@ -301,7 +318,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.015000000000000006
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 15,
@@ -318,7 +336,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.016000000000000007
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 16,
@@ -335,7 +354,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.017000000000000008
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 17,
@@ -352,7 +372,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.01800000000000001
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 18,
@@ -369,7 +390,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.01900000000000001
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 19,
@@ -386,7 +408,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.02000000000000001
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 20,
@@ -403,7 +426,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.02100000000000001
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 21,
@@ -420,7 +444,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.022000000000000013
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 22,
@@ -437,7 +462,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.023000000000000013
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 23,
@@ -454,7 +480,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.024000000000000014
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 24,
@@ -471,7 +498,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.025000000000000015
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 25,
@@ -488,7 +516,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.026000000000000016
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 26,
@@ -505,7 +534,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.027000000000000017
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 27,
@@ -522,7 +552,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.028000000000000018
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 28,
@@ -539,7 +570,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.02900000000000002
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 29,
@@ -556,7 +588,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.03000000000000002
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 30,
@@ -573,7 +606,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.03100000000000002
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 31,
@@ -590,7 +624,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.03200000000000002
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 32,
@@ -607,7 +642,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.03300000000000002
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 33,
@@ -624,7 +660,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.03400000000000002
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 34,
@@ -641,7 +678,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.035000000000000024
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 35,
@@ -658,7 +696,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.036000000000000025
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 36,
@@ -675,7 +714,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.037000000000000026
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 37,
@@ -692,7 +732,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.03800000000000003
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 38,
@@ -709,7 +750,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.03900000000000003
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 39,
@@ -726,7 +768,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.04000000000000003
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 40,
@@ -743,7 +786,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.04100000000000003
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 41,
@@ -760,7 +804,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.04200000000000003
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 42,
@@ -777,7 +822,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.04300000000000003
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 43,
@@ -794,7 +840,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.04400000000000003
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 44,
@@ -811,7 +858,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.04500000000000003
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 45,
@@ -828,7 +876,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.046000000000000034
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 46,
@@ -845,7 +894,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.047000000000000035
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 47,
@@ -862,7 +912,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.048000000000000036
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 48,
@@ -879,7 +930,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.04900000000000004
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 49,
@@ -896,7 +948,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.05000000000000004
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 50,
@@ -913,7 +966,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.05100000000000004
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 51,
@@ -930,7 +984,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.05200000000000004
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 52,
@@ -947,7 +1002,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.05300000000000004
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 53,
@@ -964,7 +1020,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.05400000000000004
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 54,
@@ -981,7 +1038,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.05500000000000004
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 55,
@@ -998,7 +1056,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.05600000000000004
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 56,
@@ -1015,7 +1074,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.057000000000000044
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 57,
@@ -1032,7 +1092,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.058000000000000045
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 58,
@@ -1049,7 +1110,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.059000000000000045
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 59,
@@ -1066,7 +1128,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.060000000000000046
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 60,
@@ -1083,7 +1146,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.06100000000000005
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 61,
@@ -1100,7 +1164,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.06200000000000005
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 62,
@@ -1117,7 +1182,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.06300000000000004
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 63,
@@ -1134,7 +1200,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.06400000000000004
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 64,
@@ -1151,7 +1218,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.06500000000000004
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 65,
@@ -1168,7 +1236,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.06600000000000004
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 66,
@@ -1185,7 +1254,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.06700000000000005
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 67,
@@ -1202,7 +1272,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.06800000000000005
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 68,
@@ -1219,7 +1290,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.06900000000000005
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 69,
@@ -1236,7 +1308,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.07000000000000005
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 70,
@@ -1253,7 +1326,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.07100000000000005
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 71,
@@ -1270,7 +1344,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.07200000000000005
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 72,
@@ -1287,7 +1362,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.07300000000000005
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 73,
@@ -1304,7 +1380,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.07400000000000005
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 74,
@@ -1321,7 +1398,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.07500000000000005
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 75,
@@ -1338,7 +1416,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.07600000000000005
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 76,
@@ -1355,7 +1434,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.07700000000000005
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 77,
@@ -1372,7 +1452,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.07800000000000006
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 78,
@@ -1389,7 +1470,8 @@
         "libration_point": 2,
         "halo_class": 0,
         "amplitude_z": 0.07804370447450572
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     }
   ],
   "tags": [

--- a/e2m2e/data/catalog_baseline/baseline-horseshoe-l4.json
+++ b/e2m2e/data/catalog_baseline/baseline-horseshoe-l4.json
@@ -13,7 +13,8 @@
       0.0
     ],
     "has_cr3bp": true,
-    "has_ephemeris": false
+    "has_ephemeris": false,
+    "taxonomy_labels": []
   },
   "status": "converged",
   "cause": "none",
@@ -69,7 +70,8 @@
         "augmented_system_rank": 5,
         "augmented_system_condition": 27.401062482621903,
         "step_size": 0.01
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 1,
@@ -92,7 +94,8 @@
         "augmented_system_rank": 5,
         "augmented_system_condition": 29.275251312243665,
         "step_size": 0.01
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 2,
@@ -115,7 +118,8 @@
         "augmented_system_rank": 5,
         "augmented_system_condition": 38.21641549696755,
         "step_size": 0.01
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 3,
@@ -138,7 +142,8 @@
         "augmented_system_rank": 5,
         "augmented_system_condition": 54.00495705932477,
         "step_size": 0.01
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 4,
@@ -161,7 +166,8 @@
         "augmented_system_rank": 5,
         "augmented_system_condition": 76.88784521721243,
         "step_size": 0.01
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 5,
@@ -184,7 +190,8 @@
         "augmented_system_rank": 5,
         "augmented_system_condition": 107.51386019949659,
         "step_size": 0.01
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 6,
@@ -207,7 +214,8 @@
         "augmented_system_rank": 5,
         "augmented_system_condition": 146.73880812668443,
         "step_size": 0.01
-      }
+      },
+      "taxonomy_label": null
     }
   ],
   "tags": [

--- a/e2m2e/data/catalog_baseline/baseline-lissajous-l1.json
+++ b/e2m2e/data/catalog_baseline/baseline-lissajous-l1.json
@@ -13,7 +13,8 @@
       7583.703192797949
     ],
     "has_cr3bp": true,
-    "has_ephemeris": false
+    "has_ephemeris": false,
+    "taxonomy_labels": []
   },
   "status": "converged",
   "cause": "none",
@@ -66,7 +67,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.01
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 1,
@@ -86,7 +88,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.02
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 2,
@@ -106,7 +109,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.03
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 3,
@@ -126,7 +130,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.04
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 4,
@@ -146,7 +151,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.05
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 5,
@@ -166,7 +172,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.06
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 6,
@@ -186,7 +193,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.07
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 7,
@@ -206,7 +214,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.08
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 8,
@@ -226,7 +235,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.09
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 9,
@@ -246,7 +256,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.1
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 10,
@@ -266,7 +277,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.11
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 11,
@@ -286,7 +298,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.12
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 12,
@@ -306,7 +319,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.13
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 13,
@@ -326,7 +340,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.14
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 14,
@@ -346,7 +361,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.15
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 15,
@@ -366,7 +382,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.16
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 16,
@@ -386,7 +403,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.17
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 17,
@@ -406,7 +424,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.18
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 18,
@@ -426,7 +445,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.19
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 19,
@@ -446,7 +466,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.2
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 20,
@@ -466,7 +487,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.21
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 21,
@@ -486,7 +508,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.22
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 22,
@@ -506,7 +529,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.23
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 23,
@@ -526,7 +550,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.24
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 24,
@@ -546,7 +571,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.25
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 25,
@@ -566,7 +592,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.26
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 26,
@@ -586,7 +613,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.27
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 27,
@@ -606,7 +634,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.28
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 28,
@@ -626,7 +655,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.29
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 29,
@@ -646,7 +676,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.3
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 30,
@@ -666,7 +697,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.31
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 31,
@@ -686,7 +718,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.32
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 32,
@@ -706,7 +739,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.33
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 33,
@@ -726,7 +760,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.34
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 34,
@@ -746,7 +781,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.35
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 35,
@@ -766,7 +802,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.36
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 36,
@@ -786,7 +823,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.37
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 37,
@@ -806,7 +844,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.38
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 38,
@@ -826,7 +865,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.39
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 39,
@@ -846,7 +886,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.4
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 40,
@@ -866,7 +907,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.41
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 41,
@@ -886,7 +928,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.42
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 42,
@@ -906,7 +949,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.43
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 43,
@@ -926,7 +970,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.44
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 44,
@@ -946,7 +991,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.45
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 45,
@@ -966,7 +1012,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.46
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 46,
@@ -986,7 +1033,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.47
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 47,
@@ -1006,7 +1054,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.48
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 48,
@@ -1026,7 +1075,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.49
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 49,
@@ -1046,7 +1096,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.5
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 50,
@@ -1066,7 +1117,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.51
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 51,
@@ -1086,7 +1138,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.52
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 52,
@@ -1106,7 +1159,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.53
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 53,
@@ -1126,7 +1180,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.54
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 54,
@@ -1146,7 +1201,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.55
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 55,
@@ -1166,7 +1222,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.56
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 56,
@@ -1186,7 +1243,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.57
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 57,
@@ -1206,7 +1264,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.58
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 58,
@@ -1226,7 +1285,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.59
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 59,
@@ -1246,7 +1306,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.6
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 60,
@@ -1266,7 +1327,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.61
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 61,
@@ -1286,7 +1348,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.62
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 62,
@@ -1306,7 +1369,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.63
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 63,
@@ -1326,7 +1390,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.64
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 64,
@@ -1346,7 +1411,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.65
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 65,
@@ -1366,7 +1432,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.66
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 66,
@@ -1386,7 +1453,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.67
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 67,
@@ -1406,7 +1474,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.68
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 68,
@@ -1426,7 +1495,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.69
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 69,
@@ -1446,7 +1516,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.7
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 70,
@@ -1466,7 +1537,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.71
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 71,
@@ -1486,7 +1558,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.72
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 72,
@@ -1506,7 +1579,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.73
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 73,
@@ -1526,7 +1600,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.74
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 74,
@@ -1546,7 +1621,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.75
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 75,
@@ -1566,7 +1642,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.76
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 76,
@@ -1586,7 +1663,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.77
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 77,
@@ -1606,7 +1684,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.78
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 78,
@@ -1626,7 +1705,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.79
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 79,
@@ -1646,7 +1726,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.8
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 80,
@@ -1666,7 +1747,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.81
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 81,
@@ -1686,7 +1768,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.82
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 82,
@@ -1706,7 +1789,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.83
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 83,
@@ -1726,7 +1810,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.84
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 84,
@@ -1746,7 +1831,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.85
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 85,
@@ -1766,7 +1852,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.86
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 86,
@@ -1786,7 +1873,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.87
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 87,
@@ -1806,7 +1894,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.88
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 88,
@@ -1826,7 +1915,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.89
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 89,
@@ -1846,7 +1936,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.9
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 90,
@@ -1866,7 +1957,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.91
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 91,
@@ -1886,7 +1978,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.92
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 92,
@@ -1906,7 +1999,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.93
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 93,
@@ -1926,7 +2020,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.94
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 94,
@@ -1946,7 +2041,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.95
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 95,
@@ -1966,7 +2062,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.96
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 96,
@@ -1986,7 +2083,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.97
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 97,
@@ -2006,7 +2104,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.98
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 98,
@@ -2026,7 +2125,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.99
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 99,
@@ -2046,7 +2146,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 1.0
-      }
+      },
+      "taxonomy_label": null
     }
   ],
   "tags": [

--- a/e2m2e/data/catalog_baseline/baseline-lissajous-l2.json
+++ b/e2m2e/data/catalog_baseline/baseline-lissajous-l2.json
@@ -13,7 +13,8 @@
       7478.512856638936
     ],
     "has_cr3bp": true,
-    "has_ephemeris": false
+    "has_ephemeris": false,
+    "taxonomy_labels": []
   },
   "status": "converged",
   "cause": "none",
@@ -66,7 +67,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.01
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 1,
@@ -86,7 +88,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.02
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 2,
@@ -106,7 +109,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.03
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 3,
@@ -126,7 +130,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.04
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 4,
@@ -146,7 +151,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.05
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 5,
@@ -166,7 +172,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.06
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 6,
@@ -186,7 +193,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.07
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 7,
@@ -206,7 +214,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.08
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 8,
@@ -226,7 +235,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.09
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 9,
@@ -246,7 +256,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.1
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 10,
@@ -266,7 +277,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.11
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 11,
@@ -286,7 +298,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.12
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 12,
@@ -306,7 +319,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.13
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 13,
@@ -326,7 +340,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.14
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 14,
@@ -346,7 +361,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.15
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 15,
@@ -366,7 +382,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.16
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 16,
@@ -386,7 +403,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.17
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 17,
@@ -406,7 +424,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.18
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 18,
@@ -426,7 +445,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.19
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 19,
@@ -446,7 +466,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.2
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 20,
@@ -466,7 +487,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.21
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 21,
@@ -486,7 +508,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.22
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 22,
@@ -506,7 +529,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.23
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 23,
@@ -526,7 +550,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.24
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 24,
@@ -546,7 +571,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.25
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 25,
@@ -566,7 +592,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.26
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 26,
@@ -586,7 +613,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.27
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 27,
@@ -606,7 +634,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.28
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 28,
@@ -626,7 +655,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.29
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 29,
@@ -646,7 +676,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.3
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 30,
@@ -666,7 +697,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.31
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 31,
@@ -686,7 +718,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.32
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 32,
@@ -706,7 +739,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.33
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 33,
@@ -726,7 +760,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.34
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 34,
@@ -746,7 +781,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.35
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 35,
@@ -766,7 +802,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.36
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 36,
@@ -786,7 +823,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.37
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 37,
@@ -806,7 +844,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.38
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 38,
@@ -826,7 +865,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.39
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 39,
@@ -846,7 +886,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.4
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 40,
@@ -866,7 +907,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.41
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 41,
@@ -886,7 +928,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.42
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 42,
@@ -906,7 +949,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.43
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 43,
@@ -926,7 +970,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.44
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 44,
@@ -946,7 +991,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.45
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 45,
@@ -966,7 +1012,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.46
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 46,
@@ -986,7 +1033,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.47
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 47,
@@ -1006,7 +1054,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.48
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 48,
@@ -1026,7 +1075,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.49
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 49,
@@ -1046,7 +1096,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.5
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 50,
@@ -1066,7 +1117,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.51
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 51,
@@ -1086,7 +1138,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.52
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 52,
@@ -1106,7 +1159,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.53
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 53,
@@ -1126,7 +1180,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.54
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 54,
@@ -1146,7 +1201,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.55
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 55,
@@ -1166,7 +1222,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.56
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 56,
@@ -1186,7 +1243,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.57
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 57,
@@ -1206,7 +1264,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.58
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 58,
@@ -1226,7 +1285,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.59
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 59,
@@ -1246,7 +1306,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.6
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 60,
@@ -1266,7 +1327,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.61
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 61,
@@ -1286,7 +1348,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.62
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 62,
@@ -1306,7 +1369,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.63
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 63,
@@ -1326,7 +1390,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.64
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 64,
@@ -1346,7 +1411,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.65
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 65,
@@ -1366,7 +1432,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.66
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 66,
@@ -1386,7 +1453,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.67
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 67,
@@ -1406,7 +1474,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.68
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 68,
@@ -1426,7 +1495,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.69
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 69,
@@ -1446,7 +1516,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.7
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 70,
@@ -1466,7 +1537,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.71
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 71,
@@ -1486,7 +1558,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.72
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 72,
@@ -1506,7 +1579,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.73
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 73,
@@ -1526,7 +1600,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.74
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 74,
@@ -1546,7 +1621,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.75
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 75,
@@ -1566,7 +1642,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.76
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 76,
@@ -1586,7 +1663,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.77
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 77,
@@ -1606,7 +1684,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.78
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 78,
@@ -1626,7 +1705,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.79
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 79,
@@ -1646,7 +1726,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.8
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 80,
@@ -1666,7 +1747,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.81
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 81,
@@ -1686,7 +1768,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.82
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 82,
@@ -1706,7 +1789,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.83
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 83,
@@ -1726,7 +1810,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.84
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 84,
@@ -1746,7 +1831,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.85
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 85,
@@ -1766,7 +1852,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.86
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 86,
@@ -1786,7 +1873,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.87
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 87,
@@ -1806,7 +1894,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.88
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 88,
@@ -1826,7 +1915,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.89
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 89,
@@ -1846,7 +1936,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.9
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 90,
@@ -1866,7 +1957,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.91
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 91,
@@ -1886,7 +1978,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.92
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 92,
@@ -1906,7 +1999,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.93
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 93,
@@ -1926,7 +2020,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.94
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 94,
@@ -1946,7 +2041,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.95
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 95,
@@ -1966,7 +2062,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.96
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 96,
@@ -1986,7 +2083,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.97
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 97,
@@ -2006,7 +2104,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.98
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 98,
@@ -2026,7 +2125,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 0.99
-      }
+      },
+      "taxonomy_label": null
     },
     {
       "index": 99,
@@ -2046,7 +2146,8 @@
         "phase_in": 0.01,
         "phase_out": 0.55,
         "sampling_fraction": 1.0
-      }
+      },
+      "taxonomy_label": null
     }
   ],
   "tags": [

--- a/e2m2e/data/catalog_baseline/baseline-lpo-l4.json
+++ b/e2m2e/data/catalog_baseline/baseline-lpo-l4.json
@@ -13,7 +13,10 @@
       0.0
     ],
     "has_cr3bp": true,
-    "has_ephemeris": false
+    "has_ephemeris": false,
+    "taxonomy_labels": [
+      "longperiod_l4"
+    ]
   },
   "status": "converged",
   "cause": "none",
@@ -69,7 +72,8 @@
         "augmented_system_rank": 5,
         "augmented_system_condition": 1188.2148840216582,
         "step_size": 0.01
-      }
+      },
+      "taxonomy_label": "longperiod_l4"
     },
     {
       "index": 1,
@@ -92,7 +96,8 @@
         "augmented_system_rank": 5,
         "augmented_system_condition": 293.1105252134052,
         "step_size": 0.01
-      }
+      },
+      "taxonomy_label": "longperiod_l4"
     },
     {
       "index": 2,
@@ -115,7 +120,8 @@
         "augmented_system_rank": 5,
         "augmented_system_condition": 151.50478493096443,
         "step_size": 0.01
-      }
+      },
+      "taxonomy_label": "longperiod_l4"
     },
     {
       "index": 3,
@@ -138,7 +144,8 @@
         "augmented_system_rank": 5,
         "augmented_system_condition": 95.01572099675319,
         "step_size": 0.01
-      }
+      },
+      "taxonomy_label": "longperiod_l4"
     },
     {
       "index": 4,
@@ -161,7 +168,8 @@
         "augmented_system_rank": 5,
         "augmented_system_condition": 63.91951593435452,
         "step_size": 0.01
-      }
+      },
+      "taxonomy_label": "longperiod_l4"
     },
     {
       "index": 5,
@@ -184,7 +192,8 @@
         "augmented_system_rank": 5,
         "augmented_system_condition": 44.49782575347792,
         "step_size": 0.01
-      }
+      },
+      "taxonomy_label": "longperiod_l4"
     },
     {
       "index": 6,
@@ -207,7 +216,8 @@
         "augmented_system_rank": 5,
         "augmented_system_condition": 32.59612446794477,
         "step_size": 0.01
-      }
+      },
+      "taxonomy_label": "longperiod_l4"
     },
     {
       "index": 7,
@@ -230,7 +240,8 @@
         "augmented_system_rank": 5,
         "augmented_system_condition": 27.401062482621903,
         "step_size": 0.01
-      }
+      },
+      "taxonomy_label": "longperiod_l4"
     },
     {
       "index": 8,
@@ -253,7 +264,8 @@
         "augmented_system_rank": 5,
         "augmented_system_condition": 29.275251312243665,
         "step_size": 0.01
-      }
+      },
+      "taxonomy_label": "longperiod_l4"
     },
     {
       "index": 9,
@@ -276,7 +288,8 @@
         "augmented_system_rank": 5,
         "augmented_system_condition": 38.21641549696755,
         "step_size": 0.01
-      }
+      },
+      "taxonomy_label": "longperiod_l4"
     },
     {
       "index": 10,
@@ -299,7 +312,8 @@
         "augmented_system_rank": 5,
         "augmented_system_condition": 54.00495705932477,
         "step_size": 0.01
-      }
+      },
+      "taxonomy_label": "longperiod_l4"
     },
     {
       "index": 11,
@@ -322,7 +336,8 @@
         "augmented_system_rank": 5,
         "augmented_system_condition": 76.88784521721243,
         "step_size": 0.01
-      }
+      },
+      "taxonomy_label": "longperiod_l4"
     },
     {
       "index": 12,
@@ -345,7 +360,8 @@
         "augmented_system_rank": 5,
         "augmented_system_condition": 107.51386019949659,
         "step_size": 0.01
-      }
+      },
+      "taxonomy_label": "longperiod_l4"
     },
     {
       "index": 13,
@@ -368,7 +384,8 @@
         "augmented_system_rank": 5,
         "augmented_system_condition": 146.73880812668443,
         "step_size": 0.01
-      }
+      },
+      "taxonomy_label": "longperiod_l4"
     }
   ],
   "tags": [

--- a/e2m2e/data/catalog_baseline/baseline-nrho-l1.json
+++ b/e2m2e/data/catalog_baseline/baseline-nrho-l1.json
@@ -13,7 +13,10 @@
       0.0
     ],
     "has_cr3bp": true,
-    "has_ephemeris": false
+    "has_ephemeris": false,
+    "taxonomy_labels": [
+      "halo_l1_southern"
+    ]
   },
   "status": "converged",
   "cause": "none",
@@ -63,7 +66,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 19966.12439306497
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 1,
@@ -80,7 +84,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 19778.345862429178
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 2,
@@ -97,7 +102,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 19591.668955508663
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 3,
@@ -114,7 +120,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 19406.097330048324
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 4,
@@ -131,7 +138,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 19221.63494870863
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 5,
@@ -148,7 +156,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 19038.2860592652
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 6,
@@ -165,7 +174,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 18856.055174421916
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 7,
@@ -182,7 +192,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 18674.947051278403
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 8,
@@ -199,7 +210,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 18494.966670473234
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 9,
@@ -216,7 +228,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 18316.119215037957
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 10,
@@ -233,7 +246,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 18138.410048976155
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 11,
@@ -250,7 +264,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 17961.84469563
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 12,
@@ -267,7 +282,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 17786.428815842344
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 13,
@@ -284,7 +300,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 17612.168185966366
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 14,
@@ -301,7 +318,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 17439.06867575974
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 15,
@@ -318,7 +336,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 17267.136226212846
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 16,
@@ -335,7 +354,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 17096.37682734395
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 17,
@@ -352,7 +372,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 16926.79649602286
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 18,
@@ -369,7 +390,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 16758.401253856362
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 19,
@@ -386,7 +408,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 16591.197105206997
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 20,
@@ -403,7 +426,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 16425.190015377306
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 21,
@@ -420,7 +444,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 16260.385889028554
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 22,
@@ -437,7 +462,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 16096.790548881114
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 23,
@@ -454,7 +480,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 15934.409714752883
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 24,
@@ -471,7 +498,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 15773.24898299699
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 25,
@@ -488,7 +516,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 15613.313806386557
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 26,
@@ -505,7 +534,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 15454.609474506628
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 27,
@@ -522,7 +552,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 15297.141094714067
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 28,
@@ -539,7 +570,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 15140.913573692245
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 29,
@@ -556,7 +588,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 14985.931599697667
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 30,
@@ -573,7 +606,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 14832.19962550183
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 31,
@@ -590,7 +624,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 14679.721852104356
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 32,
@@ -607,7 +642,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 14528.502213251419
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 33,
@@ -624,7 +660,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 14378.544360802713
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 34,
@@ -641,7 +678,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 14229.851650985534
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 35,
@@ -658,7 +696,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 14082.427131568968
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 36,
@@ -675,7 +714,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 13936.273529990418
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 37,
@@ -692,7 +732,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 13791.393242458968
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 38,
@@ -709,7 +750,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 13647.788324058873
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 39,
@@ -726,7 +768,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 13505.460479869822
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 40,
@@ -743,7 +786,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 13364.411057117197
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 41,
@@ -760,7 +804,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 13224.64103836042
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 42,
@@ -777,7 +822,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 13086.151035722829
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 43,
@@ -794,7 +840,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 12948.941286162168
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 44,
@@ -811,7 +858,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 12813.011647775891
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 45,
@@ -828,7 +876,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 12678.36159713134
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 46,
@@ -845,7 +894,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 12544.990227605489
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 47,
@@ -862,7 +912,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 12412.896248716519
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 48,
@@ -879,7 +930,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 12282.077986423925
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 49,
@@ -896,7 +948,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 12152.533384370772
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 50,
@@ -913,7 +966,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 12024.260006038532
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 51,
@@ -930,7 +984,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 11897.255037780797
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 52,
@@ -947,7 +1002,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 11771.515292700386
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 53,
@@ -964,7 +1020,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 11647.03721533093
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 54,
@@ -981,7 +1038,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 11523.816887082054
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 55,
@@ -998,7 +1056,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 11401.850032405224
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 56,
@@ -1015,7 +1074,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 11281.132025636392
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 57,
@@ -1032,7 +1092,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 11161.657898468487
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 58,
@@ -1049,7 +1110,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 11043.42234800834
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 59,
@@ -1066,7 +1128,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 10926.419745369902
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 60,
@@ -1083,7 +1146,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 10810.644144756308
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 61,
@@ -1100,7 +1164,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 10696.089292982864
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 62,
@@ -1117,7 +1182,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 10582.748639393989
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 63,
@@ -1134,7 +1200,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 10470.615346126298
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 64,
@@ -1151,7 +1218,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 10359.682298672366
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 65,
@@ -1168,7 +1236,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 10249.942116699256
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 66,
@@ -1185,7 +1254,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 10141.387165078408
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 67,
@@ -1202,7 +1272,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 10034.009565083026
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 68,
@@ -1219,7 +1290,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 9927.801205713236
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 69,
@@ -1236,7 +1308,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 9822.753755107797
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 70,
@@ -1253,7 +1326,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 9718.858672005928
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 71,
@@ -1270,7 +1344,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 9616.107217222312
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 72,
@@ -1287,7 +1362,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 9514.490465102024
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 73,
@@ -1304,7 +1380,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 9413.9993149227
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 74,
@@ -1321,7 +1398,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 9314.624502214763
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 75,
@@ -1338,7 +1416,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 9216.356609971192
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 76,
@@ -1355,7 +1434,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 9119.186079721401
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 77,
@@ -1372,7 +1452,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 9023.10322244527
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 78,
@@ -1389,7 +1470,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 8928.098229306177
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 79,
@@ -1406,7 +1488,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 8834.161182182574
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 80,
@@ -1423,7 +1506,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 8741.2820639814
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 81,
@@ -1440,7 +1524,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 8649.45076871681
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 82,
@@ -1457,7 +1542,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 8558.657111340593
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 83,
@@ -1474,7 +1560,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 8468.890837312412
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 84,
@@ -1491,7 +1578,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 8380.141631899247
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 85,
@@ -1508,7 +1596,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 8292.399129195535
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 86,
@@ -1525,7 +1614,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 8205.652920856488
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 87,
@@ -1542,7 +1632,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 8119.892564539461
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 88,
@@ -1559,7 +1650,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 8035.107592048433
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 89,
@@ -1576,7 +1668,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 7951.287517179289
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 90,
@@ -1593,7 +1686,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 7868.42184326353
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 91,
@@ -1610,7 +1704,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 7786.500070410153
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 92,
@@ -1627,7 +1722,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 7705.511702445938
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 93,
@@ -1644,7 +1740,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 7625.4462535555285
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 94,
@@ -1661,7 +1758,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 7546.29325462367
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 95,
@@ -1678,7 +1776,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 7468.042259282223
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 96,
@@ -1695,7 +1794,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 7390.68284966622
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 97,
@@ -1712,7 +1812,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 7314.20464188308
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 98,
@@ -1729,7 +1830,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 7238.597291199951
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     },
     {
       "index": 99,
@@ -1746,7 +1848,8 @@
         "libration_point": 1,
         "halo_class": 1,
         "perilune_height_km": 7163.850496954743
-      }
+      },
+      "taxonomy_label": "halo_l1_southern"
     }
   ],
   "tags": [

--- a/e2m2e/data/catalog_baseline/baseline-nrho-l2.json
+++ b/e2m2e/data/catalog_baseline/baseline-nrho-l2.json
@@ -13,7 +13,10 @@
       0.0
     ],
     "has_cr3bp": true,
-    "has_ephemeris": false
+    "has_ephemeris": false,
+    "taxonomy_labels": [
+      "halo_l2_northern"
+    ]
   },
   "status": "converged",
   "cause": "none",
@@ -63,7 +66,8 @@
         "libration_point": 2,
         "halo_class": 1,
         "perilune_height_km": 18721.949753967274
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 1,
@@ -80,7 +84,8 @@
         "libration_point": 2,
         "halo_class": 1,
         "perilune_height_km": 17207.0879272359
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 2,
@@ -97,7 +102,8 @@
         "libration_point": 2,
         "halo_class": 1,
         "perilune_height_km": 15723.719234039245
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 3,
@@ -114,7 +120,8 @@
         "libration_point": 2,
         "halo_class": 1,
         "perilune_height_km": 14276.020902151873
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 4,
@@ -131,7 +138,8 @@
         "libration_point": 2,
         "halo_class": 1,
         "perilune_height_km": 12867.771095920072
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 5,
@@ -148,7 +156,8 @@
         "libration_point": 2,
         "halo_class": 1,
         "perilune_height_km": 11502.450482323138
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 6,
@@ -165,7 +174,8 @@
         "libration_point": 2,
         "halo_class": 1,
         "perilune_height_km": 10183.356455169616
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 7,
@@ -182,7 +192,8 @@
         "libration_point": 2,
         "halo_class": 1,
         "perilune_height_km": 8913.70958020247
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 8,
@@ -199,7 +210,8 @@
         "libration_point": 2,
         "halo_class": 1,
         "perilune_height_km": 7696.7409878370145
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 9,
@@ -216,7 +228,8 @@
         "libration_point": 2,
         "halo_class": 1,
         "perilune_height_km": 6535.756868308792
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 10,
@@ -233,7 +246,8 @@
         "libration_point": 2,
         "halo_class": 1,
         "perilune_height_km": 5434.182072858479
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 11,
@@ -250,7 +264,8 @@
         "libration_point": 2,
         "halo_class": 1,
         "perilune_height_km": 4395.590362387369
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 12,
@@ -267,7 +282,8 @@
         "libration_point": 2,
         "halo_class": 1,
         "perilune_height_km": 3423.7366271776295
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 13,
@@ -284,7 +300,8 @@
         "libration_point": 2,
         "halo_class": 1,
         "perilune_height_km": 2522.622015409785
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 14,
@@ -301,7 +318,8 @@
         "libration_point": 2,
         "halo_class": 1,
         "perilune_height_km": 1696.6610953661598
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     },
     {
       "index": 15,
@@ -318,7 +336,8 @@
         "libration_point": 2,
         "halo_class": 1,
         "perilune_height_km": 951.1255604625399
-      }
+      },
+      "taxonomy_label": "halo_l2_northern"
     }
   ],
   "tags": [

--- a/e2m2e/data/catalog_baseline/baseline-spo-l4.json
+++ b/e2m2e/data/catalog_baseline/baseline-spo-l4.json
@@ -13,7 +13,10 @@
       0.0
     ],
     "has_cr3bp": true,
-    "has_ephemeris": false
+    "has_ephemeris": false,
+    "taxonomy_labels": [
+      "shortperiod_l4"
+    ]
   },
   "status": "converged",
   "cause": "none",
@@ -69,7 +72,8 @@
         "augmented_system_rank": 5,
         "augmented_system_condition": 1733.822750601573,
         "step_size": 0.01
-      }
+      },
+      "taxonomy_label": "shortperiod_l4"
     },
     {
       "index": 1,
@@ -92,7 +96,8 @@
         "augmented_system_rank": 5,
         "augmented_system_condition": 976.1290675824714,
         "step_size": 0.01
-      }
+      },
+      "taxonomy_label": "shortperiod_l4"
     },
     {
       "index": 2,
@@ -115,7 +120,8 @@
         "augmented_system_rank": 5,
         "augmented_system_condition": 686.1253312914566,
         "step_size": 0.01
-      }
+      },
+      "taxonomy_label": "shortperiod_l4"
     },
     {
       "index": 3,
@@ -138,7 +144,8 @@
         "augmented_system_rank": 5,
         "augmented_system_condition": 533.4927181868736,
         "step_size": 0.01
-      }
+      },
+      "taxonomy_label": "shortperiod_l4"
     },
     {
       "index": 4,
@@ -161,7 +168,8 @@
         "augmented_system_rank": 5,
         "augmented_system_condition": 439.5709571353263,
         "step_size": 0.01
-      }
+      },
+      "taxonomy_label": "shortperiod_l4"
     },
     {
       "index": 5,
@@ -184,7 +192,8 @@
         "augmented_system_rank": 5,
         "augmented_system_condition": 376.0869732942198,
         "step_size": 0.01
-      }
+      },
+      "taxonomy_label": "shortperiod_l4"
     },
     {
       "index": 6,
@@ -207,7 +216,8 @@
         "augmented_system_rank": 5,
         "augmented_system_condition": 330.39174586070766,
         "step_size": 0.01
-      }
+      },
+      "taxonomy_label": "shortperiod_l4"
     },
     {
       "index": 7,
@@ -230,7 +240,8 @@
         "augmented_system_rank": 5,
         "augmented_system_condition": 295.9826909746804,
         "step_size": 0.01
-      }
+      },
+      "taxonomy_label": "shortperiod_l4"
     },
     {
       "index": 8,
@@ -253,7 +264,8 @@
         "augmented_system_rank": 5,
         "augmented_system_condition": 269.17689961612894,
         "step_size": 0.01
-      }
+      },
+      "taxonomy_label": "shortperiod_l4"
     },
     {
       "index": 9,
@@ -276,7 +288,8 @@
         "augmented_system_rank": 5,
         "augmented_system_condition": 247.73339243519663,
         "step_size": 0.01
-      }
+      },
+      "taxonomy_label": "shortperiod_l4"
     },
     {
       "index": 10,
@@ -299,7 +312,8 @@
         "augmented_system_rank": 5,
         "augmented_system_condition": 230.2109903330068,
         "step_size": 0.01
-      }
+      },
+      "taxonomy_label": "shortperiod_l4"
     },
     {
       "index": 11,
@@ -322,7 +336,8 @@
         "augmented_system_rank": 5,
         "augmented_system_condition": 215.6411205649595,
         "step_size": 0.01
-      }
+      },
+      "taxonomy_label": "shortperiod_l4"
     },
     {
       "index": 12,
@@ -345,7 +360,8 @@
         "augmented_system_rank": 5,
         "augmented_system_condition": 203.34901587348506,
         "step_size": 0.01
-      }
+      },
+      "taxonomy_label": "shortperiod_l4"
     },
     {
       "index": 13,
@@ -368,7 +384,8 @@
         "augmented_system_rank": 5,
         "augmented_system_condition": 192.8503290743673,
         "step_size": 0.01
-      }
+      },
+      "taxonomy_label": "shortperiod_l4"
     },
     {
       "index": 14,
@@ -391,7 +408,8 @@
         "augmented_system_rank": 5,
         "augmented_system_condition": 183.7885018106959,
         "step_size": 0.01
-      }
+      },
+      "taxonomy_label": "shortperiod_l4"
     },
     {
       "index": 15,
@@ -414,7 +432,8 @@
         "augmented_system_rank": 5,
         "augmented_system_condition": 175.89530701594458,
         "step_size": 0.01
-      }
+      },
+      "taxonomy_label": "shortperiod_l4"
     },
     {
       "index": 16,
@@ -437,7 +456,8 @@
         "augmented_system_rank": 5,
         "augmented_system_condition": 168.96514681881555,
         "step_size": 0.01
-      }
+      },
+      "taxonomy_label": "shortperiod_l4"
     },
     {
       "index": 17,
@@ -460,7 +480,8 @@
         "augmented_system_rank": 5,
         "augmented_system_condition": 162.83782111166747,
         "step_size": 0.01
-      }
+      },
+      "taxonomy_label": "shortperiod_l4"
     },
     {
       "index": 18,
@@ -483,7 +504,8 @@
         "augmented_system_rank": 5,
         "augmented_system_condition": 157.38668110225726,
         "step_size": 0.01
-      }
+      },
+      "taxonomy_label": "shortperiod_l4"
     },
     {
       "index": 19,
@@ -506,7 +528,8 @@
         "augmented_system_rank": 5,
         "augmented_system_condition": 152.51030287328066,
         "step_size": 0.01
-      }
+      },
+      "taxonomy_label": "shortperiod_l4"
     },
     {
       "index": 20,
@@ -529,7 +552,8 @@
         "augmented_system_rank": 5,
         "augmented_system_condition": 148.12651910281548,
         "step_size": 0.01
-      }
+      },
+      "taxonomy_label": "shortperiod_l4"
     },
     {
       "index": 21,
@@ -552,7 +576,8 @@
         "augmented_system_rank": 5,
         "augmented_system_condition": 144.16806547990288,
         "step_size": 0.01
-      }
+      },
+      "taxonomy_label": "shortperiod_l4"
     },
     {
       "index": 22,
@@ -575,7 +600,8 @@
         "augmented_system_rank": 5,
         "augmented_system_condition": 140.57935457645854,
         "step_size": 0.01
-      }
+      },
+      "taxonomy_label": "shortperiod_l4"
     }
   ],
   "tags": [

--- a/scripts/backfill_baseline_taxonomy.py
+++ b/scripts/backfill_baseline_taxonomy.py
@@ -1,0 +1,73 @@
+"""给随包 baseline 数据集回填分类学标签（issue #581 / ADR 0042）。
+
+对 ``e2m2e/data/catalog_baseline/`` 每个族记录：按成员初值 + 周期实测
+分类（与生产 ingest 同一条打标路径 ``stamp_taxonomy_labels``），把
+``classification.taxonomy_labels``（记录级去重集合）与
+``members[].taxonomy_label``（成员级 primary）写回 JSON。NPZ 数组不动。
+
+期望集为空的族（lissajous 拟周期、horseshoe 不在分类学内）直接置空
+标签。dpo 前 4 成员实测逆行（设计侧族行走的另一支，ADR 0042 复现
+注记）会触发冲突告警并按实测值入库——脚本输出可见。
+
+用法（直接用 venv 解释器，同 generate_catalog_baseline）::
+
+    .venv/bin/python scripts/backfill_baseline_taxonomy.py
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+
+from e2m2e.algorithm.dynamics.cr3bp_system import CR3BP_System
+from e2m2e.api.catalog_ingest import stamp_taxonomy_labels
+from e2m2e.data.types.orbit import Orbit
+
+#: 基线数据目录（与 generate_catalog_baseline.py 同源）
+OUTPUT_DIR = Path(__file__).resolve().parents[1] / "e2m2e" / "data" / "catalog_baseline"
+
+
+def backfill_family(json_path: Path) -> tuple[str, list[str]]:
+    """回填一个族记录，返回（族名，记录级标签列表）。"""
+    meta = json.loads(json_path.read_text(encoding="utf-8"))
+    bundle = np.load(json_path.with_suffix(".npz"))
+    mu = meta["scalars"].get("mu")
+    if mu is None:
+        return json_path.stem, []
+    system = CR3BP_System(mu=float(mu), primary="earth", secondary="moon")
+    orbits = []
+    for i, member in enumerate(meta["members"]):
+        state = bundle[f"cr3bp/members/{i:04d}/states"][0]
+        orbit = Orbit(states=state.reshape(1, -1), times=np.array([0.0]), system=system)
+        orbit.period = member.get("period")
+        orbit.parameters = dict(member.get("parameters", {}))
+        orbits.append(orbit)
+    labels, member_labels = stamp_taxonomy_labels(
+        meta["classification"]["orbit_family"],
+        orbits,
+        periodicity=meta["scalars"].get("periodicity", "periodic"),
+        context=json_path.stem,
+    )
+    meta["classification"]["taxonomy_labels"] = labels
+    for member, label in zip(meta["members"], member_labels, strict=True):
+        member["taxonomy_label"] = label
+    # 与 record.meta_to_json 同格式（indent=2、不转义中文、无行尾换行）
+    json_path.write_text(json.dumps(meta, ensure_ascii=False, indent=2), encoding="utf-8")
+    return json_path.stem, labels
+
+
+def main() -> int:
+    count = 0
+    for json_path in sorted(OUTPUT_DIR.glob("baseline-*.json")):
+        name, labels = backfill_family(json_path)
+        print(f"{name}: taxonomy_labels = {labels}")
+        count += 1
+    print(f"共回填 {count} 个族记录")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/algorithm/orbit_taxonomy/test_classify.py
+++ b/tests/algorithm/orbit_taxonomy/test_classify.py
@@ -1,0 +1,312 @@
+"""orbit_taxonomy 分类器测试：baseline 数据集回归 + 合成判据用例。
+
+随包 baseline（ADR 0036）是判据的回归锚点：13 个周期族全体成员必须
+命中预期标签（映射约定为 unclassified 的族除外）。butterfly/dragonfly/
+vertical/lyapunov 无 baseline 锚点，用**判据级合成轨迹**覆盖（合成
+曲线验证穿越几何判据本身，不是动力学解——ADR 0042 验证状态表）。
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from e2m2e.algorithm.orbit_taxonomy import classify_orbit
+
+pytestmark = pytest.mark.theory
+
+#: 随包 baseline 目录。
+BASELINE_DIR = Path(__file__).resolve().parents[3] / "e2m2e" / "data" / "catalog_baseline"
+
+#: baseline 族 → 预期标签集合（成员 primary 必须落在集合内）。
+#: lissajous 是拟周期采样（成员不闭合）；horseshoe 不在分类学内
+#: （ADR 0042 映射表：入库按设计侧覆写为空标签）——两者不进本表。
+#: dpo 的前 4 个成员几何上是逆行小月心轨道（设计侧族行走的另一支，
+#: ADR 0042 复现注记）：按分类学判 distant_retrograde，入库时走
+#: 冲突告警路径。
+EXPECTED_FAMILY_LABELS = {
+    "axial-l1": {"axial_l1"},
+    "axial-l2": {"axial_l2"},
+    "dpo": {
+        "distant_prograde",
+        "low_prograde_eastern",
+        "low_prograde_western",
+        "distant_retrograde",
+    },
+    "dro": {"distant_retrograde"},
+    "halo-l1": {"halo_l1_northern"},
+    "halo-l2": {"halo_l2_northern"},
+    "lpo-l4": {"longperiod_l4"},
+    "nrho-l1": {"halo_l1_southern"},
+    "nrho-l2": {"halo_l2_northern"},
+    "spo-l4": {"shortperiod_l4"},
+}
+
+
+def _load_family(name: str) -> tuple[list[np.ndarray], list[float], str]:
+    """读 baseline 族：返回（成员单状态列表，成员周期列表，periodicity）。"""
+    meta = json.loads((BASELINE_DIR / f"baseline-{name}.json").read_text(encoding="utf-8"))
+    bundle = np.load(BASELINE_DIR / f"baseline-{name}.npz")
+    states = [bundle[f"cr3bp/members/{i:04d}/states"][0] for i in range(len(meta["members"]))]
+    periods = [member["period"] for member in meta["members"]]
+    periodicity = meta["scalars"].get("periodicity", "periodic")
+    return states, periods, periodicity
+
+
+@pytest.mark.parametrize(
+    "family,expected",
+    sorted(EXPECTED_FAMILY_LABELS.items()),
+)
+def test_baseline_family_members_classify(family: str, expected: set[str]):
+    """baseline 每个周期族全体成员的 primary 落在预期标签集合内。"""
+    states, periods, periodicity = _load_family(family)
+    assert periodicity == "periodic"
+    actual: set[str] = set()
+    for state, period in zip(states, periods, strict=True):
+        result = classify_orbit(state[None, :], period=period)
+        assert result.status.value == "converged", result.message
+        assert result.primary is not None, (family, result.diagnostics)
+        actual.add(result.primary.canonical)
+    assert actual <= expected, f"{family} 多出预期外的标签：{actual - expected}"
+    assert actual, family
+
+
+def test_baseline_dro_all_members_retrograde():
+    """DRO 全体成员（含深近月小成员）都判 distant_retrograde。"""
+    states, periods, _ = _load_family("dro")
+    for state, period in zip(states, periods, strict=True):
+        result = classify_orbit(state[None, :], period=period)
+        assert result.primary is not None
+        assert result.primary.canonical == "distant_retrograde", result.diagnostics
+
+
+def test_baseline_halo_hemisphere_matches_halo_class():
+    """halo/nrho 族的南北判定与记录参数 halo_class 一致（0=北/1=南）。"""
+    for family, point in (("halo-l1", 1), ("halo-l2", 2), ("nrho-l1", 1), ("nrho-l2", 2)):
+        meta = json.loads((BASELINE_DIR / f"baseline-{family}.json").read_text(encoding="utf-8"))
+        bundle = np.load(BASELINE_DIR / f"baseline-{family}.npz")
+        for i, member in enumerate(meta["members"]):
+            state = bundle[f"cr3bp/members/{i:04d}/states"][0]
+            result = classify_orbit(state[None, :], period=member["period"])
+            assert result.primary is not None, (family, i, result.diagnostics)
+            # nrho-l2 记录的 halo_class 与其种子几何（z0>0、vy<0）不一致，
+            # 分类器以轨迹几何为准（ADR 0042 南北约定）；此处断言几何侧。
+            seed_z, seed_vy = float(state[2]), float(state[4])
+            geometric_expected = (
+                f"halo_l{point}_northern" if seed_z * seed_vy < 0 else f"halo_l{point}_southern"
+            )
+            assert result.primary.canonical == geometric_expected, (
+                family,
+                i,
+                member["parameters"]["halo_class"],
+                result.diagnostics,
+            )
+
+
+def test_baseline_lissajous_quasi_periodic():
+    """lissajous 族按 periodicity 标注直接判 unclassified。"""
+    states, periods, periodicity = _load_family("lissajous-l1")
+    assert periodicity == "quasi-periodic"
+    result = classify_orbit(states[0][None, :], period=periods[0], periodicity=periodicity)
+    assert result.labels == ()
+    assert result.unclassified_reason == "quasi_periodic"
+
+
+def test_non_periodic_arc_unclassified():
+    """不闭合的轨迹（转移弧）判 unclassified，不报错。"""
+    t = np.linspace(0.0, 2.0, 200)
+    # 会合系中一段不闭合的漂移弧（几何构造，非动力学解）
+    states = np.column_stack(
+        [
+            0.7 + 0.1 * t,
+            0.05 * np.sin(t),
+            np.zeros_like(t),
+            np.zeros_like(t),
+            0.05 * np.cos(t),
+            np.zeros_like(t),
+        ]
+    )
+    result = classify_orbit(states, t)
+    assert result.status.value == "converged"
+    assert result.labels == ()
+    assert result.unclassified_reason == "non_periodic"
+
+
+def _closed_curve(components, period: float, n: int = 2880) -> tuple[np.ndarray, np.ndarray]:
+    """按参数式构造闭合轨迹，供判据级合成用例。
+
+    ``components`` 为 (x, y, z, vx, vy, vz) 六个 ``t → 值`` 的可调用
+    （按状态列序），首末点（含速度）解析闭合，避开数值差分的端点泄漏。
+    """
+    t = np.linspace(0.0, period, n)
+    states = np.zeros((n, 6))
+    for column, fn in enumerate(components):
+        states[:, column] = fn(t)
+    return states, t
+
+
+def test_synthetic_resonant_interior_and_exterior():
+    """判据级：绕地环绕闭合曲线按 T/T☾ 命中共振比（p:q = 卫星:月球）。"""
+    # 内共振 2:1：T = T☾/2 = π，半径 0.55 的绕地圆（不触月心/平动点分支）
+    states, t = _closed_curve(
+        (
+            lambda t: 0.55 * np.cos(2 * t),
+            lambda t: 0.55 * np.sin(2 * t),
+            lambda t: np.zeros_like(t),
+            lambda t: -1.1 * np.sin(2 * t),
+            lambda t: 1.1 * np.cos(2 * t),
+            lambda t: np.zeros_like(t),
+        ),
+        period=np.pi,
+    )
+    result = classify_orbit(states, t)
+    assert result.primary is not None and result.primary.canonical == "resonant_2_1", (
+        result.diagnostics
+    )
+
+    # 外共振 1:2：T = 2·T☾ = 4π，远距绕地圆（把月与平动点圈在内但均不局域）
+    states, t = _closed_curve(
+        (
+            lambda t: 1.6 * np.cos(0.5 * t),
+            lambda t: 1.6 * np.sin(0.5 * t),
+            lambda t: np.zeros_like(t),
+            lambda t: -0.8 * np.sin(0.5 * t),
+            lambda t: 0.8 * np.cos(0.5 * t),
+            lambda t: np.zeros_like(t),
+        ),
+        period=4 * np.pi,
+    )
+    result = classify_orbit(states, t)
+    assert result.primary is not None and result.primary.canonical == "resonant_1_2", (
+        result.diagnostics
+    )
+
+
+def test_synthetic_moon_centered_multilabel_with_resonance():
+    """判据级：绕月闭合曲线周期通约时多标签（月心族 + resonant）。"""
+    mu = 0.012150585350562453
+    moon_x = 1 - mu
+    # 逆行绕月圆，角速率 0.75 → T = (4/3)·T☾，一周期恰绕月 2π
+    r = 0.05
+    w = -0.75
+    states, t = _closed_curve(
+        (
+            lambda t: moon_x + r * np.cos(w * t),
+            lambda t: r * np.sin(w * t),
+            lambda t: np.zeros_like(t),
+            lambda t: -r * w * np.sin(w * t),
+            lambda t: r * w * np.cos(w * t),
+            lambda t: np.zeros_like(t),
+        ),
+        period=(4.0 / 3.0) * 2 * np.pi,
+    )
+    result = classify_orbit(states, t)
+    assert result.canonical_labels == ("distant_retrograde", "resonant_3_4"), result.diagnostics
+
+
+def test_synthetic_low_prograde_east_west():
+    """判据级：低月顺行圆按近月点方向半平面分东西。"""
+    mu = 0.012150585350562453
+    moon_x = 1 - mu
+    # 月心小圆（ρ_max = 偏置+r ≈0.018 < low/distant 分界，月在圆内），
+    # 圆心 −y 偏置 → 近月点落在 +y（东）半平面，反之西
+    for offset_y, expected in ((-0.006, "low_prograde_eastern"), (0.006, "low_prograde_western")):
+        r = 0.012
+        w = 2 * np.pi / 2.2
+        states, t = _closed_curve(
+            (
+                lambda t, cx=moon_x, rr=r, ww=w: cx + rr * np.cos(ww * t),
+                lambda t, oy=offset_y, rr=r, ww=w: oy + rr * np.sin(ww * t),
+                lambda t: np.zeros_like(t),
+                lambda t, rr=r, ww=w: -rr * ww * np.sin(ww * t),
+                lambda t, rr=r, ww=w: rr * ww * np.cos(ww * t),
+                lambda t: np.zeros_like(t),
+            ),
+            period=2.2,
+        )
+        result = classify_orbit(states, t)
+        assert result.primary is not None and result.primary.canonical == expected, (
+            expected,
+            result.diagnostics,
+        )
+
+
+def test_synthetic_butterfly_dragonfly_vertical_crossing_patterns():
+    """判据级：穿越计数/形态命中 butterfly/dragonfly/vertical。"""
+    l1 = 0.8369
+    # butterfly：每周期 4 次垂直 y=0 穿越的三维闭合曲线（绕 L1）
+    states, t = _closed_curve(
+        (
+            lambda t: l1 + 0.02 * np.cos(4 * t),
+            lambda t: 0.02 * np.sin(4 * t),
+            lambda t: 0.01 * np.cos(4 * t),
+            lambda t: -0.08 * np.sin(4 * t),
+            lambda t: 0.08 * np.cos(4 * t),
+            lambda t: -0.04 * np.sin(4 * t),
+        ),
+        period=np.pi,
+    )
+    result = classify_orbit(states, t)
+    assert result.primary is not None and result.primary.canonical in (
+        "butterfly_northern",
+        "butterfly_southern",
+    ), result.diagnostics
+
+    # dragonfly：6 次垂直穿越
+    states, t = _closed_curve(
+        (
+            lambda t: l1 + 0.02 * np.cos(6 * t),
+            lambda t: 0.02 * np.sin(6 * t),
+            lambda t: 0.01 * np.cos(6 * t),
+            lambda t: -0.12 * np.sin(6 * t),
+            lambda t: 0.12 * np.cos(6 * t),
+            lambda t: -0.06 * np.sin(6 * t),
+        ),
+        period=np.pi,
+    )
+    result = classify_orbit(states, t)
+    assert result.primary is not None and result.primary.canonical in (
+        "dragonfly_northern",
+        "dragonfly_southern",
+    ), result.diagnostics
+
+    # vertical：无 y=0 穿越、有垂直 z=0 穿越的三维闭合曲线（L1 邻域）
+    states, t = _closed_curve(
+        (
+            lambda t: l1 + 0.015 * (1 + np.cos(4 * t)),
+            lambda t: 0.05 + 0.015 * (1 - np.cos(4 * t)),
+            lambda t: 0.02 * np.sin(2 * t),
+            lambda t: -0.06 * np.sin(4 * t),
+            lambda t: 0.06 * np.sin(4 * t),
+            lambda t: 0.04 * np.cos(2 * t),
+        ),
+        period=np.pi,
+    )
+    result = classify_orbit(states, t)
+    assert result.primary is not None and result.primary.canonical == "vertical_l1", (
+        result.diagnostics
+    )
+
+
+def test_invalid_inputs():
+    """非法输入走 FAILED/INVALID_INPUT。"""
+    bad_shape = classify_orbit(np.zeros((3, 5)))
+    assert bad_shape.status.value == "failed" and bad_shape.cause.value == "invalid_input"
+
+    no_period = classify_orbit(np.zeros((1, 6)))
+    assert no_period.cause.value == "invalid_input"
+
+    bad_period = classify_orbit(np.zeros((1, 6)), period=-1.0)
+    assert bad_period.cause.value == "invalid_input"
+
+
+def test_baseline_files_present():
+    """基线目录文件齐备（防止测试环境缺数据静默跳过）。"""
+    jsons = {os.path.basename(p) for p in glob.glob(str(BASELINE_DIR / "*.json"))}
+    for family in EXPECTED_FAMILY_LABELS:
+        assert f"baseline-{family}.json" in jsons, family

--- a/tests/algorithm/orbit_taxonomy/test_labels.py
+++ b/tests/algorithm/orbit_taxonomy/test_labels.py
@@ -1,0 +1,137 @@
+"""orbit_taxonomy 标签词汇测试：42 标签全集、规范字符串、解析与图例。"""
+
+from __future__ import annotations
+
+import pytest
+
+from e2m2e.algorithm.orbit_taxonomy.labels import (
+    TAXONOMY,
+    TAXONOMY_BY_CANONICAL,
+    Hemisphere,
+    TaxonomyCategory,
+    label_legend,
+    parse_taxonomy_label,
+)
+
+pytestmark = pytest.mark.theory
+
+#: issue #581 清单的规范字符串全集（逐字对照，顺序即清单顺序）。
+EXPECTED_CANONICAL = (
+    # 平动点轨道
+    "lyapunov_l1",
+    "lyapunov_l2",
+    "lyapunov_l3",
+    "halo_l1_northern",
+    "halo_l1_southern",
+    "halo_l2_northern",
+    "halo_l2_southern",
+    "halo_l3_northern",
+    "halo_l3_southern",
+    "axial_l1",
+    "axial_l2",
+    "axial_l3",
+    "axial_l4",
+    "axial_l5",
+    "vertical_l1",
+    "vertical_l2",
+    "vertical_l3",
+    "vertical_l4",
+    "vertical_l5",
+    "longperiod_l4",
+    "longperiod_l5",
+    "shortperiod_l4",
+    "shortperiod_l5",
+    "butterfly_northern",
+    "butterfly_southern",
+    "dragonfly_northern",
+    "dragonfly_southern",
+    # 月球中心轨道
+    "distant_retrograde",
+    "distant_prograde",
+    "low_prograde_eastern",
+    "low_prograde_western",
+    # 共振轨道（p:q = 卫星:月球）
+    "resonant_1_1",
+    "resonant_1_2",
+    "resonant_1_3",
+    "resonant_1_4",
+    "resonant_2_1",
+    "resonant_3_1",
+    "resonant_3_2",
+    "resonant_3_4",
+    "resonant_2_3",
+    "resonant_4_1",
+    "resonant_4_3",
+)
+
+
+def test_taxonomy_covers_issue_list_verbatim():
+    """42 标签与 issue 清单一一对应，顺序一致。"""
+    assert [label.canonical for label in TAXONOMY] == list(EXPECTED_CANONICAL)
+    assert len(TAXONOMY) == 42
+    assert len(TAXONOMY_BY_CANONICAL) == 42
+
+
+def test_category_counts():
+    """三大类计数：平动点 27 / 月心 4 / 共振 11。"""
+    counts = {category: 0 for category in TaxonomyCategory}
+    for label in TAXONOMY:
+        counts[label.category] += 1
+    assert counts == {
+        TaxonomyCategory.LIBRATION_POINT: 27,
+        TaxonomyCategory.MOON_CENTERED: 4,
+        TaxonomyCategory.RESONANT: 11,
+    }
+
+
+@pytest.mark.parametrize("canonical", EXPECTED_CANONICAL)
+def test_parse_round_trip(canonical: str):
+    """规范字符串解析还原同一标签（canonical 幂等）。"""
+    label = parse_taxonomy_label(canonical)
+    assert label.canonical == canonical
+    assert TAXONOMY_BY_CANONICAL[canonical] is label
+
+
+def test_parse_rejects_unknown():
+    with pytest.raises(ValueError, match="未知的轨道分类学标签"):
+        parse_taxonomy_label("halo_l7_northern")
+
+
+def test_structured_fields():
+    """结构化字段的语义载荷抽查。"""
+    halo = parse_taxonomy_label("halo_l2_southern")
+    assert halo.category is TaxonomyCategory.LIBRATION_POINT
+    assert halo.family == "halo"
+    assert halo.libration_point == 2
+    assert halo.hemisphere is Hemisphere.SOUTHERN
+    assert halo.resonance is None
+
+    low = parse_taxonomy_label("low_prograde_eastern")
+    assert low.category is TaxonomyCategory.MOON_CENTERED
+    assert low.hemisphere is Hemisphere.EASTERN
+
+    res = parse_taxonomy_label("resonant_3_4")
+    assert res.category is TaxonomyCategory.RESONANT
+    assert res.resonance == (3, 4)
+
+    butterfly = parse_taxonomy_label("butterfly_northern")
+    assert butterfly.libration_point is None
+    assert butterfly.hemisphere is Hemisphere.NORTHERN
+
+
+def test_legend_shape():
+    """图例每个条目带六个结构化键，键集与 ADR 0042 一致。"""
+    legend = label_legend()
+    assert len(legend) == 42
+    for entry in legend.values():
+        assert set(entry) == {
+            "category",
+            "family",
+            "libration_point",
+            "hemisphere",
+            "resonance_p",
+            "resonance_q",
+        }
+    assert legend["resonant_2_1"]["resonance_p"] == 2
+    assert legend["resonant_2_1"]["resonance_q"] == 1
+    assert legend["distant_retrograde"]["category"] == "moon_centered"

--- a/tests/api/test_taxonomy_wiring.py
+++ b/tests/api/test_taxonomy_wiring.py
@@ -1,0 +1,116 @@
+"""分类学打标接线测试：入库打标、冲突告警、索引列、响应富化、成员提升继承。
+
+族对象由随包 baseline 真实成员组装（单状态 + 周期，与生产 ingest 输入
+同构），不依赖设计管线的重型生成。
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from e2m2e.algorithm.dynamics.cr3bp_system import CR3BP_System
+from e2m2e.api.catalog_ingest import build_family_record
+from e2m2e.api.facade import _family_generation_payload
+from e2m2e.api.models import FamilyGenerationRequest
+from e2m2e.data.catalog import CatalogFilter, CatalogStore
+from e2m2e.data.constants import Datum
+from e2m2e.data.templates import ConvergenceState, FailureCause
+from e2m2e.data.types.orbit import Orbit, OrbitFamily
+
+pytestmark = pytest.mark.interface
+
+BASELINE_DIR = Path(__file__).resolve().parents[2] / "e2m2e" / "data" / "catalog_baseline"
+
+
+def _family_from_baseline(
+    name: str, family_type: str, max_members: int = 3
+) -> tuple[OrbitFamily, FamilyGenerationRequest]:
+    """用 baseline 成员组装族对象与对应请求模型。"""
+    meta = json.loads((BASELINE_DIR / f"baseline-{name}.json").read_text(encoding="utf-8"))
+    bundle = np.load(BASELINE_DIR / f"baseline-{name}.npz")
+    system = CR3BP_System(mu=Datum.DE421.mu, primary="earth", secondary="moon")
+    orbits: list[Orbit] = []
+    for i, member in enumerate(meta["members"][:max_members]):
+        state = bundle[f"cr3bp/members/{i:04d}/states"][0]
+        orbit = Orbit(states=state.reshape(1, -1), times=np.array([0.0]), system=system)
+        orbit.period = member["period"]
+        orbit.parameters = dict(member.get("parameters", {}))
+        orbits.append(orbit)
+    family = OrbitFamily(orbits=orbits, family_type=family_type, system=system)
+    family.metadata = {"periodicity": meta["scalars"].get("periodicity", "periodic")}
+    return family, FamilyGenerationRequest(orbit_type=family_type.upper())
+
+
+def _record(family: OrbitFamily, request: FamilyGenerationRequest):
+    built = build_family_record(
+        request,
+        family=family,
+        status=ConvergenceState.CONVERGED,
+        cause=FailureCause.NONE,
+        message="ok",
+        requested_members=len(family),
+        generated_members=len(family),
+    )
+    assert built is not None
+    return built
+
+
+def test_family_record_stamps_dro():
+    family, request = _family_from_baseline("dro", "dro")
+    meta, _ = _record(family, request)
+    assert meta["classification"]["taxonomy_labels"] == ["distant_retrograde"]
+    assert all(m["taxonomy_label"] == "distant_retrograde" for m in meta["members"])
+
+
+def test_family_record_quasi_periodic_family_gets_empty_labels():
+    family, request = _family_from_baseline("lissajous-l1", "lissajous")
+    meta, _ = _record(family, request)
+    assert meta["classification"]["taxonomy_labels"] == []
+    assert all(m["taxonomy_label"] is None for m in meta["members"])
+
+
+def test_family_record_conflict_warns_and_keeps_measured(caplog):
+    """设计侧族与实测不符：记 warning，按实测值入库（两边都保留）。"""
+    family, request = _family_from_baseline("halo-l1", "dro")  # 谎报族：期望 distant_retrograde
+    with caplog.at_level(logging.WARNING, logger="e2m2e.api.catalog_ingest"):
+        meta, _ = _record(family, request)
+    assert meta["classification"]["taxonomy_labels"] == ["halo_l1_northern"]
+    assert any("分类学冲突" in record.message for record in caplog.records)
+
+
+def test_family_payload_enrichment():
+    family, _ = _family_from_baseline("spo-l4", "spo")
+    response = _family_generation_payload(family)
+    assert response.taxonomy_labels == ["shortperiod_l4"]
+
+
+def test_store_roundtrip_and_promote(tmp_path):
+    """入库 → 索引摘要带标签；成员提升继承成员级标签。"""
+    family, request = _family_from_baseline("dro", "dro")
+    meta, arrays = _record(family, request)
+    store = CatalogStore(tmp_path / "catalog")
+    record_id = store.put(meta, arrays)
+    summaries = store.query(CatalogFilter())
+    assert len(summaries) == 1
+    assert summaries[0]["classification"]["taxonomy_labels"] == ["distant_retrograde"]
+
+    promoted = store.promote_member(record_id, 0)
+    assert promoted.meta["classification"]["taxonomy_labels"] == ["distant_retrograde"]
+    store.close()
+
+
+def test_summary_without_taxonomy_key_reads_as_none(tmp_path):
+    """未打标的旧记录（classification 缺 taxonomy_labels 键）可读且摘要为 None。"""
+    family, request = _family_from_baseline("dro", "dro")
+    meta, arrays = _record(family, request)
+    del meta["classification"]["taxonomy_labels"]  # 模拟旧 schema 记录
+    store = CatalogStore(tmp_path / "catalog")
+    store.put(meta, arrays)
+    summaries = store.query(CatalogFilter())
+    assert summaries[0]["classification"]["taxonomy_labels"] is None
+    store.close()


### PR DESCRIPTION
## 关联

- 实现 #581（agent brief：issuecomment-5468254428）
- 决策记录：ADR 0042

## 改动摘要

- **分类内核** `e2m2e/algorithm/orbit_taxonomy/`：42 标签词汇（结构化字段 + 规范 snake_case 字符串，措辞逐字采自 STK 未发布 CODE 组件）与解析判据分类器（判据自定，ADR 0042 全量记录）。判据级联：月心（绕月卷绕 + μ^(2/5) Chebotarev SOI 展布闸）→ L4/L5 → 共线平动点（穿越几何）→ 共振（p:q = 卫星:月球）；多标签 + primary；仅周期轨道，其余 unclassified（合法输出）。
- **数据层**：ingest 实测打标（记录级 `taxonomy_labels` + 成员级 `taxonomy_label`），设计侧族标签保留 provenance，冲突 warning 不失败；索引加列（存量库 schema 重建）；成员提升继承标签；随包 baseline 13 族回填打标。
- **响应富化**：`design_orbit` / `orbit_family_generation` / `catalog_query/get` 带标签字段；MCP 工具数保持 22。`orbit_propagation` 不富化（星历力模型工具，永久 unclassified 噪音——brief 偏差，ADR 0042 §5 注记）。
- **文档**：ADR 0042、glossary 术语节、ADR 索引。
- **测试**（73 个新增）：baseline 10 族全成员回归（~430 条真实轨迹）+ 判据级合成用例（butterfly/dragonfly/vertical/lyapunov/共振）+ 接线/冲突告警/回填/提升继承测试。

## 实测发现（ADR 0042 复现注记）

1. baseline dpo 前 4 成员几何上是逆行（设计侧族行走的另一支）→ `distant_retrograde` + 入库冲突告警。
2. nrho-l2 记录 `halo_class=1`（南）与其种子几何（z0>0、vy0<0）矛盾；分类学以轨迹几何为准（`halo_l2_northern`）。
3. repo horseshoe 族末端成员与 lpo 大成员是同轨道（libration ≲50° 的 tadpole）。

## 测试命令及结果

- `uv run --no-sync ruff check .` / `ruff format --check .`：通过
- `uv run --no-sync python -m mypy e2m2e/ --ignore-missing-imports`：通过
- `uv run --no-sync python scripts/check_layer_imports.py` / `check_deleted_dir_refs.py`：通过
- `uv run --no-sync python -m pytest tests/ -n auto --dist loadscope -q`：**2130 passed, 31 skipped**