### PR TITLE
feat(sidecar): 线级任务取消与长任务 worker 路由，进度升级为真实分数（#607）

### DIFF
--- a/docs/adr/0035-sidecar-stdio-binary-frames.md
+++ b/docs/adr/0035-sidecar-stdio-binary-frames.md
@@ -97,3 +97,46 @@ frame ordering). The frame codec moved from `api/sidecar/frames.py` to
 `api/frames.py` — byte format and magic unchanged, so the cross-repo
 contract is unaffected. The unknown-tool response code is `TOOL_NOT_FOUND`
 (previously `UNKNOWN_TOOL` here), unified with the MCP transport.
+
+## Amendment (2026-09-01): job cancellation and live progress (#607)
+
+### Context
+
+The synchronous run_loop could not observe a cancel intent: while a tool
+executed, stdin went unread, and minutes-long family generation ran to
+completion regardless. The deferral recorded in ADR 0014's amendment (#601)
+is superseded by a maintainer decision: e2m2e is a foundational toolset —
+its wire contract should be complete ahead of a concrete consumer.
+
+### Decisions
+
+1. **Cancel request line**: a request of the shape `{"cancel": "<job_id>"}`
+   kills the in-flight long-running job (worker subprocess kill) and emits
+   `{"status": "cancelled", "data": null, "error": null, "meta":
+   {"job_id": ...}}`. Semantics are idempotent — cancelling an unknown or
+   finished job still emits the cancelled line and changes nothing else.
+   The cancelled request itself gets no result line (mirrors MCP
+   semantics). Consumers already tolerate unknown `status` values
+   (§2), so the extension is backward compatible.
+2. **Concurrent run_loop**: long-running tools (execution core
+   `LONG_RUNNING_TOOLS`) execute in a worker subprocess on a background
+   thread; the reader keeps consuming stdin during computation. Short
+   tools stay inline. Cancel registration happens synchronously in the
+   reader (event + process slot), so a cancel line racing job startup is
+   deterministic. Each job's output bytes (line + frames) are written
+   atomically under a lock — frames never interleave.
+3. **Live progress**: long-tool progress lines now forward the algorithm
+   layer's real fractions via the worker, superseding the single fake
+   percent=0 start line for those tools; short tools keep the start line.
+4. **Worker subprocess protocol** (internal to e2m2e, not the cross-repo
+   contract): the request may carry `binary_dtype`; the result line may
+   declare `binary_frames: N` followed by N raw frames in the §3 format.
+5. Multiple concurrent long jobs are allowed (keyed by `job_id`); jobs
+   without `job_id` run uncancellable. No queueing policy is defined.
+
+### Consequences
+
+- tod gains stop-button support: send a cancel line, tolerate the
+  `cancelled` status, correlate by `job_id`.
+- `handle_request` remains the single-request inline seam (uncancellable);
+  cancellation is a run_loop (process) feature.

--- a/e2m2e/api/cli/main.py
+++ b/e2m2e/api/cli/main.py
@@ -22,16 +22,13 @@ import typing
 from collections.abc import Sequence
 from typing import Any
 
+from e2m2e.api import execution
 from e2m2e.api.config import Config
 from e2m2e.api.execution import LONG_RUNNING_TOOLS, execute_tool, worker_request_payload
 from e2m2e.api.facade import Facade, ToolInfo, tool_inventory
 from e2m2e.api.mcp import envelope
 
 __all__ = ["main", "build_parser", "tool_subcommands"]
-
-# worker 子进程命令：与 mcp/server.py 的 _WORKER_ARGV 同一 worker 模块
-# （worker 不依赖 [mcp] extra，CLI 也不依赖）。
-_WORKER_ARGV = [sys.executable, "-m", "e2m2e.api.mcp.worker"]
 
 
 def tool_subcommands(facade: Facade) -> dict[str, ToolInfo]:
