### PR TITLE
feat(mcp): 长任务工具取消——worker 子进程隔离（#588 / #576 Phase 2，ADR 0014 增补）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Release entries record exact code references (`module/function`, issue numbers, 
 
 ## [Unreleased]
 
+### Added
+- **Long-running tool cancellation via worker subprocess isolation** (#588, #576 Phase 2, ADR 0014 amendment): `tools/call` for `transfer_design` and `orbit_family_generation` now executes in a one-shot worker subprocess — `python -m e2m2e.api.mcp.worker` reads one JSON request line on stdin (`{"tool", "arguments"}`), writes throttled progress lines plus one final result line (the unified envelope) on stdout, and exits 0; it imports no mcp SDK (envelope/tools/facade only, same dependency constraint as the sidecar). MCP `notifications/cancelled` (the SDK's interrupt mode cancels the handler scope) and client disconnect (EOF tears down the dispatcher task group) both propagate to a kill: `run_tool_in_worker` awaits the worker on fully cancellable streams and on cancellation kills the process and reaps it inside a shielded scope before re-raising — the cancelled request is never answered. Data safety rests on the existing one-shot atomic catalog write (tmp + `os.replace`): a kill loses at most the current task, never committed records. Progress forwarding survives the process boundary (worker lines forwarded from inside the event loop; the thread-path `run_coroutine_threadsafe` reporter would deadlock on the loop thread); a worker dying without a result line surfaces as a structured `WORKER_CRASHED` error with the exit code. Windows spawn overhead measured at ~1.3 s per roundtrip (interpreter boot + imports) against minutes-level computations. Other tools keep the thread-pool path unchanged. Documented in `docs/getting-started/mcp.rst` (Tool cancellation) and `docs/adr/0014` (amendment).
+
 ## [5.9.0] - 2026-08-30
 
 ### Added

--- a/docs/adr/0014-api-facade-mcp-cli.md
+++ b/docs/adr/0014-api-facade-mcp-cli.md
@@ -76,3 +76,55 @@ is where that vision gets delivered.
   (deprecating tod/generates algorithm script layers, superseded by e2m2e
   CLI); GUI parameter forms are generated from e2m2e Pydantic models and their
   conditional-domain public interfaces.
+
+## Amendment (2026-08-30): long-running tools execute in worker subprocesses (#588, #576 Phase 2)
+
+### Context
+
+Long-running tools (`transfer_design`, `orbit_family_generation` — minutes at
+production scales) run to completion with no way to abort: `notifications/
+cancelled` and client disconnects were unobserved. The python mcp SDK 2.x
+delivers both as cancellation of the handler's task scope (interrupt mode
+resp. task-group teardown on EOF) — but the handler's `anyio.to_thread.
+run_sync` thread cannot be killed, and cooperative checkpoints fail inside
+GIL-released Rust sections (family generation is a single Rust call). A
+process is the only reliable interruption unit.
+
+### Decisions
+
+1. **Execution-strategy table at the transport layer**: `LONG_RUNNING_TOOLS`
+   in `api/mcp/server.py` routes `tools/call` for the two long-running tools
+   to a one-shot worker subprocess; every other tool keeps the thread-pool
+   path unchanged. Routing is a transport concern (spawn cost vs.
+   computation cost), not Facade metadata — the Facade signatures stay as
+   they are.
+2. **Worker protocol**: `python -m e2m2e.api.mcp.worker` reads one JSON
+   request line from stdin (`{"tool", "arguments"}`), writes throttled
+   progress lines and one final result line (the unified envelope) to
+   stdout, exits 0. The worker imports no mcp SDK (envelope/tools/facade
+   only — same dependency constraint as the sidecar). Errors translate
+   inside the worker; stderr passes through to the server's logs.
+3. **Cancellation = kill**: the server-side await is fully cancellable; on
+   cancellation (peer cancel notification or EOF) the worker is killed and
+   reaped inside a shielded scope, then the cancellation propagates. The
+   cancelled request is never answered (the SDK drops its result).
+4. **Data safety**: catalog persistence is one atomic write per record
+   (tmp + `os.replace`, ADR 0031) at the end of the tool method — a kill
+   loses at most the current task's record, never corrupts committed ones.
+5. **Environment via inheritance**: the worker constructs its own
+   `Facade(Config())`; env vars (`E2M2E_CATALOG_DIR`, …) carry the
+   environment. Records a worker commits are visible to the parent
+   (SQLite index, no in-process caching).
+6. **Failure envelope**: a worker exiting without a result line surfaces as
+   `WORKER_CRASHED` (structured error; exit code in the message).
+
+### Consequences
+
+- Progress forwarding survives the process boundary: the worker emits
+  progress lines; the parent forwards them from inside the event loop (the
+  thread-path reporter would deadlock if driven on the loop thread).
+- Windows spawn cost is ~1.3 s per worker roundtrip (interpreter boot +
+  imports; measured 2026-08-30 on the dev machine) — noise against
+  minutes-long computations; short tools never pay it.
+- One worker process per call: no state reuse; a killed worker never
+  serves another request.

--- a/docs/adr/0014-api-facade-mcp-cli.md
+++ b/docs/adr/0014-api-facade-mcp-cli.md
@@ -36,6 +36,10 @@ is where that vision gets delivered.
 6. **MCP deployment = in-process library as the main body + thin CLI wrapper
    `mcp-serve`**: `create_server(facade)` function + `e2m2e mcp-serve`
    subcommand. One Facade instance = one server.
+   *(Revision note 2026-08-30, #588: the two long-running tools now execute
+   in worker subprocesses — each call constructs its own worker Facade via
+   environment inheritance; see the amendment at the end of this ADR.
+   Everything else keeps the in-process path.)*
 7. **config.py constructor injection**: `Facade(config=Config(...))`,
    covering only runtime environment (kernel paths/precision thresholds/
    logging); physical constants belong to data/templates/. SPICEManager's

--- a/docs/getting-started/mcp.rst
+++ b/docs/getting-started/mcp.rst
@@ -88,9 +88,28 @@ Long-running tools report MCP progress while they work. Include a
 Requests without a ``progressToken`` are unaffected — no notifications, no
 overhead. Intermediate notifications are throttled server-side to at most one
 per 100 ms (the final fraction-1.0 notification is never throttled), and a
-failed delivery never affects the computation. Tool cancellation is **not**
-supported yet: a running tool always runs to completion (planned as a
-separate follow-up with process-level isolation).
+failed delivery never affects the computation.
+
+Tool cancellation
+~~~~~~~~~~~~~~~~~~
+
+Long-running tools (``transfer_design``, ``orbit_family_generation``)
+execute in one-shot **worker subprocesses** (ADR 0014 amendment), which
+makes two protocol events effective:
+
+* ``notifications/cancelled`` for an in-flight request: the worker process
+  is terminated and the request is never answered (the cancelled result is
+  dropped, not turned into an error).
+* client disconnect (stdio EOF): the same propagation — the server tears
+  down its handlers and each one kills its worker.
+
+Progress notifications keep flowing while the computation runs (the worker
+streams them back to the server). Killing loses only the current task: the
+catalog persists records atomically at the end of each tool method, so
+committed records are never corrupted by a kill. A worker that dies without
+returning a result surfaces as a structured ``WORKER_CRASHED`` error. All
+other tools run in-process in the thread pool as before and cannot be
+cancelled.
 
 Tool inventory
 ~~~~~~~~~~~~~~

--- a/e2m2e/api/mcp/__init__.py
+++ b/e2m2e/api/mcp/__init__.py
@@ -2,6 +2,7 @@
 
 - ``envelope``：统一信封 {status, data, error, meta} 与异常翻译。
 - ``tools``：由 Facade 纯派生的工具规格（placeholder 不注册）。
+- ``worker``：长任务 worker 子进程（JSON 行协议，不依赖 ``[mcp]`` extra）。
 - ``server``：``create_server(facade)``（依赖 ``[mcp]`` extra）。
 
 ``server`` 惰性导出：sidecar（ADR 0035）复用 envelope/tools 但不依赖
@@ -16,6 +17,7 @@ from .envelope import error_envelope, invoke_tool, ok_envelope
 from .tools import ToolSpec, tool_specs
 
 __all__ = [
+    "LONG_RUNNING_TOOLS",
     "ToolSpec",
     "create_server",
     "error_envelope",
@@ -23,10 +25,17 @@ __all__ = [
     "handle_list_tools",
     "invoke_tool",
     "ok_envelope",
+    "run_tool_in_worker",
     "tool_specs",
 ]
 
-_LAZY = ("create_server", "handle_call_tool", "handle_list_tools")
+_LAZY = (
+    "LONG_RUNNING_TOOLS",
+    "create_server",
+    "handle_call_tool",
+    "handle_list_tools",
+    "run_tool_in_worker",
+)
 
 
 def __getattr__(name: str) -> Any:

--- a/e2m2e/api/mcp/envelope.py
+++ b/e2m2e/api/mcp/envelope.py
@@ -21,7 +21,14 @@ from e2m2e.data.types.orbit import Orbit
 from ..catalog_ingest import _finite_or_none
 from ..models import OrbitError
 
-__all__ = ["Envelope", "ok_envelope", "error_envelope", "invoke_tool", "dispatch_tool"]
+__all__ = [
+    "Envelope",
+    "error_envelope",
+    "invoke_tool",
+    "ok_envelope",
+    "dispatch_tool",
+    "tool_not_found",
+]
 
 # 信封的 JSON 形状（不是 Pydantic 模型：传输层只做序列化，不做自校验）。
 Envelope = dict[str, Any]
@@ -92,6 +99,16 @@ def error_envelope(code: str, message: str, details: dict[str, Any] | None = Non
         "error": {"code": code, "message": message, "details": details or {}},
         "meta": {},
     }
+
+
+def tool_not_found(name: str) -> Envelope:
+    """未知工具（placeholder 或未暴露的方法不注册）的失败信封。
+
+    进程内（handle_call_tool）与 worker 子进程（run_request）同名同义：
+    消息单一来源，两边不漂移。"""
+    return error_envelope(
+        "TOOL_NOT_FOUND", f"未知工具 {name!r}（placeholder 或未暴露的方法不注册）"
+    )
 
 
 def _accepted_extras(method: Any, extra_kwargs: dict[str, Any] | None) -> dict[str, Any]:

--- a/e2m2e/api/mcp/server.py
+++ b/e2m2e/api/mcp/server.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
+import subprocess
+import sys
 import time
 from typing import TYPE_CHECKING, Any
 
@@ -31,13 +33,19 @@ from mcp.types import (
 from . import envelope, tools
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from anyio.abc import ByteReceiveStream
+
     from ..facade import Facade
 
 __all__ = [
+    "LONG_RUNNING_TOOLS",
     "create_server",
     "handle_list_tools",
     "handle_call_tool",
     "make_progress_reporter",
+    "run_tool_in_worker",
 ]
 
 # 中间通知的最小发送间隔（秒）：高粒度回调（WSB 网格搜索可达数千次）
@@ -46,6 +54,20 @@ _PROGRESS_MIN_INTERVAL_SEC = 0.1
 # 单次投递等待事件循环的上限（秒）：事件循环停摆/已关时不无限阻塞
 # worker 线程；超时按投递失败处理（静默降级为无进度）。
 _PROGRESS_SEND_TIMEOUT_SEC = 5.0
+
+# 长任务工具（#588 / #576 Phase 2，子进程隔离架构）：分钟级计算改跑
+# worker 子进程（见 worker.py），使 MCP 取消（notifications/cancelled，
+# interrupt 模式取消 handler 作用域）与客户端断连（EOF 取消任务组）都能
+# 可靠传播为进程 kill。其余工具线程池直跑，行为不变。执行策略是传输层
+# 关注点，放这里而不入 Facade 元数据。
+LONG_RUNNING_TOOLS = frozenset({"transfer_design", "orbit_family_generation"})
+
+# worker 子进程命令（模块常量：测试注入 fake worker 用，同
+# _PROGRESS_MIN_INTERVAL_SEC 的 monkeypatch 先例）。
+_WORKER_ARGV = [sys.executable, "-m", "e2m2e.api.mcp.worker"]
+# 取消后 kill+收尸的时限（秒）：Windows TerminateProcess 即时生效，此为
+# 病理情形兜底，超时也不再阻塞取消收尾。
+_KILL_REAP_TIMEOUT_SEC = 10.0
 
 
 def make_progress_reporter(context: Any) -> Any:
@@ -103,6 +125,78 @@ def _to_result(env: envelope.Envelope) -> CallToolResult:
     )
 
 
+async def _iter_lines(stream: ByteReceiveStream) -> AsyncIterator[bytes]:
+    """从字节流逐行产出（不含换行符）；EOF（EndOfStream）自然结束。"""
+    buffer = bytearray()
+    while True:
+        try:
+            chunk = await stream.receive()
+        except anyio.EndOfStream:
+            return
+        buffer += chunk
+        while (newline := buffer.find(b"\n")) >= 0:
+            line = bytes(buffer[:newline])
+            del buffer[: newline + 1]
+            yield line
+
+
+async def run_tool_in_worker(
+    tool_name: str, arguments: dict[str, Any], context: Any
+) -> CallToolResult:
+    """在 worker 子进程中执行长任务工具（#588 子进程隔离）。
+
+    请求经 stdin 一行 JSON 下发，进度/结果行经 stdout 回流（协议见
+    worker.py）。等待全部走可取消的 await：MCP 请求取消（interrupt 模式
+    取消 handler 作用域）与客户端断连（EOF 取消任务组）在此汇成同一
+    处理——kill 子进程、shield 内收尸、重抛取消。kill 只丢当前任务：
+    catalog 落盘是一次性原子写（tmp + os.replace），已入库记录不受影响。
+    worker 异常退出（无结果行）译为 WORKER_CRASHED 结构化错误。
+    """
+    proc = await anyio.open_process(
+        _WORKER_ARGV, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=None
+    )
+    assert proc.stdin is not None and proc.stdout is not None  # PIPE 已请求
+    request = json.dumps({"tool": tool_name, "arguments": arguments}, ensure_ascii=True)
+    await proc.stdin.send(request.encode("ascii") + b"\n")
+    await proc.stdin.aclose()
+
+    meta = getattr(context, "meta", None)
+    token = getattr(meta, "progress_token", None)
+    session = getattr(context, "session", None)
+    result_env: envelope.Envelope | None = None
+    try:
+        async for line in _iter_lines(proc.stdout):
+            try:
+                message: dict[str, Any] = json.loads(line)
+            except ValueError:
+                continue  # 非法行（非 JSON）忽略：worker 崩溃即无结果行
+            if message.get("type") == "progress" and token is not None and session is not None:
+                # 事件循环内直投（与线程路径的 make_progress_reporter 互斥：
+                # 那个经 run_coroutine_threadsafe，在循环线程内会死锁）；
+                # worker 侧已节流，收到即转发。
+                with contextlib.suppress(Exception):
+                    await session.report_progress(
+                        message.get("fraction", 0.0), 1.0, message.get("message")
+                    )
+            elif message.get("type") == "result":
+                result_env = message.get("envelope")
+        await proc.wait()
+    except BaseException:
+        # 取消（或传输层异常）：kill + 受限时收尸后重抛。shield 保证外层
+        # 取消不打断收尾；kill 是唯一可靠打断长计算的手段（线程不可杀）。
+        with anyio.CancelScope(shield=True):
+            with contextlib.suppress(TimeoutError):
+                with anyio.fail_after(_KILL_REAP_TIMEOUT_SEC):
+                    proc.kill()
+                    await proc.wait()
+        raise
+    if result_env is None:
+        result_env = envelope.error_envelope(
+            "WORKER_CRASHED", f"worker 进程未返回结果（exit={proc.returncode}）"
+        )
+    return _to_result(result_env)
+
+
 def handle_call_tool(
     facade: Facade, name: str, arguments: dict[str, Any], extra_kwargs: dict[str, Any] | None = None
 ) -> CallToolResult:
@@ -143,8 +237,11 @@ def create_server(facade: Facade) -> Server:
     async def _call_tool(context: Any, params: Any) -> CallToolResult:
         # Facade 方法是同步长计算，放线程池避免阻塞事件循环；客户端
         # 请求进度时把线程安全回调作为额外协作者注入（未请求时 None，
-        # 注入层按方法签名过滤，其余工具零影响）。
+        # 注入层按方法签名过滤，其余工具零影响）。长任务工具例外：改跑
+        # worker 子进程，使取消/断连可靠传播为进程 kill（#588）。
         arguments = dict(params.arguments or {})
+        if params.name in LONG_RUNNING_TOOLS:
+            return await run_tool_in_worker(params.name, arguments, context)
         reporter = make_progress_reporter(context)
         extra = {"progress_callback": reporter} if reporter is not None else None
         return await anyio.to_thread.run_sync(

--- a/e2m2e/api/mcp/server.py
+++ b/e2m2e/api/mcp/server.py
@@ -207,9 +207,7 @@ def handle_call_tool(
     """
     spec = next((s for s in tools.tool_specs(facade) if s.name == name), None)
     if spec is None:
-        env = envelope.error_envelope(
-            "TOOL_NOT_FOUND", f"未知工具 {name!r}（placeholder 或未暴露的方法不注册）"
-        )
+        env = envelope.tool_not_found(name)
     else:
         env = envelope.invoke_tool(spec.method, arguments, extra_kwargs=extra_kwargs)
     return _to_result(env)

--- a/e2m2e/api/mcp/worker.py
+++ b/e2m2e/api/mcp/worker.py
@@ -70,9 +70,7 @@ def run_request(request: dict[str, Any], emit_line: Callable[[str], None]) -> No
         facade = Facade(config=Config())
         spec = next((s for s in tools.tool_specs(facade) if s.name == tool), None)
         if spec is None:
-            env = envelope.error_envelope(
-                "TOOL_NOT_FOUND", f"未知工具 {tool!r}（placeholder 或未暴露的方法不注册）"
-            )
+            env = envelope.tool_not_found(tool)
         else:
             env = envelope.invoke_tool(
                 spec.method, arguments, extra_kwargs={"progress_callback": emit_progress}

--- a/e2m2e/api/mcp/worker.py
+++ b/e2m2e/api/mcp/worker.py
@@ -1,0 +1,103 @@
+"""长任务工具 worker 子进程（#588 / #576 Phase 2，子进程隔离架构）。
+
+``python -m e2m2e.api.mcp.worker`` 一次性执行一个工具调用，供 mcp-serve
+把分钟级长计算（转移搜索、族生成）隔离到可 kill 的子进程：
+
+- stdin 读一行 JSON 请求 ``{"tool": name, "arguments": {...}}``
+- stdout 按行输出 ``{"type": "progress", "fraction": ..., "message": ...}``
+  （节流，见 ``_PROGRESS_MIN_INTERVAL_SEC``）与最终一行
+  ``{"type": "result", "envelope": {...}}``（统一信封，见 envelope.py）
+- stderr 原样透传到父进程日志；正常路径退出码 0（工具失败以信封表达）
+
+取消 = 父进程 kill 本进程：Rust 族生成在 GIL 释放下整段运行，协作式
+检查点失效，Python 工作线程不可杀——进程 kill 是唯一可靠打断手段。
+数据安全：catalog 落盘是工具方法末尾的一次性原子写（tmp + os.replace），
+kill 只丢当前任务，不损坏已入库记录。
+
+不 import mcp SDK：worker 只依赖 envelope/tools/facade/config（与 sidecar
+同款约束，缺 ``[mcp]`` extra 也能跑）。
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import threading
+import time
+from collections.abc import Callable
+from typing import Any
+
+__all__ = ["run_request", "main"]
+
+# 进度行最小发送间隔（秒）：与 server._PROGRESS_MIN_INTERVAL_SEC 同值同义
+# ——高粒度回调（WSB 网格搜索可达数千次）节流成管道可消化的节奏；
+# fraction>=1.0 的收尾行永不节流。
+_PROGRESS_MIN_INTERVAL_SEC = 0.1
+
+
+def run_request(request: dict[str, Any], emit_line: Callable[[str], None]) -> None:
+    """执行一个工具请求，进度行与结果行经 ``emit_line`` 输出。
+
+    纯进程内逻辑（可测）：``emit_line`` 收到不含换行符的完整 JSON 行。
+    进度回调可能从算法层线程触发（Rust drainer），输出以锁串行化；
+    结果行始终在进度行之后。任何失败都翻译成错误信封，不向 stderr
+    抛 traceback、不泄漏细节（api/ 边界契约）。
+    """
+    from ..config import Config
+    from ..facade import Facade
+    from . import envelope, tools
+
+    lock = threading.Lock()
+    last_sent = 0.0
+
+    def emit_progress(fraction: float, message: str | None = None) -> None:
+        nonlocal last_sent
+        now = time.monotonic()
+        if fraction < 1.0 and now - last_sent < _PROGRESS_MIN_INTERVAL_SEC:
+            return
+        last_sent = now
+        line = json.dumps(
+            {"type": "progress", "fraction": fraction, "message": message}, ensure_ascii=True
+        )
+        with lock:
+            emit_line(line)
+
+    tool = request.get("tool")
+    arguments = request.get("arguments") or {}
+    if not isinstance(tool, str) or not isinstance(arguments, dict):
+        env = envelope.error_envelope("INVALID_PARAMS", "worker 请求形状错误（tool/arguments）")
+    else:
+        facade = Facade(config=Config())
+        spec = next((s for s in tools.tool_specs(facade) if s.name == tool), None)
+        if spec is None:
+            env = envelope.error_envelope(
+                "TOOL_NOT_FOUND", f"未知工具 {tool!r}（placeholder 或未暴露的方法不注册）"
+            )
+        else:
+            env = envelope.invoke_tool(
+                spec.method, arguments, extra_kwargs={"progress_callback": emit_progress}
+            )
+    line = json.dumps({"type": "result", "envelope": env}, ensure_ascii=True)
+    with lock:
+        emit_line(line)
+
+
+def main() -> int:
+    """stdin 一行请求 → stdout 进度/结果行 → 退出。"""
+
+    def emit_line(line: str) -> None:
+        sys.stdout.write(line + "\n")
+        sys.stdout.flush()
+
+    try:
+        request: Any = json.loads(sys.stdin.readline())
+    except ValueError:
+        request = None
+    if not isinstance(request, dict):
+        request = {}
+    run_request(request, emit_line)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/api/test_mcp_worker.py
+++ b/tests/api/test_mcp_worker.py
@@ -1,0 +1,467 @@
+"""长任务工具取消——子进程隔离（#588 / #576 Phase 2）。
+
+三层接缝：
+1. worker 本体：真实子进程 spawn，JSON 行协议往返（成功/错误翻译）。
+2. server 侧 run_tool_in_worker：fake worker 注入 argv——进度转发、取消
+   kill 收尸、崩溃信封、kill 后 catalog 完整性。
+3. 协议端到端：真实 dispatcher（内存流）驱动 ``notifications/cancelled``
+   与客户端断连（EOF）两条取消路径。
+
+worker 是通用执行器（任意工具名），路由决策（哪些工具走子进程）在
+server 层的 LONG_RUNNING_TOOLS——测试用便宜工具直接打 worker。
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+pytestmark = [pytest.mark.interface]
+
+pytest.importorskip("mcp")  # [mcp] extra 未装时整文件跳过（协议层依赖）
+
+from e2m2e.api.config import Config  # noqa: E402
+from e2m2e.api.facade import Facade  # noqa: E402
+from e2m2e.api.mcp import server as mcp_server  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# 替身与辅助
+# ---------------------------------------------------------------------------
+
+
+class _Meta:
+    def __init__(self, token: Any) -> None:
+        self.progress_token = token
+
+
+class _ProgressSession:
+    """记录 report_progress 调用的 Session 替身（进度到达时置事件）。"""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[Any, ...]] = []
+        self.progress_seen: Any = None  # anyio.Event，在事件循环内创建
+
+    async def report_progress(
+        self, progress: float, total: float | None = None, message: Any = None
+    ) -> None:
+        self.calls.append((progress, total, message))
+        if self.progress_seen is not None:
+            self.progress_seen.set()
+
+
+class _Ctx:
+    """MCP 请求上下文替身（meta.progress_token / session.report_progress）。"""
+
+    def __init__(self, token: Any = None, session: Any = None) -> None:
+        self.meta = _Meta(token)
+        self.session = session
+
+
+# fake worker：pidfile 报到 → 进度行 → 按 FAKE_WORKER_MODE 收场。
+# ok：结果行后退出；sleep：睡 60s（模拟跑偏的长计算）；crash：exit(3)。
+_FAKE_WORKER_SCRIPT = """
+import json, os, sys, time
+pidfile = os.environ.get("FAKE_WORKER_PIDFILE")
+if pidfile:
+    with open(pidfile, "w") as f:
+        f.write(str(os.getpid()))
+mode = os.environ.get("FAKE_WORKER_MODE", "ok")
+def emit(obj):
+    sys.stdout.write(json.dumps(obj) + "\\n")
+    sys.stdout.flush()
+emit({"type": "progress", "fraction": 0.5, "message": "half"})
+if mode == "crash":
+    sys.exit(3)
+if mode == "sleep":
+    time.sleep(60)
+emit({"type": "result", "envelope": {"status": "ok", "data": {"mode": mode},
+        "error": None, "meta": {}}})
+"""
+
+
+@pytest.fixture
+def fake_worker(monkeypatch, tmp_path):
+    """把 worker 命令换成 ``python -c`` fake 脚本，可切模式。"""
+    pidfile = tmp_path / "fake-worker.pid"
+
+    def use(mode: str) -> None:
+        monkeypatch.setenv("FAKE_WORKER_MODE", mode)
+        monkeypatch.setenv("FAKE_WORKER_PIDFILE", str(pidfile))
+        monkeypatch.setattr(mcp_server, "_WORKER_ARGV", [sys.executable, "-c", _FAKE_WORKER_SCRIPT])
+
+    use("ok")
+    return SimpleNamespace(pidfile=pidfile, use=use)
+
+
+def _pid_alive(pid: int) -> bool:
+    """探测进程是否仍在运行（跨平台，不发送信号）。"""
+    if sys.platform == "win32":
+        import ctypes
+        from ctypes import wintypes
+
+        kernel32 = ctypes.windll.kernel32
+        handle = kernel32.OpenProcess(0x1000, False, pid)  # PROCESS_QUERY_LIMITED_INFORMATION
+        if not handle:
+            return False
+        try:
+            code = wintypes.DWORD()
+            if not kernel32.GetExitCodeProcess(handle, ctypes.byref(code)):
+                return False
+            return code.value == 259  # STILL_ACTIVE
+        finally:
+            kernel32.CloseHandle(handle)
+    import errno
+
+    try:
+        import os
+
+        os.kill(pid, 0)
+    except OSError as exc:
+        return exc.errno == errno.EPERM
+    return True
+
+
+def _pid_from_file(path) -> int:
+    return int(path.read_text(encoding="ascii").strip())
+
+
+@pytest.fixture
+def facade() -> Facade:
+    # tests/api/conftest.py 已把 E2M2E_CATALOG_DIR 重定向到独立临时目录
+    return Facade(Config())
+
+
+# ---------------------------------------------------------------------------
+# 1. 真实 worker 往返（JSON 行协议 + 信封）
+# ---------------------------------------------------------------------------
+
+
+def test_real_worker_roundtrip_ok():
+    """真实子进程：便宜工具经 worker 往返，信封 status=ok。"""
+    import anyio
+
+    from e2m2e.api.mcp import run_tool_in_worker
+
+    result = anyio.run(run_tool_in_worker, "catalog_query", {}, _Ctx())
+    assert not result.is_error
+    env = json.loads(result.content[0].text)
+    assert env["status"] == "ok"
+    assert set(env) == {"status", "data", "error", "meta"}
+
+
+def test_real_worker_translates_validation_errors():
+    """worker 侧错误翻译照旧：非法参数 → INVALID_PARAMS（无 traceback 泄漏）。"""
+    import anyio
+
+    from e2m2e.api.mcp import run_tool_in_worker
+
+    result = anyio.run(run_tool_in_worker, "catalog_query", {"libration_point": 99}, _Ctx())
+    assert result.is_error
+    env = json.loads(result.content[0].text)
+    assert env["status"] == "error"
+    assert env["error"]["code"] == "INVALID_PARAMS"
+    assert "Traceback" not in result.content[0].text
+
+
+def test_real_worker_unknown_tool():
+    import anyio
+
+    from e2m2e.api.mcp import run_tool_in_worker
+
+    result = anyio.run(run_tool_in_worker, "no_such_tool", {}, _Ctx())
+    env = json.loads(result.content[0].text)
+    assert env["error"]["code"] == "TOOL_NOT_FOUND"
+
+
+# ---------------------------------------------------------------------------
+# 2. server 侧接缝（fake worker）
+# ---------------------------------------------------------------------------
+
+
+def test_progress_forwarded_with_token(fake_worker):
+    """worker 进度行 → session.report_progress（带 token 时转发，保序）。"""
+    import anyio
+
+    session = _ProgressSession()
+    ctx = _Ctx(token="tok", session=session)
+
+    async def scenario():
+        session.progress_seen = anyio.Event()
+        return await mcp_server.run_tool_in_worker("transfer_design", {}, ctx)
+
+    result = anyio.run(scenario)
+    assert [(p, t, m) for p, t, m in session.calls] == [(0.5, 1.0, "half")]
+    env = json.loads(result.content[0].text)
+    assert env["status"] == "ok"
+    assert env["data"]["mode"] == "ok"
+
+
+def test_progress_gated_without_token(fake_worker):
+    """客户端未带 progressToken：进度行不转发（零开销直通），结果照常。"""
+    import anyio
+
+    session = _ProgressSession()
+
+    async def scenario():
+        return await mcp_server.run_tool_in_worker(
+            "transfer_design", {}, _Ctx(token=None, session=session)
+        )
+
+    result = anyio.run(scenario)
+    assert session.calls == []
+    assert not result.is_error
+
+
+def test_cancellation_kills_worker(fake_worker):
+    """取消传播：handler 被取消 → kill 子进程并收尸，快速收尾而非等满 60s。"""
+    import anyio
+
+    fake_worker.use("sleep")
+    session = _ProgressSession()
+    ctx = _Ctx(token="tok", session=session)
+    completed: dict[str, Any] = {}
+
+    async def scenario() -> float:
+        session.progress_seen = anyio.Event()
+        started = time.monotonic()
+        with anyio.CancelScope() as scope:
+            async with anyio.create_task_group() as tg:
+
+                async def cancel_on_progress() -> None:
+                    await session.progress_seen.wait()
+                    scope.cancel()
+
+                tg.start_soon(cancel_on_progress)
+                completed["result"] = await mcp_server.run_tool_in_worker(
+                    "transfer_design", {}, ctx
+                )
+        return time.monotonic() - started
+
+    elapsed = anyio.run(scenario)
+    assert "result" not in completed, "被取消的调用不得产出结果"
+    assert elapsed < 20, f"取消后须快速收尾（实测 {elapsed:.1f}s）——kill 未生效？"
+    pid = _pid_from_file(fake_worker.pidfile)
+    deadline = time.monotonic() + 15
+    while time.monotonic() < deadline and _pid_alive(pid):
+        time.sleep(0.1)
+    assert not _pid_alive(pid), "worker 子进程应已被终止"
+
+
+def test_worker_crash_yields_error_envelope(fake_worker):
+    """worker 异常退出（无结果行）→ WORKER_CRASHED 结构化错误，不炸穿 handler。"""
+    import anyio
+
+    fake_worker.use("crash")
+    result = anyio.run(mcp_server.run_tool_in_worker, "transfer_design", {}, _Ctx())
+    assert result.is_error
+    env = json.loads(result.content[0].text)
+    assert env["status"] == "error"
+    assert env["error"]["code"] == "WORKER_CRASHED"
+
+
+def test_catalog_records_survive_worker_kill():
+    """数据安全：真实 worker 被 kill 后，已入库 catalog 记录完好可读。"""
+    import anyio
+
+    from tests.api.test_facade_catalog import _fake_design, _make_design_result
+
+    # 经公共缝播种一条记录（fake 算法结果 → facade 自动入库）；fake 只作用于
+    # 播种阶段，不影响后续真实路径与 conftest 的 catalog 目录隔离。
+    with pytest.MonkeyPatch.context() as mp:
+        _fake_design(mp, _make_design_result(orbit_type="DRO"))
+        seed_facade = Facade(Config())
+        seed_facade.design_orbit(orbit_type="DRO")
+
+    started = time.monotonic()
+
+    async def scenario() -> None:
+        # 真实 worker（catalog_query）在任意阶段被取消（多半还在 import 期）：
+        # kill 不应波及已入库记录
+        with anyio.move_on_after(0.15):
+            await mcp_server.run_tool_in_worker("catalog_query", {}, _Ctx())
+
+    anyio.run(scenario)
+    assert time.monotonic() - started < 20, "取消后须快速收尾"
+
+    # kill 后重新打开库：播种记录仍在、可查（store 无跨进程内存缓存）
+    env = Facade(Config()).catalog_query(orbit_family="dro")
+    assert env.records, "kill 后已入库记录应完好可查"
+
+
+# ---------------------------------------------------------------------------
+# 3. 协议端到端：真实 dispatcher（内存流）
+# ---------------------------------------------------------------------------
+
+
+async def _recv_message(write_recv, timeout: float = 10.0):
+    """收一条服务端消息（超时抛 TimeoutError）。"""
+    import anyio
+
+    with anyio.fail_after(timeout):
+        sm = await write_recv.receive()
+    return sm.message
+
+
+async def _wait_pidfile(path, timeout: float = 15.0) -> int:
+    import anyio
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if path.exists():
+            return _pid_from_file(path)
+        await anyio.sleep(0.05)
+    raise AssertionError("fake worker pidfile 未出现（worker 未启动）")
+
+
+async def _wait_pid_dead(pid: int, timeout: float = 20.0) -> None:
+    import anyio
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not _pid_alive(pid):
+            return
+        await anyio.sleep(0.1)
+    raise AssertionError(f"worker pid={pid} 未被终止")
+
+
+class _E2E:
+    """内存流上驱动真实 server.run 的最小 MCP 客户端。"""
+
+    def __init__(self, server) -> None:
+        import anyio
+
+        self.server = server
+        self.read_send, self.read_recv = anyio.create_memory_object_stream(16)
+        self.write_send, self.write_recv = anyio.create_memory_object_stream(16)
+
+    async def send(self, message) -> None:
+        from mcp.shared.message import SessionMessage
+
+        await self.read_send.send(SessionMessage(message=message))
+
+    async def request(self, rid: int, method: str, params: dict) -> Any:
+        from mcp.types import JSONRPCRequest
+
+        await self.send(JSONRPCRequest(jsonrpc="2.0", id=rid, method=method, params=params))
+        # 跳过其间穿插的通知（进度等），等到目标响应为止
+        while True:
+            msg = await _recv_message(self.write_recv)
+            if getattr(msg, "id", None) == rid:
+                return msg
+
+    async def notify(self, method: str, params: dict) -> None:
+        from mcp.types import JSONRPCNotification
+
+        await self.send(JSONRPCNotification(jsonrpc="2.0", method=method, params=params))
+
+    async def handshake(self) -> None:
+        from mcp.types import LATEST_PROTOCOL_VERSION
+
+        result = await self.request(
+            1,
+            "initialize",
+            {
+                "protocolVersion": LATEST_PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "pytest", "version": "0"},
+            },
+        )
+        assert not hasattr(result, "error") or result.error is None
+        await self.notify("notifications/initialized", {})
+
+
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
+def test_e2e_cancelled_notification_kills_worker(fake_worker, facade):
+    """验收 1：客户端发 notifications/cancelled → 长任务进程被终止，
+    被取消的请求不回结果，server 之后仍健康应答。"""
+    import anyio
+    from mcp.types import JSONRPCRequest
+
+    from e2m2e.api.mcp import create_server
+
+    fake_worker.use("sleep")
+    server = create_server(facade)
+
+    async def client() -> None:
+        e2e = _E2E(server)
+        options = server.create_initialization_options()
+
+        async with anyio.create_task_group() as outer:
+
+            async def serve() -> None:
+                await server.run(e2e.read_recv, e2e.write_send, options)
+
+            outer.start_soon(serve)
+            await e2e.handshake()
+            await e2e.send(
+                JSONRPCRequest(
+                    jsonrpc="2.0",
+                    id=2,
+                    method="tools/call",
+                    params={"name": "transfer_design", "arguments": {}},
+                )
+            )
+            pid = await _wait_pidfile(fake_worker.pidfile)
+            await anyio.sleep(0.3)  # worker 进入睡眠（模拟长计算中段）
+            await e2e.notify("notifications/cancelled", {"requestId": 2})
+            await _wait_pid_dead(pid)
+            # 被取消的请求不回结果：等 1s 只有闭流/超时
+            import contextlib
+
+            with contextlib.suppress(Exception):
+                with anyio.fail_after(1.0):
+                    while True:
+                        msg = await e2e.write_recv.receive()
+                        assert getattr(msg.message, "id", None) != 2, "取消的请求不得回结果"
+            # server 仍健康
+            pong = await e2e.request(3, "ping", {})
+            assert getattr(pong, "result", None) is not None or not hasattr(pong, "error")
+            await e2e.read_send.aclose()
+            # server.run 随 EOF 返回，任务组自然收束
+
+    anyio.run(client)
+
+
+def test_e2e_client_disconnect_kills_worker(fake_worker, facade):
+    """验收 2：客户端断连（EOF）同样触发取消传播，worker 被终止。"""
+    import anyio
+    from mcp.types import JSONRPCRequest
+
+    from e2m2e.api.mcp import create_server
+
+    fake_worker.use("sleep")
+    server = create_server(facade)
+
+    async def client() -> None:
+        e2e = _E2E(server)
+        options = server.create_initialization_options()
+        served: dict[str, Any] = {}
+
+        async with anyio.create_task_group() as outer:
+
+            async def serve() -> None:
+                await server.run(e2e.read_recv, e2e.write_send, options)
+                served["done"] = True
+
+            outer.start_soon(serve)
+            await e2e.handshake()
+            await e2e.send(
+                JSONRPCRequest(
+                    jsonrpc="2.0",
+                    id=2,
+                    method="tools/call",
+                    params={"name": "orbit_family_generation", "arguments": {}},
+                )
+            )
+            pid = await _wait_pidfile(fake_worker.pidfile)
+            await anyio.sleep(0.3)
+            await e2e.read_send.aclose()  # 断连
+            await _wait_pid_dead(pid)
+            assert served.get("done") is True, "EOF 后 server.run 应返回"
+
+    anyio.run(client)

--- a/tests/api/test_mcp_worker.py
+++ b/tests/api/test_mcp_worker.py
@@ -21,7 +21,12 @@ from typing import Any
 
 import pytest
 
-pytestmark = [pytest.mark.interface]
+pytestmark = [
+    pytest.mark.interface,
+    # kill 子进程后 asyncio proactor 管道 __del__ 的 GC 噪声（CPython 已知
+    # 现象，非资源泄漏），触发时机随 GC 漂移：文件级静音
+    pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning"),
+]
 
 pytest.importorskip("mcp")  # [mcp] extra 未装时整文件跳过（协议层依赖）
 
@@ -375,7 +380,6 @@ class _E2E:
         await self.notify("notifications/initialized", {})
 
 
-@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 def test_e2e_cancelled_notification_kills_worker(fake_worker, facade):
     """验收 1：客户端发 notifications/cancelled → 长任务进程被终止，
     被取消的请求不回结果，server 之后仍健康应答。"""


### PR DESCRIPTION
> *This PR was prepared by an AI agent (issue triage + implementation + code review).*

Closes #588（#576 Phase 2 / ADR 0014 增补）

## 改动摘要

长任务工具取消——子进程隔离架构：

- **`e2m2e/api/mcp/worker.py`（新）**：一次性 worker 子进程入口 `python -m e2m2e.api.mcp.worker`——stdin 读一行 JSON 请求（`{"tool", "arguments"}`），stdout 按行输出节流进度行 + 最终结果行（统一信封），退出码 0；不 import mcp SDK（envelope/tools/facade/config，与 sidecar 同款约束）；stderr 透传到父进程日志。
- **`server.py`**：`LONG_RUNNING_TOOLS`（`transfer_design`、`orbit_family_generation`）路由到 worker；`run_tool_in_worker` 全程可取消 await——MCP `notifications/cancelled`（SDK interrupt 模式取消 handler 作用域）与客户端断连（EOF 拆任务组）汇成同一处理：kill 子进程、shield 内限时收尸、重抛取消；worker 无结果行退出译为 `WORKER_CRASHED` 结构化错误。跨进程进度接续：worker 发进度行，父进程事件循环内直投 session。
- **数据安全**：catalog 落盘本就是一次性原子写（tmp + `os.replace`），kill 只丢当前任务、不损坏已入库记录（`test_catalog_records_survive_worker_kill`）。
- **Windows spawn 开销**（验收 4）：实测 ~1.3s/次（解释器启动 + import 主导），对分钟级计算 <1%，已记入 ADR。
- **测试**（`tests/api/test_mcp_worker.py`，10 条）：真实 worker 往返/错误翻译/未知工具；fake worker 注入——进度转发（带/不带 token）、取消 kill 收尸、崩溃信封；真实 dispatcher（内存流）端到端 `notifications/cancelled` 与 EOF 断连两条取消路径。
- **文档**：ADR 0014 增补 + 决策 6 互指针记、`docs/getting-started/mcp.rst` Tool cancellation 章节、CHANGELOG Unreleased。

## 验收对照（#588）

- [x] 客户端发 `notifications/cancelled` 后，长任务计算进程被终止，请求以取消态收尾（`test_e2e_cancelled_notification_kills_worker`）
- [x] 客户端断连同样触发取消传播（`test_e2e_client_disconnect_kills_worker`）
- [x] kill 后已入库的 catalog 记录不损坏（结构保证 + `test_catalog_records_survive_worker_kill`）
- [x] Windows 下 spawn 开销已评估且在可接受范围（~1.3s，见 ADR 0014 增补）
- [x] 无取消路径时行为与现状一致；全量检查通过

## 测试

```
uv run --no-sync python -m pytest tests/api/ -q          # 243 passed
uv run --no-sync ruff check . && uv run --no-sync ruff format --check .
uv run --no-sync python scripts/check_layer_imports.py
uv run --no-sync python -m mypy e2m2e/ --ignore-missing-imports   # 233 files ok
cargo clippy --workspace && cargo fmt --all -- --check   #（需 Makefile 导出的 CSPICE_DIR/LIBCLANG_PATH）
```
