### PR TITLE
[AI Generated] [FEAT] design_orbit 的 NRHO/HALO 取值域放宽，HALO 逐平动点分档（#643）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Changed
 - **轨道库出默认态：库不维护数据库，提供建库基础设施**：三处默认行为移除——计算产物（design/control/transfer/族生成/sweep）默认只随响应返回、不再自动入库，`catalog_enabled` 默认关（`$E2M2E_CATALOG_ENABLED` 显式开启）；`catalog_dir` 无隐式默认（`Config(catalog_dir=...)` 或 `$E2M2E_CATALOG_DIR` 显式指定），未指定时一切库操作报 `CATALOG_NOT_CONFIGURED`、不建目录，不再"跑哪建哪"地创建 `./catalog`；基线数据集移出 wheel（瘦身约 3.5 MB），改 GitHub Release 资产分发，`import_baseline(store, source_dir)` 源必填、显式导入建库。持有 v1 旧库的 schema 弃用语义不变（ADR 0045）。(#632)
+- **design_orbit 的 NRHO/HALO 取值域放宽（HALO 逐平动点分档）**：NRHO `perilune_height` 上限 10 000 → 40 000 km（与族生成 NRHO 上限对齐）；HALO `amplitude` 按平动点分档——L1 止于族折叠常量 ±26 908 km（统一 ±73 000 对 L1 是谎报），L2 放宽到 ±77 000 km（L2 族 z0 折叠顶 ≈77 787 km 内留余量）。9:2 量级大振幅北族 Halo（近月高 ≈14 870 km）自此可完全经 `design_orbit` 设计生成（含星历修正与标称星历）。族生成域不变（HALO 按平动点折叠点、NRHO 1 000–40 000），`valid_ranges` 与校验器同源随之更新（design_orbit HALO 键拆为 `HALO_L1`/`HALO_L2`）。(#643)
 
 ### 升级注意
 - **依赖自动入库的调用方**：升级后默认 `record_id`/`family_id` 为 `None`；设 `$E2M2E_CATALOG_ENABLED=1` 或 `Config(catalog_enabled=True, catalog_dir=...)` 恢复，库目录必须显式指定。design→control（`input_record_id`）链路要求先开启入库。

--- a/e2m2e/algorithm/design/design_orbit.py
+++ b/e2m2e/algorithm/design/design_orbit.py
@@ -370,8 +370,13 @@ def _validate_params(
         phase = 0.0 if phase is None else float(phase)
         if collinear_point not in (1, 2):
             raise ValueError(f"Halo collinear_point 必须为 1 或 2，当前 {collinear_point}")
-        if not abs(amplitude) <= 73000.0:
-            raise ValueError(f"Halo amplitude 应在 -73000~73000 km 之间，实际为 {amplitude:.0f} km")
+        # L1 设计域止于族折叠常量 26 908 km（#643 探测确认）；L2 放宽到 77 000 km
+        limit = 26_908.0 if collinear_point == 1 else 77_000.0
+        if not abs(amplitude) <= limit:
+            raise ValueError(
+                f"Halo L{collinear_point} amplitude 应在 -{limit:.0f}~{limit:.0f} km 之间，"
+                f"实际为 {amplitude:.0f} km"
+            )
         if not 0.0 <= phase <= 1.0:
             raise ValueError(f"Halo phase 应在 0~1 之间，实际为 {phase}")
         return {
@@ -389,9 +394,9 @@ def _validate_params(
             raise ValueError(f"NRHO collinear_point 必须为 1 或 2，当前 {collinear_point}")
         if north_south not in (1, 2):
             raise ValueError(f"NRHO north_south 必须为 1（北）或 2（南），当前 {north_south}")
-        if not 100.0 <= perilune_height <= 10000.0:
+        if not 100.0 <= perilune_height <= 40000.0:
             raise ValueError(
-                f"NRHO perilune_height 应在 100~10000 km 之间，实际为 {perilune_height:.0f} km"
+                f"NRHO perilune_height 应在 100~40000 km 之间，实际为 {perilune_height:.0f} km"
             )
         # NRHO 的历元相位允许从 0 开始；API 模型同样定义为 [0, 1]。
         if not 0.0 <= phase <= 1.0:

--- a/e2m2e/api/models.py
+++ b/e2m2e/api/models.py
@@ -159,9 +159,8 @@ _ORBIT_TYPE_RANGES: Mapping[str, Mapping[str, NumericRange]] = MappingProxyType(
     {
         "DRO": _DRO_DPO_RANGES,
         "DPO": _DRO_DPO_RANGES,
-        "HALO": _with_global_amplitude_out(_range_map(amplitude=NumericRange(-73000.0, 73000.0))),
         "NRHO": _with_global_amplitude_out(
-            _range_map(perilune_height=NumericRange(100.0, 10000.0))
+            _range_map(perilune_height=NumericRange(100.0, 40000.0))
         ),
         "L4": _GLOBAL_AMPLITUDE_OUT_RANGES,
         "L5": _GLOBAL_AMPLITUDE_OUT_RANGES,
@@ -214,7 +213,7 @@ class DesignOrbitRequest(_ApiModel):
     phase_in: float | None = Field(default=None, ge=0.0, le=1.0)
     phase_out: float | None = Field(default=None, ge=0.0, le=1.0)
     # 共享参数
-    perilune_height: float | None = Field(default=None, gt=0.0, le=10000.0)
+    perilune_height: float | None = Field(default=None, gt=0.0, le=40000.0)
     # ELFO 形状参数
     inclination: float | None = Field(
         default=None, ge=0.0, le=180.0, description="倾角（度），ELFO 用"
@@ -253,13 +252,22 @@ class DesignOrbitRequest(_ApiModel):
         if not isinstance(orbit_type, str):
             raise ValueError(f"orbit_type 必须为字符串，当前 {orbit_type!r}")
         selection = orbit_type.upper()
-        if selection == "LISSAJOUS":
+        if selection in ("LISSAJOUS", "HALO"):
             point = 2 if collinear_point is None else collinear_point
-            if point not in (1, 2, 3):
+            if point not in (1, 2, 3) or (selection == "HALO" and point == 3):
+                allowed = "1、2 或 3" if selection == "LISSAJOUS" else "1 或 2"
                 raise ValueError(
-                    f"LISSAJOUS collinear_point 必须为 1、2 或 3，当前 {collinear_point!r}"
+                    f"{selection} collinear_point 必须为 {allowed}，当前 {collinear_point!r}"
                 )
-            ranges = _LISSAJOUS_L3_RANGES if point == 3 else _LISSAJOUS_L1_L2_RANGES
+            if selection == "LISSAJOUS":
+                ranges = _LISSAJOUS_L3_RANGES if point == 3 else _LISSAJOUS_L1_L2_RANGES
+            else:
+                # L1 设计域止于族折叠常量 26 908 km（设计路径上限，与族生成折叠点
+                # 一致，#643 探测确认）；L2 放宽到 z0 折叠顶 ≈77 787 km 内的 77 000 km
+                limit = 26_908.0 if point == 1 else 77_000.0
+                ranges = _with_global_amplitude_out(
+                    _range_map(amplitude=NumericRange(-limit, limit))
+                )
         else:
             try:
                 ranges = _ORBIT_TYPE_RANGES[selection]
@@ -271,10 +279,18 @@ class DesignOrbitRequest(_ApiModel):
     def valid_range_contexts(cls) -> tuple[tuple[str, int | None], ...]:
         """全量导出条件值域用的 (orbit_type, collinear_point) 键集。
 
-        无平动点条件的族 point 为 None；LISSAJOUS 逐点展开（1/2 同表、3 独立）。
+        无平动点条件的族 point 为 None；HALO 与 LISSAJOUS 逐点展开
+        （HALO 为 L1/L2 两档独立域，LISSAJOUS 1/2 同表、3 独立）。
         """
         contexts = [(orbit_type, None) for orbit_type in _ORBIT_TYPE_RANGES]
-        return (*contexts, ("LISSAJOUS", 1), ("LISSAJOUS", 2), ("LISSAJOUS", 3))
+        return (
+            *contexts,
+            ("HALO", 1),
+            ("HALO", 2),
+            ("LISSAJOUS", 1),
+            ("LISSAJOUS", 2),
+            ("LISSAJOUS", 3),
+        )
 
     @classmethod
     def field_units(cls) -> Mapping[str, str]:

--- a/tests/algorithm/family/test_nrho_large_amplitude.py
+++ b/tests/algorithm/family/test_nrho_large_amplitude.py
@@ -1,0 +1,40 @@
+"""9:2 量级大振幅北族 NRHO 单轨设计回归（issue #643）。
+
+近月高 14 870 km 的 L2 北族成员此前被设计侧 10 000 km 上限拒绝（该量级
+对应 9:2 共振 NRHO，z0≈77 787 km 恰在 Halo 族 z0 折叠顶附近，只能经
+NRHO 近月高路径逼近）。上限放宽到 40 000 km 后，此用例锁住算法层可达
+性：近月高命中容差、周期为正、一个周期传播闭合。
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from e2m2e.algorithm.dynamics.dynamics import CR3BP_Dynamics
+from e2m2e.algorithm.family import design_nrho
+from e2m2e.algorithm.family.cr3bp_orbits import MOON_RADIUS_KM
+
+pytestmark = pytest.mark.orchestration
+
+
+@pytest.mark.time_budget(70)
+def test_design_nrho_9_2_magnitude_north() -> None:
+    """L2 北族近月高 14 870 km：命中 ±10 km、周期为正、闭合残差 ≤ 0.1 m。"""
+    orbit = design_nrho(2, 1, 14870.0)
+    assert orbit.period is not None and orbit.period > 0.0
+
+    system = orbit.system
+    dynamics = CR3BP_Dynamics(system)
+    lu = system.characteristic_length
+    assert lu is not None
+    result = dynamics.propagate(
+        orbit.states[0], (0.0, orbit.period), t_eval=np.linspace(0.0, orbit.period, 1200)
+    )
+    states = np.asarray(result["states"])
+    moon = np.array([1.0 - system.mu, 0.0, 0.0])
+    r_moon_km = np.linalg.norm(states[:, :3] - moon, axis=1) * lu
+    assert abs((r_moon_km.min() - MOON_RADIUS_KM) - 14870.0) <= 10.0
+
+    closure_km = np.linalg.norm(states[-1, :3] - states[0, :3]) * lu
+    assert closure_km <= 1.0e-4

--- a/tests/api/test_facade.py
+++ b/tests/api/test_facade.py
@@ -50,6 +50,21 @@ class TestFacadeValidation:
         with pytest.raises(OrbitError, match="INVALID_PARAMS"):
             call(Facade())
 
+    def test_design_domain_upper_bounds_report_new_limits(self):
+        """#643：NRHO 近月高 40000 / HALO 振幅 ±77000 是设计侧新上限。"""
+        facade = Facade()
+        with pytest.raises(OrbitError, match=r"(?s)INVALID_PARAMS.*77000"):
+            facade.design_orbit(orbit_type="HALO", collinear_point=2, amplitude=77500.0)
+        with pytest.raises(OrbitError, match=r"(?s)INVALID_PARAMS.*26908"):
+            facade.design_orbit(orbit_type="HALO", collinear_point=1, amplitude=30000.0)
+        with pytest.raises(OrbitError, match="INVALID_PARAMS"):
+            facade.design_orbit(
+                orbit_type="NRHO",
+                collinear_point=2,
+                north_south=1,
+                perilune_height=40000.1,
+            )
+
 
 class TestFacadeDelegation:
     def test_control_upper_bounds_are_translated_to_orbit_error(self):

--- a/tests/api/test_models.py
+++ b/tests/api/test_models.py
@@ -70,8 +70,8 @@ class TestDesignOrbitRequest:
         [
             ("DRO", "amplitude", 1737.0, 110000.0, True),
             ("DPO", "amplitude", 1737.0, 110000.0, True),
-            ("HALO", "amplitude", -73000.0, 73000.0, True),
-            ("NRHO", "perilune_height", 100.0, 10000.0, True),
+            ("HALO", "amplitude", -77000.0, 77000.0, True),  # 无点默认 L2
+            ("NRHO", "perilune_height", 100.0, 40000.0, True),
             ("L4", "amplitude_out", 0.0, 76000.0, False),
             ("L5", "amplitude_out", 0.0, 76000.0, False),
             ("AXIAL", "amplitude", -60000.0, 60000.0, True),
@@ -108,6 +108,15 @@ class TestDesignOrbitRequest:
                 DesignOrbitRequest(orbit_type=orbit_type, **{field: minimum})
             accepted = DesignOrbitRequest(orbit_type=orbit_type, **{field: minimum + 1.0})
             assert getattr(accepted, field) == minimum + 1.0
+
+    def test_halo_l1_domain_tightened_to_family_fold(self):
+        """#643：HALO 振幅域逐平动点分档——L1 止于族折叠常量 26 908 km。"""
+        numeric_range = DesignOrbitRequest.valid_ranges("HALO", collinear_point=1)["amplitude"]
+        assert (numeric_range.minimum, numeric_range.maximum) == (-26908.0, 26908.0)
+        accepted = DesignOrbitRequest(orbit_type="HALO", collinear_point=1, amplitude=26908.0)
+        assert accepted.amplitude == 26908.0
+        with pytest.raises(ValidationError, match="amplitude"):
+            DesignOrbitRequest(orbit_type="HALO", collinear_point=1, amplitude=26908.0 + 1.0)
 
     @pytest.mark.parametrize("orbit_type", ["HALO", "NRHO", "DPO"])
     def test_unstable_family_defaults_to_segmented_silently(self, orbit_type):

--- a/tests/api/test_valid_ranges.py
+++ b/tests/api/test_valid_ranges.py
@@ -31,14 +31,30 @@ class TestValidRangesResponse:
 
     def test_design_orbit_ranges_match_validator_source(self):
         response = Facade().valid_ranges()
-        expected = DesignOrbitRequest.valid_ranges("HALO")["amplitude"]
-        got = response.design_orbit["HALO"]["amplitude"]
+        expected = DesignOrbitRequest.valid_ranges("HALO", collinear_point=2)["amplitude"]
+        got = response.design_orbit["HALO_L2"]["amplitude"]
         assert isinstance(got, RangeSpec)
         assert (got.minimum, got.maximum) == (expected.minimum, expected.maximum)
         # 开闭语义随源携带：amplitude_out 全局下界为开区间
         global_out = response.design_orbit["DRO"]["amplitude_out"]
         assert global_out.minimum == 0.0
         assert global_out.minimum_inclusive is False
+
+    def test_nrho_perilune_and_halo_amplitude_domains(self):
+        response = Facade().valid_ranges()
+        # design_orbit 侧：NRHO 近月高上限对齐族生成 40000 km；HALO 振幅逐平动点
+        # 分档——L1 止于族折叠常量 26908 km、L2 放宽到 ±77000 km（#643 探测边界）
+        nrho = response.design_orbit["NRHO"]["perilune_height"]
+        assert (nrho.minimum, nrho.maximum) == (100.0, 40000.0)
+        halo_l1 = response.design_orbit["HALO_L1"]["amplitude"]
+        assert (halo_l1.minimum, halo_l1.maximum) == (-26908.0, 26908.0)
+        halo_l2 = response.design_orbit["HALO_L2"]["amplitude"]
+        assert (halo_l2.minimum, halo_l2.maximum) == (-77000.0, 77000.0)
+        # 族生成侧能力边界不动：HALO 按平动点折叠点收紧（L2=57660），NRHO 上限 40000
+        family_halo = response.family_generation_ranges["HALO_L2"]["max_amplitude_km"]
+        assert (family_halo.minimum, family_halo.maximum) == (-57660.0, 57660.0)
+        family_nrho = response.family_generation_ranges["NRHO_L2"]["perilune_height_max_km"]
+        assert (family_nrho.minimum, family_nrho.maximum) == (1000.0, 40000.0)
 
     def test_units_are_attached_per_field(self):
         response = Facade().valid_ranges()


### PR DESCRIPTION
由 omp 会话（zhipu-coding-plan/glm-5.3）起草。

## 关联 Issue

Fixes #643

- #643（ready-for-agent，agent brief 见 issue 评论）

## 改动摘要

- **NRHO**：`perilune_height` 域 (100, 10000] → **(100, 40000] km**，三处同步（请求模型字段约束、按类型值域表、算法层形状参数校验），上限对齐族生成 NRHO。
- **HALO**：`amplitude` 域按平动点分档——`HALO_L1` **±26908 km**（族折叠常量，实测 26908 成功 / 27500 拒）、`HALO_L2` **±77000 km**（L2 族 z0 折叠顶 ≈77887 km 内留余量，实测 75000 端到端收敛）。`valid_ranges` 的 design_orbit HALO 键拆为 `HALO_L1`/`HALO_L2`。
- 族生成域不动（HALO 按平动点折叠点、NRHO 1000–40000），两条路径能力不同、各自如实申报。
- 依据：#643 分诊验证（z0 族参数折叠实测、L1/L2 撞月端探测），9:2 经 NRHO 路径验收。

## 测试

- `.venv/bin/python -m pytest tests/api -q` → 266 passed, 2 skipped
- `.venv/bin/python -m pytest tests/algorithm/family/test_nrho_large_amplitude.py -q` → 1 passed（33.8 s，近月高 14870±10 km、闭合残差 ≤0.1 m）
- `make check` → ruff format / 层依赖 / mypy 241 文件全过
- 端到端冒烟（未入库测试，分诊记录）：`Facade().design_orbit(NRHO, L2, 北, perilune_height=14870, 30 天)` CONVERGED、`halo_l2_northern`、segmented、721 点标称星历；HALO 75000 端到端 41 s CONVERGED

## 已知既存失败（与本 PR 无关）

`tests/algorithm/family` 的 5 个 DPO/NRHO 族几何用例在本机单线程 pytest 环境超 ADR 0037 时预算（stash 验证与本改动无关）。

