### PR TITLE
feat(cli): 工具子命令与 MCP 工具面对称，从 tool_inventory 派生（#602）

### DIFF
--- a/e2m2e/api/cli/main.py
+++ b/e2m2e/api/cli/main.py
@@ -1,23 +1,128 @@
 """e2m2e 命令入口。
 
-已实现子命令：mcp-serve（MCP 部署薄包装，ADR 0014 第 6 节）、
-serve-stdio（GUI sidecar 入口，ADR 0035）。
-完整 CLI 子命令（= Facade 方法，参数从同一份 Pydantic 模型生成）暂未提供。
+工具子命令与 MCP 工具面对称（ADR 0014 决策 5，#602）：每个
+`mcp_exposed` 且已实现的 Facade 方法都有一个同名子命令（下划线转连
+字符），参数从同一份 Pydantic 请求模型生成，输出是同一个统一信封。
+部署入口：mcp-serve（MCP 部署薄包装）、serve-stdio（GUI sidecar 入口，
+ADR 0035）。
+
+约定：信封 JSON 写 stdout；进度与 argparse 用法错误写 stderr；信封
+`status=ok` 退出码 0，`error` 非 0。长任务工具改跑 worker 子进程
+（路由清单在执行核心 LONG_RUNNING_TOOLS，#601），Ctrl-C kill 子进程。
 """
 
 from __future__ import annotations
 
 import argparse
+import enum
+import json
+import subprocess
 import sys
+import typing
 from collections.abc import Sequence
+from typing import Any
 
-__all__ = ["main", "build_parser"]
+from e2m2e.api.config import Config
+from e2m2e.api.execution import LONG_RUNNING_TOOLS, execute_tool, worker_request_payload
+from e2m2e.api.facade import Facade, ToolInfo, tool_inventory
+from e2m2e.api.mcp import envelope
+
+__all__ = ["main", "build_parser", "tool_subcommands"]
+
+# worker 子进程命令：与 mcp/server.py 的 _WORKER_ARGV 同一 worker 模块
+# （worker 不依赖 [mcp] extra，CLI 也不依赖）。
+_WORKER_ARGV = [sys.executable, "-m", "e2m2e.api.mcp.worker"]
 
 
-def build_parser() -> argparse.ArgumentParser:
+def tool_subcommands(facade: Facade) -> dict[str, ToolInfo]:
+    """CLI 子命令清单：连字符命名 → 工具元数据（placeholder 不注册）。"""
+    return {
+        info.name.replace("_", "-"): info
+        for info in tool_inventory(facade)
+        if info.status == "implemented"
+    }
+
+
+def _unwrap_optional(annotation: Any) -> Any:
+    """ "X | None" → X；其余原样。"""
+    if typing.get_origin(annotation) is typing.Union:
+        args = [a for a in typing.get_args(annotation) if a is not type(None)]
+        if len(args) == 1:
+            return args[0]
+    return annotation
+
+
+def _add_field_option(parser: argparse.ArgumentParser, name: str, field: Any) -> None:
+    """把请求模型字段映射为命令行选项。
+
+    标量按类型；bool 用 --x/--no-x；Enum 用 choices；容器/任意类型
+    （epoch、target_ephemeris 等）无法自然扁平化，接受 JSON 字符串
+    （--help 中注明），Pydantic 校验仍由模型负责。必填性与默认值、
+    类型名写进帮助文本（--help 契约，#602 故事 2）。
+    """
+    flag = "--" + name.replace("_", "-")
+    description = (field.description or "").strip()
+    ann = _unwrap_optional(field.annotation)
+    type_name = getattr(ann, "__name__", "") or ""
+    if field.is_required():
+        hint = f"（{type_name}，必填）" if type_name else "（必填）"
+    elif field.default is not None:
+        default_repr = repr(field.default)
+        hint = f"（{type_name}，默认 {default_repr}）" if type_name else f"（默认 {default_repr}）"
+    else:
+        hint = f"（{type_name}）" if type_name else ""
+    if ann is bool:
+        parser.add_argument(
+            flag,
+            action=argparse.BooleanOptionalAction,
+            default=None,
+            help=f"{description}{hint}",
+        )
+    elif ann in (str, int, float):
+        parser.add_argument(
+            flag,
+            type=ann,
+            default=None,
+            help=f"{description}{hint}",
+        )
+    elif isinstance(ann, type) and issubclass(ann, enum.Enum):
+        parser.add_argument(
+            flag,
+            choices=[member.value for member in ann],
+            default=None,
+            help=f"{description}{hint}",
+        )
+    else:
+        parser.add_argument(
+            flag,
+            type=json.loads,
+            default=None,
+            metavar="JSON",
+            help=f"{description}{hint}（JSON 值）",
+        )
+
+
+def _build_tool_subparser(
+    sub: argparse._SubParsersAction, facade: Facade, command: str, info: ToolInfo
+) -> None:
+    method = getattr(facade, info.name)
+    help_text = (method.__doc__ or info.name).strip().splitlines()[0]
+    tool_parser = sub.add_parser(command, help=help_text, description=help_text)
+    if info.request_model is not None:
+        for field_name, field in info.request_model.model_fields.items():
+            _add_field_option(tool_parser, field_name, field)
+
+
+def build_parser(facade: Facade | None = None) -> argparse.ArgumentParser:
+    """构建命令行解析器。
+
+    Args:
+        facade: 工具子命令从它的 `tool_inventory` 派生；None 时只注册
+            部署子命令（向后兼容既有调用）。
+    """
     parser = argparse.ArgumentParser(
         prog="e2m2e",
-        description="e2m2e 命令行（地月空间转移轨道设计库）",
+        description="e2m2e 命令行（地月空间转移轨道设计库）。工具子命令与 MCP 工具面同源对称",
     )
     sub = parser.add_subparsers(dest="command", required=True)
 