@@ -159,7 +156,7 @@ def _run_via_worker(
     进程 kill 是打断 GIL 释放下 Rust 长计算的唯一可靠手段。
     """
     proc = subprocess.Popen(
-        _WORKER_ARGV, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=None, text=True
+        execution.WORKER_ARGV, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=None, text=True
     )
     assert proc.stdin is not None and proc.stdout is not None  # PIPE 已请求
     request = worker_request_payload(tool_name, arguments, facade.config)

--- a/e2m2e/api/execution.py
+++ b/e2m2e/api/execution.py
@@ -11,6 +11,7 @@ worker 子进程本体（mcp/worker.py）同样经 :func:`execute_tool` 执行�
 
 from __future__ import annotations
 
+import sys
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -27,6 +28,7 @@ __all__ = [
     "BINARY_DTYPES",
     "BINARY_FRAME_TOOLS",
     "LONG_RUNNING_TOOLS",
+    "WORKER_ARGV",
     "execute_tool",
     "preflight",
     "worker_request_payload",
@@ -39,6 +41,10 @@ LONG_RUNNING_TOOLS = frozenset({"transfer_design", "orbit_family_generation"})
 
 # 请求方可声明的二进制 dtype（ADR 0035 决策 1：渲染 f32，复算量 f64）。
 BINARY_DTYPES = ("f32", "f64")
+
+# worker 子进程命令（#607 起两个传输层共用；测试注入 fake worker 时
+# monkeypatch 此常量）。
+WORKER_ARGV = [sys.executable, "-m", "e2m2e.api.mcp.worker"]
 
 
 # 大数组走二进制帧的工具→响应帧抽取函数映射。

--- a/e2m2e/api/frames.py
+++ b/e2m2e/api/frames.py
@@ -88,3 +88,31 @@ def decode_frame(buf: bytes | memoryview) -> tuple[np.ndarray, str, int]:
         raise FrameError(f"数据段不完整：{len(view) - shape_end} 字节 < 声明 {data_len}")
     arr = np.frombuffer(view[shape_end:data_end], dtype=_NUMPY_DTYPES[dtype]).reshape(shape)
     return arr, dtype, data_end
+
+
+def read_raw_frame(stream) -> bytes:
+    """从二进制流读取一帧完整字节（含帧头），原样返回。
+
+    供 worker stdout 泵转发帧字节用（#607）：父进程不需要解码数组，
+    只需按契约切出完整帧。magic 与长度校验失败抛 :class:`FrameError`。
+    """
+    header = stream.read(_HEADER.size)
+    if len(header) < _HEADER.size:
+        raise FrameError(f"帧头不完整：{len(header)} 字节 < {_HEADER.size}")
+    magic, dtype_code, ndim = _HEADER.unpack(header)
+    if magic != MAGIC:
+        raise FrameError(f"帧 magic 不符：0x{magic:08X}（期望 0x{MAGIC:08X}）")
+    if ndim < 1:
+        raise FrameError(f"ndim 必须 ≥ 1，帧内为 {ndim}")
+    shape_bytes = stream.read(4 * ndim)
+    if len(shape_bytes) < 4 * ndim:
+        raise FrameError("shape 段不完整")
+    shape = _U32.unpack_from(shape_bytes)
+    n_elements = 1
+    for dim in shape:
+        n_elements *= dim
+    data_len = n_elements * (4 if dtype_code == 0 else 8)
+    payload = stream.read(data_len)
+    if len(payload) < data_len:
+        raise FrameError(f"数据段不完整：{len(payload)} 字节 < 声明 {data_len}")
+    return header + shape_bytes + payload

--- a/e2m2e/api/mcp/server.py
+++ b/e2m2e/api/mcp/server.py
@@ -16,7 +16,6 @@ import asyncio
 import contextlib
 import json
 import subprocess
-import sys
 import time
 from typing import TYPE_CHECKING, Any
 
@@ -59,9 +58,8 @@ _PROGRESS_SEND_TIMEOUT_SEC = 5.0
 # 长任务工具清单（LONG_RUNNING_TOOLS）在执行核心 e2m2e.api.execution：
 # 两个传输层共同消费的单一来源（#601）。本模块只负责“何时 spawn”。
 
-# worker 子进程命令（模块常量：测试注入 fake worker 用，同
-# _PROGRESS_MIN_INTERVAL_SEC 的 monkeypatch 先例）。
-_WORKER_ARGV = [sys.executable, "-m", "e2m2e.api.mcp.worker"]
+# worker 子进程命令常量在执行核心 execution.WORKER_ARGV（#607 起
+# sidecar 同为 spawn 方，单一来源）；测试注入 fake worker 时 patch 它。
 # 取消后 kill+收尸的时限（秒）：Windows TerminateProcess 即时生效，此为
 # 病理情形兜底，超时也不再阻塞取消收尾。
 _KILL_REAP_TIMEOUT_SEC = 10.0
@@ -152,7 +150,7 @@ async def run_tool_in_worker(
     结构化错误。
     """
     proc = await anyio.open_process(
-        _WORKER_ARGV, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=None
+        execution.WORKER_ARGV, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=None
     )
     assert proc.stdin is not None and proc.stdout is not None  # PIPE 已请求
     request = execution.worker_request_payload(tool_name, arguments, facade.config)

--- a/e2m2e/api/mcp/worker.py
+++ b/e2m2e/api/mcp/worker.py
@@ -3,13 +3,16 @@
 ``python -m e2m2e.api.mcp.worker`` 一次性执行一个工具调用，供传输层把
 分钟级长计算（转移搜索、族生成）隔离到可 kill 的子进程：
 
-- stdin 读一行 JSON 请求 ``{"tool": name, "arguments": {...}, "config": {...}}``
-  （config 缺省时从环境变量重建，见 config.py；存在时经
-  ``Config.from_payload`` 还原——注入的配置穿透子进程，未知字段报错
-  而非静默降级，#601）
-- stdout 按行输出 ``{"type": "progress", "fraction": ..., "message": ...}``
-  （节流，见 ``_PROGRESS_MIN_INTERVAL_SEC``）与最终一行
-  ``{"type": "result", "envelope": {...}}``（统一信封，见 envelope.py）
+- stdin 读一行 JSON 请求 ``{"tool": name, "arguments": {...}, "config":
+  {...}, "binary_dtype": "f32"|"f64"}``——config 缺省时从环境变量重建
+  （见 config.py），存在时经 ``Config.from_payload`` 还原：注入的配置
+  穿透子进程，未知字段报错而非静默降级（#601）；声明 binary_dtype 且
+  工具在帧清单内时画布数组出帧（#607）
+- stdout 按行输出 ``{"type": "progress", "fraction": ..., "message":
+  ...}``（节流，见 ``_PROGRESS_MIN_INTERVAL_SEC``）与最终一行
+  ``{"type": "result", "envelope": {...}, "binary_frames": N}``（统一
+  信封，见 envelope.py；N>0 时行后紧跟 N 个原始帧字节，帧格式同
+  ADR 0035 §3）
 - stderr 原样透传到父进程日志；正常路径退出码 0（工具失败以信封表达）
 
 取消 = 父进程 kill 本进程：Rust 族生成在 GIL 释放下整段运行，协作式
@@ -38,15 +41,36 @@ __all__ = ["run_request", "main"]
 _PROGRESS_MIN_INTERVAL_SEC = 0.1
 
 
-def run_request(request: dict[str, Any], emit_line: Callable[[str], None]) -> None:
+def restore_config(request: dict[str, Any]) -> tuple[Any, Any]:
+    """请求 config 载荷 → Config；缺省从环境重建，坏载荷给错误信封。"""
+    from ..config import Config
+    from . import envelope
+
+    payload = request.get("config")
+    if payload is None:
+        return Config(), None
+    try:
+        return Config.from_payload(payload), None
+    except (TypeError, ValueError) as exc:
+        return None, envelope.error_envelope("INVALID_PARAMS", f"worker 配置还原失败：{exc}")
+
+
+def run_request(
+    request: dict[str, Any],
+    emit_line: Callable[[bytes], None],
+    facade: Any = None,
+) -> None:
     """执行一个工具请求，进度行与结果行经 ``emit_line`` 输出。
 
-    纯进程内逻辑（可测）：``emit_line`` 收到不含换行符的完整 JSON 行。
-    进度回调可能从算法层线程触发（Rust drainer），输出以锁串行化；
-    结果行始终在进度行之后。任何失败都翻译成错误信封，不向 stderr
+    纯进程内逻辑（可测）：``emit_line`` 收到不含换行符的完整 JSON 行
+    （字节）；结果行后按声明追加原始帧字节。进度回调可能从算法层线程
+    触发（Rust drainer），输出以锁串行化；结果行与帧始终在进度行之后，
+    且彼此原子（同一锁内写出）。任何失败都翻译成错误信封，不向 stderr
     抛 traceback、不泄漏细节（api/ 边界契约）。
+
+    ``facade`` 是测试注入缝：缺省自建 ``Facade(Config())``（与生产路径
+    一致）。
     """
-    from ..config import Config
     from ..execution import execute_tool
     from ..facade import Facade
     from . import envelope
@@ -64,40 +88,46 @@ def run_request(request: dict[str, Any], emit_line: Callable[[str], None]) -> No
             {"type": "progress", "fraction": fraction, "message": message}, ensure_ascii=True
         )
         with lock:
