### PR TITLE
[AI Generated] [FEAT] design_orbit 新增 moon_tide_mode 公开字段

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 发布条目面向调用方：写变化、用法与数值细节，issue 引用置段尾括号；内部实现路径与决策沿革不进本文件（住 ADR 与 issue）。已发布条目是不可变历史，保持写成时的语言。
 
+## [5.9.6] - 2026-09-07
+
+### Added
+- **`design_orbit` 新增 `moon_tide_mode` 字段（none/solid，默认 none）**：月球球谐引力场的潮汐模式首次可在 Facade 边界显式控制；星历修正与标称星历使用同一个月球潮汐设置（`perturbation_to_force_config` 同名 keyword 参数）。地球潮汐语义不变（仍由 `perturbation['tide']`/`['coupling']` 控制）；非法枚举值由 `Facade.design_orbit` 以 `INVALID_PARAMS` 拒绝。满配月球固体潮真值（如 qiao 的 NRHO 验证链）不再需要穿透算法层。
+
 ## [5.9.5] - 2026-09-07
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "5.9.5"
+version = "5.9.6"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://github.com/cislunarspace/e2m2e"

--- a/e2m2e/algorithm/design/design_orbit.py
+++ b/e2m2e/algorithm/design/design_orbit.py
@@ -34,7 +34,7 @@ import os
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any, Literal, Protocol
 
 import numpy as np
 
@@ -100,6 +100,7 @@ if TYPE_CHECKING:
         dyb: list[float] | None
         earth_degree: int
         moon_degree: int
+        moon_tide_mode: Literal["none", "solid"]
         correction_method: str
         correction_revolutions: int
 
@@ -862,6 +863,7 @@ def _design_elfo(
         perturbation,
         earth_degree=request.earth_degree,
         moon_degree=request.moon_degree,
+        moon_tide_mode=request.moon_tide_mode,
         dyb=request.dyb,
     )
     fm = ForceModel.from_config(force_config, full_system)