@@ -29,13 +134,79 @@ def build_parser() -> argparse.ArgumentParser:
         "serve-stdio",
         help="启动 GUI sidecar（stdio JSON 行 + 二进制帧，ADR 0035），供 Tauri 壳驱动",
     )
+
+    if facade is not None:
+        for command, info in tool_subcommands(facade).items():
+            _build_tool_subparser(sub, facade, command, info)
     return parser
 
 
-def _run_mcp_serve() -> int:
+def _emit_progress_to_stderr(fraction: float, message: str | None = None) -> None:
+    """短任务进程内执行的进度回调：写 stderr，不影响 stdout 的信封。"""
+    percent = round(fraction * 100)
+    print(f"progress: {percent}%{(' ' + message) if message else ''}", file=sys.stderr)
+
+
+def _run_via_worker(
+    facade: Facade,
+    tool_name: str,
+    arguments: dict,
+    progress_callback=None,
+) -> envelope.Envelope:
+    """长任务工具经 worker 子进程执行（#601 同款协议，同步泵）。
+
+    进度行转发 stderr；KeyboardInterrupt（Ctrl-C）kill 子进程后重抛——
+    进程 kill 是打断 GIL 释放下 Rust 长计算的唯一可靠手段。
+    """
+    proc = subprocess.Popen(
+        _WORKER_ARGV, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=None, text=True
+    )
+    assert proc.stdin is not None and proc.stdout is not None  # PIPE 已请求
+    request = worker_request_payload(tool_name, arguments, facade.config)
+    proc.stdin.write(json.dumps(request, ensure_ascii=True) + "\n")
+    proc.stdin.close()
+    env: envelope.Envelope | None = None
     try:
-        from e2m2e.api.config import Config
-        from e2m2e.api.facade import Facade
+        for raw in proc.stdout:
+            try:
+                message = json.loads(raw)
+            except ValueError:
+                continue
+            if message.get("type") == "progress":
+                if progress_callback is not None:
+                    progress_callback(message.get("fraction", 0.0), message.get("message"))
+            elif message.get("type") == "result":
+                env = message.get("envelope")
+        proc.wait()
+    except KeyboardInterrupt:
+        proc.kill()
+        proc.wait()
+        raise
+    if env is None:
+        env = envelope.error_envelope(
+            "WORKER_CRASHED", f"worker 进程未返回结果（exit={proc.returncode}）"
+        )
+    return env
+
+
+def _run_tool_command(facade: Facade, command: str, args: argparse.Namespace) -> int:
+    """执行一个工具子命令：信封写 stdout，退出码按信封状态。"""
+    info = tool_subcommands(facade)[command]
+    arguments = {
+        key: value for key, value in vars(args).items() if key != "command" and value is not None
+    }
+    if info.name in LONG_RUNNING_TOOLS:
+        env = _run_via_worker(facade, info.name, arguments, _emit_progress_to_stderr)
+    else:
+        env, _frames = execute_tool(
+            facade, info.name, arguments, progress_callback=_emit_progress_to_stderr
+        )
+    print(json.dumps(env, ensure_ascii=False))
+    return 0 if env["status"] == "ok" else 1
+
+
+def _run_mcp_serve(facade: Facade) -> int:
+    try:
         from e2m2e.api.mcp import create_server
     except ImportError as exc:
         print(
@@ -48,7 +219,6 @@ def _run_mcp_serve() -> int:
     import anyio
     from mcp.server.stdio import stdio_server
 
-    facade = Facade(config=Config())
     server = create_server(facade)
 
     async def _serve() -> None:
@@ -60,22 +230,26 @@ def _run_mcp_serve() -> int:
     return 0
 
 
-def _run_serve_stdio() -> int:
-    from e2m2e.api.config import Config
-    from e2m2e.api.facade import Facade
+def _run_serve_stdio(facade: Facade) -> int:
     from e2m2e.api.sidecar import run_loop
 
-    run_loop(Facade(config=Config()), sys.stdin.buffer, sys.stdout.buffer)
+    run_loop(facade, sys.stdin.buffer, sys.stdout.buffer)
     return 0
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    args = build_parser().parse_args(argv)
+    # 工具子命令从 Facade 派生；Facade() 构造廉价（存配置 + 目录扫描），
+    # --help 与部署子命令也顺带获得完整工具清单。
+    facade = Facade(config=Config())
+    args = build_parser(facade).parse_args(argv)
     if args.command == "mcp-serve":
-        return _run_mcp_serve()
+        return _run_mcp_serve(facade)
     if args.command == "serve-stdio":
-        return _run_serve_stdio()
-    raise AssertionError(f"未知子命令 {args.command!r}（应由 subparser 拦截）")
+        return _run_serve_stdio(facade)
+    try:
+        return _run_tool_command(facade, args.command, args)
+    except KeyboardInterrupt:
+        return 130
 
 
 if __name__ == "__main__":

--- a/tests/api/test_cli.py
+++ b/tests/api/test_cli.py
@@ -1,0 +1,221 @@
+r"""CLI 工具子命令测试（#602）：与 MCP 工具面对称。
+
+从 main(argv) 入口进，断言 stdout 的信封与退出码，不断言 argparse 内部
+结构。派生一致性对照 \`tool_inventory\`（先例：test_registered_tools_
+match_inventory）。长任务走 worker 子进程（复用 #588 fake worker 模式）。
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+pytestmark = pytest.mark.interface
+
+from e2m2e.api.cli import main as cli_main  # noqa: E402
+from e2m2e.api.cli.main import main, tool_subcommands  # noqa: E402
+from e2m2e.api.config import Config  # noqa: E402
+from e2m2e.api.facade import Facade, tool_inventory  # noqa: E402
+
+
+@pytest.fixture
+def facade() -> Facade:
+    # tests/api/conftest.py 已把 E2M2E_CATALOG_DIR 重定向到独立临时目录
+    return Facade(Config())
+
+
+# ---------------------------------------------------------------------------
+# 派生一致性（单一来源，不漂移）
+# ---------------------------------------------------------------------------
+
+
+def test_tool_subcommands_match_inventory(facade):
+    """子命令集合 = tool_inventory 中 implemented 的连字符命名；placeholder 不出现。"""
+    expected = {
+        i.name.replace("_", "-") for i in tool_inventory(facade) if i.status == "implemented"
+    }
+    assert set(tool_subcommands(facade)) == expected
+    placeholders = {i.name.replace("_", "-") for i in tool_inventory(facade)} - expected
+    assert placeholders, "前提：Facade 至少有一个 placeholder 工具"
+    assert not placeholders & set(tool_subcommands(facade))
+
+
+def test_top_help_lists_tools_and_deployments(capsys):
+    """`e2m2e --help` 同时列出工具子命令与两个部署入口。"""
+    with pytest.raises(SystemExit) as exc_info:
+        main(["--help"])
+    assert exc_info.value.code == 0
+    out = capsys.readouterr().out
+    assert "catalog-query" in out
+    assert "design-orbit" in out
+    assert "mcp-serve" in out
+    assert "serve-stdio" in out
+
+
+def test_tool_help_shows_options(capsys):
+    """`e2m2e design-orbit --help` 展示模型字段的选项、类型与默认值。"""
+    with pytest.raises(SystemExit) as exc_info:
+        main(["design-orbit", "--help"])
+    assert exc_info.value.code == 0
+    out = capsys.readouterr().out
+    assert "--orbit-type" in out
+    assert "必填" in out  # orbit_type 无默认：标注必填
+    assert "--output-step" in out
+    assert "3600.0" in out  # 模型默认值进帮助文本
+    # 复杂类型（epoch 是 Any）按 JSON 值选项暴露
+    assert "--epoch" in out
+    assert "JSON" in out
+
+
+# ---------------------------------------------------------------------------
+# 端到端：便宜工具真调用（ADR 0037 决策 2 的最小真实调用）
+# ---------------------------------------------------------------------------
+
+
+def test_catalog_query_end_to_end(capsys):
+    """`e2m2e catalog-query` 对空库：退出码 0，stdout 是 ok 信封。"""
+    rc = main(["catalog-query"])
+    assert rc == 0
+    env = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert env["status"] == "ok"
+    assert env["data"]["records"] == []
+
+
+def test_catalog_get_error_exit_code(capsys):
+    """查询不存在的记录：退出码 1，stdout 是结构化错误信封。"""
+    rc = main(["catalog-get", "--record-id", "no-such-record"])
+    assert rc == 1
+    env = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert env["status"] == "error"
+    assert env["error"]["code"] == "RECORD_NOT_FOUND"
+
+
+def test_invalid_params_exit_code(capsys):
+    """非法参数值：执行层校验 → INVALID_PARAMS 信封，退出码 1。"""
+    rc = main(["catalog-query", "--libration-point", "99"])
+    assert rc == 1
+    env = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert env["error"]["code"] == "INVALID_PARAMS"
+
+
+def test_unknown_command_exits_2():
+    with pytest.raises(SystemExit) as exc_info:
+        main(["no-such-command"])
+    assert exc_info.value.code == 2
+
+
+# ---------------------------------------------------------------------------
+# 长任务：worker 子进程路由（fake worker 模式，同 test_mcp_worker 先例）
+# ---------------------------------------------------------------------------
+
+_FAKE_WORKER_SCRIPT = """
+import json, os, sys, time
+pidfile = os.environ.get("FAKE_WORKER_PIDFILE")
+if pidfile:
+    with open(pidfile, "w") as f:
+        f.write(str(os.getpid()))
+mode = os.environ.get("FAKE_WORKER_MODE", "ok")
+def emit(obj):
+    sys.stdout.write(json.dumps(obj) + "\\n")
+    sys.stdout.flush()
+emit({"type": "progress", "fraction": 0.5, "message": "half"})
+if mode == "crash":
+    sys.exit(3)
+if mode == "sleep":
+    time.sleep(60)
+emit({"type": "result", "envelope": {"status": "ok", "data": {"mode": mode},
+        "error": None, "meta": {}}})
+"""
+
+
+@pytest.fixture
+def fake_worker(monkeypatch, tmp_path):
+    """把 CLI 的 worker 命令换成 fake 脚本，可切模式（先例：test_mcp_worker）。"""
+    pidfile = tmp_path / "fake-worker.pid"
+
+    def use(mode: str) -> None:
+        monkeypatch.setenv("FAKE_WORKER_MODE", mode)
+        monkeypatch.setenv("FAKE_WORKER_PIDFILE", str(pidfile))
+        monkeypatch.setattr(cli_main, "_WORKER_ARGV", [sys.executable, "-c", _FAKE_WORKER_SCRIPT])
+
+    use("ok")
+    return SimpleNamespace(pidfile=pidfile, use=use)
+
+
+def _pid_alive(pid: int) -> bool:
+    if sys.platform == "win32":
+        import ctypes
+        from ctypes import wintypes
+
+        kernel32 = ctypes.windll.kernel32
+        handle = kernel32.OpenProcess(0x1000, False, pid)  # PROCESS_QUERY_LIMITED_INFORMATION
+        if not handle:
+            return False
+        try:
+            code = wintypes.DWORD()
+            if not kernel32.GetExitCodeProcess(handle, ctypes.byref(code)):
+                return False
+            return code.value == 259  # STILL_ACTIVE
+        finally:
+            kernel32.CloseHandle(handle)
+    import errno
+    import os
+
+    try:
+        os.kill(pid, 0)
+    except OSError as exc:
+        return exc.errno == errno.EPERM
+    return True
+
+
+def test_long_tool_routes_via_worker(fake_worker, facade, capsys):
+    """长任务工具改跑 worker 子进程：进度进 stderr，信封进 stdout，退出码 0。"""
+    fake_worker.use("ok")
+    rc = main(
+        [
+            "transfer-design",
+            "--transfer-type",
+            "HMN",
+            "--tli-epoch",
+            "2460800.5",
+            "--target-orbit-radius-km",
+            "384405.0",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert rc == 0
+    env = json.loads(captured.out.strip().splitlines()[-1])
+    assert env["status"] == "ok"
+    assert env["data"]["mode"] == "ok"
+    assert "half" in captured.err, "worker 进度行应转发到 stderr"
+
+
+def test_worker_crash_yields_error_exit(fake_worker, capsys):
+    fake_worker.use("crash")
+    rc = main(["transfer-design", "--transfer-type", "HMN", "--tli-epoch", "2460800.5"])
+    assert rc == 1
+    env = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert env["error"]["code"] == "WORKER_CRASHED"
+
+
+def test_interrupt_kills_worker(fake_worker, facade, tmp_path):
+    """Ctrl-C（KeyboardInterrupt）传播：worker 子进程被 kill，不残留。"""
+    fake_worker.use("sleep")
+    with open(tmp_path / "raise.pid", "w") as f:
+        f.write("")  # 占位：pidfile 由 fake worker 写
+
+    def raising_progress(fraction, message=None):
+        raise KeyboardInterrupt
+
+    with pytest.raises(KeyboardInterrupt):
+        cli_main._run_via_worker(facade, "transfer_design", {}, progress_callback=raising_progress)
+    pid = int(fake_worker.pidfile.read_text(encoding="ascii").strip())
+    import time
+
+    deadline = time.monotonic() + 15
+    while time.monotonic() < deadline and _pid_alive(pid):
+        time.sleep(0.1)
+    assert not _pid_alive(pid), "KeyboardInterrupt 后 worker 子进程应已被终止"


### PR DESCRIPTION
Closes #602。

兑现 ADR 0014 决策 5：每个 `mcp_exposed` 且已实现的 Facade 方法都有一个同名 CLI 子命令（下划线转连字符），参数从同一份 Pydantic 请求模型生成，输出统一信封 JSON。加一个工具即同时得到 MCP 工具与 CLI 子命令，两个面不再漂移。

## 改动摘要

- `build_parser(facade)` 在部署子命令（`mcp-serve` / `serve-stdio`，行为不变）之外注册工具子命令；清单由 `tool_inventory` 单一来源派生，placeholder 不注册。
- 参数映射：标量按类型；`bool` 用 `--x/--no-x`；Enum 用 choices；容器与任意类型（`epoch`、`target_ephemeris` 等）接受 JSON 字符串（规格允许的扁平化替代，--help 注明）。
- `--help` 契约：每个选项带类型、默认值、必填标注与字段描述（#602 故事 2）。
- 执行走 #601 执行核心（`execute_tool`）：长任务工具消费同一 `LONG_RUNNING_TOOLS` 清单改跑 worker 子进程，进度转发 stderr，Ctrl-C kill 子进程；信封写 stdout，`status=ok` 退出码 0、`error` 非 0。

## 测试

新增 `tests/api/test_cli.py`（10 个用例，`interface` 标记）：派生一致性对照 `tool_inventory`（先例 `test_registered_tools_match_inventory`）、`--help` 契约、`catalog-query` 对空库的真实端到端、错误退出码（RECORD_NOT_FOUND / INVALID_PARAMS）、fake worker 路由（进度进 stderr、信封进 stdout、WORKER_CRASHED 退出码 1）与 KeyboardInterrupt kill（先例 `test_mcp_worker`）。

`pytest tests/api`：280 通过（3 个失败为本机 Rust 扩展过期 ABI 22 vs 23 的既有环境问题，`make dev` 可解，属 #603 范围）。ruff、mypy、层导入检查全部通过；ADR 0037 时间预算门禁通过。