-            emit_line(line)
+            emit_line((line + "\n").encode("ascii"))
 
-    def restore_config() -> tuple[Config | None, envelope.Envelope | None]:
-        """请求 config 载荷 → Config；缺省从环境重建，坏载荷给错误信封。"""
-        payload = request.get("config")
-        if payload is None:
-            return Config(), None
-        try:
-            return Config.from_payload(payload), None
-        except (TypeError, ValueError) as exc:
-            return None, envelope.error_envelope("INVALID_PARAMS", f"worker 配置还原失败：{exc}")
+    def emit_result(env: envelope.Envelope, frames: list[bytes]) -> None:
+        payload: dict[str, Any] = {"type": "result", "envelope": env}
+        if frames:
+            payload["binary_frames"] = len(frames)
+        with lock:
+            emit_line((json.dumps(payload, ensure_ascii=True) + "\n").encode("ascii"))
+            for frame in frames:
+                emit_line(frame)
 
     tool = request.get("tool")
     arguments = request.get("arguments") or {}
     if not isinstance(tool, str) or not isinstance(arguments, dict):
-        env = envelope.error_envelope("INVALID_PARAMS", "worker 请求形状错误（tool/arguments）")
-    else:
-        config, err = restore_config()
-        if err is not None:
-            env = err
-        else:
-            facade = Facade(config=config)
-            env, _frames = execute_tool(facade, tool, arguments, progress_callback=emit_progress)
-    line = json.dumps({"type": "result", "envelope": env}, ensure_ascii=True)
-    with lock:
-        emit_line(line)
+        emit_result(
+            envelope.error_envelope("INVALID_PARAMS", "worker 请求形状错误（tool/arguments）"),
+            [],
+        )
+        return
+    config, err = restore_config(request)
+    if err is not None:
+        emit_result(err, [])
+        return
+    facade = facade if facade is not None else Facade(config=config)
+    env, frames = execute_tool(
+        facade,
+        tool,
+        arguments,
+        progress_callback=emit_progress,
+        binary_dtype=request.get("binary_dtype"),
+    )
+    emit_result(env, frames)
 
 
 def main() -> int:
-    """stdin 一行请求 → stdout 进度/结果行 → 退出。"""
+    """stdin 一行请求 → stdout 进度/结果行（+ 帧）→ 退出。"""
 
-    def emit_line(line: str) -> None:
-        sys.stdout.write(line + "\n")
-        sys.stdout.flush()
+    def emit_line(line: bytes) -> None:
+        sys.stdout.buffer.write(line)
+        sys.stdout.buffer.flush()
 
     try:
         request: Any = json.loads(sys.stdin.readline())

--- a/e2m2e/api/sidecar/__init__.py
+++ b/e2m2e/api/sidecar/__init__.py
@@ -1,4 +1,4 @@
-"""GUI sidecar stdio 协议（ADR 0035）。
+"""GUI sidecar stdio 协议（ADR 0035；#607 增补任务取消与真实进度）。
 
 tod 的 Tauri 壳以常驻子进程驱动 e2m2e：请求/响应/进度是 JSON 文本行，
 复用 MCP 方向的统一信封（``{status, data, error, meta}``，单一来源在
@@ -7,17 +7,33 @@ tod 的 Tauri 壳以常驻子进程驱动 e2m2e：请求/响应/进度是 JSON �
 JSON 行流（帧格式见 ``frames.py``）。工具面 = Facade 上 ``mcp_exposed``
 的方法（纯派生，ADR 0014），不新增业务逻辑。
 
+并发模型（#607）：短任务进程内同步执行；长任务（执行核心
+``LONG_RUNNING_TOOLS``）在 worker 子进程 + 后台线程执行，读环持续消费
+stdin——取消消息（``{"cancel": "<job_id>"}`` 行）中途可达，kill 子进程
+即取消，回 ``status="cancelled"`` 行；被取消的原请求不回结果行（对齐
+MCP 语义）。单 job 的输出字节（响应行 + 帧）在锁内原子写出。
+
 本模块是薄适配器（#601）：工具面、校验规则、画布帧抽取的单一来源在执行
 核心 ``e2m2e/api/execution.py``，这里只做协议形状转换——JSON 行切分、