@@ -1002,6 +1004,7 @@ def design_orbit(
     perturbation = request.perturbation
     earth_degree = request.earth_degree
     moon_degree = request.moon_degree
+    moon_tide_mode = request.moon_tide_mode
     dyb = request.dyb
     correction_method = request.correction_method
     correction_revolutions = request.correction_revolutions
@@ -1087,7 +1090,11 @@ def design_orbit(
         origin=CelestialBodyOrigin(body="EARTH", spice=spice),
     )
     force_config = perturbation_to_force_config(
-        perturbation, earth_degree=earth_degree, moon_degree=moon_degree, dyb=dyb
+        perturbation,
+        earth_degree=earth_degree,
+        moon_degree=moon_degree,
+        moon_tide_mode=moon_tide_mode,
+        dyb=dyb,
     )
     fm = ForceModel.from_config(force_config, full_system)
     fm.rtol = 1e-12

--- a/e2m2e/algorithm/forces/force_mapping.py
+++ b/e2m2e/algorithm/forces/force_mapping.py
@@ -31,7 +31,9 @@ inputs-dac.txt（第 9~17 行 + 阶次/DYB 行）的力模型是"地球+月球�
   主项（修正项构成未确认，待 P0 对齐实验核实）。
 - ``tide=1``：地球固体潮，挂在地球 ``GravityField`` 的
   ``tide_mode="solid"`` 上——因此要求 ``earth_nonspherical=1``，
-  否则抛 ``ValueError``。月球引力场不带潮（开关写明"地球的潮汐"）。
+  否则抛 ``ValueError``。月球球谐引力场的潮汐不受开关控制，由独立的
+  ``moon_tide_mode`` 参数（none/solid）给定，默认 none（inputs-dac 侧
+  无月球潮汐开关，历史行为即不带潮）。
 - ``coupling=1`` （地球非球形×大天体耦合项）：强制启用固体潮
   ``tide_mode="solid"`` （与 ``tide=1`` 共用 IERS TN32 固体潮公式）。
 
@@ -42,7 +44,7 @@ inputs-dac.txt（第 9~17 行 + 阶次/DYB 行）的力模型是"地球+月球�
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Any
+from typing import Any, Literal
 
 from ...data.constants import SPEED_OF_LIGHT_KMS
 from ...data.templates.perturbations import DEFAULT_DYB, DEFAULT_PERTURBATION
@@ -98,6 +100,7 @@ def perturbation_to_force_config(
     *,
     earth_degree: int = 10,
     moon_degree: int = 10,
+    moon_tide_mode: Literal["none", "solid"] = "none",
     dyb: Sequence[float] | None = None,
     area_to_mass: float | None = None,
 ) -> dict[str, Any]:
@@ -108,6 +111,9 @@ def perturbation_to_force_config(
             ``DEFAULT_PERTURBATION``）；缺省项取默认值。
         earth_degree: 地球非球形引力位阶次数（degree=order）。
         moon_degree: 月球非球形引力位阶次数（degree=order）。
+        moon_tide_mode: 月球球谐引力场的潮汐模式（none/solid）。inputs-dac
+            侧没有对应的月球潮汐开关（``tide`` 只管地球），故独立成参数；
+            默认 none 保持既有行为。
         dyb: DYB 面质比系数 9 分量；``dyb[0]`` 为等效面质比（m²/kg），
             炮弹光压与大气阻力共用；其余分量在炮弹档忽略。
         area_to_mass: 显式等效面质比（m²/kg），给出时覆盖 ``dyb[0]``。
@@ -119,9 +125,12 @@ def perturbation_to_force_config(
 
     Raises:
         NotImplementedError: ``solar_radiation=2`` （ECOM）。
-        ValueError: 开关取值非法；``tide=1`` 或 ``coupling=1`` 而
-            ``earth_nonspherical=0``；``dyb`` 非 9 分量。
+        ValueError: 开关取值非法；``moon_tide_mode`` 非 none/solid；
+            ``tide=1`` 或 ``coupling=1`` 而 ``earth_nonspherical=0``；
+            ``dyb`` 非 9 分量。
     """
+    if moon_tide_mode not in ("none", "solid"):
+        raise ValueError(f"moon_tide_mode 必须为 none 或 solid，当前 {moon_tide_mode!r}")
     sw = _resolve_switches(perturbation)
 
     # coupling=1 强制启用固体潮（无论 tide 开关值）。
@@ -168,7 +177,7 @@ def perturbation_to_force_config(
                 "order": int(moon_degree),
                 "input_frame": _DEFAULT_FRAME_BY_BODY["MOON"],
                 "gravity_file": None,
-                "tide_mode": "none",
+                "tide_mode": moon_tide_mode,
                 "tide_convention": "tide_free",
             },
         )

--- a/e2m2e/api/models.py
+++ b/e2m2e/api/models.py
@@ -243,6 +243,11 @@ class DesignOrbitRequest(_ApiModel):
         "显式传入与族冲突的值时告警并改写为 segmented",
     )
     correction_revolutions: int = Field(default=1, ge=1)
+    moon_tide_mode: Literal["none", "solid"] = Field(
+        default="none",
+        description="月球球谐引力场的潮汐模式（none/solid）。地球潮汐仍由"
+        " perturbation['tide']/'coupling' 控制，本字段不影响",
+    )
 
     @classmethod
     def valid_ranges(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "e2m2e"
-version = "5.9.5"
+version = "5.9.6"
 description = "Earth to Moon, Moon to Earth — 地月空间算法工具集"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/api/test_facade.py
+++ b/tests/api/test_facade.py
@@ -65,6 +65,11 @@ class TestFacadeValidation:
                 perilune_height=40000.1,
             )
 
+    def test_design_moon_tide_mode_enum_is_validated_at_boundary(self):
+        """moon_tide_mode 非法枚举值在 Facade 边界翻译为 INVALID_PARAMS。"""
+        with pytest.raises(OrbitError, match="INVALID_PARAMS"):
+            Facade().design_orbit(orbit_type="DRO", moon_tide_mode="bogus")
+
 
 class TestFacadeDelegation:
     def test_control_upper_bounds_are_translated_to_orbit_error(self):

--- a/tests/numerical/forces/config/test_force_mapping.py
+++ b/tests/numerical/forces/config/test_force_mapping.py
@@ -245,3 +245,35 @@ class TestBuildAndRoundTrip:
         dump_force_config(fm, path)
         fm2 = load_force_config(path, system)
         assert fm2.to_config() == cfg
+
+        cfg = perturbation_to_force_config(_on(moon_nonspherical=1))
+        (gf,) = [
+            f
+            for f in cfg["forces"]
+            if f["type"] == "GravityField" and f["params"]["body"] == "MOON"
+        ]
+        assert gf["params"]["tide_mode"] == "none"
+
+    def test_solid_only_affects_moon(self):
+        """moon_tide_mode=solid 只改月球条目，地球潮汐仍由 tide 开关控制。"""
+        cfg = perturbation_to_force_config(
+            _on(earth_nonspherical=1, moon_nonspherical=1, tide=1),
+            moon_tide_mode="solid",
+        )
+        gf_by_body = {f["params"]["body"]: f for f in cfg["forces"] if f["type"] == "GravityField"}
+        assert gf_by_body["EARTH"]["params"]["tide_mode"] == "solid"
+        assert gf_by_body["MOON"]["params"]["tide_mode"] == "solid"
+
+        cfg_off = perturbation_to_force_config(
+            _on(earth_nonspherical=1, moon_nonspherical=1, tide=0, coupling=0),
+            moon_tide_mode="solid",
+        )
+        gf_by_body_off = {
+            f["params"]["body"]: f for f in cfg_off["forces"] if f["type"] == "GravityField"
+        }
+        assert gf_by_body_off["EARTH"]["params"]["tide_mode"] == "none"
+        assert gf_by_body_off["MOON"]["params"]["tide_mode"] == "solid"
+
+    def test_invalid_mode_raises(self):
+        with pytest.raises(ValueError, match="moon_tide_mode"):
+            perturbation_to_force_config(_on(moon_nonspherical=1), moon_tide_mode="bogus")


### PR DESCRIPTION
由 zhipu-coding-plan/glm-5.3（qiao 仓 agent 会话）起草。

Related to #643

## 意图

`design_orbit` 新增公开字段 `moon_tide_mode`（none/solid，默认 none），使月球球谐引力场的固体潮可在 Facade 边界显式开启。解锁 qiao 仓 NRHO 真值验证链（#326 后续）迁移到纯 Facade 路径：其现有真值口径要求月球 10×10 球谐 + 固体潮，而当前公开映射固定月球 `tide_mode="none"`。

## 变更

- `e2m2e/api/models.py`：`DesignOrbitRequest.moon_tide_mode: Literal["none","solid"] = "none"`（默认值保持既有全部调用方行为不变；非法枚举值经 Pydantic → `OrbitError(INVALID_PARAMS)`）。
- `e2m2e/algorithm/forces/force_mapping.py`：`perturbation_to_force_config` 增加同名 keyword-only 参数（默认 `none`），月球 `GravityField.params.tide_mode` 使用它；地球潮汐仍仅由 `tide`/`coupling` 开关控制，逻辑不变。
- `e2m2e/algorithm/design/design_orbit.py`：`_DesignRequest` 协议补字段；ELFO 与 CR3BP 两条力模型构造路径均传入请求值，星历修正与标称星历同弧一致。
- 版本 bump 至 5.9.6（pyproject + Cargo workspace），CHANGELOG 新增发布段——供合并后直接打 `v5.9.6` tag 发布。

## 测试

- `tests/numerical/forces/config/test_force_mapping.py`：默认 `none`（兼容性）；`solid` 只作用月球条目且地球不受影响；非法值 `ValueError`。
- `tests/api/test_facade.py`：非法枚举值经 Facade 翻译为 `INVALID_PARAMS`（复用 TestFacadeValidation 模式，不触发设计积分）。

本地验证：`make check` 全过（cargo fmt/clippy、ruff check/format、mypy、层级检查）；两测试文件全绿（25 + 37 例）。

## 影响

无既有行为变化（默认 `none` 即历史路径）；新字段为可选 kwargs，worker 协议 `Config.to_payload` 不受影响。合并后建议直接发 v5.9.6 补丁版，qiao 侧随后升级并切换生成器（qiao #326 后续）。
