### PR TITLE
feat(api): 传输层收拢为单一执行核心，注入的 Config 穿透 worker 子进程（#601）

### DIFF
--- a/docs/adr/0014-api-facade-mcp-cli.md
+++ b/docs/adr/0014-api-facade-mcp-cli.md
@@ -132,3 +132,57 @@ process is the only reliable interruption unit.
   minutes-long computations; short tools never pay it.
 - One worker process per call: no state reuse; a killed worker never
   serves another request.
+
+## Amendment (2026-09-01): transport-neutral execution core (#601)
+
+### Context
+
+The two transports (MCP server, GUI sidecar) each re-derived the tool
+surface and drifted: different unknown-tool error codes (TOOL_NOT_FOUND vs
+UNKNOWN_TOOL), duplicated canvas-contract frame extraction, per-call
+rebuild of every tool's JSON schema, and — a correctness bug — worker
+subprocesses rebuilt `Config()` from the environment, silently discarding
+the caller's constructor-injected Config on long-running tools.
+
+### Decisions
+
+1. **One execution entry**: `e2m2e/api/execution.py` owns tool-spec lookup,
+   validation, error translation, and canvas frame extraction.
+   `execute_tool(facade, tool, arguments, *, progress_callback, binary_dtype)
+   -> (envelope, frames)` is the only execution path; the MCP server wraps
+   `CallToolResult`, the sidecar wraps JSON lines + frames, the worker
+   subprocess calls the same core. `preflight()` centralizes the
+   unknown-tool and dtype checks so adapters can short-circuit before
+   protocol framing.
+2. **`LONG_RUNNING_TOOLS` moves to the execution core** (no `[mcp]` extra
+   dependency): one routing list consumed by both transports. The MCP
+   server keeps the async worker pump; a sidecar worker route is deferred
+   until tod asks for it (needs a worker-protocol frames extension and a
+   wire-level cancel message — protocol extensions belong with their
+   consumer).
+3. **Injected Config crosses the process boundary**: the worker request
+   carries `{"tool", "arguments", "config"}`; the worker rebuilds its
+   Facade from `Config.from_payload`. `from_payload` rejects unknown
+   fields and non-object payloads with `INVALID_PARAMS` — no silent
+   fallback to environment defaults when a config was supplied.
+   **The `Config` field set is now a cross-process contract** (the
+   docstring's "骨架，字段待定稿" caveat ends here): adding or removing a
+   field is a protocol change and must update `to_payload`/`from_payload`
+   together.
+4. **Error codes unified**: unknown tool is `TOOL_NOT_FOUND` everywhere
+   (sidecar's `UNKNOWN_TOOL` retired); no new codes introduced.
+5. **Frame codec relocates** from `api/sidecar/frames.py` to
+   `api/frames.py`: the execution core's canvas extraction encodes frames,
+   so the codec must sit at core level. Byte format, magic, and the
+   ADR 0035 contract are untouched.
+6. **Spec lookup is on-demand**: `tools.tool_spec(facade, name)` builds one
+   schema; per-call cost no longer grows with the tool count.
+
+### Consequences
+
+- Adding a Facade tool remains a one-place registration; both transports
+  and the worker inherit it.
+- `Facade` gains a read-only `config` property (the worker-request builder
+  serializes it).
+- `_finite_or_none` is public (`finite_or_none` in `api/catalog_ingest.py`);
+  three consumers no longer import a private name across modules.

--- a/docs/adr/0035-sidecar-stdio-binary-frames.md
+++ b/docs/adr/0035-sidecar-stdio-binary-frames.md
@@ -86,3 +86,14 @@ Offset Length Type      Meaning
   from transport, unit-testable).
 - tod's Rust shell implements peer decoding per this ADR §3; frame-format changes
   require a new ADR.
+
+## Revision (2026-09-01, #601)
+
+The sidecar delegates execution to the transport-neutral core
+(`e2m2e/api/execution.py`, see ADR 0014 amendment): validation, error
+translation, and canvas frame extraction live there; this module keeps only
+wire framing (JSON lines, job_id progress lines, `binary_frames` count and
+frame ordering). The frame codec moved from `api/sidecar/frames.py` to
+`api/frames.py` — byte format and magic unchanged, so the cross-repo
+contract is unaffected. The unknown-tool response code is `TOOL_NOT_FOUND`
+(previously `UNKNOWN_TOOL` here), unified with the MCP transport.

--- a/e2m2e/api/catalog_ingest.py
+++ b/e2m2e/api/catalog_ingest.py
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "build_control_record",
+    "finite_or_none",
     "build_design_record",
     "build_family_record",
     "build_transfer_record",
@@ -173,7 +174,7 @@ def build_design_record(request: Any, result: Any) -> tuple[dict, dict[str, np.n
     else:
         orbit_family, libration_point = selection.lower(), request.collinear_point
 
-    jacobi = _finite_or_none(result.cr3bp_jacobi)
+    jacobi = finite_or_none(result.cr3bp_jacobi)
     correction = result.correction
     taxonomy_labels: list[str] = []
     if cr3bp_orbit is not None:
@@ -257,8 +258,8 @@ def build_family_record(
         member_metas.append(
             {
                 "index": index,
-                "period": _finite_or_none(orbit.period),
-                "closure_error": _finite_or_none(getattr(orbit, "closure_error", None)),
+                "period": finite_or_none(orbit.period),
+                "closure_error": finite_or_none(getattr(orbit, "closure_error", None)),
                 "jacobi": jacobi,
                 "amplitude_km": amplitude_km,
                 "amplitudes": _sanitize_value(getattr(orbit, "amplitudes", {})),
@@ -500,10 +501,10 @@ def _member_jacobi(system: Any, orbit: Any) -> float | None:
     """成员初态 Jacobi 常数；系统不具备该能力时为 None。"""
     if system is None or not hasattr(system, "get_jacobi_constant"):
         return None
-    return _finite_or_none(system.get_jacobi_constant(orbit.states[0]))
+    return finite_or_none(system.get_jacobi_constant(orbit.states[0]))
 
 
-def _finite_or_none(value: Any) -> float | None:
+def finite_or_none(value: Any) -> float | None:
     if value is None:
         return None
     value = float(value)

--- a/e2m2e/api/config.py
+++ b/e2m2e/api/config.py
@@ -9,8 +9,10 @@ r2s2 进程单例作为已知限制用 Config 显式管理。
 
 from __future__ import annotations
 
+import dataclasses
 import os
 from dataclasses import dataclass, field
+from typing import Any
 
 __all__ = ["Config"]
 
@@ -41,3 +43,26 @@ class Config:
             os.environ.get("E2M2E_CATALOG_BASELINE_IMPORT", "1").lower() not in ("0", "false", "no")
         )
     )
+
+    def to_payload(self) -> dict[str, Any]:
+        """序列化为可跨进程传递的字典（worker 子进程请求的 config 字段）。
+
+        字段集合自此是对外契约（#601）：增删字段是协议变更，须同步
+        :meth:`from_payload` 并在 ADR 记录。
+        """
+        return dataclasses.asdict(self)
+
+    @classmethod
+    def from_payload(cls, data: Any) -> Config:
+        """从 :meth:`to_payload` 的字典还原。
+
+        非字典、未知字段均抛 ``ValueError``——跨进程配置不静默降级：
+        调用方看到的配置必须是它给的那份（#601）。
+        """
+        if not isinstance(data, dict):
+            raise ValueError(f"config 载荷必须是对象，得到 {type(data).__name__}")
+        known = {f.name for f in dataclasses.fields(cls)}
+        unknown = set(data) - known
+        if unknown:
+            raise ValueError(f"未知配置字段：{sorted(unknown)}")
+        return cls(**data)

--- a/e2m2e/api/execution.py
+++ b/e2m2e/api/execution.py
@@ -1,0 +1,202 @@
+"""传输中立执行核心：工具执行的单一入口（#601，ADR 0014 增补）。
+
+工具面派生（mcp/tools.py）、执行策略（:data:`LONG_RUNNING_TOOLS`）、二进制
+帧画布契约（本模块 ``_BINARY_TOOLS`` 一族）在此各只有一份定义；MCP server
+与 sidecar 退成薄适配器——前者包 ``CallToolResult``，后者包 JSON 行加帧。
+worker 子进程本体（mcp/worker.py）同样经 :func:`execute_tool` 执行。
+
+本模块不 import mcp SDK、不 import anyio（worker 与 sidecar 同款约束，缺
+``[mcp]`` extra 也能跑）；异步 spawn 的泵在 mcp/server.py。
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from .catalog_ingest import finite_or_none
+from .config import Config
+from .frames import FrameError, encode_frame
+from .mcp import envelope, tools
+
+if TYPE_CHECKING:
+    from ..facade import Facade
+
+__all__ = [
+    "BINARY_DTYPES",
+    "BINARY_FRAME_TOOLS",
+    "LONG_RUNNING_TOOLS",
+    "execute_tool",
+    "preflight",
+    "worker_request_payload",
+]
+
+# 长任务工具（#588 / #576 Phase 2，子进程隔离架构）：分钟级计算改跑 worker
+# 子进程，使取消（对端 cancel / 断连 EOF）可靠传播为进程 kill。执行策略是
+# 两个传输层共同消费的关注点，单一清单在此（#601）；何时 spawn 归各适配器。
+LONG_RUNNING_TOOLS = frozenset({"transfer_design", "orbit_family_generation"})
+
+# 请求方可声明的二进制 dtype（ADR 0035 决策 1：渲染 f32，复算量 f64）。
+BINARY_DTYPES = ("f32", "f64")
+
+
+# 大数组走二进制帧的工具→响应帧抽取函数映射。
+# 族生成响应的成员状态数组出帧（Orbit 对象不可 JSON 化，本就必须走帧）；
+# catalog_get 的记录数组段同理。其余工具等消费端（tod）出现真实需求再补，
+# 不预先铺开。
+def _family_binary_payload(result: Any, dtype: str) -> tuple[dict[str, Any], list[bytes]]:
+    """族生成响应的画布契约：成员状态数组出帧，JSON 行留占位。
+
+    帧序 = ``data.orbits`` 成员序；每帧是该成员的 ``(n, 6)`` 状态数组。
+    times 等小数组留在 JSON。``states`` 置 None 占位，帧是唯一真身。
+    成员级透传 ``period``、响应级透传 ``mu``（原值，归一化单位），供
+    消费端从 ``(1, 6)`` 初态重采样整条轨迹。
+    """
+    frames = [encode_frame(orbit.states, dtype) for orbit in result.orbits]
+    data = {
+        "status": result.status.value,
+        "cause": result.cause.value,
+        "message": result.message,
+        "family_type": result.family_type,
+        "mu": finite_or_none(getattr(result.system, "mu", None)),
+        "requested_members": result.requested_members,
+        "generated_members": result.generated_members,
+        "record_id": result.record_id,
+        "orbits": [
+            {
+                "states": None,
+                "times": [float(t) for t in orbit.times],
+                "period": finite_or_none(orbit.period),
+            }
+            for orbit in result.orbits
+        ],
+    }
+    return data, frames
+
+
+def _catalog_binary_payload(result: Any, dtype: str) -> tuple[dict[str, Any], list[bytes]]:
+    """catalog_get 响应的画布契约：数组段 ndarray 出帧。
+
+    帧序 = JSON 行 ``data.arrays`` 中 None 占位键的顺序；每帧是对应键的
+    数组。非数组值原样留 JSON。元数据、标量段、成员参数表不受影响。
+    本函数与族生成的帧抽取共用 states/times/period/mu 同一套画布契约
+    字段（当前各自独立实现，待第二个消费点出现再收拢）。
+    """
+    frames = []
+    arrays: dict[str, Any] = {}
+    for key, value in result.arrays.items():
+        if isinstance(value, np.ndarray):
+            frames.append(encode_frame(value, dtype))
+            arrays[key] = None
+        else:
+            arrays[key] = value
+    data = result.model_dump(mode="json", exclude={"arrays"})
+    data["arrays"] = arrays
+    return data, frames
+
+
+def _map_binary_payload(result: Any, dtype: str) -> tuple[dict[str, Any], list[bytes]]:
+    """spatiography_dynamical_map 响应的画布契约：五个场出帧，JSON 留占位。
+
+    帧序 = ``ybar_field`` / ``fate_ids``（类 id 以 f32 编码）/ ``t_escape_years_field``
+    / ``min_r_sel_km_field`` / ``min_r_geo_km_field``，均为 (n_a, n_e)，
+    行序 = a 轴；NaN 帧内保留（终端短路格无变分值）。两轴、图例、阈值、
+    场景与详情留 JSON。
+    """
+    frames = [
+        encode_frame(np.asarray(result.ybar_field, dtype=float), dtype),
+        encode_frame(np.asarray(result.fate_ids, dtype=float), dtype),
+        encode_frame(np.asarray(result.t_escape_years_field, dtype=float), dtype),
+        encode_frame(np.asarray(result.min_r_sel_km_field, dtype=float), dtype),
+        encode_frame(np.asarray(result.min_r_geo_km_field, dtype=float), dtype),
+    ]
+    data = {
+        "status": result.status.value,
+        "cause": result.cause.value,
+        "message": result.message,
+        "zone": result.zone,
+        "model": result.model,
+        "span_years": result.span_years,
+        "a_over_a_moon": [float(v) for v in result.a_over_a_moon],
+        "e_grid": [float(v) for v in result.e_grid],
+        "ybar_field": None,
+        "fate_ids": None,
+        "t_escape_years_field": None,
+        "min_r_sel_km_field": None,
+        "min_r_geo_km_field": None,
+        "diagnostic_focus": result.diagnostic_focus,
+        "thresholds": dict(result.thresholds),
+    }
+    return data, frames
+
+
+_BINARY_TOOLS: dict[str, Any] = {
+    "orbit_family_generation": _family_binary_payload,
+    "catalog_get": _catalog_binary_payload,
+    "spatiography_dynamical_map": _map_binary_payload,
+}
+
+#: 响应含大数组、走二进制帧的工具名（sidecar 协议的 requires-dtype 规则
+#: 消费这份清单；ADR 0035）。
+BINARY_FRAME_TOOLS = frozenset(_BINARY_TOOLS)
+
+
+def preflight(facade: Facade, tool: str, binary_dtype: Any = None) -> envelope.Envelope | None:
+    """执行前置校验：未知工具（含 placeholder）与非法 dtype。
+
+    合法返回 None；非法返回错误信封（不执行）。调用方（sidecar）在产出
+    进度行之前用它决定是否短路——规则单一来源在此，行数策略归适配器。
+    """
+    if tools.tool_spec(facade, tool) is None:
+        return envelope.tool_not_found(tool)
+    if binary_dtype is not None and binary_dtype not in BINARY_DTYPES:
+        return envelope.error_envelope(
+            "INVALID_PARAMS",
+            f"binary_dtype 必须是 {BINARY_DTYPES} 之一或缺省，得到 {binary_dtype!r}",
+        )
+    return None
+
+
+def execute_tool(
+    facade: Facade,
+    tool: str,
+    arguments: dict[str, Any],
+    *,
+    progress_callback: Any = None,
+    binary_dtype: Any = None,
+) -> tuple[envelope.Envelope, list[bytes]]:
+    """执行一个工具调用，返回 ``(统一信封, 二进制帧序列)``。
+
+    唯一执行入口（#601）：规格查找、校验、错误翻译、画布帧抽取都只在
+    此。``binary_dtype`` 缺省或工具不在帧清单内时走信封内联降级（MCP 纯
+    文本通道）；声明 dtype 且工具在帧清单内时数组出帧，信封里的对应字段
+    置 None 占位（``binary_frames`` 计数是 sidecar 协议字段，由适配器补）。
+    ``progress_callback`` 按方法签名过滤（见 :func:`envelope.dispatch_tool`），
+    未接受的工具零影响。
+    """
+    spec = tools.tool_spec(facade, tool)
+    if spec is None:
+        return envelope.tool_not_found(tool), []
+    payload_fn = _BINARY_TOOLS.get(tool) if binary_dtype is not None else None
+    extra = {"progress_callback": progress_callback} if progress_callback is not None else None
+    if payload_fn is not None:
+        result, err = envelope.dispatch_tool(spec.method, arguments, extra_kwargs=extra)
+        if err is not None:
+            return err, []
+        try:
+            data, frames = payload_fn(result, binary_dtype)
+        except FrameError as exc:
+            return envelope.error_envelope("INTERNAL_ERROR", f"帧编码失败：{exc}"), []
+        return envelope.ok_envelope(data), frames
+    return envelope.invoke_tool(spec.method, arguments, extra_kwargs=extra), []
+
+
+def worker_request_payload(tool: str, arguments: dict[str, Any], config: Config) -> dict[str, Any]:
+    """worker 子进程请求行载荷（``{"tool", "arguments", "config"}``）。
+
+    注入的 :class:`Config` 随请求下发（#601）：worker 用它重建 Facade，
+    不从环境变量静默重建；载荷形状的唯一定义在此，server 构建与 worker
+    解析共用。
+    """
+    return {"tool": tool, "arguments": arguments, "config": config.to_payload()}

--- a/e2m2e/api/facade.py
+++ b/e2m2e/api/facade.py
@@ -695,6 +695,16 @@ class Facade:
         self._config = config or Config()
         self._catalog_store: CatalogStore | None = None
 
+    @property
+    def config(self) -> Config:
+        """运行配置（只读视图）。
+
+        长任务工具经 worker 子进程执行时，配置经
+        :meth:`Config.to_payload` 随请求下发（#601），子进程用它重建
+        Facade——构造注入对全部工具生效，不再从环境变量静默重建。
+        """
+        return self._config
+
     # ---- 轨道库 catalog 私有设施（ADR 0031）----
 
     def _open_catalog(self) -> CatalogStore:

--- a/e2m2e/api/frames.py
+++ b/e2m2e/api/frames.py
@@ -1,4 +1,4 @@
-"""sidecar 二进制帧编解码（ADR 0035 §3）。
+"""二进制帧编解码（ADR 0035 §3）。
 
 帧格式是 tod ↔ e2m2e 的跨仓库持久契约，逐字段定义（多字节整数一律小端）：
 
@@ -10,7 +10,9 @@
     6+4·ndim  —   —         原始数组字节：C 连续、小端，长度 = prod(shape) × 元素宽度
 
 没有 version 字段：magic 兼职版本锚点，不兼容改动时换 magic（须走新 ADR）。
-本模块是帧契约的唯一实现点，不得引入 ADR 之外的字段。
+本模块是帧契约的唯一实现点，不得引入 ADR 之外的字段。位于 api/ 包根而
+非 sidecar 子包：执行核心的画布帧抽取（execution.py）与 sidecar 协议共
+用同一编解码（#601）。
 """
 
 from __future__ import annotations

--- a/e2m2e/api/mcp/__init__.py
+++ b/e2m2e/api/mcp/__init__.py
@@ -5,6 +5,11 @@
 - ``worker``：长任务 worker 子进程（JSON 行协议，不依赖 ``[mcp]`` extra）。
 - ``server``：``create_server(facade)``（依赖 ``[mcp]`` extra）。
 
+工具面派生、执行策略（``LONG_RUNNING_TOOLS``）、帧契约的单一来源在执行核心
+``e2m2e.api.execution``（#601）：不依赖 ``[mcp]`` extra 的消费方（sidecar、
+worker）直接从那里导入，不经本包转口——本包的惰性导出会拽起 server 的
+SDK 依赖。
+
 ``server`` 惰性导出：sidecar（ADR 0035）复用 envelope/tools 但不依赖
 ``[mcp]`` extra，本包在缺 ``mcp`` 库时仍可导入。
 """
@@ -14,10 +19,9 @@ from __future__ import annotations
 from typing import Any
 
 from .envelope import error_envelope, invoke_tool, ok_envelope
-from .tools import ToolSpec, tool_specs
+from .tools import ToolSpec, tool_spec, tool_specs
 
 __all__ = [
-    "LONG_RUNNING_TOOLS",
     "ToolSpec",
     "create_server",
     "error_envelope",
@@ -26,11 +30,11 @@ __all__ = [
     "invoke_tool",
     "ok_envelope",
     "run_tool_in_worker",
+    "tool_spec",
     "tool_specs",
 ]
 
 _LAZY = (
-    "LONG_RUNNING_TOOLS",
     "create_server",
     "handle_call_tool",
     "handle_list_tools",

--- a/e2m2e/api/mcp/envelope.py
+++ b/e2m2e/api/mcp/envelope.py
@@ -18,7 +18,7 @@ from pydantic import BaseModel, ValidationError
 
 from e2m2e.data.types.orbit import Orbit
 
-from ..catalog_ingest import _finite_or_none
+from ..catalog_ingest import finite_or_none
 from ..models import OrbitError
 
 __all__ = [
@@ -53,7 +53,7 @@ def _to_jsonable(value: Any) -> Any:
         return {
             "states": _to_jsonable(value.states),
             "times": _to_jsonable(value.times),
-            "period": _finite_or_none(value.period),
+            "period": finite_or_none(value.period),
             "family_type": value.family_type,
         }
     if isinstance(value, dict):
@@ -69,7 +69,7 @@ def _to_jsonable(value: Any) -> Any:
         return value
     mu = getattr(value, "mu", None)
     if mu is not None:
-        return {"mu": _finite_or_none(mu)}
+        return {"mu": finite_or_none(mu)}
     return f"<{type(value).__name__}>"
 
 

--- a/e2m2e/api/mcp/server.py
+++ b/e2m2e/api/mcp/server.py
@@ -1,9 +1,10 @@
-"""MCP 服务：LLM 工具入口。
+"""MCP 服务：LLM 工具入口（ADR 0014）。
 
-进程内库为主体 + CLI 薄包装 mcp-serve（ADR 0014）：``create_server(facade)``
-函数（进程内、可测试）+ ``e2m2e mcp-serve`` 子命令。一个 Facade 实例 = 一个
-server。MCP 工具 = facade 上 mcp_exposed=True 的方法（纯派生，见 tools.py），
-传输层包统一信封（见 envelope.py）。
+进程内库为主体 + CLI 薄包装 mcp-serve：``create_server(facade)`` 函数
+（进程内、可测试）+ ``e2m2e mcp-serve`` 子命令。一个 Facade 实例 = 一个
+server。本模块是薄适配器：工具面、执行策略、帧契约的单一来源在执行核心
+``e2m2e.api.execution``（#601），这里只做 MCP 形状转换（信封 →
+``CallToolResult``）与 worker 子进程的异步泵。
 
 依赖 ``[mcp]`` extra：本模块在缺 ``mcp`` 库时导入即失败，调用方（CLI）负责
 给出安装提示。
@@ -30,6 +31,7 @@ from mcp.types import (
     Tool,
 )
 
+from .. import execution
 from . import envelope, tools
 
 if TYPE_CHECKING:
@@ -40,7 +42,6 @@ if TYPE_CHECKING:
     from ..facade import Facade
 
 __all__ = [
-    "LONG_RUNNING_TOOLS",
     "create_server",
     "handle_list_tools",
     "handle_call_tool",
@@ -55,12 +56,8 @@ _PROGRESS_MIN_INTERVAL_SEC = 0.1
 # worker 线程；超时按投递失败处理（静默降级为无进度）。
 _PROGRESS_SEND_TIMEOUT_SEC = 5.0
 
-# 长任务工具（#588 / #576 Phase 2，子进程隔离架构）：分钟级计算改跑
-# worker 子进程（见 worker.py），使 MCP 取消（notifications/cancelled，
-# interrupt 模式取消 handler 作用域）与客户端断连（EOF 取消任务组）都能
-# 可靠传播为进程 kill。其余工具线程池直跑，行为不变。执行策略是传输层
-# 关注点，放这里而不入 Facade 元数据。
-LONG_RUNNING_TOOLS = frozenset({"transfer_design", "orbit_family_generation"})
+# 长任务工具清单（LONG_RUNNING_TOOLS）在执行核心 e2m2e.api.execution：
+# 两个传输层共同消费的单一来源（#601）。本模块只负责“何时 spawn”。
 
 # worker 子进程命令（模块常量：测试注入 fake worker 用，同
 # _PROGRESS_MIN_INTERVAL_SEC 的 monkeypatch 先例）。
@@ -141,23 +138,25 @@ async def _iter_lines(stream: ByteReceiveStream) -> AsyncIterator[bytes]:
 
 
 async def run_tool_in_worker(
-    tool_name: str, arguments: dict[str, Any], context: Any
+    facade: Facade, tool_name: str, arguments: dict[str, Any], context: Any
 ) -> CallToolResult:
     """在 worker 子进程中执行长任务工具（#588 子进程隔离）。
 
     请求经 stdin 一行 JSON 下发，进度/结果行经 stdout 回流（协议见
-    worker.py）。等待全部走可取消的 await：MCP 请求取消（interrupt 模式
-    取消 handler 作用域）与客户端断连（EOF 取消任务组）在此汇成同一
-    处理——kill 子进程、shield 内收尸、重抛取消。kill 只丢当前任务：
-    catalog 落盘是一次性原子写（tmp + os.replace），已入库记录不受影响。
-    worker 异常退出（无结果行）译为 WORKER_CRASHED 结构化错误。
+    worker.py）；注入的 Config 经 :func:`execution.worker_request_payload`
+    随请求下发（#601），子进程用它重建 Facade。等待全部走可取消的 await：
+    MCP 请求取消（interrupt 模式取消 handler 作用域）与客户端断连（EOF
+    取消任务组）在此汇成同一处理——kill 子进程、shield 内收尸、重抛取消。
+    kill 只丢当前任务：catalog 落盘是一次性原子写（tmp + os.replace），
+    已入库记录不受影响。worker 异常退出（无结果行）译为 WORKER_CRASHED
+    结构化错误。
     """
     proc = await anyio.open_process(
         _WORKER_ARGV, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=None
     )
     assert proc.stdin is not None and proc.stdout is not None  # PIPE 已请求
-    request = json.dumps({"tool": tool_name, "arguments": arguments}, ensure_ascii=True)
-    await proc.stdin.send(request.encode("ascii") + b"\n")
+    request = execution.worker_request_payload(tool_name, arguments, facade.config)
+    await proc.stdin.send(json.dumps(request, ensure_ascii=True).encode("ascii") + b"\n")
     await proc.stdin.aclose()
 
     meta = getattr(context, "meta", None)
@@ -202,14 +201,13 @@ def handle_call_tool(
 ) -> CallToolResult:
     """调用工具并包信封（纯函数，便于测试）。
 
-    ``extra_kwargs`` 是传输层注入的额外协作者（如进度回调），信封层按
-    方法签名过滤（见 :func:`envelope.dispatch_tool`），未接受的工具零影响。
+    执行委托执行核心（#601）；``extra_kwargs`` 是传输层注入的额外协作者
+    （如进度回调），核心按方法签名过滤，未接受的工具零影响。
     """
-    spec = next((s for s in tools.tool_specs(facade) if s.name == name), None)
-    if spec is None:
-        env = envelope.tool_not_found(name)
-    else:
-        env = envelope.invoke_tool(spec.method, arguments, extra_kwargs=extra_kwargs)
+    progress_callback = (extra_kwargs or {}).get("progress_callback")
+    env, _frames = execution.execute_tool(
+        facade, name, arguments, progress_callback=progress_callback
+    )
     return _to_result(env)
 
 
@@ -234,12 +232,12 @@ def create_server(facade: Facade) -> Server:
 
     async def _call_tool(context: Any, params: Any) -> CallToolResult:
         # Facade 方法是同步长计算，放线程池避免阻塞事件循环；客户端
-        # 请求进度时把线程安全回调作为额外协作者注入（未请求时 None，
-        # 注入层按方法签名过滤，其余工具零影响）。长任务工具例外：改跑
-        # worker 子进程，使取消/断连可靠传播为进程 kill（#588）。
+        # 请求进度时把线程安全回调作为额外协作者注入（未请求时 None）。
+        # 长任务工具例外：改跑 worker 子进程（路由清单在执行核心），
+        # 使取消/断连可靠传播为进程 kill（#588）。
         arguments = dict(params.arguments or {})
-        if params.name in LONG_RUNNING_TOOLS:
-            return await run_tool_in_worker(params.name, arguments, context)
+        if params.name in execution.LONG_RUNNING_TOOLS:
+            return await run_tool_in_worker(facade, params.name, arguments, context)
         reporter = make_progress_reporter(context)
         extra = {"progress_callback": reporter} if reporter is not None else None
         return await anyio.to_thread.run_sync(

--- a/e2m2e/api/mcp/tools.py
+++ b/e2m2e/api/mcp/tools.py
@@ -19,7 +19,7 @@ from ..facade import tool_inventory
 if TYPE_CHECKING:
     from ..facade import Facade
 
-__all__ = ["ToolSpec", "tool_specs"]
+__all__ = ["ToolSpec", "tool_spec", "tool_specs"]
 
 
 @dataclasses.dataclass(frozen=True)
@@ -32,23 +32,34 @@ class ToolSpec:
     method: Callable[..., Any]
 
 
+def tool_spec(facade: Facade, name: str) -> ToolSpec | None:
+    """单个工具的规格：按需构造 schema，不重建全量清单（#601）。
+
+    未知工具或 placeholder 返回 None——placeholder 不注册，调用未知
+    工具同义。
+    """
+    for info in tool_inventory(facade):
+        if info.name == name and info.status == "implemented":
+            return _build_spec(facade, info)
+    return None
+
+
 def tool_specs(facade: Facade) -> list[ToolSpec]:
     """由 Facade 纯派生工具规格（placeholder 不注册）。"""
-    specs: list[ToolSpec] = []
-    for info in tool_inventory(facade):
-        if info.status != "implemented":
-            continue
-        method = getattr(facade, info.name)
-        if info.request_model is not None:
-            schema = info.request_model.model_json_schema()
-        else:
-            schema = {"type": "object", "properties": {}, "additionalProperties": False}
-        specs.append(
-            ToolSpec(
-                name=info.name,
-                description=(method.__doc__ or info.name).strip().splitlines()[0],
-                input_schema=schema,
-                method=method,
-            )
-        )
-    return specs
+    return [
+        _build_spec(facade, info) for info in tool_inventory(facade) if info.status == "implemented"
+    ]
+
+
+def _build_spec(facade: Facade, info: Any) -> ToolSpec:
+    method = getattr(facade, info.name)
+    if info.request_model is not None:
+        schema = info.request_model.model_json_schema()
+    else:
+        schema = {"type": "object", "properties": {}, "additionalProperties": False}
+    return ToolSpec(
+        name=info.name,
+        description=(method.__doc__ or info.name).strip().splitlines()[0],
+        input_schema=schema,
+        method=method,
+    )

--- a/e2m2e/api/mcp/worker.py
+++ b/e2m2e/api/mcp/worker.py
@@ -1,9 +1,12 @@
 """长任务工具 worker 子进程（#588 / #576 Phase 2，子进程隔离架构）。
 
-``python -m e2m2e.api.mcp.worker`` 一次性执行一个工具调用，供 mcp-serve
-把分钟级长计算（转移搜索、族生成）隔离到可 kill 的子进程：
+``python -m e2m2e.api.mcp.worker`` 一次性执行一个工具调用，供传输层把
+分钟级长计算（转移搜索、族生成）隔离到可 kill 的子进程：
 
-- stdin 读一行 JSON 请求 ``{"tool": name, "arguments": {...}}``
+- stdin 读一行 JSON 请求 ``{"tool": name, "arguments": {...}, "config": {...}}``
+  （config 缺省时从环境变量重建，见 config.py；存在时经
+  ``Config.from_payload`` 还原——注入的配置穿透子进程，未知字段报错
+  而非静默降级，#601）
 - stdout 按行输出 ``{"type": "progress", "fraction": ..., "message": ...}``
   （节流，见 ``_PROGRESS_MIN_INTERVAL_SEC``）与最终一行
   ``{"type": "result", "envelope": {...}}``（统一信封，见 envelope.py）
@@ -14,7 +17,7 @@
 数据安全：catalog 落盘是工具方法末尾的一次性原子写（tmp + os.replace），
 kill 只丢当前任务，不损坏已入库记录。
 
-不 import mcp SDK：worker 只依赖 envelope/tools/facade/config（与 sidecar
+不 import mcp SDK：worker 只依赖执行核心与 Facade/Config（与 sidecar
 同款约束，缺 ``[mcp]`` extra 也能跑）。
 """
 
@@ -44,8 +47,9 @@ def run_request(request: dict[str, Any], emit_line: Callable[[str], None]) -> No
     抛 traceback、不泄漏细节（api/ 边界契约）。
     """
     from ..config import Config
+    from ..execution import execute_tool
     from ..facade import Facade
-    from . import envelope, tools
+    from . import envelope
 
     lock = threading.Lock()
     last_sent = 0.0
@@ -62,19 +66,27 @@ def run_request(request: dict[str, Any], emit_line: Callable[[str], None]) -> No
         with lock:
             emit_line(line)
 
+    def restore_config() -> tuple[Config | None, envelope.Envelope | None]:
+        """请求 config 载荷 → Config；缺省从环境重建，坏载荷给错误信封。"""
+        payload = request.get("config")
+        if payload is None:
+            return Config(), None
+        try:
+            return Config.from_payload(payload), None
+        except (TypeError, ValueError) as exc:
+            return None, envelope.error_envelope("INVALID_PARAMS", f"worker 配置还原失败：{exc}")
+
     tool = request.get("tool")
     arguments = request.get("arguments") or {}
     if not isinstance(tool, str) or not isinstance(arguments, dict):
         env = envelope.error_envelope("INVALID_PARAMS", "worker 请求形状错误（tool/arguments）")
     else:
-        facade = Facade(config=Config())
-        spec = next((s for s in tools.tool_specs(facade) if s.name == tool), None)
-        if spec is None:
-            env = envelope.tool_not_found(tool)
+        config, err = restore_config()
+        if err is not None:
+            env = err
         else:
-            env = envelope.invoke_tool(
-                spec.method, arguments, extra_kwargs={"progress_callback": emit_progress}
-            )
+            facade = Facade(config=config)
+            env, _frames = execute_tool(facade, tool, arguments, progress_callback=emit_progress)
     line = json.dumps({"type": "result", "envelope": env}, ensure_ascii=True)
     with lock:
         emit_line(line)

--- a/e2m2e/api/sidecar/__init__.py
+++ b/e2m2e/api/sidecar/__init__.py
@@ -6,6 +6,10 @@ tod 的 Tauri 壳以常驻子进程驱动 e2m2e：请求/响应/进度是 JSON �
 时，JSON 行带 ``"binary_frames": N``，换行符后紧跟 N 个二进制帧，帧后恢复
 JSON 行流（帧格式见 ``frames.py``）。工具面 = Facade 上 ``mcp_exposed``
 的方法（纯派生，ADR 0014），不新增业务逻辑。
+
+本模块是薄适配器（#601）：工具面、校验规则、画布帧抽取的单一来源在执行
+核心 ``e2m2e/api/execution.py``，这里只做协议形状转换——JSON 行切分、
+job_id 进度行、``binary_frames`` 计数与帧字节排序。
 """
 
 from __future__ import annotations
@@ -13,11 +17,8 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING, Any
 
-import numpy as np
-
-from ..catalog_ingest import _finite_or_none
-from ..mcp import envelope, tools
-from .frames import FrameError, encode_frame
+from ..execution import BINARY_FRAME_TOOLS, execute_tool, preflight
+from ..mcp import envelope
 
 if TYPE_CHECKING:
     from typing import BinaryIO
@@ -25,108 +26,6 @@ if TYPE_CHECKING:
     from ..facade import Facade
 
 __all__ = ["handle_request", "run_loop"]
-
-# 请求方可声明的二进制 dtype（ADR 0035 决策 1：渲染 f32，复算量 f64）。
-_BINARY_DTYPES = ("f32", "f64")
-
-
-# 大数组走二进制帧的工具→响应帧抽取函数映射。
-# 族生成响应的成员状态数组出帧（Orbit 对象不可 JSON 化，本就必须走帧）；
-# catalog_get 的记录数组段同理。其余工具等消费端（tod）出现真实需求再补，
-# 不预先铺开。
-def _family_binary_payload(result: Any, dtype: str) -> tuple[dict[str, Any], list[bytes]]:
-    """族生成响应的画布契约：成员状态数组出帧，JSON 行留占位。
-
-    帧序 = ``data.orbits`` 成员序；每帧是该成员的 ``(n, 6)`` 状态数组。
-    times 等小数组留在 JSON。``states`` 置 None 占位，帧是唯一真身。
-    成员级透传 ``period``、响应级透传 ``mu``（原值，归一化单位），供
-    消费端从 ``(1, 6)`` 初态重采样整条轨迹。
-    """
-    frames = [encode_frame(orbit.states, dtype) for orbit in result.orbits]
-    data = {
-        "status": result.status.value,
-        "cause": result.cause.value,
-        "message": result.message,
-        "family_type": result.family_type,
-        "mu": _finite_or_none(getattr(result.system, "mu", None)),
-        "requested_members": result.requested_members,
-        "generated_members": result.generated_members,
-        "record_id": result.record_id,
-        "orbits": [
-            {
-                "states": None,
-                "times": [float(t) for t in orbit.times],
-                "period": _finite_or_none(orbit.period),
-            }
-            for orbit in result.orbits
-        ],
-    }
-    return data, frames
-
-
-def _catalog_binary_payload(result: Any, dtype: str) -> tuple[dict[str, Any], list[bytes]]:
-    """catalog_get 响应的画布契约：数组段 ndarray 出帧。
-
-    帧序 = JSON 行 ``data.arrays`` 中 None 占位键的顺序；每帧是对应键的
-    数组。非数组值原样留 JSON。元数据、标量段、成员参数表不受影响。
-    本函数与族生成的帧抽取共用 states/times/period/mu 同一套画布契约
-    字段（当前各自独立实现，待第二个消费点出现再收拢）。
-    """
-    frames = []
-    arrays: dict[str, Any] = {}
-    for key, value in result.arrays.items():
-        if isinstance(value, np.ndarray):
-            frames.append(encode_frame(value, dtype))
-            arrays[key] = None
-        else:
-            arrays[key] = value
-    data = result.model_dump(mode="json", exclude={"arrays"})
-    data["arrays"] = arrays
-    return data, frames
-
-
-def _map_binary_payload(result: Any, dtype: str) -> tuple[dict[str, Any], list[bytes]]:
-    """spatiography_dynamical_map 响应的画布契约：五个场出帧，JSON 留占位。
-
-    帧序 = ``ybar_field`` / ``fate_ids``（类 id 以 f32 编码）/ ``t_escape_years_field``
-    / ``min_r_sel_km_field`` / ``min_r_geo_km_field``，均为 (n_a, n_e)，
-    行序 = a 轴；NaN 帧内保留（终端短路格无变分值）。两轴、图例、阈值、
-    场景与详情留 JSON。
-    """
-    import numpy as _np
-
-    frames = [
-        encode_frame(_np.asarray(result.ybar_field, dtype=float), dtype),
-        encode_frame(_np.asarray(result.fate_ids, dtype=float), dtype),
-        encode_frame(_np.asarray(result.t_escape_years_field, dtype=float), dtype),
-        encode_frame(_np.asarray(result.min_r_sel_km_field, dtype=float), dtype),
-        encode_frame(_np.asarray(result.min_r_geo_km_field, dtype=float), dtype),
-    ]
-    data = {
-        "status": result.status.value,
-        "cause": result.cause.value,
-        "message": result.message,
-        "zone": result.zone,
-        "model": result.model,
-        "span_years": result.span_years,
-        "a_over_a_moon": [float(v) for v in result.a_over_a_moon],
-        "e_grid": [float(v) for v in result.e_grid],
-        "ybar_field": None,
-        "fate_ids": None,
-        "t_escape_years_field": None,
-        "min_r_sel_km_field": None,
-        "min_r_geo_km_field": None,
-        "diagnostic_focus": result.diagnostic_focus,
-        "thresholds": dict(result.thresholds),
-    }
-    return data, frames
-
-
-_BINARY_TOOLS: dict[str, Any] = {
-    "orbit_family_generation": _family_binary_payload,
-    "catalog_get": _catalog_binary_payload,
-    "spatiography_dynamical_map": _map_binary_payload,
-}
 
 
 def _line(payload: Any) -> bytes:
@@ -154,57 +53,32 @@ def handle_request(facade: Facade, request: Any) -> list[bytes]:
     """处理一个已解析的请求，返回待写出的字节块。
 
     字节块是零个或多个 JSON 行（含换行符）加原始帧字节；调用方顺序写出
-    即得到协议流。
+    即得到协议流。校验与执行委托执行核心；本模块保有行数策略——前置
+    校验失败时单行返回（不产出进度行），执行结果前总是先产出进度行。
     """
     if not isinstance(request, dict) or not isinstance(request.get("tool"), str):
         return [
             _line(envelope.error_envelope("INVALID_PARAMS", "请求必须是含 tool 字段的 JSON 对象"))
         ]
     tool: str = request["tool"]
-    spec = next((s for s in tools.tool_specs(facade) if s.name == tool), None)
-    if spec is None:
-        return [_line(envelope.error_envelope("UNKNOWN_TOOL", f"未知工具 {tool!r}"))]
     dtype = request.get("binary_dtype")
-    if dtype is not None and dtype not in _BINARY_DTYPES:
-        return [
-            _line(
-                envelope.error_envelope(
-                    "INVALID_PARAMS",
-                    f"binary_dtype 必须是 {_BINARY_DTYPES} 之一或缺省，得到 {dtype!r}",
-                )
-            )
-        ]
+    err = preflight(facade, tool, dtype)
+    if err is None and dtype is None and tool in BINARY_FRAME_TOOLS:
+        # 协议约定（非参数校验）：响应含 ndarray/Orbit 对象，本协议要求
+        # 走帧（执行核心在缺省 dtype 时走内联降级，MCP 通道即此用法），
+        # 缺省 dtype 视为协议用法错误，借用 INVALID_PARAMS 错误码。
+        err = envelope.error_envelope(
+            "INVALID_PARAMS", f"工具 {tool} 的响应含大数组，请求必须声明 binary_dtype（f32/f64）"
+        )
+    if err is not None:
+        return [_line(err)]
     job_id = request.get("job_id")
-    arguments = request.get("arguments") or {}
     started = _progress_line(job_id, 0.0, f"开始 {tool}")
-    chunks = [started]
 
-    payload_fn = _BINARY_TOOLS.get(tool)
-    if payload_fn is not None:
-        if dtype is None:
-            # 协议约定（非参数校验）：响应含 ndarray/Orbit 对象，本协议要求
-            # 走帧（MCP 传输层由 envelope 降级内联 JSON，帧仍是首选通道），
-            # 缺省 dtype 视为协议用法错误，借用 INVALID_PARAMS 错误码。
-            return [
-                _line(
-                    envelope.error_envelope(
-                        "INVALID_PARAMS",
-                        f"工具 {tool} 的响应含大数组，请求必须声明 binary_dtype（f32/f64）",
-                    )
-                )
-            ]
-        result, err = envelope.dispatch_tool(spec.method, arguments)
-        if err is not None:
-            return [started, _line(err)]
-        try:
-            data, frames = payload_fn(result, dtype)
-        except FrameError as exc:
-            return [started, _line(envelope.error_envelope("INTERNAL_ERROR", f"帧编码失败：{exc}"))]
-        response = envelope.ok_envelope(data)
-        response["binary_frames"] = len(frames)
-        return [*chunks, _line(response), *frames]
-
-    return [*chunks, _line(envelope.invoke_tool(spec.method, arguments))]
+    env, frames = execute_tool(facade, tool, request.get("arguments") or {}, binary_dtype=dtype)
+    if frames:
+        env["binary_frames"] = len(frames)
+    return [started, _line(env), *frames]
 
 
 def run_loop(facade: Facade, stdin: BinaryIO, stdout: BinaryIO) -> None:

--- a/tests/api/test_execution.py
+++ b/tests/api/test_execution.py
@@ -1,0 +1,225 @@
+"""执行核心测试（#601）：单一入口的信封/帧/配置语义。
+
+只走接缝外部行为：给核心一个 facade 和一份参数，断言信封与帧内容。
+本文件不依赖 ``[mcp]`` extra——执行核心是 sidecar 与 worker 的共同依赖。
+"""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+
+from e2m2e.api import execution
+from e2m2e.api.config import Config
+from e2m2e.api.facade import Facade, mcp_exposed
+from e2m2e.api.frames import decode_frame
+from e2m2e.api.models import (
+    CatalogGetRequest,
+    CatalogQueryRequest,
+    CatalogQueryResponse,
+    CatalogRecordResponse,
+    FamilyGenerationRequest,
+    FamilyGenerationResponse,
+)
+from e2m2e.data.templates import ConvergenceState, FailureCause
+from e2m2e.data.types.orbit import Orbit
+
+pytestmark = pytest.mark.interface
+
+_ARGS = {"orbit_type": "HALO", "libration_point": 1}  # 能过 FamilyGenerationRequest 校验的最小参数
+
+
+class _System:
+    """鸭子类型 system：仅供画布契约读取 mu。"""
+
+    mu = 1.215e-2
+
+
+def _orbit(seed: float, n: int = 3, period: float | None = None) -> Orbit:
+    states = np.arange(n * 6, dtype=float).reshape(n, 6) + seed
+    orbit = Orbit(states=states, times=np.linspace(0.0, 1.0, n))
+    orbit.period = period
+    return orbit
+
+
+@pytest.fixture
+def facade(tmp_path, monkeypatch) -> Facade:
+    monkeypatch.setenv("E2M2E_CATALOG_DIR", str(tmp_path / "catalog"))
+
+    class _StubFacade(Facade):
+        @mcp_exposed(request_model=FamilyGenerationRequest)
+        def orbit_family_generation(self, **params) -> FamilyGenerationResponse:
+            return FamilyGenerationResponse(
+                status=ConvergenceState.CONVERGED,
+                cause=FailureCause.NONE,
+                message="ok",
+                orbits=[_orbit(0.0, period=2.5), _orbit(10.0)],
+                family_type="halo",
+                system=_System(),
+                requested_members=2,
+                generated_members=2,
+            )
+
+        @mcp_exposed(request_model=CatalogQueryRequest)
+        def catalog_query(self, **params) -> CatalogQueryResponse:
+            return CatalogQueryResponse(
+                status=ConvergenceState.CONVERGED,
+                cause=FailureCause.NONE,
+                message="查询完成：0 条记录",
+                records=[],
+            )
+
+        @mcp_exposed(request_model=CatalogGetRequest)
+        def catalog_get(self, **params) -> CatalogRecordResponse:
+            return CatalogRecordResponse(
+                record_id="r1",
+                created_at="2026-01-01T00:00:00Z",
+                source_tool="orbit_family_generation",
+                source_record_id=None,
+                orbit_family="halo_n",
+                libration_point=1,
+                jacobi=None,
+                amplitude=None,
+                has_cr3bp=True,
+                has_ephemeris=False,
+                status=ConvergenceState.CONVERGED,
+                cause=FailureCause.NONE,
+                message="ok",
+                member_count=2,
+                tags=[],
+                note="",
+                scalars={"mu": 0.1},
+                request={"orbit_type": "HALO"},
+                members=[{"index": 0}, {"index": 1}],
+                arrays={
+                    "cr3bp/members/0/states": np.arange(18.0).reshape(3, 6),
+                    "cr3bp/members/1/states": np.arange(18.0).reshape(3, 6) + 10.0,
+                },
+            )
+
+    return _StubFacade(Config())
+
+
+def test_unknown_tool_yields_tool_not_found(facade):
+    """未知工具（含 placeholder）统一 TOOL_NOT_FOUND（#601 单一编码）。"""
+    env, frames = execution.execute_tool(facade, "no_such_tool", {})
+    assert env["status"] == "error"
+    assert env["error"]["code"] == "TOOL_NOT_FOUND"
+    assert frames == []
+
+
+def test_preflight_unknown_tool_and_bad_dtype(facade):
+    assert execution.preflight(facade, "no_such_tool") is not None
+    assert execution.preflight(facade, "catalog_query", "f16") is not None
+    assert execution.preflight(facade, "catalog_query", "f32") is None
+    assert execution.preflight(facade, "catalog_query", None) is None
+
+
+def test_binary_tool_frames_and_placeholder(facade):
+    """声明 dtype 且工具在帧清单内：数组出帧，信封字段 None 占位。"""
+    env, frames = execution.execute_tool(
+        facade, "orbit_family_generation", _ARGS, binary_dtype="f32"
+    )
+    assert env["status"] == "ok"
+    assert len(frames) == 2
+    # binary_frames 计数是 sidecar 协议字段，核心不掺入
+    assert "binary_frames" not in env
+    orbits = env["data"]["orbits"]
+    assert [o["states"] for o in orbits] == [None, None]
+    assert [o["period"] for o in orbits] == [2.5, None]
+    assert env["data"]["mu"] == pytest.approx(1.215e-2)
+    arr0, dtype, _ = decode_frame(frames[0])
+    assert dtype == "f32"
+    np.testing.assert_allclose(arr0, np.arange(18, dtype=float).reshape(3, 6).astype(np.float32))
+
+
+def test_dtype_on_non_frame_tool_is_ignored(facade):
+    """dtype 声明对不在帧清单的工具无影响：照常内联信封，无帧。"""
+    env, frames = execution.execute_tool(facade, "catalog_query", {}, binary_dtype="f32")
+    assert env["status"] == "ok"
+    assert frames == []
+    assert env["data"]["message"] == "查询完成：0 条记录"
+
+
+def test_invalid_params_yields_error_envelope(facade):
+    env, frames = execution.execute_tool(facade, "orbit_family_generation", {"libration_point": 99})
+    assert env["status"] == "error"
+    assert env["error"]["code"] == "INVALID_PARAMS"
+    assert frames == []
+
+
+def test_progress_callback_forwarded_only_when_accepted(facade):
+    """回调按方法签名过滤：未声明 progress_callback 形参的工具不注入。"""
+    seen: list[float] = []
+
+    env, _ = execution.execute_tool(
+        facade,
+        "catalog_query",
+        {},
+        progress_callback=lambda fraction, message=None: seen.append(fraction),
+    )
+    assert env["status"] == "ok"
+    assert seen == [], "未声明形参的工具不得收到回调"
+
+
+def test_progress_callback_reaches_accepting_method(tmp_path, monkeypatch):
+    """声明了 progress_callback 形参的 Facade 方法确实收到核心注入的回调。
+
+    族生成的回调是 Facade 阶段级使用（起止两端上报，不透传算法层），
+    所以直接观测回调被触发（先例：tests/api/test_facade_progress.py）。
+    """
+    import e2m2e.algorithm.family as family_pkg
+
+    class _FakeFamily:
+        family_type = "dro"
+        system = None
+        metadata: dict = {}
+
+        def __init__(self) -> None:
+            self.orbits: list = []
+
+        def __iter__(self):
+            return iter(self.orbits)
+
+        def __len__(self) -> int:
+            return len(self.orbits)
+
+    monkeypatch.setattr(family_pkg, "design_dro_family", lambda *a, **k: _FakeFamily())
+    seen: list[float] = []
+    facade = Facade(Config(catalog_dir=str(tmp_path / "catalog")))
+    env, _ = execution.execute_tool(
+        facade,
+        "orbit_family_generation",
+        {"orbit_type": "DRO", "n_orbits": 2},
+        progress_callback=lambda fraction, message=None: seen.append(fraction),
+    )
+    assert env["status"] == "ok"
+    assert seen == [0.0, 1.0], "声明的工具应收到核心注入的回调并触发它"
+
+
+def test_config_payload_roundtrip():
+    """Config 载荷往返保真（#601 跨进程契约）。"""
+    config = Config(catalog_dir="somewhere", catalog_enabled=False)
+    restored = Config.from_payload(config.to_payload())
+    assert restored == config
+
+
+def test_config_payload_rejects_unknown_field():
+    """未知字段抛 ValueError：跨进程配置不静默降级（#601）。"""
+    with pytest.raises(ValueError, match="bogus"):
+        Config.from_payload({"bogus_field": 1})
+    with pytest.raises(ValueError, match="必须是对象"):
+        Config.from_payload([1, 2])
+
+
+def test_worker_request_payload_carries_config():
+    """worker 请求载荷形状：tool/arguments/config 三键（#601）。"""
+    config = Config(catalog_dir="d")
+    payload = execution.worker_request_payload("catalog_query", {"a": 1}, config)
+    assert set(payload) == {"tool", "arguments", "config"}
+    assert payload["tool"] == "catalog_query"
+    assert payload["arguments"] == {"a": 1}
+    assert Config.from_payload(payload["config"]) == config
+    json.dumps(payload)  # 载荷必须可 JSON 行传输

--- a/tests/api/test_mcp_worker.py
+++ b/tests/api/test_mcp_worker.py
@@ -7,8 +7,9 @@
 3. 协议端到端：真实 dispatcher（内存流）驱动 ``notifications/cancelled``
    与客户端断连（EOF）两条取消路径。
 
-worker 是通用执行器（任意工具名），路由决策（哪些工具走子进程）在
-server 层的 LONG_RUNNING_TOOLS——测试用便宜工具直接打 worker。
+worker 是通用执行器（任意工具名），路由决策（哪些工具走子进程）在执行核心
+LONG_RUNNING_TOOLS（e2m2e.api.execution，#601）——测试用便宜工具直接打 worker。
+注入的 Config 随请求下发（#601）：worker 用它构造 Facade，不从环境重建。
 """
 
 from __future__ import annotations
@@ -146,26 +147,26 @@ def facade() -> Facade:
 # ---------------------------------------------------------------------------
 
 
-def test_real_worker_roundtrip_ok():
+def test_real_worker_roundtrip_ok(facade):
     """真实子进程：便宜工具经 worker 往返，信封 status=ok。"""
     import anyio
 
     from e2m2e.api.mcp import run_tool_in_worker
 
-    result = anyio.run(run_tool_in_worker, "catalog_query", {}, _Ctx())
+    result = anyio.run(run_tool_in_worker, facade, "catalog_query", {}, _Ctx())
     assert not result.is_error
     env = json.loads(result.content[0].text)
     assert env["status"] == "ok"
     assert set(env) == {"status", "data", "error", "meta"}
 
 
-def test_real_worker_translates_validation_errors():
+def test_real_worker_translates_validation_errors(facade):
     """worker 侧错误翻译照旧：非法参数 → INVALID_PARAMS（无 traceback 泄漏）。"""
     import anyio
 
     from e2m2e.api.mcp import run_tool_in_worker
 
-    result = anyio.run(run_tool_in_worker, "catalog_query", {"libration_point": 99}, _Ctx())
+    result = anyio.run(run_tool_in_worker, facade, "catalog_query", {"libration_point": 99}, _Ctx())
     assert result.is_error
     env = json.loads(result.content[0].text)
     assert env["status"] == "error"
@@ -173,12 +174,12 @@ def test_real_worker_translates_validation_errors():
     assert "Traceback" not in result.content[0].text
 
 
-def test_real_worker_unknown_tool():
+def test_real_worker_unknown_tool(facade):
     import anyio
 
     from e2m2e.api.mcp import run_tool_in_worker
 
-    result = anyio.run(run_tool_in_worker, "no_such_tool", {}, _Ctx())
+    result = anyio.run(run_tool_in_worker, facade, "no_such_tool", {}, _Ctx())
     env = json.loads(result.content[0].text)
     assert env["error"]["code"] == "TOOL_NOT_FOUND"
 
@@ -188,7 +189,7 @@ def test_real_worker_unknown_tool():
 # ---------------------------------------------------------------------------
 
 
-def test_progress_forwarded_with_token(fake_worker):
+def test_progress_forwarded_with_token(fake_worker, facade):
     """worker 进度行 → session.report_progress（带 token 时转发，保序）。"""
     import anyio
 
@@ -197,7 +198,7 @@ def test_progress_forwarded_with_token(fake_worker):
 
     async def scenario():
         session.progress_seen = anyio.Event()
-        return await mcp_server.run_tool_in_worker("transfer_design", {}, ctx)
+        return await mcp_server.run_tool_in_worker(facade, "transfer_design", {}, ctx)
 
     result = anyio.run(scenario)
     assert [(p, t, m) for p, t, m in session.calls] == [(0.5, 1.0, "half")]
@@ -206,7 +207,7 @@ def test_progress_forwarded_with_token(fake_worker):
     assert env["data"]["mode"] == "ok"
 
 
-def test_progress_gated_without_token(fake_worker):
+def test_progress_gated_without_token(fake_worker, facade):
     """客户端未带 progressToken：进度行不转发（零开销直通），结果照常。"""
     import anyio
 
@@ -214,7 +215,7 @@ def test_progress_gated_without_token(fake_worker):
 
     async def scenario():
         return await mcp_server.run_tool_in_worker(
-            "transfer_design", {}, _Ctx(token=None, session=session)
+            facade, "transfer_design", {}, _Ctx(token=None, session=session)
         )
 
     result = anyio.run(scenario)
@@ -222,7 +223,7 @@ def test_progress_gated_without_token(fake_worker):
     assert not result.is_error
 
 
-def test_cancellation_kills_worker(fake_worker):
+def test_cancellation_kills_worker(fake_worker, facade):
     """取消传播：handler 被取消 → kill 子进程并收尸，快速收尾而非等满 60s。"""
     import anyio
 
@@ -243,7 +244,7 @@ def test_cancellation_kills_worker(fake_worker):
 
                 tg.start_soon(cancel_on_progress)
                 completed["result"] = await mcp_server.run_tool_in_worker(
-                    "transfer_design", {}, ctx
+                    facade, "transfer_design", {}, ctx
                 )
         return time.monotonic() - started
 
@@ -257,16 +258,68 @@ def test_cancellation_kills_worker(fake_worker):
     assert not _pid_alive(pid), "worker 子进程应已被终止"
 
 
-def test_worker_crash_yields_error_envelope(fake_worker):
+def test_worker_crash_yields_error_envelope(fake_worker, facade):
     """worker 异常退出（无结果行）→ WORKER_CRASHED 结构化错误，不炸穿 handler。"""
     import anyio
 
     fake_worker.use("crash")
-    result = anyio.run(mcp_server.run_tool_in_worker, "transfer_design", {}, _Ctx())
+    result = anyio.run(mcp_server.run_tool_in_worker, facade, "transfer_design", {}, _Ctx())
     assert result.is_error
     env = json.loads(result.content[0].text)
     assert env["status"] == "error"
     assert env["error"]["code"] == "WORKER_CRASHED"
+
+
+def test_injected_config_crosses_worker_boundary(monkeypatch, tmp_path):
+    """#601 钉子：构造注入的 Config（禁用环境变量表达）穿过 worker 子进程。
+
+    改动前 worker 自行 ``Config()``（从环境重建），注入被静默丢弃：
+    本测试在改动前必须失败——环境里放的诱饵目录是空的，worker 若读环境
+    就查不到注入目录里播种的记录。
+    """
+    import anyio
+
+    from e2m2e.api.mcp import run_tool_in_worker
+    from tests.api.test_facade_catalog import _fake_design, _make_design_result
+
+    injected_dir = tmp_path / "injected-catalog"
+    env_dir = tmp_path / "env-catalog"  # 诱饵：注入的 Config 必须赢过环境变量
+    monkeypatch.setenv("E2M2E_CATALOG_DIR", str(env_dir))
+
+    facade = Facade(config=Config(catalog_dir=str(injected_dir)))
+    with pytest.MonkeyPatch.context() as mp:
+        _fake_design(mp, _make_design_result(orbit_type="DRO"))
+        facade.design_orbit(orbit_type="DRO")
+    # 前提：记录确实落在注入目录（同 facade 进程内可查）
+    assert facade.catalog_query(orbit_family="dro").records
+
+    result = anyio.run(run_tool_in_worker, facade, "catalog_query", {}, _Ctx())
+    env = json.loads(result.content[0].text)
+    assert env["status"] == "ok"
+    assert env["data"]["records"], "worker 必须读到注入目录里的记录——注入的 Config 未穿透子进程？"
+
+
+def test_worker_rejects_unknown_config_field():
+    """配置载荷含未知字段：明确的错误信封，不静默降级到默认配置（#601）。"""
+    from types import SimpleNamespace
+
+    import anyio
+
+    from e2m2e.api.mcp import run_tool_in_worker
+
+    bad_config = SimpleNamespace(to_payload=lambda: {"bogus_field": 1})
+    facade = SimpleNamespace(config=bad_config)
+
+    result = anyio.run(
+        run_tool_in_worker,
+        facade,  # type: ignore[arg-type]
+        "catalog_query",
+        {},
+        _Ctx(),
+    )
+    env = json.loads(result.content[0].text)
+    assert env["status"] == "error"
+    assert env["error"]["code"] == "INVALID_PARAMS"
 
 
 def test_catalog_records_survive_worker_kill():
@@ -288,7 +341,7 @@ def test_catalog_records_survive_worker_kill():
         # 真实 worker（catalog_query）在任意阶段被取消（多半还在 import 期）：
         # kill 不应波及已入库记录
         with anyio.move_on_after(0.15):
-            await mcp_server.run_tool_in_worker("catalog_query", {}, _Ctx())
+            await mcp_server.run_tool_in_worker(seed_facade, "catalog_query", {}, _Ctx())
 
     anyio.run(scenario)
     assert time.monotonic() - started < 20, "取消后须快速收尾"

--- a/tests/api/test_sidecar.py
+++ b/tests/api/test_sidecar.py
@@ -16,6 +16,7 @@ pytestmark = [pytest.mark.interface]
 
 from e2m2e.api.config import Config  # noqa: E402
 from e2m2e.api.facade import Facade, mcp_exposed  # noqa: E402
+from e2m2e.api.frames import decode_frame  # noqa: E402
 from e2m2e.api.mcp import envelope  # noqa: E402
 from e2m2e.api.models import (  # noqa: E402
     CatalogGetRequest,
@@ -26,7 +27,6 @@ from e2m2e.api.models import (  # noqa: E402
     FamilyGenerationResponse,
 )
 from e2m2e.api.sidecar import handle_request, run_loop  # noqa: E402
-from e2m2e.api.sidecar.frames import decode_frame  # noqa: E402
 from e2m2e.data.templates import ConvergenceState, FailureCause  # noqa: E402
 from e2m2e.data.types.orbit import Orbit  # noqa: E402
 
@@ -163,16 +163,23 @@ def test_family_generation_requires_binary_dtype(facade):
 
 
 def test_error_envelope_for_unknown_tool_and_bad_dtype(facade):
-    for request in (
-        {"tool": "no_such_tool", "arguments": {}},
-        {"tool": "orbit_family_generation", "arguments": _ARGS, "binary_dtype": "f16"},
-        {"tool": "orbit_family_generation", "arguments": _ARGS, "binary_dtype": 0},
+    # 未知工具与 TOOL_NOT_FOUND 统一编码（#601：两个传输层单一来源）
+    for request, expected in (
+        ({"tool": "no_such_tool", "arguments": {}}, "TOOL_NOT_FOUND"),
+        (
+            {"tool": "orbit_family_generation", "arguments": _ARGS, "binary_dtype": "f16"},
+            "INVALID_PARAMS",
+        ),
+        (
+            {"tool": "orbit_family_generation", "arguments": _ARGS, "binary_dtype": 0},
+            "INVALID_PARAMS",
+        ),
     ):
         chunks = handle_request(facade, request)
         assert len(chunks) == 1
         line = json.loads(chunks[0])
         assert line["status"] == "error"
-        assert line["error"]["code"] in ("UNKNOWN_TOOL", "INVALID_PARAMS")
+        assert line["error"]["code"] == expected
 
 
 def test_progress_line_then_response(facade):

--- a/tests/api/test_sidecar_frames.py
+++ b/tests/api/test_sidecar_frames.py
@@ -1,4 +1,4 @@
-"""sidecar 二进制帧编解码测试。
+"""二进制帧编解码测试（sidecar/MCP 画布契约共用，e2m2e.api.frames）。
 
 帧契约的字节级黄金断言在本文件：magic/dtype/ndim/shape/数据逐字段
 逐项对照，实现漂移会在这里被抓住。
@@ -11,7 +11,7 @@ import pytest
 
 pytestmark = [pytest.mark.interface]
 
-from e2m2e.api.sidecar.frames import (  # noqa: E402
+from e2m2e.api.frames import (  # noqa: E402
     MAGIC,
     FrameError,
     decode_frame,


### PR DESCRIPTION
Closes #601。

## 改动摘要

- 新增 `e2m2e/api/execution.py` 传输中立执行核心：`execute_tool` 是唯一的工具执行入口（规格查找、校验、错误翻译、画布帧抽取）；MCP server 与 sidecar 退成薄适配器，worker 子进程经同一核心执行。
- 修 bug：长任务工具（`transfer_design` / `orbit_family_generation`）的 worker 此前自行 `Config()`，构造注入的配置被静默丢弃。现随请求下发 Config 载荷（`to_payload`/`from_payload`，未知字段报 `INVALID_PARAMS` 不静默降级）；钉子测试用非环境变量配置验证红→绿。
- 未知工具错误码统一为 `TOOL_NOT_FOUND`（sidecar 的 `UNKNOWN_TOOL` 退役）。
- `tools.tool_spec` 按需构造单个 schema，调用成本不再随工具数增长。
- `LONG_RUNNING_TOOLS` 移入核心，不依赖 `[mcp]` extra。
- 帧编解码自 `sidecar/frames.py` 提至 `api/frames.py`（字节格式与 magic 不变，ADR 0035 契约不受影响）；`_finite_or_none` 转公开名。
- ADR 0014 增补执行核心决策与 Config 跨进程契约；ADR 0035 记修订注。
- 有意推迟：sidecar 长任务 worker 路由与线级取消（需协议扩展，待 tod 消费方提出），见 ADR 0014 增补与 issue 评论。

## 测试

`pytest tests/api`：255 通过。另 3 个失败（spatiography 两文件）为本机 Rust 扩展过期（ABI 22 vs 源码 23，`make dev` 可解）的既有环境问题，属 #603 范围，与本 PR 无关。ruff、mypy、层导入检查、已删目录检查全部通过；ADR 0037 时间预算门禁通过。