### PR TITLE
[AI Generated] [FIX] read_raw_frame 多维帧 shape 只解首维，worker 帧流必失步

### DIFF
--- a/e2m2e/api/frames.py
+++ b/e2m2e/api/frames.py
@@ -107,7 +107,9 @@ def read_raw_frame(stream) -> bytes:
     shape_bytes = stream.read(4 * ndim)
     if len(shape_bytes) < 4 * ndim:
         raise FrameError("shape 段不完整")
-    shape = _U32.unpack_from(shape_bytes)
+    # 解全部 ndim 个 u32（#622）：unpack_from 只取首维，多维帧数据段会
+    # 少读，worker 帧流自此失步
+    shape = struct.unpack(f"<{ndim}I", shape_bytes)
     n_elements = 1
     for dim in shape:
         n_elements *= dim

--- a/tests/api/test_sidecar_frames.py
+++ b/tests/api/test_sidecar_frames.py
@@ -6,6 +6,8 @@
 
 from __future__ import annotations
 
+import io
+
 import numpy as np
 import pytest
 
@@ -16,6 +18,7 @@ from e2m2e.api.frames import (  # noqa: E402
     FrameError,
     decode_frame,
     encode_frame,
+    read_raw_frame,
 )
 
 
@@ -103,3 +106,27 @@ def test_encode_normalizes_dtype_and_order():
     arr = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=">f8")
     assert encode_frame(arr, "f64") == encode_frame(np.ascontiguousarray(arr.astype("<f8")), "f64")
     assert MAGIC == 0x324D3245
+
+
+def test_read_raw_frame_multidim_consumes_full_frame():
+    """（#622）read_raw_frame 必须按全部 ndim 个 shape 维计算帧长。
+
+    只解首维会让 (1,6) 帧被当成 1 个元素读 4 字节数据（应 24），worker
+    帧流自此失步——worker stdout 泵转发时表现为后续帧 magic 校验失败。
+    帧后尾随字节（下一 JSON 行）必须原样留在流里。
+    """
+    frame = encode_frame(np.ones((1, 6), dtype=np.float32), "f32")
+    tail = b'\n{"type": "result"}'
+    stream = io.BytesIO(frame + tail)
+    assert read_raw_frame(stream) == frame
+    assert stream.read() == tail
+
+
+def test_read_raw_frame_1d_and_truncated():
+    """一维帧整帧读回；头/数据段不完整按契约抛 FrameError。"""
+    frame = encode_frame(np.array([1.0, 2.0], dtype=np.float32), "f32")
+    assert read_raw_frame(io.BytesIO(frame)) == frame
+    with pytest.raises(FrameError, match="帧头不完整"):
+        read_raw_frame(io.BytesIO(frame[:3]))
+    with pytest.raises(FrameError, match="数据段不完整"):
+        read_raw_frame(io.BytesIO(frame[:-4]))


### PR DESCRIPTION
generated by AI（Claude Code，GLM）。

Closes #622

**关联 Issue**

#622：`read_raw_frame` 用 `_U32.unpack_from` 只解 shape 首维，ndim≥2 的帧数据段读取不足，worker stdout 帧流自此失步；`LONG_RUNNING_TOOLS`（transfer_design / orbit_family_generation）经 MCP/sidecar 的带帧调用全部失败。

**变更与验证**

<details>
<summary>点开</summary>

变更（2 文件）：

- `e2m2e/api/frames.py`：`read_raw_frame` 的 shape 改按全部 ndim 个 u32 解包（`struct.unpack(f"<{ndim}I", …)`）。
- `tests/api/test_sidecar_frames.py`：补 `read_raw_frame` 回归单测——多维帧整帧消费且尾随 JSON 行原样留在流里（修复前红：(1,6) f32 帧只消费 18/38 字节）；一维帧整帧读回；头/数据段截断抛 FrameError。

验证（本机 Windows，e2m2e venv）：

- `python -m pytest tests/api -q`：**294 passed**（292 既有 + 2 新增；修复前新增多维用例红）
- `python -m ruff check` / `mypy` 改动文件：通过
- 修复前实测：worker 直跑 orbit_family_generation 输出帧字节干净，server 端 `_read_worker_message` 消费 10/10 抛 `帧 magic 不符`；本地按本修复改读法复跑同路径 10/10 通过
</details>