-job_id 进度行、``binary_frames`` 计数与帧字节排序。
+job_id 进度行、``binary_frames`` 计数与帧字节排序、取消与生命周期。
 """
 
 from __future__ import annotations
 
 import json
+import subprocess
+import threading
 from typing import TYPE_CHECKING, Any
 
-from ..execution import BINARY_FRAME_TOOLS, execute_tool, preflight
+from .. import execution
+from ..execution import (
+    BINARY_FRAME_TOOLS,
+    LONG_RUNNING_TOOLS,
+    execute_tool,
+    preflight,
+    worker_request_payload,
+)
+from ..frames import FrameError, read_raw_frame
 from ..mcp import envelope
 
 if TYPE_CHECKING:
@@ -34,11 +50,7 @@ def _line(payload: Any) -> bytes:
 
 
 def _progress_line(job_id: Any, percent: float, message: str) -> bytes:
-    """进度行：可丢弃的信封 JSON 行（ADR 0035 决策 3）。
-
-    当前进度行只有任务开始事件（percent=0）：真进度需要算法层回调
-    通道，Facade 尚未提供；待消费端（tod）需要时再接，不在本层虚构。
-    """
+    """进度行：可丢弃的信封 JSON 行（ADR 0035 决策 3）。"""
     return _line(
         {
             "status": "progress",
@@ -49,17 +61,26 @@ def _progress_line(job_id: Any, percent: float, message: str) -> bytes:
     )
 
 
-def handle_request(facade: Facade, request: Any) -> list[bytes]:
-    """处理一个已解析的请求，返回待写出的字节块。
+def _cancelled_line(job_id: Any) -> bytes:
+    """取消确认行（#607）：幂等——未知/已结束的 job 也回此行。"""
+    return _line(
+        {
+            "status": "cancelled",
+            "data": None,
+            "error": None,
+            "meta": {"job_id": job_id},
+        }
+    )
 
-    字节块是零个或多个 JSON 行（含换行符）加原始帧字节；调用方顺序写出
-    即得到协议流。校验与执行委托执行核心；本模块保有行数策略——前置
-    校验失败时单行返回（不产出进度行），执行结果前总是先产出进度行。
+
+def _request_error(facade: Facade, request: Any) -> envelope.Envelope | None:
+    """请求级校验（单一规则来源在执行核心，此处只拼协议错误码）。
+
+    形状非法 / 未知工具 / 非法 binary_dtype / 帧工具缺 dtype，返回错误
+    信封；合法返回 None。
     """
     if not isinstance(request, dict) or not isinstance(request.get("tool"), str):
-        return [
-            _line(envelope.error_envelope("INVALID_PARAMS", "请求必须是含 tool 字段的 JSON 对象"))
-        ]
+        return envelope.error_envelope("INVALID_PARAMS", "请求必须是含 tool 字段的 JSON 对象")
     tool: str = request["tool"]
     dtype = request.get("binary_dtype")
     err = preflight(facade, tool, dtype)
@@ -70,8 +91,22 @@ def handle_request(facade: Facade, request: Any) -> list[bytes]:
         err = envelope.error_envelope(
             "INVALID_PARAMS", f"工具 {tool} 的响应含大数组，请求必须声明 binary_dtype（f32/f64）"
         )
+    return err
+
+
+def handle_request(facade: Facade, request: Any) -> list[bytes]:
+    """处理一个已解析的请求（内联执行），返回待写出的字节块。
+
+    字节块是零个或多个 JSON 行（含换行符）加原始帧字节；调用方顺序写出
+    即得到协议流。校验与执行委托执行核心。注意：长任务的内联执行不可
+    取消——并发读环（:func:`run_loop`）会把长任务路由到 worker 子进程，
+    本函数是单请求缝（测试与无取消消费方用）。
+    """
+    err = _request_error(facade, request)
     if err is not None:
         return [_line(err)]
+    tool: str = request["tool"]
+    dtype = request.get("binary_dtype")
     job_id = request.get("job_id")
     started = _progress_line(job_id, 0.0, f"开始 {tool}")
 
@@ -81,32 +116,182 @@ def handle_request(facade: Facade, request: Any) -> list[bytes]:
     return [started, _line(env), *frames]
 
 
