### PR TITLE
docs(station-keeping): 新增站保章节，持久化参数标定依据（#541）

### DIFF
--- a/docs/algorithms/station-keeping.rst
+++ b/docs/algorithms/station-keeping.rst
@@ -1,0 +1,53 @@
+Station Keeping
+===============
+
+.. sectionauthor:: e2m2e
+
+Station keeping: orbit design delivers a nominal orbit; in flight, navigation
+errors, thrust execution errors, and SRP parameter errors drift the real
+trajectory away from it, and station-keeping control laws periodically compute
+corrective maneuvers to pull the orbit back. ``e2m2e/algorithm/station_keeping/``
+provides target-point strict/loose control and special-point control laws,
+with error models, momentum management, and three-orbit Monte Carlo evaluation,
+orchestrated by ``controller`` and reached through the Facade ``control_orbit``
+entry point.
+
+Calibration Basis of Parameters
+-------------------------------
+
+The two empirical conclusions below originally lived in code comments and were
+moved here after comment-level cleanup removed the historical war-story
+narratives (calibration measurements: `#541
+<https://github.com/cislunarspace/e2m2e/issues/541>`__); the values stated are
+the current code defaults.
+
+Monte Carlo evaluation uses screening-level tolerance
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Monte Carlo evaluation targets statistical features — mean/variance-level
+judgments at ±30% magnitude — not the exact position of one trajectory.
+Screening-level propagation tolerance therefore suffices: research-grade
+tolerance (1e-12 full chain) does not improve the conclusions, it only costs
+time. Measured calibration:
+
+- ``tolerance=1e-12``: 4 controls × 2 samples, about 156 s;
+- loosened to ``1e-10``: about 3× speedup, statistical conclusions unchanged.
+
+The default ``rtol``/``atol`` of ``PropagatorFactory`` (both 1e-10)
+take the loose side; tighten separately only for a future
+single-sample precise-trajectory re-verification.
+
+Strict target-point control needs max_iter of at least 6
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Nonlinear effects are strong for strict target-point control on NRHOs: the
+differential-correction iteration cap ``max_iter`` of
+:class:`~e2m2e.algorithm.station_keeping.target_point.StrictTargetPointLaw`
+defaults to 6:
+
+- a cap of 2 fails to converge;
+- 6 is the measured working floor;
+- larger values only cost time.
+
+The ``tight_max_iter`` default used when Monte Carlo evaluation builds the
+strict law (``control_mode=2``) is likewise 6.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -64,6 +64,12 @@ through these layers is told in the README's "How to read this repository".
 
 .. toctree::
    :maxdepth: 2
+   :caption: Station Keeping
+
+   algorithms/station-keeping
+
+.. toctree::
+   :maxdepth: 2
    :caption: Transfer Design
 
    transfer/overview


### PR DESCRIPTION
Closes #541

## 关联

- #541（[agent brief](https://github.com/cislunarspace/e2m2e/issues/541#issuecomment-5468663570)）

## 改动摘要

- 新增 `docs/algorithms/station-keeping.rst`：站保章节，持久化两条参数标定依据——
  - 蒙特卡洛评估用筛选级容差：1e-12 下 4 次控制 × 2 个样本约 156 s，放宽到 1e-10 约 3 倍提速、统计结论不变；默认取宽松一侧
  - 严格目标点控制 `max_iter` 不低于 6：上限为 2 时收敛失败，6 是实测可行的经验下限
  - 正文英文，对齐 #551 文档单语化政策
- `docs/index.rst`：新增 "Station Keeping" toctree caption（镜像 Spatiography 单页先例）
- 无代码改动；文中默认值已与代码逐一核对（`PropagatorFactory`/`RustPropagator` rtol/atol=1e-10、`StrictTargetPointLaw.max_iter=6`、蒙特卡洛 `tight_max_iter=6`）

## 验证

- `make docs` 构建成功，无新增告警（存量 6 warnings + 1 error 均在本次改动之外）
- `StrictTargetPointLaw` 交叉引用解析到 API 文档锚点；`PropagatorFactory` 不在 `monte_carlo.__all__` 中（autodoc 不收录），以字面量呈现
