### PR TITLE
fix(test): native 符号缺失应 skip 而非硬失败，清理 tests 幽灵目录（#603）

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ DEV_SYNC := uv sync --group dev --no-install-project
 
 .DEFAULT_GOAL := help
 
-.PHONY: help setup cspice kernels dev dev-release test test-rust test-python docs check fmt clean
+.PHONY: help setup cspice kernels dev dev-release test test-rust test-python docs check fmt clean clean-tests
 
 help:  ## 显示本帮助
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  \033[36m%-14s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -116,3 +116,6 @@ fmt:  ## 就地格式化（Rust + Python）
 
 clean:  ## 清理 Rust 构建产物（保留 .cspice / kernels 缓存）
 	cargo clean
+
+clean-tests:  ## 清理 tests/ 幽灵目录与 __pycache__（#603；配套门禁在 tests/_meta）
+	$(PYTHON) scripts/clean_test_residue.py --fix

--- a/scripts/clean_test_residue.py
+++ b/scripts/clean_test_residue.py
@@ -1,0 +1,76 @@
+r"""清理 tests/ 下的幽灵目录与字节码缓存（#603）。
+
+历次测试重组删除测试文件后，本地残留只剩 __pycache__ 的空目录（不进
+git）。本脚本做两件事：
+
+1. 删除 tests/ 下所有 ``__pycache__`` 目录；
+2. 删除之后递归内容为空的目录（浅层在后，父目录随子目录清空而移除）。
+
+默认只报告；``--fix`` 才真正删除。与 tests/_meta/test_no_ghost_test_dirs.py
+的判据一致（递归无非 __pycache__ 文件即幽灵），互为独立实现：门禁不能与
+清洁工具共享同一段可能有 bug 的逻辑。
+
+用法：\`make clean-tests\`（即 \`python scripts/clean_test_residue.py --fix\`）。
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import shutil
+import sys
+
+TESTS_DIR = pathlib.Path(__file__).resolve().parents[1] / "tests"
+
+
+def find_pycache_dirs(tests_dir: pathlib.Path) -> list[pathlib.Path]:
+    return sorted(tests_dir.rglob("__pycache__"))
+
+
+def find_ghost_dirs(tests_dir: pathlib.Path) -> list[pathlib.Path]:
+    """仅含 __pycache__ 内容的目录（含彼此嵌套的父目录），浅层在前。"""
+    ghosts: list[pathlib.Path] = []
+    for directory in sorted(tests_dir.rglob("*")):
+        if not directory.is_dir() or directory.name == "__pycache__":
+            continue
+        if not any(p.is_file() and "__pycache__" not in p.parts for p in directory.rglob("*")):
+            ghosts.append(directory)
+    return ghosts
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--fix", action="store_true", help="真正删除；缺省只报告")
+    options = parser.parse_args()
+
+    pycache = find_pycache_dirs(TESTS_DIR)
+    ghosts = find_ghost_dirs(TESTS_DIR)
+    if not pycache and not ghosts:
+        print("tests/ 干净：无 __pycache__，无幽灵目录")
+        return 0
+
+    for directory in pycache:
+        print(f"__pycache__: {directory.relative_to(TESTS_DIR.parent)}")
+    for directory in ghosts:
+        print(f"幽灵目录:   {directory.relative_to(TESTS_DIR.parent)}")
+    if not options.fix:
+        print(f"\n共 {len(pycache)} 个 __pycache__、{len(ghosts)} 个幽灵目录（未删除；加 --fix）")
+        return 0
+
+    for directory in pycache:
+        shutil.rmtree(directory, ignore_errors=True)
+    # 浅层在前：子目录清空后父目录才能被判空删除（rmtree 对非空不报错地
+    # 失败会留残渣，故按 find_ghost_dirs 的浅层序整树删除）。
+    for directory in ghosts:
+        shutil.rmtree(directory, ignore_errors=True)
+    leftover = find_ghost_dirs(TESTS_DIR)
+    if leftover:
+        names = "、".join(str(d) for d in leftover)
+        print(f"清理后仍残留：{names}", file=sys.stderr)
+        return 1
+    print(f"已清理 {len(pycache)} 个 __pycache__、{len(ghosts)} 个幽灵目录")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/_meta/test_native_symbol_guard.py
+++ b/tests/_meta/test_native_symbol_guard.py
@@ -1,0 +1,49 @@
+"""native 符号守卫的行为测试（#603）。
+
+符号存在与缺失两种情况下谓词分别判真/判假（用 monkeypatch 模拟，不改
+真实扩展）；skip 的落点是 pytest 的 skipif 机制本身。文案口径与
+spice_ext 的报错一致，由 skip reason 断言钉住。
+"""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+
+import pytest
+from kernel_helpers import native_symbols_available, requires_native_symbols
+
+pytestmark = pytest.mark.aux
+
+
+@pytest.fixture
+def fake_facade(monkeypatch):
+    """往 sys.modules 放一个带指定符号的 integrators 门面替身。"""
+    module = ModuleType("e2m2e.integrators")
+    monkeypatch.setitem(sys.modules, "e2m2e.integrators", module)
+    return module
+
+
+def test_symbols_present_reads_true(fake_facade):
+    fake_facade.propagate_geocentric_fate_map_py = object()
+    assert native_symbols_available("propagate_geocentric_fate_map_py")
+
+
+def test_missing_symbol_reads_false(fake_facade):
+    fake_facade.other_symbol = object()
+    assert not native_symbols_available("propagate_geocentric_fate_map_py")
+
+
+def test_unimportable_facade_reads_false(monkeypatch):
+    monkeypatch.setitem(sys.modules, "e2m2e.integrators", None)  # import 即 ImportError
+    assert not native_symbols_available("any_symbol")
+
+
+def test_skip_reason_cites_make_dev(fake_facade):
+    """skip reason 复用 spice_ext 的 make dev 口径（#603：不另造表述）。"""
+    fake_facade.other_symbol = object()
+    mark = requires_native_symbols("propagate_geocentric_fate_map_py")
+    assert mark.mark.name == "skipif"
+    reason = mark.mark.kwargs["reason"]
+    assert "make dev" in reason
+    assert "propagate_geocentric_fate_map_py" in reason

--- a/tests/_meta/test_no_ghost_test_dirs.py
+++ b/tests/_meta/test_no_ghost_test_dirs.py
@@ -1,0 +1,42 @@
+r"""tests/ 目录卫生门禁：不存在只剩 __pycache__ 的幽灵目录。
+
+历次测试重组（ADR 0021/0026）删除测试文件后，残留的空目录（仅含
+__pycache__）不进 git，只在本地可见，误导导航。本门禁断言 tests/ 下
+不存在这种目录；发现残渣时运行 \`make clean-tests\` 清理。
+
+判据是"递归无非 __pycache__ 文件"而非"无测试文件"：tests/data/types/
+fixtures 等夹具目录合法地不含测试文件，不是幽灵。
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+pytestmark = pytest.mark.aux
+
+_TESTS_DIR = pathlib.Path(__file__).resolve().parents[1]
+
+
+def _ghost_dirs(tests_dir: pathlib.Path) -> list[str]:
+    """返回仅含 __pycache__ 内容的目录（相对 tests/ 的路径，浅层在前）。"""
+    ghosts: list[str] = []
+    for directory in sorted(tests_dir.rglob("*")):
+        if not directory.is_dir() or directory.name == "__pycache__":
+            continue
+        real_files = [
+            p for p in directory.rglob("*") if p.is_file() and "__pycache__" not in p.parts
+        ]
+        if not real_files:
+            ghosts.append(directory.relative_to(tests_dir).as_posix())
+    return ghosts
+
+
+def test_no_pycache_only_dirs_under_tests():
+    ghosts = _ghost_dirs(_TESTS_DIR)
+    assert not ghosts, (
+        f"tests/ 下存在只剩 __pycache__ 的幽灵目录（{len(ghosts)} 个）：\n"
+        + "\n".join(f"  {g}" for g in ghosts)
+        + "\n运行 `make clean-tests` 清理后重试。"
+    )

--- a/tests/api/test_facade_spatiography.py
+++ b/tests/api/test_facade_spatiography.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+from kernel_helpers import requires_native_symbols
 
 from e2m2e.api.facade import Facade
 from e2m2e.api.models import (
@@ -131,6 +132,9 @@ class TestSpatiographyResonanceAtlas:
 
 
 class TestSpatiographyDynamicalMap:
+    # 制图单格传播依赖 Rust 扩展符号（propagate_geocentric_fate_map_py），
+    # 缺符号时跳过而非硬失败（#603）；同类的纯校验用例不需守卫。
+    @requires_native_symbols("propagate_geocentric_fate_map_py")
     def test_map_smoke_with_gateway_note(self):
         response = Facade().spatiography_dynamical_map(zone="SC", n_a=3, n_e=2, span_years=0.5)
         assert response.status.value == "converged"
@@ -149,6 +153,7 @@ class TestSpatiographyDynamicalMap:
         with pytest.raises(OrbitError, match="INVALID_PARAMS"):
             Facade().spatiography_dynamical_map(zone="SC", model="bogus")
 
+    @requires_native_symbols("propagate_geocentric_fate_map_py")
     def test_ems_model_routes_through_facade(self):
         response = Facade().spatiography_dynamical_map(
             zone="CG", n_a=2, n_e=2, model="ems", span_years=0.2

--- a/tests/api/test_sidecar.py
+++ b/tests/api/test_sidecar.py
@@ -14,6 +14,8 @@ import pytest
 
 pytestmark = [pytest.mark.interface]
 
+from kernel_helpers import requires_native_symbols  # noqa: E402
+
 from e2m2e.api.config import Config  # noqa: E402
 from e2m2e.api.facade import Facade, mcp_exposed  # noqa: E402
 from e2m2e.api.frames import decode_frame  # noqa: E402
@@ -339,6 +341,7 @@ def test_catalog_query_unchanged_by_binary_mapping(facade):
     assert lines[1]["data"]["message"] == "查询完成：0 条记录"
 
 
+@requires_native_symbols("propagate_geocentric_fate_map_py")
 def test_spatiography_dynamical_map_binary_roundtrip(facade):
     """画布契约：五个场走二进制帧（E2M2 帧），JSON 行留占位与两轴。"""
     chunks = handle_request(

--- a/tests/kernel_helpers.py
+++ b/tests/kernel_helpers.py
@@ -1,6 +1,8 @@
 """测试用的 SPICE 内核加载/卸载辅助模块。"""
 
+import importlib
 import os
+import sys
 
 import pytest
 
@@ -73,3 +75,45 @@ def unload_kernels(spice, paths: list[str]) -> None:
     """逆序卸载 ``load_body_fixed_kernels`` 之类返回的内核路径列表。"""
     for path in reversed(paths):
         spice.unload_kernel(path)
+
+
+# =============================================================================
+# Rust 扩展符号守卫（#603）：native 符号缺失时跳过而非硬失败
+#
+# 判据口径对齐 e2m2e/spice_ext.py 的 _ensure_symbols 报错文案（被现存
+# match="make dev" 测试钉住，勿另造表述）；与 requires_spice 同款先例：
+# 环境能力不足统一表达为 skip，读日志的人据此分清环境问题与代码问题。
+# =============================================================================
+
+
+def native_symbols_available(*symbols: str) -> bool:
+    """Rust 扩展可导入且指定符号在 integrators 门面命名空间非 None。
+
+    门面（``e2m2e.integrators``）在导入时从 ``e2m2e._integrators`` 装载
+    扩展符号，缺失的符号为 ``None``——与本套件其他可用性探测一样做
+    存在性检查，不触发真实计算。查 sys.modules 优先于 import 语句：
+    ``import a.b as x`` 绑定时父包属性优先，会拿到测试替换不掉的真模块。
+    """
+    module = sys.modules.get("e2m2e.integrators")
+    if module is None:
+        try:
+            module = importlib.import_module("e2m2e.integrators")
+        except ImportError:
+            return False
+    return all(getattr(module, symbol, None) is not None for symbol in symbols)
+
+
+def requires_native_symbols(*symbols: str):
+    """native 符号守卫：缺符号的用例跳过并说明重建指引（#603）。
+
+    用法与 :data:`requires_spice` 相同：``@requires_native_symbols("foo_py")``
+    叠加在测试或类上。reason 口径与 spice_ext 的报错一致。
+    """
+    return pytest.mark.skipif(
+        not native_symbols_available(*symbols),
+        reason=(
+            "e2m2e._integrators 缺少所需符号："
+            + ", ".join(symbols)
+            + "。spice 是默认且唯一支持的 feature；请用 make dev 重建扩展"
+        ),
+    )


### PR DESCRIPTION
Closes #603。

## 改动摘要

两处判据统一为规格意图——**环境能力不足统一表达为 skip**：

- `tests/kernel_helpers.py` 新增 `requires_native_symbols` 守卫（对齐 `requires_spice` 先例），skip reason 复用 `spice_ext.py` 的 `make dev` 文案口径。套在三个符号依赖用例上：`test_map_smoke_with_gateway_note`、`test_ems_model_routes_through_facade`（facade spatiography 制图）与 `test_spatiography_dynamical_map_binary_roundtrip`（sidecar 帧往返）；同类的纯校验用例不守卫、照常运行。
- **验收判据**：改动前 3 个用例硬失败（`SPATIOGRAPHY_FAILED`），改动后 3 个 SKIP——变 skip 而非 pass，守卫没有误禁用例。
- `tests/_meta/test_no_ghost_test_dirs.py` 幽灵目录门禁：递归无非 `__pycache__` 文件的目录即幽灵（不误伤 `data/types/fixtures` 等合法夹具目录）。RED 起步，抓到 24 个本地残留目录。
- `make clean-tests` + `scripts/clean_test_residue.py`（缺省只报告，`--fix` 才删），本次清理 24 目录 / 66 个 `__pycache__`，幂等。

## 实现注记

守卫谓词读 `sys.modules` 优先于 import 语句：`import a.b as x` 绑定时父包属性优先于 sys.modules，monkeypatch 模拟失效——该语义有行为测试钉住（`tests/_meta/test_native_symbol_guard.py`，符号存在/缺失两分支 + reason 口径）。

## 测试

`pytest tests/api tests/_meta`：323 passed / 3 skipped / 0 failed（此前 3 failed）。ruff、mypy、层导入检查、已删目录引用检查全部通过。范围外说明：本机另有约 34 个 native 测试失败（ABI 22 vs 23 同一环境问题），跑 `make dev` 重建扩展即可恢复，属构建侧事务，不在本规格范围。