+# ---------------------------------------------------------------------------
+# 并发读环（#607）
+# ---------------------------------------------------------------------------
+
+
+class _Job:
+    """一个在飞长任务：取消事件 + 子进程槽位（读环同步登记，杜绝竞态）。"""
+
+    def __init__(self) -> None:
+        self.cancel = threading.Event()
+        self.proc: subprocess.Popen | None = None
+
+
+def _read_worker_message(stdout: Any) -> tuple[dict[str, Any] | None, list[bytes]]:
+    """从 worker stdout 读一条 JSON 行及其后声明的全部原始帧。
+
+    EOF 返回 ``(None, [])``；JSON 行坏则跳过继续读（worker 崩溃即无
+    结果行）。帧按结果行 ``binary_frames`` 声明消费。
+    """
+    raw = stdout.readline()
+    if not raw:
+        return None, []
+    try:
+        message = json.loads(raw)
+    except ValueError:
+        return None, []
+    if not isinstance(message, dict):
+        return None, []
+    frames: list[bytes] = []
+    for _ in range(message.get("binary_frames", 0) or 0):
+        frames.append(read_raw_frame(stdout))
+    return message, frames
+
+
+def _run_long_job(
+    facade: Facade, request: dict[str, Any], job: _Job, job_id: Any, write: Any
+) -> None:
+    """长任务的 worker 子进程泵（后台线程）：进度行转发，结果行 + 帧原子写出。
+
+    崩溃（无结果行）回 WORKER_CRASHED；取消（kill 致 EOF）静默收场——
+    cancelled 行已由取消处理器发出。帧解码失败回 INTERNAL_ERROR。
+    """
+    tool: str = request["tool"]
+    try:
+        # 运行时属性访问（非 from-import）：测试 patch execution.WORKER_ARGV
+        # 注入 fake worker 时必须生效。
+        proc = subprocess.Popen(
+            execution.WORKER_ARGV,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=None,
+        )
+    except Exception as exc:
+        write(_line(envelope.error_envelope("WORKER_CRASHED", f"worker 启动失败：{exc}")))
+        return
+    job.proc = proc
+    if job.cancel.is_set():
+        # 取消在读环同步登记后、子进程创建前就已到达：立即收场。
+        proc.kill()
+        proc.wait()
+        return
+    assert proc.stdin is not None and proc.stdout is not None  # PIPE 已请求
+    payload = worker_request_payload(tool, request.get("arguments") or {}, facade.config)
+    payload["binary_dtype"] = request.get("binary_dtype")
+    try:
+        proc.stdin.write((json.dumps(payload, ensure_ascii=True) + "\n").encode("ascii"))
+        proc.stdin.close()
+    except Exception as exc:
+        proc.kill()
+        proc.wait()
+        write(_line(envelope.error_envelope("WORKER_CRASHED", f"worker 请求下发失败：{exc}")))
+        return
+
+    result_sent = False
+    try:
+        while True:
+            message, frames = _read_worker_message(proc.stdout)
+            if message is None:
+                break
+            if message.get("type") == "progress":
+                write(
+                    _progress_line(
+                        job_id, message.get("fraction", 0.0), message.get("message") or ""
+                    )
+                )
+            elif message.get("type") == "result":
+                env = message.get("envelope")
+                assert env is not None, "result 行必带 envelope（worker 协议）"
+                if frames:
+                    env["binary_frames"] = len(frames)
+                write(_line(env), *frames)
+                result_sent = True
+                break
+        proc.wait()
+    except FrameError as exc:
+        write(_line(envelope.error_envelope("INTERNAL_ERROR", f"帧解码失败：{exc}")))
+    finally:
+        if not job.cancel.is_set() and proc.poll() is None:
+            proc.kill()
+            proc.wait()
+    if not result_sent and not job.cancel.is_set():
+        write(
+            _line(
+                envelope.error_envelope(
+                    "WORKER_CRASHED", f"worker 进程未返回结果（exit={proc.returncode}）"
+                )
+            )
+        )
+
+
+def _handle_cancel(request: dict[str, Any], jobs: dict[str, _Job], write: Any) -> None:
+    """取消行处理：kill 在飞子进程（幂等），回 cancelled 行。"""
+    job_id = request.get("cancel")
+    job = jobs.pop(job_id, None) if isinstance(job_id, str) else None
+    if job is not None:
+        job.cancel.set()
+        proc = job.proc
+        if proc is not None and proc.poll() is None:
+            proc.kill()
+            proc.wait()
+    write(_cancelled_line(job_id))
+
+
 def run_loop(facade: Facade, stdin: BinaryIO, stdout: BinaryIO) -> None:
-    """std io 主循环：逐行读请求 JSON，写出进度/响应行与二进制帧。
+    """stdio 主循环：逐行读请求 JSON，写出进度/响应行与二进制帧。
 
     坏 JSON 行返回错误信封并继续，不中断循环。请求处理的任何未预期
-    异常（含响应信封化失败）同样兑成 INTERNAL_ERROR 信封：
-    字节块在 handle_request 返回前不落盘，故不存在半写出的帧污染流。
+    异常（含响应信封化失败）同样兑成 INTERNAL_ERROR 信封。长任务在
+    worker 子进程 + 后台线程执行（读环持续可读取消行）；单 job 的输出
+    字节在锁内原子写出，帧永不交叉。
     """
+    out_lock = threading.Lock()
+    jobs: dict[str, _Job] = {}
+
+    def write(*chunks: bytes) -> None:
+        with out_lock:
+            for chunk in chunks:
+                stdout.write(chunk)
+            stdout.flush()
+
     for raw in stdin:
         if not raw.strip():
             continue
         try:
             request = json.loads(raw)
         except (UnicodeDecodeError, json.JSONDecodeError):
-            chunks = [_line(envelope.error_envelope("INVALID_PARAMS", "请求行不是合法 JSON"))]
-        else:
-            try:
-                chunks = handle_request(facade, request)
-            except Exception as exc:
-                chunks = [
-                    _line(
-                        envelope.error_envelope(
-                            "INTERNAL_ERROR",
-                            f"响应处理失败（{type(exc).__name__}）",
-                        )
+            write(_line(envelope.error_envelope("INVALID_PARAMS", "请求行不是合法 JSON")))
+            continue
+        if isinstance(request, dict) and "cancel" in request:
+            _handle_cancel(request, jobs, write)
+            continue
+        err = _request_error(facade, request)
+        if err is not None:
+            write(_line(err))
+            continue
+        tool: str = request["tool"]
+        if tool in LONG_RUNNING_TOOLS:
+            job_id = request.get("job_id")
+            job = _Job()
+            if isinstance(job_id, str):
+                jobs[job_id] = job  # 读环同步登记：后续取消行必然命中
+            threading.Thread(
+                target=_run_long_job,
+                args=(facade, request, job, job_id, write),
+                daemon=True,
+            ).start()
+            continue
+        try:
+            chunks = handle_request(facade, request)
+        except Exception as exc:
+            chunks = [
+                _line(
+                    envelope.error_envelope(
+                        "INTERNAL_ERROR",
+                        f"响应处理失败（{type(exc).__name__}）",
                     )
-                ]
-        for chunk in chunks:
-            stdout.write(chunk)
-        stdout.flush()
+                )
+            ]
+        write(*chunks)

--- a/tests/api/test_cli.py
+++ b/tests/api/test_cli.py
@@ -15,6 +15,7 @@ import pytest
 
 pytestmark = pytest.mark.interface
 
+from e2m2e.api import execution  # noqa: E402
 from e2m2e.api.cli import main as cli_main  # noqa: E402
 from e2m2e.api.cli.main import main, tool_subcommands  # noqa: E402
 from e2m2e.api.config import Config  # noqa: E402
@@ -139,7 +140,7 @@ def fake_worker(monkeypatch, tmp_path):
     def use(mode: str) -> None:
         monkeypatch.setenv("FAKE_WORKER_MODE", mode)
         monkeypatch.setenv("FAKE_WORKER_PIDFILE", str(pidfile))
-        monkeypatch.setattr(cli_main, "_WORKER_ARGV", [sys.executable, "-c", _FAKE_WORKER_SCRIPT])
+        monkeypatch.setattr(execution, "WORKER_ARGV", [sys.executable, "-c", _FAKE_WORKER_SCRIPT])
 
     use("ok")
     return SimpleNamespace(pidfile=pidfile, use=use)

--- a/tests/api/test_mcp_worker.py
+++ b/tests/api/test_mcp_worker.py
@@ -31,6 +31,7 @@ pytestmark = [
 
 pytest.importorskip("mcp")  # [mcp] extra 未装时整文件跳过（协议层依赖）
 
+from e2m2e.api import execution  # noqa: E402
 from e2m2e.api.config import Config  # noqa: E402
 from e2m2e.api.facade import Facade  # noqa: E402
 from e2m2e.api.mcp import server as mcp_server  # noqa: E402
@@ -98,7 +99,7 @@ def fake_worker(monkeypatch, tmp_path):
     def use(mode: str) -> None:
         monkeypatch.setenv("FAKE_WORKER_MODE", mode)
         monkeypatch.setenv("FAKE_WORKER_PIDFILE", str(pidfile))
-        monkeypatch.setattr(mcp_server, "_WORKER_ARGV", [sys.executable, "-c", _FAKE_WORKER_SCRIPT])
+        monkeypatch.setattr(execution, "WORKER_ARGV", [sys.executable, "-c", _FAKE_WORKER_SCRIPT])
 
     use("ok")
     return SimpleNamespace(pidfile=pidfile, use=use)

--- a/tests/api/test_sidecar.py
+++ b/tests/api/test_sidecar.py
@@ -8,6 +8,10 @@ from __future__ import annotations
 
 import io
 import json
+import os
+import sys
+import threading
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
@@ -16,6 +20,7 @@ pytestmark = [pytest.mark.interface]
 
 from kernel_helpers import requires_native_symbols  # noqa: E402
 
+from e2m2e.api import execution  # noqa: E402
 from e2m2e.api.config import Config  # noqa: E402
 from e2m2e.api.facade import Facade, mcp_exposed  # noqa: E402
 from e2m2e.api.frames import decode_frame  # noqa: E402
@@ -204,10 +209,14 @@ def test_progress_line_then_response(facade):
 
 
 def test_run_loop_end_to_end(facade):
-    """run_loop：请求行→(进度行+响应行+帧)，坏 JSON 行得错误信封不中断。"""
+    """run_loop：短工具请求行→(进度行+响应行+帧)，坏 JSON 行得错误信封不中断。
+
+    长任务（族生成等）在 #607 起走 worker 子进程线程，由取消端到端
+    测试覆盖；本测试用短工具保持字节顺序确定性。
+    """
     requests = (
-        b'{"tool": "orbit_family_generation", "arguments": {"orbit_type": "HALO", '
-        b'"libration_point": 1}, "binary_dtype": "f64", "job_id": "j"}\n'
+        b'{"tool": "catalog_get", "arguments": {"record_id": "r1"}, '
+        b'"binary_dtype": "f64"}\n'
         b"this is not json\n"
     )
     stdout = io.BytesIO()
@@ -272,8 +281,7 @@ def test_run_loop_survives_envelope_serialization_failure(facade):
         requests = (
             b'{"tool": "catalog_get", "arguments": {"record_id": "r1"}, '
             b'"binary_dtype": "f32"}\n'
-            b'{"tool": "orbit_family_generation", "arguments": {"orbit_type": "HALO", '
-            b'"libration_point": 1}, "binary_dtype": "f32"}\n'
+            b'{"tool": "catalog_query", "arguments": {}}\n'
         )
         stdout = io.BytesIO()
         run_loop(facade, io.BytesIO(requests), stdout)  # 不应抛异常
@@ -281,9 +289,9 @@ def test_run_loop_survives_envelope_serialization_failure(facade):
         # 坏请求兑成 INTERNAL_ERROR 信封（进度行随失败丢弃），循环存活
         assert lines[0][0]["status"] == "error"
         assert lines[0][0]["error"]["code"] == "INTERNAL_ERROR"
-        # 第二个请求正常处理：进度行 + ok 响应 + 帧
+        # 第二个请求正常处理：进度行 + ok 响应
         assert lines[1][0]["status"] == "progress"
-        assert lines[2][0]["status"] == "ok" and lines[2][0]["binary_frames"] == 2
+        assert lines[2][0]["status"] == "ok"
     finally:
         facade._broken_response = False
 
@@ -377,3 +385,216 @@ def test_spatiography_dynamical_map_requires_binary_dtype(facade):
     [line] = [json.loads(c) for c in chunks]
     assert line["status"] == "error"
     assert line["error"]["code"] == "INVALID_PARAMS"
+
+
+# ---------------------------------------------------------------------------
+# 长任务 worker 路由与线级取消（#607）
+# ---------------------------------------------------------------------------
+
+_SIDECAKE_FAKE_WORKER = """
+import json, os, struct, sys, time
+pidfile = os.environ.get("SIDECAKE_PIDFILE")
+if pidfile:
+    with open(pidfile, "w") as f:
+        f.write(str(os.getpid()))
+mode = os.environ.get("SIDECAKE_MODE", "progress-ok")
+out = sys.stdout.buffer
+def emit(obj):
+    out.write((json.dumps(obj) + "\\n").encode()); out.flush()
+emit({"type": "progress", "fraction": 0.5, "message": "half"})
+if mode == "sleep":
+    time.sleep(60)
+if mode == "crash":
+    sys.exit(3)
+if mode == "frame":
+    frame = struct.pack("<IBB", 0x324D3245, 0, 1) + struct.pack("<I", 2)
+    frame += struct.pack("<2f", 1.0, 2.0)
+    emit({"type": "result", "envelope": {"status": "ok", "data": {}, "error": None,
+          "meta": {}}, "binary_frames": 1})
+    out.write(frame); out.flush()
+    sys.exit(0)
+emit({"type": "result", "envelope": {"status": "ok", "data": {"mode": mode},
+      "error": None, "meta": {}}})
+"""
+
+
+@pytest.fixture
+def sidecar_worker(monkeypatch, tmp_path):
+    """sidecar 的 worker 命令换成 fake 脚本，可切模式（#607）。"""
+    pidfile = tmp_path / "sidecar-worker.pid"
+
+    def use(mode: str) -> None:
+        monkeypatch.setenv("SIDECAKE_MODE", mode)
+        monkeypatch.setenv("SIDECAKE_PIDFILE", str(pidfile))
+        monkeypatch.setattr(execution, "WORKER_ARGV", [sys.executable, "-c", _SIDECAKE_FAKE_WORKER])
+
+    use("progress-ok")
+    return SimpleNamespace(pidfile=pidfile, use=use)
+
+
+def _pid_alive(pid: int) -> bool:
+    if sys.platform == "win32":
+        import ctypes
+        from ctypes import wintypes
+
+        kernel32 = ctypes.windll.kernel32
+        handle = kernel32.OpenProcess(0x1000, False, pid)
+        if not handle:
+            return False
+        try:
+            code = wintypes.DWORD()
+            if not kernel32.GetExitCodeProcess(handle, ctypes.byref(code)):
+                return False
+            return code.value == 259
+        finally:
+            kernel32.CloseHandle(handle)
+    import errno
+    import os
+
+    try:
+        os.kill(pid, 0)
+    except OSError as exc:
+        return exc.errno == errno.EPERM
+    return True
+
+
+def test_long_tool_streams_progress_and_result(sidecar_worker, facade):
+    """长任务经 worker：真实进度行（fraction）与结果行依次流出。"""
+    stdin_r, stdin_w = os.pipe()
+    stdout_r, stdout_w = os.pipe()
+    worker = threading.Thread(
+        target=run_loop,
+        args=(facade, os.fdopen(stdin_r, "rb"), os.fdopen(stdout_w, "wb")),
+        daemon=True,
+    )
+    worker.start()
+    os.write(
+        stdin_w,
+        b'{"tool": "orbit_family_generation", "arguments": {"orbit_type": "HALO", '
+        b'"libration_point": 1}, "binary_dtype": "f32", "job_id": "j1"}\n',
+    )
+    import time as _time
+
+    deadline = _time.monotonic() + 15
+    collected = bytearray()
+    collector = threading.Thread(
+        target=lambda: [collected.extend(os.read(stdout_r, 4096)) for _ in iter(int, 1)],
+        daemon=True,
+    )
+    collector.start()
+    while _time.monotonic() < deadline and b'"mode"' not in bytes(collected):
+        _time.sleep(0.05)
+    os.close(stdin_w)
+    worker.join(timeout=10)
+    text = collected.decode("utf-8", errors="replace")
+    assert '"status": "progress"' in text and "half" in text, "worker 进度应带真实 fraction 转发"
+    assert '"status": "ok"' in text
+
+
+def test_cancel_line_kills_worker_and_emits_cancelled(sidecar_worker, facade):
+    """取消行 → 子进程被 kill + cancelled 状态行；循环存活可继续服务。"""
+    sidecar_worker.use("sleep")
+    stdin_r, stdin_w = os.pipe()
+    stdout_r, stdout_w = os.pipe()
+    worker = threading.Thread(
+        target=run_loop,
+        args=(facade, os.fdopen(stdin_r, "rb"), os.fdopen(stdout_w, "wb")),
+        daemon=True,
+    )
+    worker.start()
+    os.write(
+        stdin_w,
+        b'{"tool": "orbit_family_generation", "arguments": {"orbit_type": "HALO", '
+        b'"libration_point": 1}, "binary_dtype": "f32", "job_id": "j1"}\n',
+    )
+    import time as _time
+
+    deadline = _time.monotonic() + 15
+    while _time.monotonic() < deadline and not sidecar_worker.pidfile.exists():
+        _time.sleep(0.05)
+    pid = int(sidecar_worker.pidfile.read_text(encoding="ascii").strip())
+    os.write(stdin_w, b'{"cancel": "j1"}\n')
+    collected = bytearray()
+    collector = threading.Thread(
+        target=lambda: [collected.extend(os.read(stdout_r, 4096)) for _ in iter(int, 1)],
+        daemon=True,
+    )
+    collector.start()
+    deadline = _time.monotonic() + 15
+    while _time.monotonic() < deadline and b'"cancelled"' not in bytes(collected):
+        _time.sleep(0.05)
+    assert b'"cancelled"' in bytes(collected), "取消后必须回 cancelled 状态行"
+    deadline = _time.monotonic() + 15
+    while _time.monotonic() < deadline and _pid_alive(pid):
+        _time.sleep(0.1)
+    assert not _pid_alive(pid), "取消后 worker 子进程应已被终止"
+    # 循环存活：后续请求照常处理
+    os.write(stdin_w, b'{"tool": "catalog_query", "arguments": {}}\n')
+    deadline = _time.monotonic() + 15
+    while _time.monotonic() < deadline and b'"records"' not in bytes(collected):
+        _time.sleep(0.05)
+    os.close(stdin_w)
+    assert b'"cancelled"' in bytes(collected)
+
+
+def test_cancel_unknown_job_is_idempotent(sidecar_worker, facade):
+    """对未知 job 的取消：幂等回 cancelled 行，不崩溃。"""
+    stdin_r, stdin_w = os.pipe()
+    stdout_r, stdout_w = os.pipe()
+    worker = threading.Thread(
+        target=run_loop,
+        args=(facade, os.fdopen(stdin_r, "rb"), os.fdopen(stdout_w, "wb")),
+        daemon=True,
+    )
+    worker.start()
+    os.write(stdin_w, b'{"cancel": "no-such-job"}\n')
+    import time as _time
+
+    collected = bytearray()
+    deadline = _time.monotonic() + 15
+    while _time.monotonic() < deadline and b'"cancelled"' not in bytes(collected):
+        chunk = os.read(stdout_r, 4096)
+        if chunk:
+            collected.extend(chunk)
+        else:
+            _time.sleep(0.05)
+    os.close(stdin_w)
+    line = json.loads(bytes(collected).splitlines()[0])
+    assert line["status"] == "cancelled"
+    assert line["meta"]["job_id"] == "no-such-job"
+
+
+def test_worker_frames_pass_through(sidecar_worker, facade):
+    """worker 结果行声明的二进制帧原样透传（帧序 = 声明序）。"""
+    sidecar_worker.use("frame")
+    stdin_r, stdin_w = os.pipe()
+    stdout_r, stdout_w = os.pipe()
+    worker = threading.Thread(
+        target=run_loop,
+        args=(facade, os.fdopen(stdin_r, "rb"), os.fdopen(stdout_w, "wb")),
+        daemon=True,
+    )
+    worker.start()
+    os.write(
+        stdin_w,
+        b'{"tool": "orbit_family_generation", "arguments": {"orbit_type": "HALO", '
+        b'"libration_point": 1}, "binary_dtype": "f32", "job_id": "j2"}\n',
+    )
+    import time as _time
+
+    collected = bytearray()
+    deadline = _time.monotonic() + 15
+    while _time.monotonic() < deadline and len(bytes(collected)) < 120:
+        chunk = os.read(stdout_r, 4096)
+        if chunk:
+            collected.extend(chunk)
+        else:
+            _time.sleep(0.05)
+    os.close(stdin_w)
+    worker.join(timeout=10)
+    lines = _lines_and_frames([bytes(collected)])
+    result_line, frames = next(line for line in lines if line[0].get("binary_frames"))
+    assert result_line["status"] == "ok" and result_line["binary_frames"] == 1
+    arr, dtype, _ = decode_frame(frames[0])
+    assert dtype == "f32"
+    np.testing.assert_allclose(arr, np.array([1.0, 2.0], dtype=np.float32))


### PR DESCRIPTION
Closes #607。解除 #601 的推迟（维护者决策：e2m2e 是基础工具集，协议面先于消费方完整），ADR 0035 增补记录协议契约变更。

## 改动摘要

- **并发 run_loop**：长任务（执行核心 `LONG_RUNNING_TOOLS`，sidecar 成为第二消费方）在 worker 子进程 + 后台线程执行，读环持续消费 stdin；短任务内联不变。单 job 的输出字节（行 + 帧）锁内原子写出，帧永不交叉。
- **线级取消**：新请求行 `{"cancel": "<job_id>"}` → kill 子进程 → 回 `cancelled` 状态行；幂等（未知 job 也回确认行）；被取消的原请求不回结果行（对齐 MCP 语义）。取消事件在读环同步登记，与 job 启动的竞争是确定性的。
- **worker 协议扩展**（e2m2e 内部，非跨仓库契约）：请求可带 `binary_dtype`，结果行声明 `binary_frames: N` 后跟原始帧（帧格式不变，复用 ADR 0035 §3）；`frames.py` 新增 `read_raw_frame` 供泵转发。
- **进度升级**：长任务进度行是算法层真实分数（经 worker 回流），取代伪造的 percent=0 起始行；短任务保留起始行。
- worker spawn 命令收敛为 `execution.WORKER_ARGV`（server/cli/sidecar 三方运行时属性访问，测试 patch 单点生效）。
- 健壮性：worker 崩溃（无结果行）回 `WORKER_CRASHED` 而非静默；帧解码失败回 `INTERNAL_ERROR`；取消路径静默收场不抢跑 cancelled 行。

## 测试

新增 fake worker 端到端（真实进度转发、取消 kill + cancelled 行 + 循环存活、幂等取消、帧透传）与进程内 `run_request` 帧回传测试；现有 run_loop 测试改用短工具保持字节顺序确定性。取消与 job 启动的竞争由"读环同步登记取消事件"消除。

`pytest tests/api tests/_meta`：327 passed / 3 skipped（3 个 skip 为 #603 守卫，预期行为）。ruff、mypy、层导入检查全部通过；ADR 0037 时间预算门禁通过。